### PR TITLE
Broadcast address and subnet mask for IEEE802.11 network interface

### DIFF
--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -1150,7 +1150,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 				case AF_INET:
 				{
 					// Windows lists broadcast address on localhost
-					bool hasBroadcast = (pAddress->IfType == IF_TYPE_ETHERNET_CSMACD) || (pAddress->IfType == IF_TYPE_SOFTWARE_LOOPBACK);
+					bool hasBroadcast = (pAddress->IfType == IF_TYPE_ETHERNET_CSMACD) || (pAddress->IfType == IF_TYPE_SOFTWARE_LOOPBACK) || (pAddress->IfType == IF_TYPE_IEEE80211);
 					if (hasBroadcast)
 					{
 						// On Windows, a valid broadcast address will be all 1's (== address | ~subnetMask); additionaly, on pre-Vista versions of


### PR DESCRIPTION
On Windows NetworkInterface::map doesn't retrieve broadcast address and subnet mask for wireless IEEE802.11 network interfaces. The patch fixes this.
