### PR TITLE
remove std:: namespace from copysignf and copysign

### DIFF
--- a/Foundation/include/Poco/FPEnvironment_DUMMY.h
+++ b/Foundation/include/Poco/FPEnvironment_DUMMY.h
@@ -131,13 +131,13 @@ inline bool FPEnvironmentImpl::isNaNImpl(long double value)
 
 inline float FPEnvironmentImpl::copySignImpl(float target, float source)
 {
-	return std::copysignf(target, source);
+	return copysignf(target, source);
 }
 
 
 inline double FPEnvironmentImpl::copySignImpl(double target, double source)
 {
-	return std::copysign(target, source);
+	return copysign(target, source);
 }
 
 


### PR DESCRIPTION
Aleksandar's recommendation for an Android compile error fix ended up fixing the same compile error for iPhone and iPhonesimulator:

"copysign\* is C99/C++ TR1, apparently still not in std namespace with
gcc 4.7. Remove std:: in front of it and see if it helps. If you
provide a patch, we'll test and include it for future releases."
