### PR TITLE
include and library dirs as configure params

### DIFF
--- a/Data/PostgreSQL/Makefile
+++ b/Data/PostgreSQL/Makefile
@@ -8,9 +8,7 @@
 
 include $(POCO_BASE)/build/rules/global
 
-SYSLIBS += -L/usr/local/lib$(LIB64SUFFIX)/postgresql/9.3/lib -L/usr/lib$(LIB64SUFFIX)/postgresql/9.3/lib -L$(POSTGRESQL_BASE)/lib -lpq
-INCLUDE += -I/usr/local/include/postgresql/ -I/usr/include/postgresql/ -I$(POSTGRESQL_BASE)/include
-SYSFLAGS += -DTHREADSAFE -DNO_TCL
+SYSLIBS += -lpq
 
 objects = Extractor Binder SessionImpl Connector \
 	PostgreSQLStatementImpl PostgreSQLException \


### PR DESCRIPTION
With potentially many postgresql versions installed, the include and
library directories need to be selectable via parameters to configure
and not be hardcoded in the Makefile for Mac OSX and Linux
