### PR TITLE
Fixed ODBC on Win64.

### DIFF
--- a/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
@@ -177,7 +177,7 @@ private:
 
 	Poco::UInt32 getDefaultTransactionIsolation();
 
-	Poco::UInt32 transactionIsolation(SQLUINTEGER isolation);
+	Poco::UInt32 transactionIsolation(SQLULEN isolation);
 
 	std::string            _connector;
 	const ConnectionHandle _db;

--- a/Data/ODBC/src/SessionImpl.cpp
+++ b/Data/ODBC/src/SessionImpl.cpp
@@ -100,7 +100,7 @@ void SessionImpl::open(const std::string& connect)
 
 	poco_assert_dbg (!connectionString().empty());
 
-	SQLUINTEGER tout = static_cast<SQLUINTEGER>(getLoginTimeout());
+	SQLULEN tout = static_cast<SQLULEN>(getLoginTimeout());
 	if (Utility::isError(SQLSetConnectAttr(_db, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER) tout, 0)))
 	{
 		if (Utility::isError(SQLGetConnectAttr(_db, SQL_ATTR_LOGIN_TIMEOUT, &tout, 0, 0)) ||
@@ -162,7 +162,7 @@ void SessionImpl::open(const std::string& connect)
 
 bool SessionImpl::isConnected()
 {
-	SQLUINTEGER value = 0;
+	SQLULEN value = 0;
 
 	if (Utility::isError(Poco::Data::ODBC::SQLGetConnectAttr(_db,
 		SQL_ATTR_CONNECTION_DEAD,
@@ -187,7 +187,7 @@ void SessionImpl::setConnectionTimeout(std::size_t timeout)
 
 std::size_t SessionImpl::getConnectionTimeout()
 {
-	SQLUINTEGER value = 0;
+	SQLULEN value = 0;
 
 	checkError(Poco::Data::ODBC::SQLGetConnectAttr(_db,
 		SQL_ATTR_CONNECTION_TIMEOUT,
@@ -238,7 +238,7 @@ void SessionImpl::setTransactionIsolation(Poco::UInt32 ti)
 
 Poco::UInt32 SessionImpl::getTransactionIsolation()
 {
-	SQLUINTEGER isolation = 0;
+	SQLULEN isolation = 0;
 	checkError(SQLGetConnectAttr(_db, SQL_ATTR_TXN_ISOLATION,
 		&isolation,
 		0,
@@ -273,7 +273,7 @@ Poco::UInt32 SessionImpl::getDefaultTransactionIsolation()
 }
 
 
-Poco::UInt32 SessionImpl::transactionIsolation(SQLUINTEGER isolation)
+Poco::UInt32 SessionImpl::transactionIsolation(SQLULEN isolation)
 {
 	if (0 == isolation)
 		throw InvalidArgumentException("transactionIsolation(SQLUINTEGER)");
@@ -311,7 +311,7 @@ void SessionImpl::autoCommit(const std::string&, bool val)
 
 bool SessionImpl::isAutoCommit(const std::string&)
 {
-	Poco::UInt32 value = 0;
+	SQLULEN value = 0;
 
 	checkError(Poco::Data::ODBC::SQLGetConnectAttr(_db,
 		SQL_ATTR_AUTOCOMMIT,
@@ -327,7 +327,7 @@ bool SessionImpl::isTransaction()
 {
 	if (!canTransact()) return false;
 
-	Poco::UInt32 value = 0;
+	SQLULEN value = 0;
 	checkError(Poco::Data::ODBC::SQLGetConnectAttr(_db,
 		SQL_ATTR_AUTOCOMMIT,
 		&value,


### PR DESCRIPTION
The SQLGetConnectAttr() function can write up to 64-bit integers, as documented by MSDN here: http://msdn.microsoft.com/en-us/library/ms710297%28v=vs.85%29.aspx
This fix uses 64-bit integers instead of 32-bit ones, the original code corrupted the stack when used on win7-x64 with MSSQL 2008.

Tested on Win7-x64 with MSSQL 2008, I don't have the infrastructure required to test this change against the other SQL engines.
