### PR TITLE
NumberParser::parseUnsigned should not parse negative numbers

### DIFF
--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -110,6 +110,8 @@ bool strToInt(const char* pStr, I& result, short base, char thSep = ',')
 	char sign = 1;
 	if ((base == 10) && (*pStr == '-'))
 	{
+		// Unsigned types can't be negative so abort parsing
+		if (std::numeric_limits<I>::min() >= 0) return false;
 		sign = -1;
 		++pStr;
 	}

--- a/Foundation/testsuite/src/NumberParserTest.cpp
+++ b/Foundation/testsuite/src/NumberParserTest.cpp
@@ -274,6 +274,12 @@ void NumberParserTest::testParseError()
 
 	try
 	{
+		NumberParser::parseUnsigned("-123");
+		failmsg("must throw SyntaxException");
+	} catch (SyntaxException&) { }
+
+	try
+	{
 		NumberParser::parseHex("z23");
 		failmsg("must throw SyntaxException");
 	} catch (SyntaxException&) { }


### PR DESCRIPTION
The function should abort if a negative number (e.g. "-123") is passed as input
