### PR TITLE
Make TemporaryFile append a slash to tempDir

### DIFF
--- a/Foundation/src/TemporaryFile.cpp
+++ b/Foundation/src/TemporaryFile.cpp
@@ -154,6 +154,10 @@ std::string TemporaryFile::tempName(const std::string& tempDir)
 	unsigned long n = count++;
 	mutex.unlock();
 	name << (tempDir.empty() ? Path::temp() : tempDir);
+	if (name.str().at(name.str().size() - 1) != Path::separator())
+	{
+		name << Path::separator();
+	}
 #if defined(POCO_VXWORKS)
 	name << "tmp";
 #else


### PR DESCRIPTION
I could not find in the documentation that I am required to provide tempDir with a trailing slash, and in my opinion one should not be required to, hence this change.

Umh, will this work for Windows?

Cheers,
Ezra.
