### PR TITLE
Mingw64

### DIFF
--- a/Foundation/include/Poco/Foundation.h
+++ b/Foundation/include/Poco/Foundation.h
@@ -66,7 +66,7 @@
 // Foundation_API functions as being imported from a DLL, wheras this DLL sees symbols
 // defined with this macro as being exported.
 //
-#if (defined(_WIN32) || defined(_WIN32_WCE)) && defined(POCO_DLL)
+#if (defined(_WIN32) || defined(_WIN64) || defined(_WIN32_WCE)) && defined(POCO_DLL)
 	#if defined(Foundation_EXPORTS)
 		#define Foundation_API __declspec(dllexport)
 	#else
@@ -118,7 +118,7 @@
 // Include platform-specific definitions
 //
 #include "Poco/Platform.h"
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(_WIN64)
 	#include "Poco/Platform_WIN32.h"
 #elif defined(__VMS)
 	#include "Poco/Platform_VMS.h"

--- a/Foundation/include/Poco/Platform_WIN32.h
+++ b/Foundation/include/Poco/Platform_WIN32.h
@@ -160,7 +160,9 @@
 
 
 // Enable C++11 support for VS 2010 and newer
-#if defined(_MSC_VER) && (_MSC_VER >= 1700) && !defined(POCO_ENABLE_CPP11)
+#if __cplusplus >= 201103L
+ 	#define POCO_ENABLE_CPP11
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700) && !defined(POCO_ENABLE_CPP11)
 	#define POCO_ENABLE_CPP11
 #endif
 

--- a/Foundation/include/Poco/Types.h
+++ b/Foundation/include/Poco/Types.h
@@ -42,6 +42,9 @@
 
 #include "Poco/Foundation.h"
 
+#if defined(_WIN64)
+#define __LLP64__
+#endif
 
 namespace Poco {
 
@@ -77,14 +80,22 @@ namespace Poco {
 	typedef unsigned short         UInt16;
 	typedef signed int             Int32;
 	typedef unsigned int           UInt32;
-	typedef signed long            IntPtr;
-	typedef unsigned long          UIntPtr;
 	#if defined(__LP64__)
 		#define POCO_PTR_IS_64_BIT 1
 		#define POCO_LONG_IS_64_BIT 1
+		typedef signed long        IntPtr;
+		typedef unsigned long      UIntPtr;
 		typedef signed long        Int64;
 		typedef unsigned long      UInt64;
+	#elif defined(__LLP64__)
+		#define POCO_PTR_IS_64_BIT 1
+		typedef signed long long   IntPtr;
+		typedef unsigned long long UIntPtr;
+		typedef signed long long   Int64;
+		typedef unsigned long long UInt64;
 	#else
+		typedef signed long        IntPtr;
+		typedef unsigned long      UIntPtr;
 		typedef signed long long   Int64;
 		typedef unsigned long long UInt64;
 	#endif

--- a/Foundation/src/Environment_WIN32.cpp
+++ b/Foundation/src/Environment_WIN32.cpp
@@ -39,6 +39,9 @@
 #include <sstream>
 #include <cstring>
 #include "Poco/UnWindows.h"
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <wincrypt.h>
 #include <iphlpapi.h>
 
 

--- a/Foundation/src/Environment_WIN32U.cpp
+++ b/Foundation/src/Environment_WIN32U.cpp
@@ -41,6 +41,9 @@
 #include <sstream>
 #include <cstring>
 #include "Poco/UnWindows.h"
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <wincrypt.h>
 #include <iphlpapi.h>
 
 

--- a/Foundation/src/File_WIN32.cpp
+++ b/Foundation/src/File_WIN32.cpp
@@ -112,7 +112,7 @@ bool FileImpl::existsImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributes(_path.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -134,7 +134,7 @@ bool FileImpl::canReadImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributes(_path.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -153,7 +153,7 @@ bool FileImpl::canWriteImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributes(_path.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_READONLY) == 0;
 }
@@ -177,7 +177,7 @@ bool FileImpl::isDirectoryImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributes(_path.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
 }
@@ -210,7 +210,7 @@ bool FileImpl::isHiddenImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributes(_path.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_HIDDEN) != 0;
 }
@@ -275,7 +275,7 @@ void FileImpl::setSizeImpl(FileSizeImpl size)
 	FileHandle fh(_path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING);
 	LARGE_INTEGER li;
 	li.QuadPart = size;
-	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == -1)
+	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
 		handleLastErrorImpl(_path);
 	if (SetEndOfFile(fh.get()) == 0) 
 		handleLastErrorImpl(_path);

--- a/Foundation/src/File_WIN32U.cpp
+++ b/Foundation/src/File_WIN32U.cpp
@@ -116,7 +116,7 @@ bool FileImpl::existsImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -138,7 +138,7 @@ bool FileImpl::canReadImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -157,7 +157,7 @@ bool FileImpl::canWriteImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_READONLY) == 0;
 }
@@ -181,7 +181,7 @@ bool FileImpl::isDirectoryImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
 }
@@ -214,7 +214,7 @@ bool FileImpl::isHiddenImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_HIDDEN) != 0;
 }
@@ -279,7 +279,7 @@ void FileImpl::setSizeImpl(FileSizeImpl size)
 	FileHandle fh(_path, _upath, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING);
 	LARGE_INTEGER li;
 	li.QuadPart = size;
-	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == -1)
+	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
 		handleLastErrorImpl(_path);
 	if (SetEndOfFile(fh.get()) == 0) 
 		handleLastErrorImpl(_path);
@@ -291,7 +291,7 @@ void FileImpl::setWriteableImpl(bool flag)
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == -1)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	if (flag)
 		attr &= ~FILE_ATTRIBUTE_READONLY;

--- a/Foundation/src/File_WINCE.cpp
+++ b/Foundation/src/File_WINCE.cpp
@@ -117,7 +117,7 @@ bool FileImpl::existsImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -139,7 +139,7 @@ bool FileImpl::canReadImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 	{
 		switch (GetLastError())
 		{
@@ -158,7 +158,7 @@ bool FileImpl::canWriteImpl() const
 	poco_assert (!_path.empty());
 	
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_READONLY) == 0;
 }
@@ -182,7 +182,7 @@ bool FileImpl::isDirectoryImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
 }
@@ -205,7 +205,7 @@ bool FileImpl::isHiddenImpl() const
 	poco_assert (!_path.empty());
 
 	DWORD attr = GetFileAttributesW(_upath.c_str());
-	if (attr == 0xFFFFFFFF)
+	if (attr == INVALID_FILE_ATTRIBUTES)
 		handleLastErrorImpl(_path);
 	return (attr & FILE_ATTRIBUTE_HIDDEN) != 0;
 }
@@ -270,7 +270,7 @@ void FileImpl::setSizeImpl(FileSizeImpl size)
 	FileHandle fh(_path, _upath, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING);
 	LARGE_INTEGER li;
 	li.QuadPart = size;
-	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == -1)
+	if (SetFilePointer(fh.get(), li.LowPart, &li.HighPart, FILE_BEGIN) == INVALID_SET_FILE_POINTER)
 		handleLastErrorImpl(_path);
 	if (SetEndOfFile(fh.get()) == 0) 
 		handleLastErrorImpl(_path);

--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -273,7 +273,7 @@ void Logger::formatDump(std::string& message, const void* buffer, std::size_t le
 	message.reserve(message.size() + length*6);
 	if (!message.empty()) message.append("\n");
 	unsigned char* base = (unsigned char*) buffer;
-	int addr = 0;
+	std::size_t addr = 0;
 	while (addr < length)
 	{
 		if (addr > 0) message.append("\n");

--- a/Foundation/src/NumberFormatter.cpp
+++ b/Foundation/src/NumberFormatter.cpp
@@ -36,20 +36,13 @@
 
 #include "Poco/NumberFormatter.h"
 #include "Poco/MemoryStream.h"
+#include <ios>
+#include <sstream>
 #include <iomanip>
 #if !defined(POCO_NO_LOCALE)
 #include <locale>
 #endif
 #include <cstdio>
-
-
-#if defined(_MSC_VER) || defined(__MINGW32__)
-	#define I64_FMT "I64"
-#elif defined(__APPLE__) 
-	#define I64_FMT "q"
-#else
-	#define I64_FMT "ll"
-#endif
 
 
 namespace Poco {
@@ -384,17 +377,15 @@ void NumberFormatter::append(std::string& str, double value, int width, int prec
 
 void NumberFormatter::append(std::string& str, const void* ptr)
 {
-	char buffer[24];
-#if defined(POCO_PTR_IS_64_BIT)
-	#if defined(POCO_LONG_IS_64_BIT)
-		std::sprintf(buffer, "%016lX", (UIntPtr) ptr);
-	#else
-		std::sprintf(buffer, "%016" I64_FMT "X", (UIntPtr) ptr);
-	#endif
-#else
-	std::sprintf(buffer, "%08lX", (UIntPtr) ptr);
-#endif
-	str.append(buffer);
+	std::ostringstream os;
+
+	os	<< std::hex
+		<< std::setw(sizeof(ptr) * 2)
+		<< std::setfill('0')
+		<< setiosflags(std::ios::uppercase)
+		<< ptr;
+
+	str.append(os.str());
 }
 
 

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -63,6 +63,9 @@ void pad(std::string& str, int precision, int width, char prefix = ' ', char dec
 	poco_assert_dbg (precision > 0);
 	poco_assert_dbg (str.length());
 
+	std::string::size_type _precision = static_cast<std::string::size_type>(precision);
+	std::string::size_type _width = static_cast<std::string::size_type>(width);
+	
 	std::string::size_type decSepPos = str.find(decSep);
 	if (decSepPos == std::string::npos)
 	{
@@ -81,17 +84,17 @@ void pad(std::string& str, int precision, int width, char prefix = ' ', char dec
 		str = str.substr(0, str.length() - eStr->length());
 	}
 
-	if (frac != precision)
+	if (frac != _precision)
 	{
-		if (frac < precision)
-			str.append(precision - frac, '0');
-		else if ((frac > precision) && (decSepPos != std::string::npos)) 
-			str = str.substr(0, decSepPos + 1 + precision);
+		if (frac < _precision)
+			str.append(_precision - frac, '0');
+		else if ((frac > _precision) && (decSepPos != std::string::npos)) 
+			str = str.substr(0, decSepPos + 1 + _precision);
 	}
 
 	if (eStr.get()) str += *eStr;
 
-	if (width && (str.length() < width)) str.insert(str.begin(), width - str.length(), prefix);
+	if (_width && (str.length() < _width)) str.insert(str.begin(), _width - str.length(), prefix);
 }
 
 

--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -35,6 +35,11 @@
 #ifndef ASSERT
 #define ASSERT(condition)      (assert(condition))
 #endif
+#if __cplusplus >= 201103L
+#define STATIC_ASSERT(b, str) static_assert(b, str)
+#else
+#define STATIC_ASSERT(b, str) typedef char __StaticAssertCheck[b ? 1 : -1]
+#endif
 #ifndef UNIMPLEMENTED
 #define UNIMPLEMENTED() (abort())
 #endif
@@ -296,7 +301,7 @@ template <class Dest, class Source>
 inline Dest BitCast(const Source& source) {
   // Compile time assertion: sizeof(Dest) == sizeof(Source)
   // A compile error here means your Dest and Source have different sizes.
-  typedef char VerifySizesAreEqual[sizeof(Dest) == sizeof(Source) ? 1 : -1];
+  STATIC_ASSERT(sizeof(Dest) == sizeof(Source), "Dest and Source must have the same size");
 
   Dest dest;
   memmove(&dest, &source, sizeof(dest));

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ sinclude config.build
 
 ifndef POCO_BASE
 $(warning WARNING: POCO_BASE is not defined. Assuming current directory.)
-export POCO_BASE=$(shell pwd)
+export POCO_BASE=$(CURDIR)
 endif
 
 ifndef POCO_PREFIX

--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -53,7 +53,7 @@
 // Net_API functions as being imported from a DLL, wheras this DLL sees symbols
 // defined with this macro as being exported.
 //
-#if defined(_WIN32) && defined(POCO_DLL)
+#if (defined(_WIN32) || defined(_WIN64)) && defined(POCO_DLL)
 	#if defined(Net_EXPORTS)
 		#define Net_API __declspec(dllexport)
 	#else
@@ -110,7 +110,7 @@ inline void Net_API uninitializeNetwork();
 // Automate network initialization (only relevant on Windows).
 //
 
-#if defined(POCO_OS_FAMILY_WINDOWS) && !defined(POCO_NO_AUTOMATIC_LIB_INIT)
+#if defined(POCO_OS_FAMILY_WINDOWS) && !defined(POCO_NO_AUTOMATIC_LIB_INIT) && !defined(__GNUC__)
 
 extern "C" const struct Net_API NetworkInitializer pocoNetworkInitializer;
 

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -50,6 +50,9 @@
 		#include "Poco/UnicodeConverter.h"
 		#include "Poco/Error.h"
 	#endif
+	#include <winsock2.h>
+	#include <ws2ipdef.h>
+	#include <wincrypt.h>
 	#include <iphlpapi.h>
 	#include <ipifcons.h>
 #endif

--- a/Util/include/Poco/Util/Application.h
+++ b/Util/include/Poco/Util/Application.h
@@ -490,7 +490,7 @@ inline Poco::Timespan Application::uptime() const
 //
 // Macro to implement main()
 //
-#if defined(_WIN32) && defined(POCO_WIN32_UTF8) && !defined(POCO_NO_WSTRING)
+#if (defined(_WIN32) || defined(_WIN64)) && defined(POCO_WIN32_UTF8) && !defined(POCO_NO_WSTRING) && !defined(MINGW32)
 	#define POCO_APP_MAIN(App) \
 	int wmain(int argc, wchar_t** argv)		\
 	{										\

--- a/Util/include/Poco/Util/ServerApplication.h
+++ b/Util/include/Poco/Util/ServerApplication.h
@@ -246,7 +246,7 @@ private:
 //
 // Macro to implement main()
 //
-#if defined(_WIN32) && defined(POCO_WIN32_UTF8)
+#if defined(_WIN32) && defined(POCO_WIN32_UTF8) && !defined(MINGW32)
 	#define POCO_SERVER_MAIN(App) \
 	int wmain(int argc, wchar_t** argv)	\
 	{									\

--- a/build/config/MinGW32-W64
+++ b/build/config/MinGW32-W64
@@ -1,0 +1,74 @@
+#
+# $Id: //poco/1.4/build/config/MinGW#2 $
+#
+# MinGW32
+#
+# Make settings for MinGW on WinXP
+#
+
+#
+# General Settings
+#
+LINKMODE = STATIC
+POCO_TARGET_OSNAME = MinGW
+POCO_TARGET_OSARCH = x86_64
+
+#
+# Define Tools
+#
+CC      = gcc
+CXX     = g++
+LINK    = $(CXX)
+LIB     = ar -cr
+RANLIB  = ranlib
+SHLIB   = $(CXX) -shared -o $@ -Wl,--out-implib=$(dir $@)$(subst cyg,lib,$(basename $(notdir $@))).a
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   =
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc 
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .dll
+SHAREDLIBLINKEXT = .dll
+
+BINEXT          = .exe
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          =
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = -std=c++11
+CXXFLAGS32      =
+CXXFLAGS64      =
+LINKFLAGS       = -Wl,--allow-multiple-definition
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  = -static
+SHAREDOPT_CC    =
+SHAREDOPT_CXX   =
+SHAREDOPT_LINK  = -shared
+DEBUGOPT_CC     = -g -D_DEBUG
+DEBUGOPT_CXX    = -g -D_DEBUG
+DEBUGOPT_LINK   = -g
+RELEASEOPT_CC   = -O2 -DNDEBUG
+RELEASEOPT_CXX  = -O2 -DNDEBUG
+RELEASEOPT_LINK = -O2
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -Wall -m64 -D_WIN64 -DMINGW32 -DWINVER=0x500 -DPOCO_NO_FPENVIRONMENT -DPCRE_STATIC -DPOCO_THREAD_STACK_SIZE -DPOCO_STATIC -I/usr/local/include -I/usr/include
+# -DFoundation_Config_INCLUDED
+#
+# System Specific Libraries
+#
+SYSLIBS  =  -lmingw32 -L/usr/local/lib -L/usr/lib -liphlpapi -lws2_32 -lws2_32

--- a/build/rules/global
+++ b/build/rules/global
@@ -51,7 +51,7 @@ export POCO_BUILD
 # Also, if we're building under $POCO_BASE, disarm
 # $PROJECT_BASE
 #
-cwd = $(shell pwd)
+cwd = $(CURDIR)
 inpoco = $(shell echo | awk '{print index("$(cwd)","$(POCO_BASE)")}')
 inproj = $(shell echo | awk '{print index("$(cwd)","$(PROJECT_BASE)")}')
 ifneq ($(inpoco),0)

--- a/configure
+++ b/configure
@@ -101,6 +101,12 @@ Options:
     depends upon target. Can be specified together
     with --static to build both.
 
+  --basedir=<path>
+    Set the sources path. Default: `cd dirname $0;pwd`
+
+  --builddir=<path>
+    Set the building path. Default: `pwd`
+
 ENDHELP
 }
 
@@ -186,6 +192,12 @@ while [ $# -ge 1 ]; do
 
 	--shared)
 		shared=1 ;;
+
+	--basedir=*)
+		base="`echo ${1} | awk '{print substr($0,11)}'`" ;;
+
+	--builddir=*)
+		build="`echo ${1} | awk '{print substr($0,12)}'`" ;;
 
 	--help)
  		showhelp


### PR DESCRIPTION
Hi all,

I'm just trying to compile under MinGW32-W64 compiler.

Here there are some patches. I think that 91c8f61 can be used to format strings without check the potinters size. This code can be used also in other places, removing the printf-like code.
4c87b5f must be also included because when we compile using mingw-make tool, the directory schema uses the Windows convention (C:/xxxxx) instead Cygwin (/c/....). $(CURDIR) is filled by make tool with the correct value.

ciao

luigi