### PR TITLE
Fix for sqlite dropping data intermittantly, and add handling for SQLITE_BUSY errors introduced in later sqlite revisions.

### DIFF
--- a/Data/SQLite/src/SQLiteStatementImpl.cpp
+++ b/Data/SQLite/src/SQLiteStatementImpl.cpp
@@ -217,19 +217,31 @@ bool SQLiteStatementImpl::hasNext()
 	for (int i = 0; i <= _maxRetryAttempts; i++)
 	{
 		_nextResponse = sqlite3_step(_pStmt);
-		// Notes: When we get SQLITE_BUSY, we do need to reset the statement 
-		// to try again.
-		// When we get SQLITE_LOCKED, we must reset the statement before trying
-		// again. SQLITE_LOCKED is only returned for the first call to sqlite3_step,
-		// so resetting and retrying is safe.
-		if ( (_nextResponse & SQLITE_BUSY) || (_nextResponse & SQLITE_LOCKED) )
+			switch (_nextResponse)
 		{
+			// When we get SQLITE_BUSY or SQLITE_LOCKED, we must reset the statement before trying
+			// again. SQLITE_LOCKED is only returned for the first call to sqlite3_step,
+			// so resetting and retrying is safe.
+		case SQLITE_LOCKED:
+		case SQLITE_LOCKED_SHAREDCACHE:
+		case SQLITE_BUSY:	
+#ifdef SQLITE_BUSY_RECOVERY
+		case SQLITE_BUSY_RECOVERY:
+#endif
+#ifdef SQLITE_BUSY_SNAPSHOT
+		case SQLITE_BUSY_SNAPSHOT:
+#endif
+			sqlite3_reset(_pStmt);
 			if (i < _maxRetryAttempts)
 			{
-				sqlite3_reset(_pStmt);
 				sleep();
+				continue;
 			}
+			break;
+		default:
+			break;
 		}
+
 	}
 
 	if (_nextResponse != SQLITE_ROW && _nextResponse != SQLITE_OK && _nextResponse != SQLITE_DONE)


### PR DESCRIPTION
Check for SQLITE_BUSY and SQLITE_LOCKED by bitmask, 
and call sqlite3_reset when SQLITE_BUSY is returned. 

Otherwise, data loss is suffered, with no error.
