### PR TITLE
fix JSON stringify to escape special characters

### DIFF
--- a/JSON/src/Stringifier.cpp
+++ b/JSON/src/Stringifier.cpp
@@ -55,14 +55,10 @@ void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int inde
 	{
 		out << "null";
 	}
-	else if ( any.isString() )
+	else
 	{
 		std::string value = any.convert<std::string>();
 		formatString(value, out);
-	}
-	else
-	{
-		out << any.convert<std::string>();
 	}
 }
 


### PR DESCRIPTION
When converting from non string types the converted string was not escaped

Here is an example / testcase that was fixed by this PR.

```
template <typename T>
void PrintJSON(T&& v)
{
    std::stringstream ss;
    Poco::JSON::Array json;
    json.add(std::forward<T>(v));
    json.stringify(ss);
    std::cout << ss.str() << std::endl;
}

int main()
{
    std::string teststr = "hello \\ world";
    Poco::Dynamic::Array testvec{ teststr };

    PrintJSON(teststr);
    PrintJSON(testvec);
}
```

The code generated the following output. Notice that the second string is not valid JSON, because of the not escaped backslash.

```
["hello \\ world"]
[[ "hello \ world" ]]
```
