### PR TITLE
correct path for CONFIGURE_FILE in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ endif(APRUTIL_FOUND AND APACHE_FOUND)
 #############################################################
 # Uninstall stuff see: http://www.vtk.org/Wiki/CMake_FAQ
 CONFIGURE_FILE(
-  "${CMAKE_MODULE_PATH}/cmake_uninstall.cmake.in"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 


### PR DESCRIPTION
If CMAKE_MODULE_PATH is empty before appending
'${CMAKE_CURRENT_SOURCE_DIR}/cmake' to it (CMakeLists.txt:27),
CONFIGURE_FILE (CMakeLists.txt:182) works as intended.
However, when CMAKE_MODULE_PATH is not empty, e.g., because of
further tool-chain settings, CONFIGURE_FILE fails with:

CMake Error: File <SOME-OTHER-PATH>;<POCO-SRC-PATH>/cmake/cmake_uninstall.cmake.in does not exist.
| CMake Error at CMakeLists.txt:182 (CONFIGURE_FILE):
|   configure_file Problem configuring file

This commit addresses this problem by only using
'${CMAKE_CURRENT_SOURCE_DIR}/cmake' in CONFIGURE_FILE.
The problem was discovered in the meta-ros layer project
(http://github.com/bmwcarit/meta-ros) when creating a libpoco
bitbake recipe, which uses poco's cmake installation scripts.

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
