### PR TITLE
Add a POCO_LOG_DEBUG flag

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -181,5 +181,9 @@
 	#define POCO_NO_LOCALE
 #endif
 
+// Enable the poco_debug_* and poco_trace_* macros
+// even if the _DEBUG variable is not set.
+// This allows the use of these macros in a release version.
+// #define POCO_LOG_DEBUG
 
 #endif // Foundation_Config_INCLUDED

--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -595,7 +595,7 @@ private:
 #define poco_information_f4(logger, fmt, arg1, arg2, arg3, arg4) \
 	if ((logger).information()) (logger).information(Poco::format((fmt), (arg1), (arg2), (arg3), (arg4)), __FILE__, __LINE__); else (void) 0
 
-#if defined(_DEBUG)
+#if defined(_DEBUG) || defined(POCO_LOG_DEBUG)
 	#define poco_debug(logger, msg) \
 		if ((logger).debug()) (logger).debug(msg, __FILE__, __LINE__); else (void) 0
 


### PR DESCRIPTION
If the POCO_LOG_DEBUG is defined the poco_trace\* and the poco_debug*
produce logs even if the _DEBUG flag is not set.
This makes the macros usable for applications that need to enable
higher log levels later at run time.
