### PR TITLE
Add CTests for all components

### DIFF
--- a/Crypto/testsuite/CMakeLists.txt
+++ b/Crypto/testsuite/CMakeLists.txt
@@ -15,6 +15,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoCrypto PocoNetSSL PocoXML PocoUtil PocoFoundation CppUnit pthread)
 

--- a/Data/testsuite/CMakeLists.txt
+++ b/Data/testsuite/CMakeLists.txt
@@ -20,6 +20,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoData PocoUtil PocoXML PocoFoundation CppUnit)
 

--- a/Foundation/testsuite/CMakeLists.txt
+++ b/Foundation/testsuite/CMakeLists.txt
@@ -145,17 +145,28 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
+set_tests_properties(${LIBNAME} PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=.") # The SharedLibaryTest has to look for shared libraries in the working directory
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoFoundation CppUnit )
 if (NOT ANDROID)
   target_link_libraries( ${TESTUNIT} pthread)
 endif ()
 
+# The test is run in the build directory. So the test data is copied there too
+add_custom_command(TARGET ${TESTUNIT} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data )
+
 add_executable( TestApp src/TestApp.cpp )
+# The test is run in the build directory. So the TestApp is built there too because it is used by the tests
+set_target_properties( TestApp PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
 #set_target_properties( TestApp PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( TestApp PocoFoundation )
 
-add_library( TestLibrary SHARED src/TestApp.cpp )
+add_library( TestLibrary SHARED src/TestLibrary.cpp )
+set_target_properties( TestLibrary PROPERTIES PREFIX "") # The test requires the library named TestLibrary. By default it is prefixed with lib.
+# The test is run in the build directory. So the TestLibrary is built there too because it is used by the tests
+set_target_properties( TestLibrary PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
 #set_target_properties( TestLibrary PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( TestLibrary PocoFoundation )
 

--- a/JSON/testsuite/CMakeLists.txt
+++ b/JSON/testsuite/CMakeLists.txt
@@ -15,6 +15,11 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT}  PocoJSON PocoFoundation CppUnit )
+
+# The test is run in the build directory. So the test data is copied there too
+add_custom_command(TARGET ${TESTUNIT} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data )
 

--- a/MongoDB/testsuite/CMakeLists.txt
+++ b/MongoDB/testsuite/CMakeLists.txt
@@ -15,6 +15,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT}  PocoMongoDB PocoFoundation CppUnit )
 

--- a/Net/testsuite/CMakeLists.txt
+++ b/Net/testsuite/CMakeLists.txt
@@ -68,6 +68,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoNet PocoUtil PocoXML PocoFoundation CppUnit)
 

--- a/NetSSL_OpenSSL/testsuite/CMakeLists.txt
+++ b/NetSSL_OpenSSL/testsuite/CMakeLists.txt
@@ -20,6 +20,14 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoNetSSL PocoCrypto PocoNet PocoUtil PocoXML PocoFoundation CppUnit)
+
+# The test is run in the build directory. So the test data is copied there too
+add_custom_command(TARGET ${TESTUNIT} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_CURRENT_BINARY_DIR}
+                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_CURRENT_BINARY_DIR}
+                   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_CURRENT_BINARY_DIR}/${TESTUNIT}.xml
+                   )
 

--- a/PDF/testsuite/CMakeLists.txt
+++ b/PDF/testsuite/CMakeLists.txt
@@ -15,6 +15,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT}  PocoPDF PocoFoundation CppUnit )
 

--- a/Util/testsuite/CMakeLists.txt
+++ b/Util/testsuite/CMakeLists.txt
@@ -34,5 +34,6 @@ src/WindowsTestSuite.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoUtil PocoJSON PocoXML PocoFoundation CppUnit)

--- a/XML/testsuite/CMakeLists.txt
+++ b/XML/testsuite/CMakeLists.txt
@@ -31,6 +31,7 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT} PocoXML PocoFoundation CppUnit)
 

--- a/Zip/testsuite/CMakeLists.txt
+++ b/Zip/testsuite/CMakeLists.txt
@@ -15,6 +15,11 @@ src/WinDriver.cpp
 set(TESTUNIT "${LIBNAME}-testrunner")
 
 add_executable( ${TESTUNIT} ${TEST_SRCS} )
+add_test(NAME ${LIBNAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${TESTUNIT} -all)
 #set_target_properties( ${TESTUNIT} PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries( ${TESTUNIT}  PocoZip PocoNet PocoFoundation CppUnit )
+
+# The test is run in the build directory. So the test data is copied there too
+add_custom_command(TARGET ${TESTUNIT} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data )
 


### PR DESCRIPTION
Add support for CTest to all CMake enabled components.
Usage:
`mkdir cmake_build && cd cmake_build`
`cmake -DENABLE_TESTS=On ..`
`make`
`make test`

Every components test is executed seperatly. The result of the test runs can be found under: `Testing/Temporary/LastTest.log`
