### PR TITLE
* Glob from start path, for platforms where it is not possible to transverse from root (Android)

### DIFF
--- a/Foundation/include/Poco/Glob.h
+++ b/Foundation/include/Poco/Glob.h
@@ -139,6 +139,18 @@ public:
 		/// Directories that for whatever reason cannot be traversed are
 		/// ignored.
 
+	static void glob(const Path& pathPattern, const Path& basePath, std::set<std::string>& files, int options = 0);
+		/// Creates a set of files that match the given pathPattern, starting from basePath.
+		///
+		/// The pattern may contain wildcard expressions even in intermediate
+		/// directory names (e.g. /usr/include/*/*.h).
+		///
+		/// Note that, for obvious reasons, escaping characters in a pattern
+		/// with a backslash does not work in Windows-style paths.
+		///
+		/// Directories that for whatever reason cannot be traversed are
+		/// ignored.
+
 protected:
 	bool match(TextIterator& itp, const TextIterator& endp, TextIterator& its, const TextIterator& ends);
 	bool matchAfterAsterisk(TextIterator itp, const TextIterator& endp, TextIterator its, const TextIterator& ends);

--- a/Foundation/src/Glob.cpp
+++ b/Foundation/src/Glob.cpp
@@ -106,6 +106,18 @@ void Glob::glob(const Path& pathPattern, std::set<std::string>& files, int optio
 }
 
 
+void Glob::glob(const Path& pathPattern, const Path& basePath, std::set<std::string>& files, int options)
+{
+	Path pattern(pathPattern);
+	pattern.makeDirectory(); // to simplify pattern handling later on
+	Path absBase(basePath);
+	absBase.makeAbsolute();
+	if (pathPattern.isDirectory())
+		options |= GLOB_DIRS_ONLY;
+	collect(pattern, absBase, basePath, pathPattern[basePath.depth()], files, options);
+}
+
+
 bool Glob::match(TextIterator& itp, const TextIterator& endp, TextIterator& its, const TextIterator& ends)
 {
 	while (itp != endp)

--- a/Foundation/testsuite/src/GlobTest.cpp
+++ b/Foundation/testsuite/src/GlobTest.cpp
@@ -470,6 +470,14 @@ void GlobTest::testGlob()
 	assert (files.find("globtest/src/") != files.end());
 	assert (files.find("globtest/testsuite/") != files.end());
 
+	files.clear();
+	Glob::glob("globtest/testsuite/src/*", "globtest/testsuite/", files);
+	translatePaths(files);
+	assert (files.size() == 3);
+	assert (files.find("globtest/testsuite/src/test.h") != files.end());
+	assert (files.find("globtest/testsuite/src/test.c") != files.end());
+	assert (files.find("globtest/testsuite/src/main.c") != files.end());
+
 #if !defined(_WIN32_WCE)
 	// won't work if current directory is root dir
 	files.clear();


### PR DESCRIPTION
On Android, for some directories (like /data/data) can't be transversed, even if each application can access its own directory. As Glob works by reading from the root directory, it does not work in Android.

This change adds a new static function that received the basePath as a parameter, so it starts from it. This workaround makes possible to use Glob in Android.

The change is simple, as the private "collect" method already supports a base path.
