### PR TITLE
Allow absolute index to be used when all values has been used.

### DIFF
--- a/Foundation/src/Format.cpp
+++ b/Foundation/src/Format.cpp
@@ -350,7 +350,7 @@ void format(std::string& result, const std::string& fmt, const std::vector<Any>&
 		{
 		case '%':
 			++itFmt;
-			if (itFmt != endFmt && itVal != endVal)
+			if (itFmt != endFmt && (itVal != endVal || *itFmt == '['))
 			{
 				if (*itFmt == '[')
 				{

--- a/Foundation/testsuite/src/FormatTest.cpp
+++ b/Foundation/testsuite/src/FormatTest.cpp
@@ -349,6 +349,9 @@ void FormatTest::testIndex()
 
 	s = format("%%%[1]d%%%[2]d%%%d", 1, 2, 3);
 	assert(s == "%2%3%1");
+
+	s = format("%%%d%%%d%%%[0]d", 1, 2);
+	assert(s == "%1%2%1");
 }
 
 


### PR DESCRIPTION
This fixes formatting when the indexed value is used after all arguments has been used normally. I am using the patch with 1.4.6 for a long time now with no problems.
