### PR TITLE
Harden RecursiveDirectoryIterator when walking the filesystem.

### DIFF
--- a/Foundation/include/Poco/DirectoryIteratorStrategy.h
+++ b/Foundation/include/Poco/DirectoryIteratorStrategy.h
@@ -30,6 +30,82 @@
 namespace Poco {
 
 
+class Foundation_API AbstractTraverseErrorCallback
+	/// This is the base class for all instantiations of
+	/// the TraverseErrorCallback template.
+{
+public:
+	AbstractTraverseErrorCallback()
+	{
+	}
+
+	AbstractTraverseErrorCallback(const AbstractTraverseErrorCallback& callback)
+	{
+	}
+
+	virtual ~AbstractTraverseErrorCallback()
+	{
+	}
+	
+	AbstractTraverseErrorCallback& operator = (const AbstractTraverseErrorCallback& callback)
+	{
+		return *this;
+	}
+
+	virtual void invoke(const std::string& path) const = 0;
+	virtual AbstractTraverseErrorCallback* clone() const = 0;
+};
+
+
+template <class C> 
+class TraverseErrorCallback: public AbstractTraverseErrorCallback
+	/// This template class implements an adapter that sits between
+	/// a TraverseBase iterator and an object's method invoked during a
+	/// directory read error.
+{
+public:
+	typedef void (C::*Callback)(const std::string& path);
+
+	TraverseErrorCallback(C& object, Callback method): _pObject(&object), _method(method)
+	{
+	}
+
+	TraverseErrorCallback(const TraverseErrorCallback& callback): _pObject(callback._pObject), _method(callback._method)
+	{
+	}
+
+	~TraverseErrorCallback()
+	{
+	}
+
+	TraverseErrorCallback& operator = (const TraverseErrorCallback& callback)
+	{
+		if (&callback != this)
+		{
+			_pObject = callback._pObject;
+			_method  = callback._method;
+		}
+		return *this;
+	}
+
+	void invoke(const std::string& path) const
+	{
+		(_pObject->*_method)(path);
+	}
+
+	AbstractTraverseErrorCallback* clone() const
+	{
+		return new TraverseErrorCallback(*this);
+	}
+
+private:
+	TraverseErrorCallback();
+
+	C*       _pObject;
+	Callback _method;
+};
+
+
 class Foundation_API TraverseBase
 {
 public:
@@ -43,13 +119,24 @@ public:
 
 	TraverseBase(DepthFunPtr depthDeterminer, UInt16 maxDepth = D_INFINITE);
 
+        TraverseBase& setOnError(const AbstractTraverseErrorCallback& cb);
+        	/// Binds the option to the given method.
+        	///
+        	/// The callback method will be called if the Traverse class fails
+		/// to read a directory. 
+        	///
+        	/// Usage:
+        	///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
+
 protected:
 	bool isFiniteDepth();
 	bool isDirectory(Poco::File& file);
+	void invokeOnError(const std::string& path) const;
 
 	DepthFunPtr _depthDeterminer;
 	UInt16 _maxDepth;
 	DirectoryIterator _itEnd;
+	AbstractTraverseErrorCallback* _pCallback;
 
 private:
 	TraverseBase();

--- a/Foundation/include/Poco/DirectoryIteratorStrategy.h
+++ b/Foundation/include/Poco/DirectoryIteratorStrategy.h
@@ -66,11 +66,15 @@ class TraverseErrorCallback: public AbstractTraverseErrorCallback
 public:
 	typedef void (C::*Callback)(const std::string& path);
 
-	TraverseErrorCallback(C& object, Callback method): _pObject(&object), _method(method)
+	TraverseErrorCallback(C& object, Callback method)
+        : _pObject(&object), 
+          _method(method)
 	{
 	}
 
-	TraverseErrorCallback(const TraverseErrorCallback& callback): _pObject(callback._pObject), _method(callback._method)
+	TraverseErrorCallback(const TraverseErrorCallback& callback)
+        : _pObject(callback._pObject), 
+          _method(callback._method)
 	{
 	}
 
@@ -119,14 +123,14 @@ public:
 
 	TraverseBase(DepthFunPtr depthDeterminer, UInt16 maxDepth = D_INFINITE);
 
-        TraverseBase& setOnError(const AbstractTraverseErrorCallback& cb);
-        	/// Binds the option to the given method.
-        	///
-        	/// The callback method will be called if the Traverse class fails
-		/// to read a directory. 
-        	///
-        	/// Usage:
-        	///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
+    TraverseBase& setOnError(const AbstractTraverseErrorCallback& cb);
+        /// Binds the option to the given method.
+        ///
+        /// The callback method will be called if the Traverse class fails
+        /// to read a directory. 
+        ///
+        /// Usage:
+        ///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
 
 protected:
 	bool isFiniteDepth();

--- a/Foundation/include/Poco/RecursiveDirectoryIterator.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIterator.h
@@ -135,14 +135,14 @@ public:
 		return _pImpl->maxDepth();
 	}
 
-        RecursiveDirectoryIterator& setOnError(const AbstractTraverseErrorCallback& cb)
-        	/// Binds the option to the given method.
-        	///
-        	/// The callback method will be called if the Traverse class fails
-		/// to read a directory. 
-        	///
-        	/// Usage:
-        	///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
+    RecursiveDirectoryIterator& setOnError(const AbstractTraverseErrorCallback& cb)
+        /// Binds the option to the given method.
+        ///
+        /// The callback method will be called if the Traverse class fails
+        /// to read a directory. 
+        ///
+        /// Usage:
+        ///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
 	{
 		_pImpl->setOnError(cb);
 		return *this;

--- a/Foundation/include/Poco/RecursiveDirectoryIterator.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIterator.h
@@ -135,6 +135,18 @@ public:
 		return _pImpl->maxDepth();
 	}
 
+        RecursiveDirectoryIterator& setOnError(const AbstractTraverseErrorCallback& cb)
+        	/// Binds the option to the given method.
+        	///
+        	/// The callback method will be called if the Traverse class fails
+		/// to read a directory. 
+        	///
+        	/// Usage:
+        	///     onError(TraverseErrorCallback<MyClass>(this, &MyClass::myCallback));
+	{
+		_pImpl->setOnError(cb);
+		return *this;
+	}
 
 	MyType& operator = (const MyType& it)
 	{
@@ -222,6 +234,7 @@ private:
 	ImplType* _pImpl;
 	Path _path;
 	File _file;
+	AbstractTraverseErrorCallback* _pCallback;	
 };
 
 

--- a/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
@@ -78,6 +78,13 @@ public:
 	{
 		return _current;
 	}
+
+        RecursiveDirectoryIteratorImpl& setOnError(const AbstractTraverseErrorCallback& cb)
+	{
+		_traverseStrategy.setOnError(cb);
+		return *this;
+	}
+
 	const std::string& next()
 	{
 		if (_isFinished)

--- a/Foundation/testsuite/src/DirectoryIteratorsTest.h
+++ b/Foundation/testsuite/src/DirectoryIteratorsTest.h
@@ -30,8 +30,9 @@ public:
 	void testDirectoryIterator();
 	void testSortedDirectoryIterator();
 	void testSimpleRecursiveDirectoryIterator();
+	void testSimpleRecursiveDirectoryIteratorOnError();
 	void testSiblingsFirstRecursiveDirectoryIterator();
-	
+	void testSiblingsFirstRecursiveDirectoryIteratorOnError();
 	void setUp();
 	void tearDown();
 
@@ -40,6 +41,8 @@ public:
 protected:
 	Poco::Path path() const;
 	void createSubdir(Poco::Path& p);
+	void onError(const std::string& path);
+	std::string _onErrorPath;
 
 private:
 };


### PR DESCRIPTION
In the implementation for the *Traverse strategies the next method performs an unguarded list directory.  If the directory is not accessible an unrecoverable error is raised thus ruining the walk.  This changeset adopts and adapts the error handling protocol as defined in Python's os.walk function where errors from listdir are ignored or are reported to an optional on error callback function.

Building a unittest to demonstrate this issue did not seem feasible as it would require the test program to contain privileges necessary to alter the access permissions of a directory then setuid to an alternative user.

To exercise this error condition I defined a folder structure as follows:

```
sudo ls -la test/
total 0
drwxr-xr-x   4 mjdorma  staff   136 29 Aug 03:10 .
drwxr-xr-x  62 mjdorma  staff  2108 29 Aug 04:48 ..
-rw-r--r--   1 mjdorma  staff     0 29 Aug 03:10 blah
drwxr-x---   3 root     wheel   102 29 Aug 03:10 hidden
```

I then added the following functions to the Foundation testsuite DirectoryIteratorsTest:

``` C++
void DirectoryIteratorsTest::onerror(const std::string& path)
{
    std::cout << "Error on: " << path << std::endl;
}

void DirectoryIteratorsTest::testSimpleRecursiveDirectoryIteratorProtectedTestDirs()
{
    Path p("./test");
    SimpleRecursiveDirectoryIterator dirIterator(p);
    dirIterator.setOnError(TraverseErrorCallback<DirectoryIteratorsTest>(*this, &DirectoryIteratorsTest::onerror));
    SimpleRecursiveDirectoryIterator end;
    std::vector<std::string> result;
    std::string file;

    while (dirIterator != end)
    {
        file = dirIterator->path();
        ++dirIterator;
        result.push_back(file);
    }
}
```

When ran:

```
$ Foundation/testsuite/bin/Darwin/x86_64/testrunner DirectoryIteratorsTest

testDirectoryIterator:
testSortedDirectoryIterator:
testSimpleRecursiveDirectoryIterator: Error on: test/hidden

testSiblingsFirstRecursiveDirectoryIterator:

OK (4 tests)
```

Desired result achieved.
