### PR TITLE
Allow RemoteSyslogChannel to be used again after being closed.

### DIFF
--- a/Net/src/RemoteSyslogChannel.cpp
+++ b/Net/src/RemoteSyslogChannel.cpp
@@ -89,8 +89,8 @@ void RemoteSyslogChannel::open()
 {
 	if (_open) return;
 
-    // reset socket for the case that it has been previously closed
-    _socket = DatagramSocket();
+	// reset socket for the case that it has been previously closed
+	_socket = DatagramSocket();
 
 	if (_logHost.find(':') != std::string::npos)
 		_socketAddress = SocketAddress(_logHost);
@@ -108,8 +108,8 @@ void RemoteSyslogChannel::open()
 			_host = _socket.address().host().toString();
 		}
 	}
-    
-    _open = true;
+
+	_open = true;
 }
 
 	

--- a/Net/testsuite/src/SyslogTest.h
+++ b/Net/testsuite/src/SyslogTest.h
@@ -47,6 +47,7 @@ public:
 	~SyslogTest();
 
 	void testListener();
+	void testChannelOpenClose();
 	void testOldBSD();
 
 	void setUp();


### PR DESCRIPTION
There was an issue with restarting the RemoteSyslogChannel and having the datagram socket send again correctly. This should fix that problem.
