### PR TITLE
Fix for Sockets and SIGPIPE

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -1078,6 +1078,10 @@ void SocketImpl::error(int code, const std::string& arg)
 		throw NetException("Host is down", arg, code);
 	case POCO_EHOSTUNREACH:
 		throw NetException("No route to host", arg, code);
+#if defined(POCO_OS_FAMILY_UNIX)
+	case EPIPE:
+		throw IOException("Broken pipe", code);
+#endif
 	default:
 		throw IOException(NumberFormatter::format(code), arg, code);
 	}


### PR DESCRIPTION
On Unix systems, when a socket is open and writing and the receiving socket is closed during the write, a SIGPIPE signal is generated. If left un-handled (which is the default), the SIGPIPE will terminate the process. At best this leads to inconsistent use of `Socket` across platforms, and at worst it makes `Socket` very unreliable to use on Unix platforms (especially Mac OS X and iOS).

By ignoring the SIGPIPE when Socket is initialized, we can avoid this problem. This is the same approach used in `boost::asio`.
