### PR TITLE
cmake: Set an output directory for Windows DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(PROJECT_VERSION ${COMPLETE_VERSION})
 # tree rather than installed Boost libraries.
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+# Windows DLLs are "runtime" for CMake. Output them to "bin" like the Visual Studio projects do.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Append our module directory to CMake
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Windows DLLs are treated as "runtime" objects in CMake, so they were previously put in hard to find default leaf directories. The choice of "bin" as the folder name is mimiced from the Visual Studio project files of POCO.

Apart from that everything went fine with the build on Windows with CMake (except from SevenZip, but that's not in the current release anyway). I would love to see the CMake build files included in the next official release. Is there anything else with it that needs work? I did not find a TODO, but I offer my help.
