### PR TITLE
Fix documentation: OptionException gets thrown by Poco::Util::Validator

### DIFF
--- a/Util/include/Poco/Util/Validator.h
+++ b/Util/include/Poco/Util/Validator.h
@@ -62,7 +62,7 @@ public:
 		/// Validates the value for the given option.
 		/// Does nothing if the value is valid.
 		///
-		/// Throws an InvalidOptionException otherwise.
+		/// Throws an OptionException otherwise.
 
 protected:
 	Validator();


### PR DESCRIPTION
A small fix of the documentation: OptionException gets thrown by a Poco::Util::Validator, not InvalidOptionException.
