### PR TITLE
Code clean-up based on real app usage

### DIFF
--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Extractor.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Extractor.h
@@ -43,19 +43,17 @@
 #include "Poco/Data/PostgreSQL/PostgreSQL.h"
 #include "Poco/Data/PostgreSQL/PostgreSQLTypes.h"
 #include "Poco/Data/PostgreSQL/StatementExecutor.h"
-//#include "Poco/Data/PostgreSQL/ResultMetadata.h"
 
 #include "Poco/Data/AbstractExtractor.h"
 #include "Poco/Data/LOB.h"
+
 #include "Poco/Types.h"
+#include "Poco/Any.h"
+#include "Poco/DynamicAny.h"
+#include "Poco/Dynamic/Var.h"
 
 
 namespace Poco {
-
-namespace Dynamic {
-	class Var;
-}
-
 namespace Data {
 namespace PostgreSQL {
 
@@ -348,6 +346,30 @@ private:
     const OutputParameter & extractPreamble( std::size_t aPosition ) const;
 
     bool isColumnNull( const OutputParameter & anOutputParameter ) const;
+    
+	template <typename T>
+	bool extractStringImpl(std::size_t pos, T& val)
+    /// Utility function for extraction of Any and DynamicAny.
+	{
+        OutputParameter outputParameter = extractPreamble( pos );
+        
+        if ( isColumnNull( outputParameter ) )
+        {
+            return false;
+        }
+        
+        std::string tempString;  // since the postgreSQL API in use is all about strings...
+        
+        bool returnValue = extract( pos, tempString );
+        
+        if ( returnValue )
+        {
+            val = tempString;
+        }
+        
+		return returnValue;
+	}
+    
 
 	// Prevent VC8 warning "operator= could not be generated"
 	Extractor& operator=( const Extractor & );

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
@@ -42,13 +42,8 @@
 #include "Poco/Data/PostgreSQL/PostgreSQL.h"
 #include "Poco/Data/DataException.h"
 
-#include <libpq-fe.h>
-
 #include <typeinfo>
 #include <string>
-
-typedef struct st_postgresql POSTGRESQL;
-typedef struct st_postgresql_stmt POSTGRESQL_STMT;
 
 namespace Poco {
 namespace Data {

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLStatementImpl.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLStatementImpl.h
@@ -103,7 +103,7 @@ protected:
 		/// Returns the concrete binder used by the statement.
 
 private:
-	enum
+	enum NextState
 	{
 		NEXT_DONTKNOW,
 		NEXT_TRUE,
@@ -113,7 +113,7 @@ private:
 	StatementExecutor _statementExecutor;
 	Binder::Ptr       _pBinder;
 	Extractor::Ptr    _pExtractor;
-	int               _hasNext;
+	NextState         _hasNext;
 };
 
 

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLTypes.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLTypes.h
@@ -109,9 +109,9 @@ class OutputParameter
 public:
     explicit OutputParameter( PostgreSQLSupportedFieldTypes aFieldType,
                               Oid                           anInternalFieldType,
-                              int                           aRowNumber,
+                              std::size_t                   aRowNumber,
                               const char *                  aDataPtr,
-                              int                           theSize,
+                              std::size_t                   theSize,
                               bool                          anIsNull );
     
     explicit OutputParameter();
@@ -120,24 +120,24 @@ public:
     
     void                            setValues( PostgreSQLSupportedFieldTypes aFieldType,
                                                Oid                           anInternalFieldType,
-                                               int                           aRowNumber,
+                                               std::size_t                   aRowNumber,
                                                const char *                  aDataPtr,
-                                               int                           theSize,
+                                               std::size_t                   theSize,
                                                bool                          anIsNull);
     
     PostgreSQLSupportedFieldTypes   fieldType() const;
     Oid                             internalFieldType() const;
-    int                             rowNumber() const;
+    std::size_t                     rowNumber() const;
     const char *                    pData() const;
-    int                             size() const;
+    std::size_t                     size() const;
     bool                            isNull() const;
 
 private:
     PostgreSQLSupportedFieldTypes   _fieldType;
     Oid                             _internalFieldType;
-    int                             _rowNumber;
+    std::size_t                     _rowNumber;
     const char *                    _pData;
-    int                             _size;
+    std::size_t                     _size;
     bool                            _isNull;
 };
 
@@ -218,7 +218,7 @@ inline
 InputParameter::InputParameter()
     : _fieldType                      ( POSTGRESQL_TYPE_NONE ),
       _pData                          ( 0 ),
-      _size                           ( -1 ),
+      _size                           ( 0 ),
       _isBinary                       ( false ),
      _pNonStringVersionRepresentation ( 0 )
 {
@@ -321,15 +321,15 @@ InputParameter::pInternalRepresentation() const
 inline
 OutputParameter::OutputParameter( PostgreSQLSupportedFieldTypes aFieldType,
                                   Oid                           anInternalFieldType,
-                                  int                           aRowNumber,
+                                  std::size_t                   aRowNumber,
                                   const char *                  aDataPtr,
-                                  int                           theSize,
+                                  std::size_t                   theSize,
                                   bool                          anIsNull )
     : _fieldType         ( aFieldType ),
       _internalFieldType ( anInternalFieldType ),
       _rowNumber         ( aRowNumber ),
       _pData             ( aDataPtr ),
-      _size              ( theSize),
+      _size              ( theSize ),
       _isNull            ( anIsNull )
 {
 }
@@ -338,9 +338,9 @@ inline
 OutputParameter::OutputParameter( )
     : _fieldType         ( POSTGRESQL_TYPE_NONE ),
       _internalFieldType ( -1 ),
-      _rowNumber         ( -1 ),
+      _rowNumber         ( 0 ),
       _pData             ( 0 ),
-      _size              ( -1 ),
+      _size              ( 0 ),
       _isNull            ( true )
 {
 }
@@ -354,9 +354,9 @@ inline
 void
 OutputParameter::setValues( PostgreSQLSupportedFieldTypes aFieldType,
                             Oid                           anInternalFieldType,
-                            int                           aRowNumber,
+                            std::size_t                   aRowNumber,
                             const char *                  aDataPtr,
-                            int                           theSize,
+                            std::size_t                   theSize,
                             bool                          anIsNull )
 {
     _fieldType         = aFieldType;
@@ -383,7 +383,7 @@ OutputParameter::internalFieldType() const
 }
 
 inline
-int
+std::size_t
 OutputParameter::rowNumber() const
 {
     return _rowNumber;
@@ -397,7 +397,7 @@ OutputParameter::pData() const
 }
 
 inline
-int
+std::size_t
 OutputParameter::size() const
 {
     return _size;

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
@@ -103,6 +103,8 @@ public:
 
 private:
 
+    void clearResults();
+
 	StatementExecutor            ( const StatementExecutor & );
 	StatementExecutor& operator= ( const StatementExecutor & );
 

--- a/Data/PostgreSQL/src/Extractor.cpp
+++ b/Data/PostgreSQL/src/Extractor.cpp
@@ -417,8 +417,8 @@ bool Extractor::extract(std::size_t pos, Poco::Data::BLOB& val)
     // Format: \x10843029479abcf ...  two characters for every byte
     //
     //  The code below can be made more efficient by converting more than one byte at a time
-    //  also if the blob had a resize nethod it would be useful to allocate memory in one
-    //  attempt
+    //  also if BLOB had a resize method it would be useful to allocate memory in one
+    //  attempt.
     //
     
     const char * pBLOB = reinterpret_cast< const char * >( outputParameter.pData() );
@@ -537,13 +537,13 @@ bool Extractor::extract(std::size_t pos, Time& val)
 
 bool Extractor::extract(std::size_t pos, Any& val)
 {
-	return false;
+    return extractStringImpl ( pos, val );
 }
 
 
 bool Extractor::extract(std::size_t pos, Dynamic::Var& val)
 {
-	return false;
+    return extractStringImpl ( pos, val );
 }
 
 


### PR DESCRIPTION
1) Remove references To ResultMetadata.h/.cpp not carried over from
MySQL
2) Add extractions for Any & Dynamic::Var
3) Allow Exceptions header to be included in code that does not link
with PostgreSQL directly (AKA remove #include <libpq-fe.h> from
PostgreSQLException.h
4) Provide name for NextState Enum and use enum Type name instead of int
5) Standardize on std::size_t as opposed to int
6) Allow Statement reuse by making sure to clear results between
statement executions
7) Fix Bug where the same statement placeholder would have to be listed
in multiple use calls (e.g. where X = $1 and Y = $1 required the same
use call twice as they were thought to be two different placeholders).
8) Switch away from -1 (int) for invalid values to 0 (std::size_t).
