### PR TITLE
Fix warnings in headers visible to poco user

### DIFF
--- a/Foundation/include/Poco/ActiveStarter.h
+++ b/Foundation/include/Poco/ActiveStarter.h
@@ -56,7 +56,7 @@ class ActiveStarter
 	/// thread pool.
 {
 public:
-	static void start(OwnerType* pOwner, ActiveRunnableBase::Ptr pRunnable)
+	static void start(OwnerType* /*pOwner*/, ActiveRunnableBase::Ptr pRunnable)
 	{
 		ThreadPool::defaultPool().start(*pRunnable);
 		pRunnable->duplicate(); // The runnable will release itself.

--- a/Foundation/include/Poco/BufferAllocator.h
+++ b/Foundation/include/Poco/BufferAllocator.h
@@ -61,7 +61,7 @@ public:
 		return new char_type[static_cast<std::size_t>(size)];
 	}
 	
-	static void deallocate(char_type* ptr, std::streamsize size)
+	static void deallocate(char_type* ptr, std::streamsize /*size*/)
 	{
 		delete [] ptr;
 	}

--- a/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
+++ b/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
@@ -153,12 +153,12 @@ protected:
 	}
 
 private:
-	virtual int readFromDevice(char_type* buffer, std::streamsize length)
+	virtual int readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	virtual int writeToDevice(const char_type* buffer, std::streamsize length)
+	virtual int writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}

--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -146,12 +146,12 @@ protected:
 	}
 
 private:
-	virtual int readFromDevice(char_type* buffer, std::streamsize length)
+	virtual int readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	virtual int writeToDevice(const char_type* buffer, std::streamsize length)
+	virtual int writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}

--- a/Foundation/include/Poco/FunctionDelegate.h
+++ b/Foundation/include/Poco/FunctionDelegate.h
@@ -217,7 +217,7 @@ public:
 		return *this;
 	}
 
-	bool notify(const void* sender, TArgs& arguments)
+	bool notify(const void* /*sender*/, TArgs& arguments)
 	{
 		Mutex::ScopedLock lock(_mutex);
 		if (_receiverMethod)
@@ -427,7 +427,7 @@ public:
 		return *this;
 	}
 
-	bool notify(const void* sender)
+	bool notify(const void* /*sender*/)
 	{
 		Mutex::ScopedLock lock(_mutex);
 		if (_receiverMethod)

--- a/Foundation/include/Poco/MemoryStream.h
+++ b/Foundation/include/Poco/MemoryStream.h
@@ -84,7 +84,7 @@ public:
 	{
 	}
 
-	virtual int_type overflow(int_type c)
+	virtual int_type overflow(int_type /*c*/)
 	{
 		return char_traits::eof();
 	}

--- a/Foundation/include/Poco/MetaObject.h
+++ b/Foundation/include/Poco/MetaObject.h
@@ -207,7 +207,7 @@ public:
 		return *_object.get();
 	}
 
-	bool isAutoDelete(B* pObject) const
+	bool isAutoDelete(B* /*pObject*/) const
 	{
 		return true;
 	}

--- a/Foundation/include/Poco/RotateStrategy.h
+++ b/Foundation/include/Poco/RotateStrategy.h
@@ -114,7 +114,7 @@ public:
 	{
 	}
 	
-	bool mustRotate(LogFile* pFile)
+	bool mustRotate(LogFile* /*pFile*/)
 	{
 		if (DT() >= _threshold)
 		{

--- a/Foundation/include/Poco/Void.h
+++ b/Foundation/include/Poco/Void.h
@@ -77,13 +77,13 @@ public:
 };
 
 
-inline bool Void::operator ==(const Void& v) const
+inline bool Void::operator ==(const Void& /*v*/) const
 {
 	return true;
 }
 
 
-inline bool Void::operator !=(const Void& v) const
+inline bool Void::operator !=(const Void& /*v*/) const
 {
 	return false;
 }

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -229,7 +229,7 @@ public:
 
 private:
 	template <typename C>
-	void doStringify(const C& container, std::ostream& out, unsigned int indent, int step) const
+	void doStringify(const C& container, std::ostream& out, unsigned int indent, unsigned int step) const
 	{
 		out << '{';
 
@@ -239,7 +239,7 @@ private:
 		typename C::const_iterator end = container.end();
 		for (; it != end;)
 		{
-			for(int i = 0; i < indent; i++) out << ' ';
+			for(unsigned int i = 0; i < indent; i++) out << ' ';
 
 			out << '"' << getKey(it) << '"';
 			out << ((indent > 0) ? " : " : ":");
@@ -248,12 +248,12 @@ private:
 
 			if ( ++it != container.end() ) out << ',';
 
-			if (step > 0) out << '\n';
+			if (step > 0) out << std::endl;
 		}
 
 		if (indent >= step) indent -= step;
 
-		for (int i = 0; i < indent; i++)
+		for (unsigned int i = 0; i < indent; i++)
 			out << ' ';
 
 		out << '}';

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -112,7 +112,7 @@ void Object::getNames(std::vector<std::string>& names) const
 
 void Object::stringify(std::ostream& out, unsigned int indent, int step) const
 {
-	if (step == -1) step = indent;
+	if (step < 0) step = indent;
 
 	if(!_preserveInsOrder)
 		doStringify(_values, out, indent, step);


### PR DESCRIPTION
The -Wno-unused-variable, etc settings are fine for compiling poco itself, but we compile with -Wall -Wextra and thus using poco results in warnings in almost every file we compile because we use poco::foundation for everything.

This fixes almost all header file warnings that I could find in poco using clang 3.3.
