### PR TITLE
Fix executable path for recent Android NDK.

### DIFF
--- a/build/config/Android
+++ b/build/config/Android
@@ -24,7 +24,7 @@ ARCHFLAGS = -march=armv7-a -mfloat-abi=softfp
 LINKFLAGS = -Wl,--fix-cortex-a8
 else
 ifeq ($(ANDROID_ABI),x86)
-TOOL      = i686-android-linux
+TOOL      = i686-linux-android
 ARCHFLAGS = -march=i686 -msse3 -mstackrealign -mfpmath=sse
 else
 $(error Invalid ABI specified in ANDROID_ABI)


### PR DESCRIPTION
In the recent Android NDK, this executable path is switched.
