### PR TITLE
Remove troublesome last-ditch attempt to get IP address prefix

### DIFF
--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -71,7 +71,7 @@ public:
 	typedef NetworkInterface::AddressTuple AddressTuple;
 	typedef NetworkInterface::AddressList  AddressList;
 	typedef NetworkInterface::Type         Type;
-	
+
 	NetworkInterfaceImpl(unsigned index);
 	NetworkInterfaceImpl(const std::string& name, const std::string& displayName, const std::string& adapterName, const IPAddress& address, unsigned index, NetworkInterface::MACAddress* pMACAddress = 0);
 	NetworkInterfaceImpl(const std::string& name, const std::string& displayName, const std::string& adapterName, unsigned index = 0, NetworkInterface::MACAddress* pMACAddress = 0);
@@ -130,11 +130,11 @@ public:
 	void setType(Type type);
 	void setIndex(unsigned index);
 	void setPhyParams();
-	
+
 protected:
 	~NetworkInterfaceImpl();
 
-private:	
+private:
 	std::string _name;
 	std::string _displayName;
 	std::string _adapterName;
@@ -325,7 +325,7 @@ bool NetworkInterfaceImpl::hasAddress(const IPAddress& address) const
 	NetworkInterface::ConstAddressIterator end = _addressList.end();
 	for (; it != end; ++it)
 	{
-		if (it->get<NetworkInterface::IP_ADDRESS>() == address) 
+		if (it->get<NetworkInterface::IP_ADDRESS>() == address)
 			return true;
 	}
 	return false;
@@ -347,7 +347,7 @@ inline const NetworkInterface::AddressList& NetworkInterfaceImpl::addressList() 
 
 const IPAddress& NetworkInterfaceImpl::subnetMask(unsigned index) const
 {
-	if (index < _addressList.size()) 
+	if (index < _addressList.size())
 		return _addressList[index].get<NetworkInterface::SUBNET_MASK>();
 
 	throw NotFoundException(Poco::format("No subnet mask with index %u.", index));
@@ -356,7 +356,7 @@ const IPAddress& NetworkInterfaceImpl::subnetMask(unsigned index) const
 
 const IPAddress& NetworkInterfaceImpl::broadcastAddress(unsigned index) const
 {
-	if (index < _addressList.size()) 
+	if (index < _addressList.size())
 		return _addressList[index].get<NetworkInterface::BROADCAST_ADDRESS>();
 
 	throw NotFoundException(Poco::format("No subnet mask with index %u.", index));
@@ -365,11 +365,11 @@ const IPAddress& NetworkInterfaceImpl::broadcastAddress(unsigned index) const
 
 const IPAddress& NetworkInterfaceImpl::destAddress(unsigned index) const
 {
-	if (!pointToPoint()) 
+	if (!pointToPoint())
 		throw InvalidAccessException("Only PPP addresses have destination address.");
-	else if (index < _addressList.size()) 
+	else if (index < _addressList.size())
 		return _addressList[index].get<NetworkInterface::BROADCAST_ADDRESS>();
-	
+
 	throw NotFoundException(Poco::format("No address with index %u.", index));
 }
 
@@ -525,7 +525,7 @@ inline void NetworkInterfaceImpl::addAddress(const IPAddress& addr)
 
 inline void NetworkInterfaceImpl::setMACAddress(const NetworkInterface::MACAddress& addr)
 {
-	
+
 
 	_macAddress = addr;
 }
@@ -735,7 +735,7 @@ bool NetworkInterface::supportsIPv4() const
 	return _pImpl->supportsIPv4();
 }
 
-	
+
 bool NetworkInterface::supportsIPv6() const
 {
 	return _pImpl->supportsIPv6();
@@ -815,7 +815,7 @@ NetworkInterface NetworkInterface::forName(const std::string& name, IPVersion ip
 	throw InterfaceNotFoundException(name);
 }
 
-	
+
 NetworkInterface NetworkInterface::forAddress(const IPAddress& addr)
 {
 	Map map = NetworkInterface::map(true, false);
@@ -834,7 +834,7 @@ NetworkInterface NetworkInterface::forAddress(const IPAddress& addr)
 	throw InterfaceNotFoundException(addr.toString());
 }
 
-	
+
 NetworkInterface NetworkInterface::forIndex(unsigned i)
 {
 	if (i != NetworkInterface::NO_INDEX)
@@ -884,7 +884,7 @@ NetworkInterface::List NetworkInterface::list(bool ipOnly, bool upOnly)
 			list.push_back(ni);
 		}
 	}
-	
+
 	return list;
 }
 
@@ -915,10 +915,10 @@ namespace {
 
 
 IPAddress getBroadcastAddress(PIP_ADAPTER_PREFIX pPrefix, const IPAddress& addr, ULONG* pprefix = 0)
-	/// This function relies on (1) subnet prefix being at the position 
+	/// This function relies on (1) subnet prefix being at the position
 	/// immediately preceding and (2) broadcast address being at the position
 	/// immediately succeeding the IPv4 unicast address.
-	/// 
+	///
 	/// Since there is no explicit guarantee on order, to ensure correctness,
 	/// the above constraints are checked prior to returning the result.
 	/// Additionally, on pre-Vista versions on Windows, the main structure does
@@ -934,7 +934,7 @@ IPAddress getBroadcastAddress(PIP_ADAPTER_PREFIX pPrefix, const IPAddress& addr,
 		pPrev = pPrefix;
 	}
 
-	if (pPrefix && pPrefix->Next && pPrev) 
+	if (pPrefix && pPrefix->Next && pPrev)
 	{
 		IPAddress ipPrefix(pPrev->PrefixLength, IPAddress::IPv4);
 		IPAddress mask(pPrefix->Next->Address);
@@ -944,14 +944,14 @@ IPAddress getBroadcastAddress(PIP_ADAPTER_PREFIX pPrefix, const IPAddress& addr,
 			return IPAddress(pPrefix->Next->Address);
 		}
 	}
-	
+
 	return IPAddress(IPAddress::IPv4);
 }
 
 
 NetworkInterface::Type fromNative(DWORD type)
 {
-	switch (type) 
+	switch (type)
 	{
 	case IF_TYPE_ETHERNET_CSMACD:    return NetworkInterface::NI_TYPE_ETHERNET_CSMACD;
 	case IF_TYPE_ISO88025_TOKENRING: return NetworkInterface::NI_TYPE_ISO88025_TOKENRING;
@@ -1069,15 +1069,15 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 		ifIndex = pAddress->Ipv6IfIndex;
 	#elif (_WIN32_WINNT >= 0x0501) && (NTDDI_VERSION >= 0x05010100) // Win XP SP1
 		#if defined (IP_ADAPTER_IPV6_ENABLED) // Vista
-			if ((pAddress->Flags & IP_ADAPTER_IPV6_ENABLED) && 
-				(osvi.dwMajorVersion >= 5) && 
-				(osvi.dwMinorVersion >= 1) && 
+			if ((pAddress->Flags & IP_ADAPTER_IPV6_ENABLED) &&
+				(osvi.dwMajorVersion >= 5) &&
+				(osvi.dwMinorVersion >= 1) &&
 				(osvi.dwBuildNumber >=1))
 			{
 				ifIndex = pAddress->Ipv6IfIndex;
 			}
 		#else // !defined(IP_ADAPTER_IPV6_ENABLED)
-			if ((osvi.dwMajorVersion >= 5) && 
+			if ((osvi.dwMajorVersion >= 5) &&
 				(osvi.dwMinorVersion >= 1) &&
 				(osvi.dwBuildNumber >= 1))
 			{
@@ -1094,7 +1094,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 		}
 #else // !IP_ADAPTER_IPV4_ENABLED
 		ifIndex = pAddress->IfIndex;
-#endif	
+#endif
 		if (ifIndex == 0) continue;
 
 		std::string name;
@@ -1123,7 +1123,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			Map::iterator ifIt = result.find(ifIndex);
 			if (ifIt == result.end())
 				ifIt = result.insert(Map::value_type(ifIndex, ni)).first;
-		
+
 			ifIt->second.impl().setFlags(pAddress->Flags, pAddress->IfType);
 			ifIt->second.impl().setMTU(pAddress->Mtu);
 			ifIt->second.impl().setUp(pAddress->OperStatus == IfOperStatusUp);
@@ -1139,8 +1139,8 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			if (pAddress->PhysicalAddressLength)
 				ifIt->second.impl().setMACAddress(pAddress->PhysicalAddress, pAddress->PhysicalAddressLength);
 
-			for (PIP_ADAPTER_UNICAST_ADDRESS pUniAddr = pAddress->FirstUnicastAddress; 
-				pUniAddr; 
+			for (PIP_ADAPTER_UNICAST_ADDRESS pUniAddr = pAddress->FirstUnicastAddress;
+				pUniAddr;
 				pUniAddr = pUniAddr->Next)
 			{
 				address = IPAddress(pUniAddr->Address);
@@ -1176,9 +1176,6 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 	#else // _WIN32_WINNT < 0x0600
 						ULONG prefixLength = 0;
 						broadcastAddress = getBroadcastAddress(pAddress->FirstPrefix, address, &prefixLength);
-						// if previous call did not do it, make last-ditch attempt for prefix and broadcast
-						if (prefixLength == 0 && pAddress->FirstPrefix)
-							prefixLength = pAddress->FirstPrefix->PrefixLength;
 						poco_assert (prefixLength <= 32);
 						if (broadcastAddress.isWildcard())
 						{
@@ -1253,7 +1250,7 @@ NetworkInterface::NetworkInterfaceList NetworkInterface::list()
 			IPAddress mask;
 			IPAddress bcst;
 			if (ifAddrGet(ifName, ifAddr) == OK)
-			{			
+			{
 				addr = IPAddress(std::string(ifAddr));
 			}
 			int ifMask;
@@ -1268,7 +1265,7 @@ NetworkInterface::NetworkInterfaceList NetworkInterface::list()
 			result.push_back(NetworkInterface(name, name, name, addr, mask, bcst));
 			ifIndex++;
 		}
-		else break;	
+		else break;
 	}
 
 	return result;
@@ -1297,10 +1294,10 @@ namespace Net {
 
 
 namespace {
-	
+
 NetworkInterface::Type fromNative(u_char nativeType)
 {
-	switch (nativeType) 
+	switch (nativeType)
 	{
 #ifndef POCO_NO_NET_IFTYPES
 		case IFT_ETHER:		return NetworkInterface::NI_TYPE_ETHERNET_CSMACD;
@@ -1309,7 +1306,7 @@ NetworkInterface::Type fromNative(u_char nativeType)
 		case IFT_PPP:		return NetworkInterface::NI_TYPE_PPP;
 		case IFT_LOOP:		return NetworkInterface::NI_TYPE_SOFTWARE_LOOPBACK;
 		case IFT_ATM:		return NetworkInterface::NI_TYPE_ATM;
-#if (POCO_OS != POCO_OS_SOLARIS)		
+#if (POCO_OS != POCO_OS_SOLARIS)
 		case IFT_IEEE1394:	return NetworkInterface::NI_TYPE_IEEE1394;
 #endif
 #endif
@@ -1344,20 +1341,20 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 	struct ifaddrs* ifaces = 0;
 	struct ifaddrs* currIface = 0;
 
-	if (getifaddrs(&ifaces) < 0) 
+	if (getifaddrs(&ifaces) < 0)
 		throw NetException("cannot get network adapter list");
 
-	try 
+	try
 	{
-		for (currIface = ifaces; currIface != 0; currIface = currIface->ifa_next) 
+		for (currIface = ifaces; currIface != 0; currIface = currIface->ifa_next)
 		{
 			if (!currIface->ifa_addr) continue;
-			
+
 			IPAddress address, subnetMask, broadcastAddress;
 			unsigned family = currIface->ifa_addr->sa_family;
 			switch (family)
 			{
-#if defined(POCO_OS_FAMILY_BSD) 
+#if defined(POCO_OS_FAMILY_BSD)
 			case AF_LINK:
 			{
 				struct sockaddr_dl* sdl = (struct sockaddr_dl*) currIface->ifa_addr;
@@ -1376,9 +1373,9 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 				setInterfaceParams(currIface, intf.impl());
 				if ((ifIt == result.end()) && ((upOnly && intf.isUp()) || !upOnly))
 					ifIt = result.insert(Map::value_type(ifIndex, intf)).first;
-				
+
 				address = IPAddress(*(currIface->ifa_addr));
-				
+
 				if (( currIface->ifa_flags & IFF_LOOPBACK ) == 0 && currIface->ifa_netmask)
 					subnetMask = IPAddress(*(currIface->ifa_netmask));
 
@@ -1397,7 +1394,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 				setInterfaceParams(currIface, intf.impl());
 				if ((ifIt == result.end()) && ((upOnly && intf.isUp()) || !upOnly))
 					ifIt = result.insert(Map::value_type(ifIndex, intf)).first;
-				
+
 				address = IPAddress(&reinterpret_cast<const struct sockaddr_in6*>(currIface->ifa_addr)->sin6_addr,
 					sizeof(struct in6_addr), ifIndex);
 				subnetMask = IPAddress(*(currIface->ifa_netmask));
@@ -1407,7 +1404,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			default:
 				continue;
 			}
-			
+
 			if (family == AF_INET
 #ifdef POCO_HAVE_IPv6
 			|| family == AF_INET6
@@ -1422,7 +1419,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			}
 		}
 	}
-	catch (...) 
+	catch (...)
 	{
 	}
 	if (ifaces) freeifaddrs(ifaces);
@@ -1438,7 +1435,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			else ++it;
 		}
 	}
-	
+
 	return result;
 }
 
@@ -1469,7 +1466,7 @@ namespace {
 
 static NetworkInterface::Type fromNative(unsigned arphrd)
 {
-	switch (arphrd) 
+	switch (arphrd)
 	{
 	case ARPHRD_ETHER:     return NetworkInterface::NI_TYPE_ETHERNET_CSMACD;
 	case ARPHRD_IEEE802:   return NetworkInterface::NI_TYPE_ISO88025_TOKENRING;
@@ -1516,15 +1513,15 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 	struct ifaddrs* ifaces = 0;
 	struct ifaddrs* iface = 0;
 
-	if (getifaddrs(&ifaces) < 0) 
+	if (getifaddrs(&ifaces) < 0)
 		throw NetException("cannot get network adapter list");
-	
-	try 
+
+	try
 	{
-		for (iface = ifaces; iface; iface = iface->ifa_next) 
+		for (iface = ifaces; iface; iface = iface->ifa_next)
 		{
 			if (!iface->ifa_addr) continue;
-			
+
 			IPAddress address, subnetMask, broadcastAddress;
 			unsigned family = iface->ifa_addr->sa_family;
 			switch (family)
@@ -1535,10 +1532,10 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 				ifIndex = sll->sll_ifindex;
 				intf = NetworkInterface(ifIndex);
 				setInterfaceParams(iface, intf.impl());
-				
+
 				if ((result.find(ifIndex) == result.end()) && ((upOnly && intf.isUp()) || !upOnly))
 					ifIt = result.insert(Map::value_type(ifIndex, intf)).first;
-				
+
 				break;
 			}
 			case AF_INET:
@@ -1596,12 +1593,12 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 			}
 		} // for interface
 	}
-	catch (...) 
+	catch (...)
 	{
 		if (ifaces) freeifaddrs(ifaces);
 		throw;
 	}
-	
+
 	if (ifaces) freeifaddrs(ifaces);
 
 	if (ipOnly)


### PR DESCRIPTION
When running NetworkInterface::map compiled for Windows XP on newer version of Windows, the assert on line 1182 (now 1179) is often tripped because the "last-ditch" attempt to get the IP address prefix assumes that the first prefix in the interface list is the one we need. Unfortunately, the first prefix can sometimes correspond to an IPv6 address with a prefix length of 64 bits, causing the assertion to fail. This occurs consistently when attempting to enumerate disabled interfaces in addition to enabled ones.
