### PR TITLE
Fixed setting of MYSQL_BIND is_unsigned value.

### DIFF
--- a/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
@@ -98,7 +98,6 @@ public:
 	virtual bool extract(std::size_t pos, long& val);
 		/// Extracts a long. Returns false if null was received.
 
-
 	virtual bool extract(std::size_t pos, unsigned long& val);
 		/// Extracts an unsigned long. Returns false if null was received.
 #endif
@@ -342,7 +341,7 @@ public:
 	
 private:
 
-	bool realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, std::size_t length = 0, bool isUnsigned = false);
+	bool realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, bool isUnsigned = false);
 
 	// Prevent VC8 warning "operator= could not be generated"
 	Extractor& operator=(const Extractor&);

--- a/Data/MySQL/src/Extractor.cpp
+++ b/Data/MySQL/src/Extractor.cpp
@@ -257,7 +257,7 @@ void Extractor::reset()
 }
 
 
-bool Extractor::realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, std::size_t length, bool isUnsigned)
+bool Extractor::realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, bool isUnsigned)
 {
 	MYSQL_BIND bind = {0};
 	my_bool isNull = 0;
@@ -265,7 +265,6 @@ bool Extractor::realExtractFixed(std::size_t pos, enum_field_types type, void* b
 	bind.is_null	   = &isNull;
 	bind.buffer_type   = type;
 	bind.buffer		= buffer;
-	bind.buffer_length = static_cast<unsigned long>(length);
 	bind.is_unsigned   = isUnsigned;
 	
 	if (!_stmt.fetchColumn(pos, &bind))


### PR DESCRIPTION
If you look at the places where realExtractFixed() is called in /Data/MySQL/src/Extractor.cpp, it always uses the default value for 'length'. It also specifies a non-default value for 'isUnsigned' in several situations:

``` cpp
return realExtractFixed(pos, MYSQL_TYPE_TINY, &val);
return realExtractFixed(pos, MYSQL_TYPE_TINY, &val, true);
return realExtractFixed(pos, MYSQL_TYPE_SHORT, &val);
return realExtractFixed(pos, MYSQL_TYPE_SHORT, &val, true);
return realExtractFixed(pos, MYSQL_TYPE_LONG, &val);
return realExtractFixed(pos, MYSQL_TYPE_LONG, &val, true);
return realExtractFixed(pos, MYSQL_TYPE_LONGLONG, &val);
return realExtractFixed(pos, MYSQL_TYPE_LONGLONG, &val, true);
return realExtractFixed(pos, MYSQL_TYPE_LONG, &val);
return realExtractFixed(pos, MYSQL_TYPE_LONG, &val, true);
return realExtractFixed(pos, MYSQL_TYPE_TINY, &val);
return realExtractFixed(pos, MYSQL_TYPE_FLOAT, &val);
return realExtractFixed(pos, MYSQL_TYPE_DOUBLE, &val);
return realExtractFixed(pos, MYSQL_TYPE_TINY, &val);
```

Where 'true' is used to specify the 'isUnsigned' value, this will be implicitly converted to size_t and interpreted as a length value by realExtractFixed().

The MYSQL_BIND buffer_length field is only used for character and binary C data. See: http://dev.mysql.com/doc/refman/5.5/en/c-api-prepared-statement-data-structures.html

realExtractFixed is not used for those data types. Therefore the most efficient solution is just to remove the length parameter.
