### PR TITLE
iOS arm64 compile fix

### DIFF
--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -53,8 +53,8 @@
 // disabled.)
 // On Linux,x86 89255e-22 != Div_double(89255.0/1e22)
 #if defined(_M_X64) || defined(__x86_64__) || \
-    defined(__ARMEL__) || defined(_M_ARM) || defined(__arm__) || \
-	defined(__avr32__) || \
+    defined(__ARMEL__) || defined(_M_ARM) || defined(__arm__) || defined(__arm64__) || \
+    defined(__avr32__) || \
     defined(__hppa__) || defined(__ia64__) || \
     defined(__mips__) || defined(__powerpc__) || \
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \


### PR DESCRIPTION
Fix for issue #508 “Can't compile for arm64 architecture”

Tested and working with the proposed change.
