### PR TITLE
Fix to #380. DialogSocket+SecureServerSocket was crashing (SIGSEGV) when a timeout occours 

### DIFF
--- a/Net/src/DialogSocket.cpp
+++ b/Net/src/DialogSocket.cpp
@@ -239,8 +239,11 @@ void DialogSocket::refill()
 	if (_pNext == _pEnd)
 	{
 		int n = receiveBytes(_pBuffer, RECEIVE_BUFFER_SIZE);
-		_pNext = _pBuffer;
-		_pEnd  = _pBuffer + n;
+		if (n > 0)
+		{
+			_pNext = _pBuffer;
+			_pEnd  = _pBuffer + n;
+		}
 	}
 }
 


### PR DESCRIPTION
DialogSocket was crashing (SIGSEGV) when a timeout occours when it is used combined to SecureServerSocket (#380)

That happens because receibeBytes() will return an error code (n < 0) when there is a timeout (or other errors). Then when DialogSocket wants to refill its buffer, it will "refill" with a negative number of bytes and crash. 

This fix checks the value of n. If it is >0, there is new data and the refill proceeds. If it is an error, it wont proceed. 
