### PR TITLE
Prevent warnings by removing parameters from methods that don't use them...

### DIFF
--- a/Foundation/include/Poco/AbstractDelegate.h
+++ b/Foundation/include/Poco/AbstractDelegate.h
@@ -94,7 +94,7 @@ public:
 	{
 	}
 
-	AbstractDelegate(const AbstractDelegate& del)
+	AbstractDelegate(const AbstractDelegate&)
 	{
 	}
 

--- a/Foundation/include/Poco/Dynamic/Struct.h
+++ b/Foundation/include/Poco/Dynamic/Struct.h
@@ -236,62 +236,62 @@ public:
 		return typeid(Struct<std::string>);
 	}
 
-	void convert(Int8& val) const
+	void convert(Int8&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int8");
 	}
 
-	void convert(Int16& val) const
+	void convert(Int16&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int16");
 	}
 	
-	void convert(Int32& val) const
+	void convert(Int32&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int32");
 	}
 
-	void convert(Int64& val) const
+	void convert(Int64&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int64");
 	}
 
-	void convert(UInt8& val) const
+	void convert(UInt8&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt8");
 	}
 
-	void convert(UInt16& val) const
+	void convert(UInt16&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt16");
 	}
 	
-	void convert(UInt32& val) const
+	void convert(UInt32&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt32");
 	}
 
-	void convert(UInt64& val) const
+	void convert(UInt64&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt64");
 	}
 
-	void convert(bool& val) const
+	void convert(bool&) const
 	{
 		throw BadCastException("Cannot cast Struct type to bool");
 	}
 
-	void convert(float& val) const
+	void convert(float&) const
 	{
 		throw BadCastException("Cannot cast Struct type to float");
 	}
 
-	void convert(double& val) const
+	void convert(double&) const
 	{
 		throw BadCastException("Cannot cast Struct type to double");
 	}
 
-	void convert(char& val) const
+	void convert(char&) const
 	{
 		throw BadCastException("Cannot cast Struct type to char");
 	}
@@ -412,62 +412,62 @@ public:
 		return typeid(Struct<int>);
 	}
 
-	void convert(Int8& val) const
+	void convert(Int8&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int8");
 	}
 
-	void convert(Int16& val) const
+	void convert(Int16&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int16");
 	}
 	
-	void convert(Int32& val) const
+	void convert(Int32&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int32");
 	}
 
-	void convert(Int64& val) const
+	void convert(Int64&) const
 	{
 		throw BadCastException("Cannot cast Struct type to Int64");
 	}
 
-	void convert(UInt8& val) const
+	void convert(UInt8&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt8");
 	}
 
-	void convert(UInt16& val) const
+	void convert(UInt16&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt16");
 	}
 	
-	void convert(UInt32& val) const
+	void convert(UInt32&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt32");
 	}
 
-	void convert(UInt64& val) const
+	void convert(UInt64&) const
 	{
 		throw BadCastException("Cannot cast Struct type to UInt64");
 	}
 
-	void convert(bool& val) const
+	void convert(bool&) const
 	{
 		throw BadCastException("Cannot cast Struct type to bool");
 	}
 
-	void convert(float& val) const
+	void convert(float&) const
 	{
 		throw BadCastException("Cannot cast Struct type to float");
 	}
 
-	void convert(double& val) const
+	void convert(double&) const
 	{
 		throw BadCastException("Cannot cast Struct type to double");
 	}
 
-	void convert(char& val) const
+	void convert(char&) const
 	{
 		throw BadCastException("Cannot cast Struct type to char");
 	}

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -281,6 +281,7 @@ protected:
 		/// smal object optimization is enabled.
 	{
 #ifdef POCO_NO_SOO
+		(void)pVarHolder;
 		return new VarHolderImpl<T>(val);
 #else
 		poco_check_ptr (pVarHolder);


### PR DESCRIPTION
If your project builds with -Wextra you get unused-variable warnings. In a file like VarHolder.h this spreads to almost every file in our project, creating 1000s of warnings.
