### PR TITLE
fix alignas specifier

### DIFF
--- a/Foundation/include/Poco/Alignment.h
+++ b/Foundation/include/Poco/Alignment.h
@@ -126,7 +126,7 @@ template <size_t Alignment> struct AlignedCharArrayImpl;
 			#define POCO_ALIGNEDCHARARRAY_TEMPLATE_ALIGNMENT(x) \
 				template <> struct AlignedCharArrayImpl<x> \
 				{ \
-					char alignas(x) aligned; \
+					char aligned alignas(x); \
 				}
 			#define POCO_HAVE_ALIGNMENT
 		#endif


### PR DESCRIPTION
Clang chokes on alignas before the identifier, see http://stackoverflow.com/questions/15788947/where-can-i-use-alignas-in-c11. Moving alignas directly behind the identifier fixes that.
