### PR TITLE
Only clean targets not listed in --omit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ install: libexecs
 libexecs =  Foundation-libexec XML-libexec JSON-libexec Util-libexec Net-libexec Crypto-libexec NetSSL_OpenSSL-libexec Data-libexec Data/SQLite-libexec Data/ODBC-libexec Data/MySQL-libexec Zip-libexec PageCompiler-libexec PageCompiler/File2Page-libexec PDF-libexec CppParser-libexec MongoDB-libexec
 tests    =  Foundation-tests XML-tests JSON-tests Util-tests Net-tests Crypto-tests NetSSL_OpenSSL-tests Data-tests Data/SQLite-tests Data/ODBC-tests Data/MySQL-tests Zip-tests PDF-tests CppParser-tests MongoDB-tests
 samples  =  Foundation-samples XML-samples JSON-samples Util-samples Net-samples Crypto-samples NetSSL_OpenSSL-samples Data-samples Zip-samples PageCompiler-samples PDF-samples
+cleans =    Foundation-clean XML-clean JSON-clean Util-clean Net-clean Crypto-clean NetSSL_OpenSSL-clean Data-clean Data/SQLite-clean Data/ODBC-clean Data/MySQL-clean Zip-clean PageCompiler-clean PageCompiler/File2Page-clean PDF-clean CppParser-clean MongoDB-clean
 
 .PHONY: poco all libexecs cppunit tests samples clean distclean install
 .PHONY: $(libexecs)
@@ -63,6 +64,7 @@ samples  =  Foundation-samples XML-samples JSON-samples Util-samples Net-samples
 libexecs: $(filter-out $(foreach f,$(OMIT),$f%),$(libexecs))
 tests: $(filter-out $(foreach f,$(OMIT),$f%),$(tests))
 samples: $(filter-out $(foreach f,$(OMIT),$f%),$(samples))
+cleans: $(filter-out $(foreach f,$(OMIT),$f%),$(cleans))
 
 Foundation-libexec: 
 	$(MAKE) -C $(POCO_BASE)/Foundation
@@ -73,6 +75,11 @@ Foundation-tests: Foundation-libexec cppunit
 Foundation-samples: Foundation-libexec 
 	$(MAKE) -C $(POCO_BASE)/Foundation/samples
 
+Foundation-clean:
+	$(MAKE) -C $(POCO_BASE)/Foundation clean
+	$(MAKE) -C $(POCO_BASE)/Foundation/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Foundation/samples clean
+
 XML-libexec:  Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/XML
 
@@ -81,6 +88,11 @@ XML-tests: XML-libexec cppunit
 
 XML-samples: XML-libexec 
 	$(MAKE) -C $(POCO_BASE)/XML/samples
+
+XML-clean:
+	$(MAKE) -C $(POCO_BASE)/XML clean
+	$(MAKE) -C $(POCO_BASE)/XML/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/XML/samples clean
 
 JSON-libexec:  Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/JSON
@@ -91,6 +103,11 @@ JSON-tests: JSON-libexec cppunit
 JSON-samples: JSON-libexec 
 	$(MAKE) -C $(POCO_BASE)/JSON/samples
 
+JSON-clean:
+	$(MAKE) -C $(POCO_BASE)/JSON clean
+	$(MAKE) -C $(POCO_BASE)/JSON/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/JSON/samples clean
+
 Util-libexec:  Foundation-libexec XML-libexec
 	$(MAKE) -C $(POCO_BASE)/Util
 
@@ -99,6 +116,11 @@ Util-tests: Util-libexec cppunit
 
 Util-samples: Util-libexec 
 	$(MAKE) -C $(POCO_BASE)/Util/samples
+
+Util-clean:
+	$(MAKE) -C $(POCO_BASE)/Util clean
+	$(MAKE) -C $(POCO_BASE)/Util/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Util/samples clean
 
 Net-libexec:  Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/Net
@@ -109,6 +131,11 @@ Net-tests: Net-libexec cppunit
 Net-samples: Net-libexec  Foundation-libexec XML-libexec Util-libexec
 	$(MAKE) -C $(POCO_BASE)/Net/samples
 
+Net-clean:
+	$(MAKE) -C $(POCO_BASE)/Net clean
+	$(MAKE) -C $(POCO_BASE)/Net/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Net/samples clean
+
 Crypto-libexec:  Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/Crypto
 
@@ -117,6 +144,11 @@ Crypto-tests: Crypto-libexec cppunit
 
 Crypto-samples: Crypto-libexec  Foundation-libexec Util-libexec
 	$(MAKE) -C $(POCO_BASE)/Crypto/samples
+
+Crypto-clean:
+	$(MAKE) -C $(POCO_BASE)/Crypto clean
+	$(MAKE) -C $(POCO_BASE)/Crypto/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Crypto/samples clean
 
 NetSSL_OpenSSL-libexec:  Foundation-libexec Net-libexec Util-libexec Crypto-libexec
 	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL
@@ -127,6 +159,11 @@ NetSSL_OpenSSL-tests: NetSSL_OpenSSL-libexec cppunit
 NetSSL_OpenSSL-samples: NetSSL_OpenSSL-libexec 
 	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL/samples
 
+NetSSL_OpenSSL-clean:
+	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL clean
+	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL/samples clean
+
 Data-libexec:  Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/Data
 
@@ -136,11 +173,20 @@ Data-tests: Data-libexec cppunit
 Data-samples: Data-libexec  Data-libexec Data/SQLite-libexec
 	$(MAKE) -C $(POCO_BASE)/Data/samples
 
+Data-clean:
+	$(MAKE) -C $(POCO_BASE)/Data clean
+	$(MAKE) -C $(POCO_BASE)/Data/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Data/samples clean
+
 Data/SQLite-libexec:  Foundation-libexec Data-libexec
 	$(MAKE) -C $(POCO_BASE)/Data/SQLite
 
 Data/SQLite-tests: Data/SQLite-libexec cppunit
 	$(MAKE) -C $(POCO_BASE)/Data/SQLite/testsuite
+
+Data/SQLite-clean:
+	$(MAKE) -C $(POCO_BASE)/Data/SQLite clean
+	$(MAKE) -C $(POCO_BASE)/Data/SQLite/testsuite clean
 
 Data/ODBC-libexec:  Foundation-libexec Data-libexec
 	$(MAKE) -C $(POCO_BASE)/Data/ODBC
@@ -148,11 +194,19 @@ Data/ODBC-libexec:  Foundation-libexec Data-libexec
 Data/ODBC-tests: Data/ODBC-libexec cppunit
 	$(MAKE) -C $(POCO_BASE)/Data/ODBC/testsuite
 
+Data/ODBC-clean:
+	$(MAKE) -C $(POCO_BASE)/Data/ODBC clean
+	$(MAKE) -C $(POCO_BASE)/Data/ODBC/testsuite clean
+
 Data/MySQL-libexec:  Foundation-libexec Data-libexec
 	$(MAKE) -C $(POCO_BASE)/Data/MySQL
 
 Data/MySQL-tests: Data/MySQL-libexec cppunit
 	$(MAKE) -C $(POCO_BASE)/Data/MySQL/testsuite
+
+Data/MySQL-clean:
+	$(MAKE) -C $(POCO_BASE)/Data/MySQL clean
+	$(MAKE) -C $(POCO_BASE)/Data/MySQL/testsuite clean
 
 Zip-libexec:  Foundation-libexec Net-libexec Util-libexec XML-libexec
 	$(MAKE) -C $(POCO_BASE)/Zip
@@ -163,14 +217,26 @@ Zip-tests: Zip-libexec cppunit
 Zip-samples: Zip-libexec 
 	$(MAKE) -C $(POCO_BASE)/Zip/samples
 
+Zip-clean:
+	$(MAKE) -C $(POCO_BASE)/Zip clean
+	$(MAKE) -C $(POCO_BASE)/Zip/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/Zip/samples clean
+
 PageCompiler-libexec:  Net-libexec Util-libexec XML-libexec Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/PageCompiler
 
 PageCompiler-samples: PageCompiler-libexec 
 	$(MAKE) -C $(POCO_BASE)/PageCompiler/samples
 
+PageCompiler-clean:
+	$(MAKE) -C $(POCO_BASE)/PageCompiler clean
+	$(MAKE) -C $(POCO_BASE)/PageCompiler/samples clean
+
 PageCompiler/File2Page-libexec:  Net-libexec Util-libexec XML-libexec Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/PageCompiler/File2Page
+
+PageCompiler/File2Page-clean:
+	$(MAKE) -C $(POCO_BASE)/PageCompiler/File2Page clean
 
 PDF-libexec: Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/PDF
@@ -181,11 +247,20 @@ PDF-tests: PDF-libexec cppunit
 PDF-samples: PDF-libexec 
 	$(MAKE) -C $(POCO_BASE)/PDF/samples
 
+PDF-clean:
+	$(MAKE) -C $(POCO_BASE)/PDF clean
+	$(MAKE) -C $(POCO_BASE)/PDF/testsuite clean
+	$(MAKE) -C $(POCO_BASE)/PDF/samples clean
+
 CppParser-libexec: Foundation-libexec
 	$(MAKE) -C $(POCO_BASE)/CppParser
 
 CppParser-tests: CppParser-libexec 
 	$(MAKE) -C $(POCO_BASE)/CppParser/testsuite
+
+CppParser-clean:
+	$(MAKE) -C $(POCO_BASE)/CppParser clean
+	$(MAKE) -C $(POCO_BASE)/CppParser/testsuite clean
 
 MongoDB-libexec: Foundation-libexec Net-libexec
 	$(MAKE) -C $(POCO_BASE)/MongoDB
@@ -193,52 +268,11 @@ MongoDB-libexec: Foundation-libexec Net-libexec
 MongoDB-tests: MongoDB-libexec Net-libexec cppunit
 	$(MAKE) -C $(POCO_BASE)/MongoDB/testsuite
 
-
-clean:
-	$(MAKE) -C $(POCO_BASE)/Foundation clean
-	$(MAKE) -C $(POCO_BASE)/Foundation/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Foundation/samples clean
-	$(MAKE) -C $(POCO_BASE)/XML clean
-	$(MAKE) -C $(POCO_BASE)/XML/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/XML/samples clean
-	$(MAKE) -C $(POCO_BASE)/Util clean
-	$(MAKE) -C $(POCO_BASE)/Util/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Util/samples clean
-	$(MAKE) -C $(POCO_BASE)/Net clean
-	$(MAKE) -C $(POCO_BASE)/Net/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Net/samples clean
-	$(MAKE) -C $(POCO_BASE)/Crypto clean
-	$(MAKE) -C $(POCO_BASE)/Crypto/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Crypto/samples clean
-	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL clean
-	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/NetSSL_OpenSSL/samples clean
-	$(MAKE) -C $(POCO_BASE)/Data clean
-	$(MAKE) -C $(POCO_BASE)/Data/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Data/samples clean
-	$(MAKE) -C $(POCO_BASE)/Data/SQLite clean
-	$(MAKE) -C $(POCO_BASE)/Data/SQLite/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Data/ODBC clean
-	$(MAKE) -C $(POCO_BASE)/Data/ODBC/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Data/MySQL clean
-	$(MAKE) -C $(POCO_BASE)/Data/MySQL/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Zip clean
-	$(MAKE) -C $(POCO_BASE)/Zip/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/Zip/samples clean
-	$(MAKE) -C $(POCO_BASE)/PageCompiler clean
-	$(MAKE) -C $(POCO_BASE)/PageCompiler/samples clean
-	$(MAKE) -C $(POCO_BASE)/PageCompiler/File2Page clean
-	$(MAKE) -C $(POCO_BASE)/PDF clean
-	$(MAKE) -C $(POCO_BASE)/PDF/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/PDF/samples clean
-	$(MAKE) -C $(POCO_BASE)/CppParser clean
-	$(MAKE) -C $(POCO_BASE)/CppParser/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/CppUnit clean
-	$(MAKE) -C $(POCO_BASE)/JSON clean
-	$(MAKE) -C $(POCO_BASE)/JSON/testsuite clean
-	$(MAKE) -C $(POCO_BASE)/JSON/samples clean
+MongoDB-clean:
 	$(MAKE) -C $(POCO_BASE)/MongoDB clean
 	$(MAKE) -C $(POCO_BASE)/MongoDB/testsuite clean
+
+clean: cleans
 
 distclean:
 	rm -rf $(POCO_BUILD)/lib


### PR DESCRIPTION
If omitting Data/ODBC, a "make clean" command fails because the Data/ODBC makefile always checks for an available ODBC library. Only cleaning the not-omitted targets solves the problem. "make distclean" still provides a way to thoroughly clean everything.
