### PR TITLE
cmake: added /bigobj option for msvc

### DIFF
--- a/Data/CMakeLists.txt
+++ b/Data/CMakeLists.txt
@@ -8,6 +8,11 @@ if (NOT POCO_STATIC)
   add_definitions(-DData_EXPORTS -DTHREADSAFE -DODBC_EXPORTS -DMySQL_EXPORTS -DSQLite_EXPORTS)
 endif (NOT POCO_STATIC)
 
+if(MSVC AND NOT(MSVC_VERSION LESS 1400))
+    set_source_files_properties(src/StatementImpl.cpp
+        PROPERTIES COMPILE_FLAGS "/bigobj")
+endif()
+
 add_library( ${LIBNAME} ${LIB_MODE} ${SRCS} )
 set_target_properties( ${LIBNAME} 
 	PROPERTIES


### PR DESCRIPTION
Fixed issue with cmake generated project for msvc on develop branch

\CMakeFiles\PocoData.dir/ -c C:\work\github\poco\Data\src\StatementImpl.cpp
C:\work\github\poco\Data\src\StatementImpl.cpp : fatal error C1128: number of sections exceeded object file format limit : compile with /bigobj

Added option to handle this compiler switch.
