### PR TITLE
make HTTPAuthenticationParams::parse() add value on end of string

### DIFF
--- a/Net/src/HTTPAuthenticationParams.cpp
+++ b/Net/src/HTTPAuthenticationParams.cpp
@@ -298,6 +298,9 @@ void HTTPAuthenticationParams::parse(std::string::const_iterator first, std::str
 		}
 	}
 
+	if (state == STATE_VALUE)
+		add(token, value);
+
 	if (!(state & STATE_FINAL))
 		throw SyntaxException("Invalid authentication information");
 }


### PR DESCRIPTION
There is a bug in `Poco::Net::HTTPAuthenticationParams` parser. It doesn't add parameter to the name-value collection if the parameters value is unquoted and it's at the end of the input string. E.g., parameter `nc` will not be in the resulting name-value collection:

```
username="xyz", nc=00000001
```

This commit fixes that.
