### PR TITLE
Fix #279 by not checking CMAKE_BUILD_TYPE when setting CMAKE_DEBUG_POSTF...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,9 @@ endif ()
 #    * Release (CMAKE_C_FLAGS_RELEASE or CMAKE_CXX_FLAGS_RELEASE)
 #    * RelWithDebInfo (CMAKE_C_FLAGS_RELWITHDEBINFO or CMAKE_CXX_FLAGS_RELWITHDEBINFO
 #    * MinSizeRel (CMAKE_C_FLAGS_MINSIZEREL or CMAKE_CXX_FLAGS_MINSIZEREL) 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  message(STATUS "Debug output enabled")
-  set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
-else ()
-  message(STATUS "Optimized output enabled")
-  set(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Set debug library postfix" FORCE)
-endif ()
+
+# For Debug build types, append a "d" to the library names.
+set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
 
 option(ENABLE_TESTS
   "Set to OFF|ON (default is OFF) to control build of POCO tests & samples" OFF)


### PR DESCRIPTION
...IX.

CMAKE_DEBUG_POSTFIX is already build-type specific and only applied
in case of "Debug" builds. The build-type is correctly inferred from
either CMAKE_BUILD_TYPE for MAkefile based generators or the selected
build type in the Visual Studio IDE. This fix allows to switch the
build type in Visual Studio and have Poco compile/link correctly.
