### PR TITLE
Catch NoAddressFoundException from DNS.

### DIFF
--- a/NetSSL_OpenSSL/src/X509Certificate.cpp
+++ b/NetSSL_OpenSSL/src/X509Certificate.cpp
@@ -124,6 +124,9 @@ bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, c
 					}
 				}
 			}
+			catch (NoAddressFoundException&)
+			{
+			}
 			catch (HostNotFoundException&)
 			{
 			}


### PR DESCRIPTION
The certificate validation might fail on NoAddressFoundException - if the
hostname from certificate could not be translated to IP address.
