### PR TITLE
Fix build errors in HTTPCookieTest

### DIFF
--- a/Net/testsuite/src/HTTPCookieTest.cpp
+++ b/Net/testsuite/src/HTTPCookieTest.cpp
@@ -52,7 +52,6 @@ using Poco::DateTimeParser;
 using Poco::DateTime;
 using Poco::Net::NameValueCollection;
 using Poco::Net::HTTPCookie;
-using Poco::DateTimeParser;
 
 
 HTTPCookieTest::HTTPCookieTest(const std::string& name): CppUnit::TestCase(name)


### PR DESCRIPTION
Ack, I screwed up the merge with current upstream and a couple of include directives went missing. Fixed this and tested that everything builds and the tests all pass. Sorry!!
