### PR TITLE
Added configurations for building with clang/libc++ for iPhone, iPhoneSimulator and Darwin

### DIFF
--- a/build/config/Darwin-clang-libc++
+++ b/build/config/Darwin-clang-libc++
@@ -1,0 +1,77 @@
+#
+# $Id: //poco/1.4/build/config/Darwin-clang#4 $
+#
+# Darwin
+#
+# Build settings for Mac OS X 10.6 (clang++)
+# The build settings defined in this file are compatible
+# with XCode 4 C++ projects.
+# 
+# NOTE: This build configuration will build 64-bit binaries.
+# Use the Darwin32-clang build configuration to build 32-bit binaries.
+#
+
+#
+# General Settings
+#
+LINKMODE ?= SHARED
+
+POCO_TARGET_OSARCH ?= x86_64
+POCO_HOST_OSARCH   := $(POCO_TARGET_OSARCH)
+ARCHFLAGS          ?= -arch $(POCO_TARGET_OSARCH)
+
+
+#
+# Tools
+#
+CC      = $(shell xcrun -find clang)
+CXX     = $(shell xcrun -find clang++)
+LINK    = $(CXX) -bind_at_load
+LIB     = libtool -static -o
+RANLIB  = ranlib
+SHLIB   = $(CXX) -dynamiclib -o $@
+DYLIB   = $(CXX) -dynamic -bundle -read_only_relocs suppress -Wl,-bind_at_load -o $@ 
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   = 
+DEP     = $(POCO_BASE)/build/script/makedepend.clang
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .$(target_version).dylib
+SHAREDLIBLINKEXT = .dylib
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          = $(ARCHFLAGS)
+CXXFLAGS        = $(ARCHFLAGS) -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
+LINKFLAGS       = $(ARCHFLAGS) -stdlib=libc++
+SHLIBFLAGS      = $(ARCHFLAGS) -stdlib=libc++
+DYLIBFLAGS      = $(ARCHFLAGS)
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  =
+SHAREDOPT_CC    = -fPIC 
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = 
+DEBUGOPT_CC     = -O0 -g -gdwarf-2 -fasm-blocks -D_DEBUG=$(DEBUGLEVEL)
+DEBUGOPT_CXX    = -O0 -g -gdwarf-2 -fasm-blocks -D_DEBUG=$(DEBUGLEVEL) 
+DEBUGOPT_LINK   =
+RELEASEOPT_CC   = -DNDEBUG -Os -fasm-blocks
+RELEASEOPT_CXX  = -DNDEBUG -O2 -fasm-blocks
+RELEASEOPT_LINK =
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -DPOCO_HAVE_IPv6 -DPOCO_NO_STAT64
+
+#
+# System Specific Libraries
+#
+SYSLIBS  = -ldl

--- a/build/config/Darwin32-clang-libc++
+++ b/build/config/Darwin32-clang-libc++
@@ -1,0 +1,14 @@
+#
+# $Id: //poco/1.4/build/config/Darwin32-clang#1 $
+#
+# Darwin32
+#
+# Build settings for Mac OS X 10.5/10.6 (GCC 4.0.1), 32-bits
+# The build settings defined in this file are compatible
+# with XCode 3.1 C++ projects.
+# 
+
+ARCHFLAGS = -arch i386
+POCO_TARGET_OSARCH = i386
+
+include $(POCO_BASE)/build/config/Darwin-clang-libc++

--- a/build/config/Darwin64-clang-libc++
+++ b/build/config/Darwin64-clang-libc++
@@ -1,0 +1,14 @@
+#
+# $Id: //poco/1.4/build/config/Darwin64-clang#1 $
+#
+# Darwin64
+#
+# Build settings for Mac OS X 10.5/10.6 (GCC 4.0.1), 64-bits
+# The build settings defined in this file are compatible
+# with XCode 3.1 C++ projects.
+# 
+
+ARCHFLAGS = -arch x86_64
+POCO_TARGET_OSARCH = x86_64
+
+include $(POCO_BASE)/build/config/Darwin-clang-libc++

--- a/build/config/iPhone-clang-libc++
+++ b/build/config/iPhone-clang-libc++
@@ -1,0 +1,98 @@
+#
+# $Id: //poco/1.4/build/config/iPhone#3 $
+#
+# iPhone
+#
+# Build settings for iPhone OS, using Apple's iPhone SDK
+# 
+
+#
+# General Settings
+#
+# iPhone OS does not allow dynamic linking to user libraries
+#
+LINKMODE ?= STATIC
+
+#
+# If the SDK is defined use it
+# Otherwise find the latest version installed
+#
+# IPHONE_SDK_VERSION = 2.2.1
+
+# if IPHONE_SDK_VERSION_MIN is defined use that
+# Otherwise use the version found. 
+
+IPHONE_SDK             ?= iPhoneOS
+IPHONE_SDK_ROOT        ?= $(shell xcode-select -print-path)/Platforms/$(IPHONE_SDK).platform/Developer/SDKs
+IPHONE_SDK_ROOT_DIR     = $(IPHONE_SDK_ROOT)/$(IPHONE_SDK)
+IPHONE_SDK_BASE         = $(shell ls -d $(IPHONE_SDK_ROOT_DIR)$(IPHONE_SDK_VERSION)*.sdk | tail -1)
+IPHONE_SDK_VERSION_MIN ?= $(patsubst %.sdk,%,$(patsubst $(IPHONE_SDK_ROOT_DIR)%,%,$(IPHONE_SDK_BASE)))
+
+POCO_TARGET_OSNAME     ?= $(IPHONE_SDK)
+POCO_TARGET_OSARCH     ?= armv7
+TOOL_PREFIX            ?= $(shell xcode-select -print-path)/Platforms/$(IPHONE_SDK).platform/Developer/usr/bin
+OSFLAGS                ?= -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -mthumb -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
+
+#
+# Tools
+#
+# If GCC_VER is defined then use it.
+# Otherwise select the latest version
+#
+
+CC		= $(shell xcrun -find clang)
+CXX		= $(shell xcrun -find clang++)
+
+LINK    = $(CXX) -bind_at_load
+LIB     = libtool -static -o
+RANLIB  = ranlib
+SHLIB   = $(CXX) $(OSFLAGS) -dynamiclib -Wl,-install_name,$@ -o $@
+DYLIB   = $(CXX) $(OSFLAGS) -dynamic -bundle -read_only_relocs suppress -Wl,-bind_at_load -o $@ 
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   = 
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .$(target_version).dylib
+SHAREDLIBLINKEXT = .dylib
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          = $(OSFLAGS)
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = $(OSFLAGS) -stdlib=libc++ -Wall -Wno-sign-compare 
+CXXFLAGS32      =
+CXXFLAGS64      = 
+LINKFLAGS       = $(OSFLAGS) -stdlib=libc++
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  =
+SHAREDOPT_CC    = -fPIC 
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = 
+DEBUGOPT_CC     = -g -D_DEBUG=$(DEBUGLEVEL)
+DEBUGOPT_CXX    = -g -D_DEBUG=$(DEBUGLEVEL) 
+DEBUGOPT_LINK   =
+RELEASEOPT_CC   = -DNDEBUG -O2
+RELEASEOPT_CXX  = -DNDEBUG -O 
+RELEASEOPT_LINK =
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -DPOCO_HAVE_IPv6 -DPOCO_NO_FPENVIRONMENT -DPOCO_NO_STAT64 -DPOCO_NO_SHAREDLIBS -DPOCO_NO_NET_IFTYPES
+
+#
+# System Specific Libraries
+#
+SYSLIBS  = -ldl

--- a/build/config/iPhoneSimulator-clang-libc++
+++ b/build/config/iPhoneSimulator-clang-libc++
@@ -1,0 +1,13 @@
+#
+# $Id: //poco/1.4/build/config/iPhoneSimulator#1 $
+#
+# iPhoneSimulator
+#
+# Build settings for iPhone Simulator, using Apple's iPhone SDK
+# 
+
+IPHONE_SDK         = iPhoneSimulator
+POCO_TARGET_OSARCH = i686
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
+
+include $(POCO_BASE)/build/config/iPhone-clang-libc++


### PR DESCRIPTION
I added some simple new configs to enable building with latest Xcode using clang and libc++ so as to enable usage of c++11 in client applications.

Would you consider for merging?

Regards, Andrea Bigagli
