### PR TITLE
Prevent near-infinite loop with stringifying JSON objects.

### DIFF
--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -150,7 +150,7 @@ void Array::stringify(std::ostream& out, unsigned int indent) const
 		out << std::endl;
 	}
 
-	if ( indent > 0 )
+	if ( indent > 1 )
 		indent -= 2;
 
 	for(int i = 0; i < indent; i++)

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -145,7 +145,7 @@ void Object::stringify(std::ostream& out, unsigned int indent) const
 		}
 	}
 
-	if ( indent > 0 )
+	if ( indent > 1 )
 		indent -= 2;
 	for(int i = 0; i < indent; i++)
 	{


### PR DESCRIPTION
If you are stringifying a JSON array or object, and you happen
to pass in indent=1, we would get uint overflow and try to write
' ' chars for UINT_MAX-1 times. Instead don't reduce the indent
if it's less than 2.
