### PR TITLE
use c++11 for ios clang; additional fix for #234

### DIFF
--- a/build/config/iPhone-clang-libc++
+++ b/build/config/iPhone-clang-libc++
@@ -71,7 +71,7 @@ SHAREDLIBLINKEXT = .dylib
 CFLAGS          = $(OSFLAGS)
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = $(OSFLAGS) -stdlib=libc++ -Wall -Wno-sign-compare 
+CXXFLAGS        = $(OSFLAGS) -std=c++11 -stdlib=libc++ -Wall -Wno-sign-compare 
 CXXFLAGS32      =
 CXXFLAGS64      = 
 LINKFLAGS       = $(OSFLAGS) -stdlib=libc++


### PR DESCRIPTION
Related to commit https://github.com/pocoproject/poco/commit/be59dcf91329b1a8cd47001fabd4df2c2916762c

This also makes the config fix for iOS for issue #234.
