### PR TITLE
SSL & unclean shutdown response

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
@@ -170,6 +170,7 @@ protected:
 	void connect(const SocketAddress& address);
 	std::string proxyRequestPrefix() const;
 	void proxyAuthenticate(HTTPRequest& request);
+	int read(char* buffer, std::streamsize length);
 
 private:
 	HTTPSClientSession(const HTTPSClientSession&);

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -38,6 +38,7 @@
 #include "Poco/Net/SecureStreamSocket.h"
 #include "Poco/Net/SecureStreamSocketImpl.h"
 #include "Poco/Net/SSLManager.h"
+#include "Poco/Net/SSLException.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPResponse.h"
 #include "Poco/Net/NetException.h"
@@ -186,6 +187,15 @@ void HTTPSClientSession::connect(const SocketAddress& address)
 		{
 			_pSession = secureSocket.currentSession();
 		}
+	}
+}
+
+
+int HTTPSClientSession::read(char* buffer, std::streamsize length) {
+	try {
+		return HTTPClientSession::read(buffer, length);
+	} catch(SSLConnectionUnexpectedlyClosedException&) {
+		return 0;
 	}
 }
 

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
@@ -58,6 +58,9 @@ public:
 	void testInterop();
 	void testProxy();
 	void testCachedSession();
+	void testUnknownContentLength();
+	void testServerAbort();
+
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
When the server responds without "Content-Length" and ssl connection is closed without close_notify alert, the StreamCopier can't perform a buffered copy from stream. It works when i use an unbuffered copy.

SSL specification says: "Each party is _required_ to send a close_notify alert before closing", but some gateways, load-balancers and servers don't respect that.
