### PR TITLE
Add NIOS2 double conversion detection, fixes compile errors

### DIFF
--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -60,7 +60,8 @@
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
     defined(_MIPS_ARCH_MIPS32R2) || \
-    defined(__AARCH64EL__)
+    defined(__AARCH64EL__) || \
+    defined(nios2) || defined(__nios2) || defined(__nios2__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
 #if defined(_WIN32)


### PR DESCRIPTION
This change gets Foundation compiling for Nios2. Previously, double conversion on this platform was not getting detected at all.

I tested the double conversion process on a Nios2 Linux system with this program:

``` c++
#include <iostream>
int main() {
    double num = 89255.0;
    double denom = 1e22;

    if(num / denom == 89255e-22) {
        std::cout << "Double operations appear correct: " << num / denom << " == " << 89255e-22 << std::endl;
    } else {
        std::cout << "Double operations appear wrong: " << num / denom << " != " << 89255e-22 << std::endl;
    }

}
```

It outputs that the operations appear correct.

After this change, I was able to build for the Nios2 with:

```
$ ./configure --config=NIOS2-Linux --no-fpenvironment --omit=Data,Data/ODBC,Data/MySQL,Crypto,NetSSL_OpenSSL,MongoDB
$ make
```
