### PR TITLE
Add example backtrace in exceptions

### DIFF
--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -96,6 +96,10 @@ public:
 		/// Returns a string consisting of the
 		/// message name and the message text.
 
+	std::string backtraceText() const;
+		/// Returns a backtrace from time the exception was
+		/// created. Available on platforms supported by Poco::Backtrace.
+
 	virtual Exception* clone() const;
 		/// Creates an exact copy of the exception.
 		///
@@ -120,7 +124,10 @@ protected:
 		/// Sets the extended message for the exception.
 		
 private:
+	void saveBacktrace();
+
 	std::string _msg;
+	std::string _bt;
 	Exception*  _pNested;
 	int			_code;
 };

--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -37,22 +37,29 @@
 #include "Poco/Exception.h"
 #include <typeinfo>
 
+// for saveBacktrace
+#include <execinfo.h>
+#include <cstdlib>
+#include <sstream>
 
 namespace Poco {
 
 
 Exception::Exception(int code): _pNested(0), _code(code)
 {
+	saveBacktrace();
 }
 
 
 Exception::Exception(const std::string& msg, int code): _msg(msg), _pNested(0), _code(code)
 {
+	saveBacktrace();
 }
 
 
 Exception::Exception(const std::string& msg, const std::string& arg, int code): _msg(msg), _pNested(0), _code(code)
 {
+	saveBacktrace();
 	if (!arg.empty())
 	{
 		_msg.append(": ");
@@ -63,6 +70,22 @@ Exception::Exception(const std::string& msg, const std::string& arg, int code): 
 
 Exception::Exception(const std::string& msg, const Exception& nested, int code): _msg(msg), _pNested(nested.clone()), _code(code)
 {
+	saveBacktrace();
+}
+
+
+void Exception::saveBacktrace()
+{
+	std::stringstream s;
+	void * array[25];
+	int nSize = backtrace(array, 25);
+	char ** symbols = backtrace_symbols(array, nSize);
+	for (int i = 0; i < nSize; i++)
+	{
+		s << symbols[i] << std::endl;
+	}
+	free(symbols);
+	_bt = s.str();
 }
 
 
@@ -123,6 +146,10 @@ std::string Exception::displayText() const
 	return txt;
 }
 
+std::string Exception::backtraceText() const
+{
+	return _bt;
+}
 
 void Exception::extendedMessage(const std::string& arg)
 {


### PR DESCRIPTION
A pull request only for you to see the code... 

I always find myself missing backtraces in c++ exceptions. I don't know if this is a totally terrible idea for some reason, but I tried this out and it works OK. The method it uses doesn't give line numbers, but you can at least find the function that the exception was thrown from.

I have only tested this on Linux, but if it makes sense could investigate other platforms.

Thoughts?
