### PR TITLE
Adds support for building from paths with spaces.

### DIFF
--- a/buildwin.cmd
+++ b/buildwin.cmd
@@ -280,7 +280,7 @@ for /f %%G in ('findstr /R "." components') do (
       )
     )
   )
-  cd %POCO_BASE%
+  cd "%POCO_BASE%"
 )
 )
 
@@ -435,7 +435,7 @@ for /f %%G in ('findstr /R "." components') do (
       echo. && echo. && echo.
     )
     
-    cd %POCO_BASE%
+    cd "%POCO_BASE%"
   
     echo.
     echo ------------------------------------------------------------------------


### PR DESCRIPTION
Attempting to build POCO on Windows when it was sitting in a path with spaces (e.g., C:\my source\poco-1.4.6p2) fails.  This occurs if you do the following from a VS command prompt:
cd "C:\my source\poco-1.4.6p2"
buildwin.cmd 110

The root cause is storing the output of the CD command in a local variable and then attempting to cd into that variable later without appropriately quoting it.
