### PR TITLE
Updates to remove c++ 11 code, remove prepared statements properly, clea...

### DIFF
--- a/Data/PostgreSQL/PostgreSQL.progen
+++ b/Data/PostgreSQL/PostgreSQL.progen
@@ -1,0 +1,17 @@
+vc.project.guid = 73E19FDE-1570-488C-B3DB-72A60FADD4BB
+vc.project.name = PostgreSQL
+vc.project.target = PocoDataPostgreSQL
+vc.project.type = library
+vc.project.pocobase = ..\\..
+vc.project.outdir = ${vc.project.pocobase}
+vc.project.platforms = Win32, x64
+vc.project.configurations = debug_shared, release_shared, debug_static_mt, release_static_mt, debug_static_md, release_static_md
+vc.project.prototype = ${vc.project.name}_vs90.vcproj
+vc.project.compiler.include = ..\\..\\Foundation\\include;..\\..\\Data\\include
+vc.project.compiler.defines = THREADSAFE;__LCC__
+vc.project.compiler.defines.shared = ${vc.project.name}_EXPORTS
+vc.project.compiler.defines.debug_shared = ${vc.project.compiler.defines.shared}
+vc.project.compiler.defines.release_shared = ${vc.project.compiler.defines.shared}
+vc.project.linker.dependencies = libpq.lib
+vc.solution.create = true
+vc.solution.include = testsuite\\TestSuite

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Extractor.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Extractor.h
@@ -54,6 +54,11 @@
 
 
 namespace Poco {
+
+//namespace Dynamic {
+//	class Var;
+//}
+
 namespace Data {
 namespace PostgreSQL {
 
@@ -366,6 +371,7 @@ private:
         {
             val = tempString;
         }
+       
         
 		return returnValue;
 	}

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLTypes.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLTypes.h
@@ -164,7 +164,7 @@ class PQResultClear
 {
 public:
     explicit PQResultClear( PGresult * aPQResultPtr );
-    PQResultClear();
+    ~PQResultClear();
         
 private:
     PQResultClear             ( const PQResultClear & );
@@ -180,7 +180,7 @@ class PGCancelFree
 {
 public:
     explicit PGCancelFree( PGcancel * aStatementCancelPtr );
-    PGCancelFree();
+    ~PGCancelFree();
         
 private:
     PGCancelFree             ( const PGCancelFree & );
@@ -437,7 +437,7 @@ PQResultClear::PQResultClear( PGresult * aPQResultPtr  )
 }
 
 inline
-PQResultClear::PQResultClear()
+PQResultClear::~PQResultClear()
 {
     if ( _pPQResult )
     {
@@ -455,7 +455,7 @@ PGCancelFree::PGCancelFree( PGcancel * aStatementCancelPtr  )
 }
 
 inline
-PGCancelFree::PGCancelFree()
+PGCancelFree::~PGCancelFree()
 {
     if ( _pPGCancel )
     {

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionImpl.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionImpl.h
@@ -141,7 +141,6 @@ private:
 	std::string     _connectorName;
 	SessionHandle   _sessionHandle;
 
-	bool            _inTransaction;
 	std::size_t     _timeout;
 };
 
@@ -167,12 +166,6 @@ inline const std::string& SessionImpl::connectorName() const
 }
 
 
-inline bool SessionImpl::isTransaction()
-{
-	return _inTransaction;
-}
-
-
 inline bool SessionImpl::isTransactionIsolation( Poco::UInt32 aTI )
 {
 	return getTransactionIsolation() == aTI;
@@ -183,29 +176,6 @@ inline std::size_t SessionImpl::getConnectionTimeout()
 {
 	return _timeout;
 }
-
-/*
-inline
-void
-SessionImpl::setInsertId( const std::string &, const Poco::Any & )
-{
-}
-
-
-inline
-Poco::Any
-SessionImpl::getInsertId( const std::string & )
-{
-	return Poco::Any(Poco::UInt64(postgresql_insert_id(_sessionHandle)));
-}
-
-template <>
-inline std::string& SessionImpl::getValue(POSTGRESQL_BIND* pResult, std::string& val)
-{
-	val.assign((char*) pResult->buffer, pResult->buffer_length);
-	return val;
-}
-*/
 
 
 } } } // namespace Poco::Data::PostgreSQL

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
@@ -59,7 +59,7 @@ class StatementExecutor
 public:
 	enum State
 	{
-		STMT_INITED,
+        STMT_INITED,
 		STMT_COMPILED,
 		STMT_EXECUTED
 	};

--- a/Data/PostgreSQL/src/Extractor.cpp
+++ b/Data/PostgreSQL/src/Extractor.cpp
@@ -42,7 +42,6 @@
 #include "Poco/NumberParser.h"
 #include "Poco/DateTimeParser.h"
 
-#include <cstdint>
 #include <limits>
 
 namespace Poco {
@@ -59,29 +58,23 @@ Extractor::Extractor(StatementExecutor& st /*, ResultMetadata& md */ )
 Extractor::~Extractor()
 {
 }
-
+    
 
 bool Extractor::extract(std::size_t pos, Poco::Int8& val)
 {
     
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-
-    int tempInt = -1;
-   
-    if (    ! Poco::NumberParser::tryParse( outputParameter.pData(), tempInt )
-         || tempInt > INT8_MAX
-         || tempInt < INT8_MIN
+    int tempVal;
+    
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParse( outputParameter.pData(), tempVal )
        )
     {
         return false;
     }
-
-    val = tempInt;
+    
+    val = tempVal;
 
     return true;
 }
@@ -90,22 +83,17 @@ bool Extractor::extract(std::size_t pos, Poco::Int8& val)
 bool Extractor::extract(std::size_t pos, Poco::UInt8& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
-
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-
-    unsigned int tempUInt = -1;
     
-    if (   ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), tempUInt )
-        || tempUInt > UINT8_MAX
+    unsigned int tempVal;
+
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), tempVal )
        )
     {
         return false;
     }
-    
-    val = tempUInt;
+   
+    val = tempVal;
     
     return true;
 }
@@ -115,23 +103,17 @@ bool Extractor::extract(std::size_t pos, Poco::Int16& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
 
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
+    int tempVal;
     
-    int tempInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParse( outputParameter.pData(), tempInt )
-        || tempInt > INT16_MAX
-        || tempInt < INT16_MIN
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParse( outputParameter.pData(), tempVal )
        )
     {
         return false;
     }
+ 
+    val = tempVal;
     
-    val = tempInt;
-
     return true;
 }
 
@@ -139,23 +121,18 @@ bool Extractor::extract(std::size_t pos, Poco::Int16& val)
 bool Extractor::extract(std::size_t pos, Poco::UInt16& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
+    
+    unsigned int tempVal;
 
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-    
-    unsigned int tempUInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), tempUInt )
-        || tempUInt > UINT16_MAX
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), tempVal )
        )
     {
         return false;
     }
+ 
+    val = tempVal;
     
-    val = tempUInt;
-
     return true;
 }
 
@@ -164,22 +141,12 @@ bool Extractor::extract(std::size_t pos, Poco::Int32& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-
-    int tempInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParse( outputParameter.pData(), tempInt )
-        || tempInt > INT32_MAX  // useless here - size issues
-        || tempInt < INT32_MIN  // useless here - size issues
+    if (     isColumnNull( outputParameter )
+        || ! Poco::NumberParser::tryParse( outputParameter.pData(), val )
        )
     {
         return false;
     }
-    
-    val = tempInt;
 
     return true;
 }
@@ -189,22 +156,13 @@ bool Extractor::extract(std::size_t pos, Poco::UInt32& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
 
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-    
-    unsigned int tempUInt = -1;
-    
-    if (    ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), tempUInt )
-        || tempUInt > UINT32_MAX  // useless here - size issues
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseUnsigned( outputParameter.pData(), val )
        )
     {
         return false;
     }
     
-    val = tempUInt;
-
     return true;
 }
 
@@ -213,22 +171,12 @@ bool Extractor::extract(std::size_t pos, Poco::Int64& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-
-    Poco::Int64 tempInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParse64( outputParameter.pData(), tempInt )
-        || tempInt > INT64_MAX  // useless here - size issues
-        || tempInt < INT64_MIN  // useless here - size issues
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParse64( outputParameter.pData(), val )
        )
     {
         return false;
     }
-    
-    val = tempInt;
 
     return true;
 }
@@ -238,21 +186,12 @@ bool Extractor::extract(std::size_t pos, Poco::UInt64& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
-    {
-        return false;
-    }
-
-    Poco::UInt64 tempUInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParseUnsigned64( outputParameter.pData(), tempUInt )
-        || tempUInt > UINT64_MAX  // useless here - size issues
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseUnsigned64( outputParameter.pData(), val )
        )
     {
         return false;
     }
-    
-    val = tempUInt;
 
     return true;
 }
@@ -263,22 +202,12 @@ bool Extractor::extract(std::size_t pos, long& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParse64( outputParameter.pData(), val )
+       )
     {
         return false;
     }
-
-    Poco::Int64 tempInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParse64( outputParameter.pData(), tempInt )
-        || tempInt > INT64_MAX  // useless here - size issues
-        || tempInt < INT64_MIN  // useless here - size issues
-        )
-    {
-        return false;
-    }
-    
-    val = tempInt;
 
     return true;
 }
@@ -288,21 +217,12 @@ bool Extractor::extract(std::size_t pos, unsigned long& val)
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseUnsigned64( outputParameter.pData(), val )
+       )
     {
         return false;
     }
-
-    Poco::UInt64 tempUInt = -1;
-    
-    if (   ! Poco::NumberParser::tryParseUnsigned64( outputParameter.pData(), tempUInt )
-        || tempUInt > UINT64_MAX  // useless here - size issues
-        )
-    {
-        return false;
-    }
-    
-    val = tempUInt;
 
     return true;
 }
@@ -333,21 +253,18 @@ bool Extractor::extract(std::size_t pos, bool& val)
 bool Extractor::extract(std::size_t pos, float& val )
 {
     OutputParameter outputParameter = extractPreamble( pos );
+    
+    double tempVal;
 
-    if ( isColumnNull( outputParameter ) )
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseFloat( outputParameter.pData(), tempVal )
+       )
     {
         return false;
     }
 
-    double tempDouble = std::numeric_limits<double>::quiet_NaN();
+    val = tempVal;
     
-    if ( ! Poco::NumberParser::tryParseFloat( outputParameter.pData(), tempDouble ) )
-    {
-        return false;
-    }
-    
-    val = tempDouble;
-
     return true;
 }
 
@@ -356,19 +273,12 @@ bool Extractor::extract(std::size_t pos, double& val )
 {
     OutputParameter outputParameter = extractPreamble( pos );
     
-    if ( isColumnNull( outputParameter ) )
+    if (      isColumnNull( outputParameter )
+         || ! Poco::NumberParser::tryParseFloat( outputParameter.pData(), val )
+        )
     {
         return false;
     }
-
-    double tempDouble = std::numeric_limits<double>::quiet_NaN();
-    
-    if ( ! Poco::NumberParser::tryParseFloat( outputParameter.pData(), tempDouble ) )
-    {
-        return false;
-    }
-    
-    val = tempDouble;
 
     return true;
 }
@@ -581,8 +491,8 @@ Extractor::extractPreamble( std::size_t aPosition ) const
 bool
 Extractor::isColumnNull ( const OutputParameter & anOutputParameter ) const
 {
-    return   anOutputParameter.isNull()
-          || 0 == anOutputParameter.pData();
+    return    anOutputParameter.isNull()
+           || 0 == anOutputParameter.pData();
 }
 
 

--- a/Data/PostgreSQL/testsuite/TestSuite.progen
+++ b/Data/PostgreSQL/testsuite/TestSuite.progen
@@ -1,0 +1,10 @@
+vc.project.guid = 4D6E42AE-EB6A-47EB-A186-B8A183FABCFF
+vc.project.name = TestSuite
+vc.project.target = TestSuite
+vc.project.type = testsuite
+vc.project.pocobase = ..\\..\\..
+vc.project.platforms = Win32, x64
+vc.project.configurations = debug_shared, release_shared, debug_static_mt, release_static_mt, debug_static_md, release_static_md
+vc.project.prototype = TestSuite_vs90.vcproj
+vc.project.compiler.include = ..\\..\\..\\Foundation\\include;..\\..\\..\\Data\\include
+vc.project.linker.dependencies = libpq.lib

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ poco: libexecs $(if $(TESTS),tests) $(if $(SAMPLES),samples)
 all: libexecs tests samples
 
 INSTALLDIR = $(DESTDIR)$(POCO_PREFIX)
-COMPONENTS = Foundation XML JSON Util Net Crypto NetSSL_OpenSSL Data Data/SQLite Data/ODBC Data/MySQL MongoDB Zip PageCompiler PageCompiler/File2Page CppParser PDF
+COMPONENTS = Foundation XML JSON Util Net Crypto NetSSL_OpenSSL Data Data/SQLite Data/ODBC Data/MySQL Data/PostgreSQL MongoDB Zip PageCompiler PageCompiler/File2Page CppParser PDF
 
 cppunit:
 	$(MAKE) -C $(POCO_BASE)/CppUnit 
@@ -50,10 +50,10 @@ install: libexecs
 	find $(POCO_BUILD)/lib -name "libPoco*" -type f -exec cp -f {} $(INSTALLDIR)/lib \;
 	find $(POCO_BUILD)/lib -name "libPoco*" -type l -exec cp -Rf {} $(INSTALLDIR)/lib \;
 
-libexecs =  Foundation-libexec XML-libexec JSON-libexec Util-libexec Net-libexec Crypto-libexec NetSSL_OpenSSL-libexec Data-libexec Data/SQLite-libexec Data/ODBC-libexec Data/MySQL-libexec MongoDB-libexec Zip-libexec PageCompiler-libexec PageCompiler/File2Page-libexec CppParser-libexec PDF-libexec
-tests    =  Foundation-tests XML-tests JSON-tests Util-tests Net-tests Crypto-tests NetSSL_OpenSSL-tests Data-tests Data/SQLite-tests Data/ODBC-tests Data/MySQL-tests MongoDB-tests Zip-tests CppParser-tests PDF-tests
+libexecs =  Foundation-libexec XML-libexec JSON-libexec Util-libexec Net-libexec Crypto-libexec NetSSL_OpenSSL-libexec Data-libexec Data/SQLite-libexec Data/ODBC-libexec Data/MySQL-libexec Data/PostgreSQL-libexec MongoDB-libexec Zip-libexec PageCompiler-libexec PageCompiler/File2Page-libexec CppParser-libexec PDF-libexec
+tests    =  Foundation-tests XML-tests JSON-tests Util-tests Net-tests Crypto-tests NetSSL_OpenSSL-tests Data-tests Data/SQLite-tests Data/ODBC-tests Data/MySQL-tests Data/PostgreSQL-tests MongoDB-tests Zip-tests CppParser-tests PDF-tests
 samples  =  Foundation-samples XML-samples JSON-samples Util-samples Net-samples Crypto-samples NetSSL_OpenSSL-samples Data-samples MongoDB-samples Zip-samples PageCompiler-samples PDF-samples
-cleans   =  Foundation-clean XML-clean JSON-clean Util-clean Net-clean Crypto-clean NetSSL_OpenSSL-clean Data-clean Data/SQLite-clean Data/ODBC-clean Data/MySQL-clean MongoDB-clean Zip-clean PageCompiler-clean PageCompiler/File2Page-clean CppParser-clean PDF-clean
+cleans   =  Foundation-clean XML-clean JSON-clean Util-clean Net-clean Crypto-clean NetSSL_OpenSSL-clean Data-clean Data/SQLite-clean Data/ODBC-clean Data/MySQL-clean Data/PostgreSQL-clean MongoDB-clean Zip-clean PageCompiler-clean PageCompiler/File2Page-clean CppParser-clean PDF-clean
 
 .PHONY: $(libexecs)
 .PHONY: $(tests)
@@ -206,6 +206,16 @@ Data/MySQL-tests: Data/MySQL-libexec cppunit
 Data/MySQL-clean:
 	$(MAKE) -C $(POCO_BASE)/Data/MySQL clean
 	$(MAKE) -C $(POCO_BASE)/Data/MySQL/testsuite clean
+
+Data/PostgreSQL-libexec:  Foundation-libexec Data-libexec
+	$(MAKE) -C $(POCO_BASE)/Data/PostgreSQL
+
+Data/PostgreSQL-tests: Data/PostgreSQL-libexec cppunit
+	$(MAKE) -C $(POCO_BASE)/Data/PostgreSQL/testsuite
+
+Data/PostgreSQL-clean:
+	$(MAKE) -C $(POCO_BASE)/Data/PostgreSQL clean
+	$(MAKE) -C $(POCO_BASE)/Data/PostgreSQL/testsuite clean
 
 MongoDB-libexec:  Foundation-libexec Net-libexec
 	$(MAKE) -C $(POCO_BASE)/MongoDB

--- a/components
+++ b/components
@@ -11,6 +11,7 @@ Data
 Data/SQLite
 Data/ODBC
 Data/MySQL
+Data/PostgreSQL
 Zip
 PageCompiler
 PageCompiler/File2Page


### PR DESCRIPTION
...n-up locking on sessionHandle

Per Alek’s observations the following changes were made:
1) Update components and Makefile to include PostgreSQL code and test
suite
2) remove C++11 code references

Additional changes made to adhere to PostgreSQL libpq requirements

1) Remove Prepared statements when statements go out of scope.  This is
complicated by transactions such that prepared statements created
during a transaction must continue to exist as prepared statements.
Code updated to delete prepared statements at the proper time.  CLIENTS
ARE REQUIRED TO ISSIE Poco::Data API CALLS FOR TRANSACTION SUPPORT AND
NOT SEND BEGIN, COMMIT OR ROLLBACK STATEMENTS DIRECTLY.

Also update SessionHandle.cpp code to make better use of locking where
public methods request the lock and private methods do not.  This is to
prevent deadlock conditions from occurring
