### PR TITLE
cmake: added missing sources to CMakeLists.txt

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -52,6 +52,7 @@ set( BASE_SRCS
   src/DigestEngine.cpp
   src/DigestStream.cpp
   src/DirectoryIterator.cpp
+  src/DirectoryIteratorStrategy.cpp
   src/DirectoryWatcher.cpp
   src/Environment.cpp
   src/Error.cpp

--- a/Foundation/testsuite/CMakeLists.txt
+++ b/Foundation/testsuite/CMakeLists.txt
@@ -52,6 +52,7 @@ src/HexBinaryTest.cpp
 src/LRUCacheTest.cpp
 src/LineEndingConverterTest.cpp
 src/LinearHashTableTest.cpp
+src/ListMapTest.cpp
 src/LocalDateTimeTest.cpp
 src/LogStreamTest.cpp
 src/LoggerTest.cpp

--- a/Net/CMakeLists.txt
+++ b/Net/CMakeLists.txt
@@ -65,6 +65,7 @@ set( BASE_SRCS
   src/NullPartHandler.cpp
   src/PartHandler.cpp
   src/PartSource.cpp
+  src/PartStore.cpp
   src/POP3ClientSession.cpp
   src/QuotedPrintableDecoder.cpp
   src/QuotedPrintableEncoder.cpp


### PR DESCRIPTION
fixes missing symbol errors
