### PR TITLE
using c++11 and fixing libc++ linking for clang

### DIFF
--- a/build/config/Darwin-clang-libc++
+++ b/build/config/Darwin-clang-libc++
@@ -49,10 +49,10 @@ SHAREDLIBLINKEXT = .dylib
 # Compiler and Linker Flags
 #
 CFLAGS          = $(ARCHFLAGS)
-CXXFLAGS        = $(ARCHFLAGS) -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
+CXXFLAGS        = $(ARCHFLAGS) -std=c++11 -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
 LINKFLAGS       = $(ARCHFLAGS) -stdlib=libc++
 SHLIBFLAGS      = $(ARCHFLAGS) -stdlib=libc++
-DYLIBFLAGS      = $(ARCHFLAGS)
+DYLIBFLAGS      = $(ARCHFLAGS) -stdlib=libc++
 STATICOPT_CC    =
 STATICOPT_CXX   =
 STATICOPT_LINK  =


### PR DESCRIPTION
I had to add some flags to get things building properly on 10.8 with clang
