### PR TITLE
Update doc/00100-GuidedTour.page

### DIFF
--- a/doc/00100-GuidedTour.page
+++ b/doc/00100-GuidedTour.page
@@ -305,7 +305,7 @@ server.
     using Poco::Util::Application;
     using Poco::Util::Option;
     using Poco::Util::OptionSet;
-    using Poco::Util::OptionCallback
+    using Poco::Util::OptionCallback;
     using Poco::Util::HelpFormatter;
     
     class TimeRequestHandler: public HTTPRequestHandler


### PR DESCRIPTION
added missing semicolon in the HTTPTimeServer example
