### PR TITLE
* BUGFIX: URI::addQueryParameter was adding an extra '?' to the query string

### DIFF
--- a/Foundation/src/URI.cpp
+++ b/Foundation/src/URI.cpp
@@ -344,8 +344,7 @@ void URI::addQueryParameter(const std::string& param, const std::string& val)
 {
 	std::string reserved(RESERVED_QUERY);
 	reserved += "=&";
-	if (_query.empty()) _query.append(1, '?');
-	else _query.append(1, '&');
+	if (!_query.empty()) _query.append(1, '&');
 	encode(param, reserved, _query);
 	_query.append(1, '=');
 	encode(val, reserved, _query);


### PR DESCRIPTION
URI::toString already adds the '?' character, it must not be added to _query
