### PR TITLE
Add Message::findProperty so that there is no exception thrown when acce...

### DIFF
--- a/Foundation/include/Poco/Message.h
+++ b/Foundation/include/Poco/Message.h
@@ -177,7 +177,17 @@ public:
 		/// Returns the source file line of the statement
 		/// generating the log message. May be 0
 		/// if not set.
-		
+
+    const std::string* findProperty(const std::string& param) const;
+		/// Returns a const pointer to the value of the parameter
+		/// with the given name. Returns nullptr if the
+		/// parameter does not exist.
+        ///
+        /// This method offers a slight performance gain over operator[] since
+        /// it doesn't throw an exception. It also helps by not getting trapped
+        /// on debug exception breakpoints.
+
+
 	const std::string& operator [] (const std::string& param) const;
 		/// Returns a const reference to the value of the parameter
 		/// with the given name. Throws a NotFoundException if the

--- a/Foundation/src/Message.cpp
+++ b/Foundation/src/Message.cpp
@@ -240,4 +240,17 @@ std::string& Message::operator [] (const std::string& param)
 }
 
 
+const std::string* Message::findProperty(const std::string& param) const
+{
+	if (_pMap)
+    {
+        StringMap::const_iterator it = _pMap->find(param);
+		if (it == _pMap->end())
+            return 0;
+        return &it->second;
+    }
+	else
+		return 0;
+}
+
 } // namespace Poco


### PR DESCRIPTION
...ssing log properties.

This method offers a slight performance gain over operator[] since it doesn't throw an exception. It also helps by not getting trapped on debug exception breakpoints.
