### PR TITLE
* Method to get JSON object value using Poco::Nullable

### DIFF
--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -46,6 +46,7 @@
 #include "Poco/SharedPtr.h"
 #include "Poco/Dynamic/Var.h"
 #include "Poco/Dynamic/Struct.h"
+#include "Poco/Nullable.h"
 #include <map>
 #include <vector>
 #include <deque>
@@ -140,6 +141,22 @@ public:
 		/// which can also throw exceptions for invalid values.
 		/// Note: This will not work for an array or an object.
 	{
+		Dynamic::Var value = get(key);
+		return value.convert<T>();
+	}
+
+	template<typename T>
+	Poco::Nullable<T> getNullableValue(const std::string& key) const
+		/// Retrieves the property with the given name and will
+		/// try to convert the value to the given template type.
+		/// Returns null if isNull.
+		/// The convert<T> method of Dynamic is called
+		/// which can also throw exceptions for invalid values.
+		/// Note: This will not work for an array or an object.
+	{
+		if (isNull(key))
+			return Poco::Nullable<T>();
+
 		Dynamic::Var value = get(key);
 		return value.convert<T>();
 	}

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -51,6 +51,7 @@
 #include "Poco/UTF8Encoding.h"
 #include "Poco/Latin1Encoding.h"
 #include "Poco/TextConverter.h"
+#include "Poco/Nullable.h"
 
 #include "Poco/Dynamic/Struct.h"
 
@@ -104,6 +105,9 @@ void JSONTest::testNullProperty()
 	assert(object->isNull("test"));
 	Var test = object->get("test");
 	assert(test.isEmpty());
+
+	Poco::Nullable<int> test2 = object->getNullableValue<int>("test");
+	assert(test2.isNull());
 
 	DynamicStruct ds = *object;
 	assert (ds["test"].isEmpty());


### PR DESCRIPTION
This is very useful when using Poco::Data, as Poco::Nullable<T> is used to save / retrieve NULL values.
