### PR TITLE
add hasDelegates() method to AbstractEvent

### DIFF
--- a/Foundation/include/Poco/AbstractEvent.h
+++ b/Foundation/include/Poco/AbstractEvent.h
@@ -243,6 +243,10 @@ public:
 		strategy.notify(pSender, args);
 	}
 
+	bool hasDelegates() const {
+		return !(_strategy.empty());
+	}
+
 	ActiveResult<TArgs> notifyAsync(const void* pSender, const TArgs& args)
 		/// Sends a notification to all registered delegates. The order is 
 		/// determined by the TStrategy. This method is not blocking and will


### PR DESCRIPTION
Hi,

Normally objects subscribe to events in their constructor, and unsubscribe in their destructor, but a very common mistake (due to copy/paste) is to subscribe again in the destructor. This hasDelegates() method allows to write a custom detector for such situations.
