### PR TITLE
Fixed code page warning.

### DIFF
--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -61,7 +61,7 @@ class Foundation_API Var
 	/// Var puts forth the best effort to provide intuitive and reasonable conversion semantics and prevent 
 	/// unexpected data loss, particularly when performing narrowing or signedness conversions of numeric data types.
 	///
-	/// An attempt to convert or extract from a non-initialized (“empty”) Var variable shall result
+	/// An attempt to convert or extract from a non-initialized ("empty") Var variable shall result
 	/// in an exception being thrown.
 	///
 	/// Loss of signedness is not allowed for numeric values. This means that if an attempt is made to convert 


### PR DESCRIPTION
Fixed VC warning on Japanese environment:
"warning C4819: The file contains a character that cannot be represented in the current code page"
