### PR TITLE
Foundation/include/Poco/Platform.h: Add support for AArch64.

### DIFF
--- a/Foundation/include/Poco/Platform.h
+++ b/Foundation/include/Poco/Platform.h
@@ -145,6 +145,7 @@
 #define POCO_ARCH_S390    0x0c
 #define POCO_ARCH_SH      0x0d
 #define POCO_ARCH_NIOS2   0x0e
+#define POCO_ARCH_AARCH64 0x0f
 
 
 #if defined(__ALPHA) || defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA)
@@ -207,7 +208,12 @@
 	#else
 		#define POCO_ARCH_BIG_ENDIAN 1
 	#endif
-
+#elif defined(__AARCH64EL__)
+	#define POCO_ARCH POCO_ARCH_AARCH64
+	#define POCO_ARCH_LITTLE_ENDIAN 1
+#elif defined(__AARCH64EB__)
+	#define POCO_ARCH POCO_ARCH_AARCH64
+	#define POCO_ARCH_BIG_ENDIAN 1
 #endif
 
 


### PR DESCRIPTION
Add support for big and little endian AArch64 preprocessor defines.
