### PR TITLE
Add extern "C" around <net/if.h> on HPUX platform.

### DIFF
--- a/Net/include/Poco/Net/SocketDefs.h
+++ b/Net/include/Poco/Net/SocketDefs.h
@@ -179,6 +179,11 @@
 			extern unsigned int if_nametoindex (__const char *__ifname) __THROW;
 			extern char *if_indextoname (unsigned int __ifindex, char *__ifname) __THROW;
 			}
+		#elif (POCO_OS == POCO_OS_HPUX)
+			extern "C"
+			{
+				#include <net/if.h>
+			}
 		#else
 			#include <net/if.h>
 		#endif


### PR DESCRIPTION
On hpux platform, functions(such as `if_nametoindex` and `if_indextoname`) in net/if.h doesn't declare with `extern "C"`. Fix this bug by add `extern "C"`. See http://www.boost.org/doc/libs/1_40_0/boost/asio/detail/socket_ops.hpp
