### PR TITLE
Fix: handle unhandled exceptions

### DIFF
--- a/Net/src/HTTPStream.cpp
+++ b/Net/src/HTTPStream.cpp
@@ -71,13 +71,20 @@ void HTTPStreamBuf::close()
 
 int HTTPStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	return _session.read(buffer, length);
+	int ret = 0;
+	try
+	{
+		ret = _session.read(buffer, length);
+	}
+	catch(...)
+	{
+	}
+	return ret;
 }
 
 
 int HTTPStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
-
 	return _session.write(buffer, length);
 }
 


### PR DESCRIPTION
Hi all!

I was working with poco-1.4.6 but I see this bug was also in previous versions.
Stable version of poco-1.4.6 works well on my Ubuntu-12.04_x64-86 but it works wrong on Windows 8.1 x64.

I am using Poco::Net::HTTPSStreamFactory. Sample:

Poco::Net::HTTPSStreamFactory httpsFactory;
std::istream\* pIStream = httpsFactory.open( some_url );

This code should download some data and it does it but... with additional extra zero-byte in the end of these data.
After investigation I found that istream's implementation on Linux differs from Windows 8.1 one. Both handle exceptions that can be inside of istream::get(). But in Linux in this case EOF will be returned and in Windows 8.1 we get zero.

So I offer this patch.

Thanks,
Oleg

@obiltschnig @aleks-f 
