### PR TITLE
Using #include <linux/if.h> conflicts with other libraries and code that use #include <net/if.h>

### DIFF
--- a/Net/include/Poco/Net/SocketDefs.h
+++ b/Net/include/Poco/Net/SocketDefs.h
@@ -169,16 +169,9 @@
 	#include <netdb.h>
 	#if defined(POCO_OS_FAMILY_UNIX)
 		#if (POCO_OS == POCO_OS_LINUX)
-			// <linux/if.h> is needed by NetworkInterface for ifmap, ifreq and ifconf definitions
-			#include <linux/if.h>
-			// if_nametoindex and if_indextoname are needed by IPAddress and NetworkInterface
-			// we can't get them from <net/if.h> because of a conflict with <linux/if.h>, so
-			// we declare them here
-			extern "C"
-			{
-			extern unsigned int if_nametoindex (__const char *__ifname) __THROW;
-			extern char *if_indextoname (unsigned int __ifindex, char *__ifname) __THROW;
-			}
+			// Net/src/NetworkInterface.cpp changed #include <linux/if.h> to #include <net/if.h>
+			// no more conflict, can use #include <net/if.h> here
+			#include <net/if.h>
 		#elif (POCO_OS == POCO_OS_HPUX)
 			extern "C"
 			{

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -1369,7 +1369,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 #ifndef POCO_ANDROID // Android doesn't have <ifaddrs.h>
 #include <ifaddrs.h>
 #endif
-#include <linux/if.h>
+#include <net/if.h>
 #include <linux/if_packet.h>
 #include <net/if_arp.h>
 #include <iostream>


### PR DESCRIPTION
User space applications on Linux should use #include <net/if.h> instead of #include <linux/if.h>, which is intended for kernel level.

Including linux/if.h conflicts easily with everything that uses net/if.h such as Boost.Asio.
