### PR TITLE
Improve SQLite multi-threaded use

### DIFF
--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -195,14 +195,6 @@ void SessionImpl::open(const std::string& connect)
 		throw ConnectionFailedException(ex.displayText());
 	}
 
-	if (SQLITE_OK != sqlite3_exec(_pDB,
-		"attach database ':memory:' as sys;"
-		"create table sys.dual (dummy);", 
-		0, 0, 0))
-	{
-		throw ExecutionException("Cannot create system database.");
-	}
-
 	_connected = true;
 }
 

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -2557,55 +2557,6 @@ void SQLiteTest::testReconnect()
 }
 
 
-void SQLiteTest::testSystemTable()
-{
-	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
-	int cntFile = 0;
-	session << "DROP TABLE IF EXISTS Test", now;
-	session << "CREATE TABLE Test (Test INTEGER)", now;
-	session << "INSERT INTO Test VALUES (1)", now;
-	session << "SELECT count(*) FROM Test", into(cntFile), now;
-	assert (1 == cntFile);
-
-	int cntMem = -1;
-	session << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (0 == cntMem);
-
-	session << "INSERT INTO sys.dual VALUES ('test')", now;
-	session << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (1 == cntMem);
-
-	// connect another session
-	Session session2(Poco::Data::SQLite::Connector::KEY, "dummy.db");
-	// verify it has it's own sys table
-	session2 << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (0 == cntMem);
-	// verify it shares the file table
-	session2 << "SELECT count(*) FROM Test", into(cntFile), now;
-	assert (1 == cntFile);
-	session2 << "INSERT INTO sys.dual VALUES ('test')", now;
-	session2 << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (1 == cntMem);
-
-	session << "DELETE FROM sys.dual", now;
-	session << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (0 == cntMem);
-	session2 << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (1 == cntMem);
-	session2 << "DELETE FROM sys.dual", now;
-	session2 << "SELECT count(*) FROM sys.dual", into(cntMem), now;
-	assert (0 == cntMem);
-
-	try
-	{
-		session << "DROP TABLE sys.dual", now;
-		fail ("must throw");
-	}
-	catch (InvalidAccessException&) { }
-
-}
-
-
 void SQLiteTest::testThreadModes()
 {
 	using namespace Poco::Data::SQLite;
@@ -2747,7 +2698,6 @@ CppUnit::Test* SQLiteTest::suite()
 	CppUnit_addTest(pSuite, SQLiteTest, testMultipleResults);
 	CppUnit_addTest(pSuite, SQLiteTest, testPair);
 	CppUnit_addTest(pSuite, SQLiteTest, testReconnect);
-	CppUnit_addTest(pSuite, SQLiteTest, testSystemTable);
 	CppUnit_addTest(pSuite, SQLiteTest, testThreadModes);
 
 	return pSuite;

--- a/Data/SQLite/testsuite/src/SQLiteTest.h
+++ b/Data/SQLite/testsuite/src/SQLiteTest.h
@@ -132,7 +132,6 @@ public:
 	void testMultipleResults();
 
 	void testReconnect();
-	void testSystemTable();
 
 	void testThreadModes();
 


### PR DESCRIPTION
- Use sqlite3_stmt_readonly to determine if sqlite3_changes should be called
- Remove sys.dual dependency, improving multi-threaded applications

sqlite3_changes shouldn't be called for select statements. If a statement is readonly, by definition it should't make any changes. Using this logic, the sys.dual hack don't need to be used, which was giving problems in multi-threaded applications.

All tests passed with this change.
