### PR TITLE
HTMLForm Content-Length calculation

### DIFF
--- a/Foundation/include/Poco/CountingStream.h
+++ b/Foundation/include/Poco/CountingStream.h
@@ -89,6 +89,15 @@ public:
 	int getCurrentLineNumber() const;
 		/// Returns the current line number (same as lines()).
 
+	void addChars(int chars);
+		/// Add to the total number of characters.
+		
+	void addLines(int lines);
+		/// Add to the total number of lines.
+		
+	void addPos(int pos);
+		/// Add to the number of characters on the current line.
+
 protected:
 	int readFromDevice();
 	int writeToDevice(char c);
@@ -143,6 +152,15 @@ public:
 		
 	int getCurrentLineNumber() const;
 		/// Returns the current line number (same as lines()).
+
+	void addChars(int chars);
+		/// Add to the total number of characters.
+		
+	void addLines(int lines);
+		/// Add to the total number of lines.
+		
+	void addPos(int pos);
+		/// Add to the number of characters on the current line.
 
 	CountingStreamBuf* rdbuf();
 		/// Returns a pointer to the underlying streambuf.

--- a/Foundation/src/CountingStream.cpp
+++ b/Foundation/src/CountingStream.cpp
@@ -116,6 +116,24 @@ void CountingStreamBuf::setCurrentLineNumber(int line)
 }
 
 
+void CountingStreamBuf::addChars(int chars)
+{
+	_chars += chars;
+}
+
+		
+void CountingStreamBuf::addLines(int lines)
+{
+	_lines += lines;
+}
+
+		
+void CountingStreamBuf::addPos(int pos)
+{
+	_pos += pos;
+}
+
+
 CountingIOS::CountingIOS()
 {
 	poco_ios_init(&_buf);
@@ -148,6 +166,24 @@ void CountingIOS::reset()
 void CountingIOS::setCurrentLineNumber(int line)
 {
 	_buf.setCurrentLineNumber(line);
+}
+
+
+void CountingIOS::addChars(int chars)
+{
+	_buf.addChars(chars);
+}
+
+		
+void CountingIOS::addLines(int lines)
+{
+	_buf.addLines(lines);
+}
+
+		
+void CountingIOS::addPos(int pos)
+{
+	_buf.addPos(pos);
 }
 
 

--- a/Foundation/testsuite/src/CountingStreamTest.cpp
+++ b/Foundation/testsuite/src/CountingStreamTest.cpp
@@ -74,6 +74,16 @@ void CountingStreamTest::testInput()
 	assert (ci3.lines() == 2);
 	assert (ci3.chars() == 8);
 	assert (ci3.pos() == 0);
+
+	std::istringstream istr4("foo");
+	CountingInputStream ci4(istr4);
+	while (ci4.good()) ci4.get(c);
+	ci4.addChars(10);
+	ci4.addLines(2);
+	ci4.addPos(3);
+	assert (ci4.lines() == 1 + 2);
+	assert (ci4.chars() == 3 + 10);
+	assert (ci4.pos() == 3 + 3);
 }
 
 
@@ -100,6 +110,16 @@ void CountingStreamTest::testOutput()
 	assert (co3.lines() == 2);
 	assert (co3.chars() == 8);
 	assert (co3.pos() == 0);
+
+	std::ostringstream ostr4;
+	CountingOutputStream co4(ostr4);
+	co4 << "foo";
+	co4.addChars(10);
+	co4.addLines(2);
+	co4.addPos(3);
+	assert (co4.lines() == 1 + 2);
+	assert (co4.chars() == 3 + 10);
+	assert (co4.pos() == 3 + 3);
 }
 
 

--- a/Net/include/Poco/Net/FilePartSource.h
+++ b/Net/include/Poco/Net/FilePartSource.h
@@ -83,7 +83,11 @@ public:
 	const std::string& filename() const;
 		/// Returns the filename portion of the path.
 
+	std::streamsize getContentLength() const;
+		/// Returns the file size.
+
 private:
+	std::string _path;
 	std::string _filename;
 	Poco::FileInputStream _istr;
 };

--- a/Net/include/Poco/Net/HTMLForm.h
+++ b/Net/include/Poco/Net/HTMLForm.h
@@ -173,7 +173,14 @@ public:
 		/// Otherwise, if the request's HTTP version is HTTP/1.1:
 		///    - the request's persistent connection state is left unchanged
 		///    - the content transfer encoding is set to chunked
-		
+
+
+	std::streamsize calculateContentLength();
+		/// Calculate the content length for the form.
+		/// May be UNKNOWN_CONTENT_LENGTH if not possible
+		/// to calculate
+
+
 	void write(std::ostream& ostr, const std::string& boundary);
 		/// Writes the form data to the given output stream,
 		/// using the specified encoding.
@@ -203,6 +210,7 @@ public:
 	static const std::string ENCODING_URL;       /// "application/x-www-form-urlencoded"
 	static const std::string ENCODING_MULTIPART; /// "multipart/form-data"
 
+	static const int         UNKNOWN_CONTENT_LENGTH;
 protected:
 	void readUrl(std::istream& istr);
 	void readMultipart(std::istream& istr, PartHandler& handler);

--- a/Net/include/Poco/Net/PartSource.h
+++ b/Net/include/Poco/Net/PartSource.h
@@ -77,9 +77,15 @@ public:
 		/// Returns a MessageHeader containing additional header
 		/// fields for the part.
 
+	virtual std::streamsize getContentLength() const;
+		/// Returns the content length for this part
+		/// which may be UNKNOWN_CONTENT_LENGTH if
+		/// not available.
+
 	virtual ~PartSource();
 		/// Destroys the PartSource.
 	
+	static const int         UNKNOWN_CONTENT_LENGTH;
 protected:
 	PartSource();
 		/// Creates the PartSource, using

--- a/Net/include/Poco/Net/StringPartSource.h
+++ b/Net/include/Poco/Net/StringPartSource.h
@@ -75,6 +75,9 @@ public:
 	const std::string& filename() const;
 		/// Returns the filename portion of the path.
 
+	std::streamsize getContentLength() const;
+		/// Returns the string size.
+
 private:
 	std::istringstream _istr;
 	std::string        _filename;

--- a/Net/src/FilePartSource.cpp
+++ b/Net/src/FilePartSource.cpp
@@ -36,6 +36,7 @@
 
 #include "Poco/Net/FilePartSource.h"
 #include "Poco/Path.h"
+#include "Poco/File.h"
 #include "Poco/Exception.h"
 
 
@@ -48,7 +49,7 @@ namespace Net {
 
 
 FilePartSource::FilePartSource(const std::string& path):
-	_istr(path)
+	_path(path), _istr(path)
 {
 	Path p(path);
 	_filename = p.getFileName();
@@ -59,6 +60,7 @@ FilePartSource::FilePartSource(const std::string& path):
 
 FilePartSource::FilePartSource(const std::string& path, const std::string& mediaType):
 	PartSource(mediaType),
+	_path(path),
 	_istr(path)
 {
 	Path p(path);
@@ -70,6 +72,7 @@ FilePartSource::FilePartSource(const std::string& path, const std::string& media
 
 FilePartSource::FilePartSource(const std::string& path, const std::string& filename, const std::string& mediaType):
 	PartSource(mediaType),
+	_path(path),
 	_filename(filename),
 	_istr(path)
 {
@@ -93,6 +96,13 @@ std::istream& FilePartSource::stream()
 const std::string& FilePartSource::filename() const
 {
 	return _filename;
+}
+
+
+std::streamsize FilePartSource::getContentLength() const
+{
+	Poco::File p(_path);
+	return p.getSize();
 }
 
 

--- a/Net/src/PartSource.cpp
+++ b/Net/src/PartSource.cpp
@@ -41,6 +41,9 @@ namespace Poco {
 namespace Net {
 
 
+const int         PartSource::UNKNOWN_CONTENT_LENGTH     = -1;
+
+
 PartSource::PartSource():
 	_mediaType("application/octet-stream")
 {
@@ -69,5 +72,9 @@ const std::string& PartSource::filename() const
 	return EMPTY;
 }
 
+std::streamsize PartSource::getContentLength() const
+{
+	return UNKNOWN_CONTENT_LENGTH;
+}
 
 } } // namespace Poco::Net

--- a/Net/src/StringPartSource.cpp
+++ b/Net/src/StringPartSource.cpp
@@ -80,4 +80,10 @@ const std::string& StringPartSource::filename() const
 }
 
 
+std::streamsize StringPartSource::getContentLength() const
+{
+	return _istr.str().length();
+}
+
+
 } } // namespace Poco::Net

--- a/Net/testsuite/src/HTMLFormTest.cpp
+++ b/Net/testsuite/src/HTMLFormTest.cpp
@@ -167,6 +167,7 @@ void HTMLFormTest::testWriteMultipart()
 		"This is another attachment\r\n"
 		"--MIME_boundary_0123456789--\r\n"
 	);
+	assert(s.length() == form.calculateContentLength());
 }
 
 


### PR DESCRIPTION
To post multipart/form-data to squid < 3.2, it is necessary to use HTTP 1.0, but HTTP 1.0 requires the Content-Length header to be set for this type of post.

This patch adds a "calculateContentLength" method to HTMLForm, that returns the number of bytes if possible.

As it is not guaranteed that streams can be seeked, PartSource sizes cannot be returned from the stream, so a new getContentLength method was added to PartSource.

Also support for adding arbitrary amount of chars in CountintStream was added, so that the Part size can be added without really writing bytes.

This is tested to be compatible with squid 2.7 and up, using HTTP 1.0.
