### PR TITLE
Add requisite header for Windows intrinsic types.

### DIFF
--- a/Foundation/include/Poco/Error.h
+++ b/Foundation/include/Poco/Error.h
@@ -41,6 +41,7 @@
 
 
 #include "Poco/Foundation.h"
+#include "Poco/UnWindows.h"
 
 
 namespace Poco {


### PR DESCRIPTION
Otherwise DWORD is undefined.
