### PR TITLE
Make the copy assignment operator of Exception class exception safe

### DIFF
--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -65,9 +65,10 @@ Exception& Exception::operator = (const Exception& exc)
 {
 	if (&exc != this)
 	{
+		Exception *new_pNested = exc._pNested? exc._pNested->clone() : 0;
 		delete _pNested;
 		_msg     = exc._msg;
-		_pNested = exc._pNested ? exc._pNested->clone() : 0;
+		_pNested = new_pNested;
 		_code    = exc._code;
 	}
 	return *this;


### PR DESCRIPTION
Exception object would be in unstable state when the `clone()` call throws an exception, so I moved it prior to object member updates so when exception was thrown, members of `*this` would remain untouched.
