### PR TITLE
.travis.yml: force old config on apt-get upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - clang
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get upgrade -qq -y
+ - sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
  - sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev
 script: ./configure & make -s
 


### PR DESCRIPTION
do "The Miracle Combination" for apt-get by default
see http://debian-handbook.info/browse/wheezy/sect.automatic-upgrades.html#idm140081895560704

Signed-off-by: Roger Meier roger@bufferoverflow.ch
