### PR TITLE
fix pocomsg.h generation so the target stops rebuilding

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -204,7 +204,7 @@ set(WIN_SRCS
 )
 
 if (WIN32)
-  set(RES_SRCS ${CMAKE_SOURCE_DIR}/Foundation/include/Poco/pocomsg.h)
+  set(RES_SRCS ${CMAKE_SOURCE_DIR}/Foundation/src/pocomsg.h)
   set_source_files_properties(${RES_SRCS} PROPERTIES GENERATED true)
   add_custom_command(
     OUTPUT ${RES_SRCS}


### PR DESCRIPTION
The output directory specified by -h should match the RES_SRCS directory.
Changed the RES_SRCS to specify the srcs directory.

The real bug here is that the add_custom_command() DEPENDS rule is never satisfied because this mismatch. The mismatch causes the target to always be out of date. This fix changes nothing about the location of the generated file.
