### PR TITLE
The logic of checking whether the year is a Leap Year is wrong.

### DIFF
--- a/Foundation/include/Poco/DateTime.h
+++ b/Foundation/include/Poco/DateTime.h
@@ -421,7 +421,7 @@ inline bool DateTime::operator >= (const DateTime& dateTime) const
 
 inline bool DateTime::isLeapYear(int year)
 {
-	return (year % 4) == 0 && ((year % 100) != 0 || (year % 400) == 0);
+	return ((year % 4) == 0 && (year % 100) != 0) || (year % 400) == 0;
 }
 
 


### PR DESCRIPTION
Two cases to check the Leap Year:
1. The Year could be divisible by 4 and not be divisible by 100
or
2. The Year could be divisible by 400
