### PR TITLE
Close listening socket before stopping running connections

### DIFF
--- a/Net/src/HTTPServer.cpp
+++ b/Net/src/HTTPServer.cpp
@@ -70,8 +70,8 @@ HTTPServer::~HTTPServer()
 
 void HTTPServer::stopAll(bool abortCurrent)
 {
-	_pFactory->serverStopped(this, abortCurrent);
 	stop();
+	_pFactory->serverStopped(this, abortCurrent);
 }
 
 


### PR DESCRIPTION
Proposed fix for issue #436

If sending the serverStopped event to currently active connections
happens before actually closing the server socket, new connections will
be accepted in between, which in turn will stay open and prevent the
HTTP server from stopping completely.
