### PR TITLE
add qualifiers for FPEnvironment in C99

### DIFF
--- a/Foundation/include/Poco/FPEnvironment_C99.h
+++ b/Foundation/include/Poco/FPEnvironment_C99.h
@@ -95,37 +95,37 @@ private:
 //
 inline bool FPEnvironmentImpl::isInfiniteImpl(float value)
 {
-	return isinf(value) != 0;
+	return std::isinf(value) != 0;
 }
 
 
 inline bool FPEnvironmentImpl::isInfiniteImpl(double value)
 {
-	return isinf(value) != 0;
+	return std::isinf(value) != 0;
 }
 
 
 inline bool FPEnvironmentImpl::isInfiniteImpl(long double value)
 {
-	return isinf((double) value) != 0;
+	return std::isinf((double) value) != 0;
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(float value)
 {
-	return isnan(value) != 0;
+	return std::isnan(value) != 0;
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(double value)
 {
-	return isnan(value) != 0;
+	return std::isnan(value) != 0;
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(long double value)
 {
-	return isnan((double) value) != 0;
+	return std::isnan((double) value) != 0;
 }
 
 


### PR DESCRIPTION
This caused the build to fail with gcc version 4.7.3 (Debian 4.7.3-4).
