### PR TITLE
* Allows SecureStreamSocket::attach to be used in server connections

### DIFF
--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -358,7 +358,7 @@ long SecureSocketImpl::verifyPeerCertificateImpl(const std::string& hostName)
 {
 	Context::VerificationMode mode = _pContext->verificationMode();
 	if (mode == Context::VERIFY_NONE || !_pContext->extendedCertificateVerificationEnabled() ||
-	    (isLocalHost(hostName) && mode != Context::VERIFY_STRICT))
+	    (mode != Context::VERIFY_STRICT && isLocalHost(hostName)))
 	{
 		return X509_V_OK;
 	}

--- a/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
@@ -153,7 +153,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket)
 {
 	SecureStreamSocketImpl* pImpl = new SecureStreamSocketImpl(static_cast<StreamSocketImpl*>(streamSocket.impl()), SSLManager::instance().defaultClientContext());
 	SecureStreamSocket result(pImpl);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 
@@ -162,7 +165,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket, 
 {
 	SecureStreamSocketImpl* pImpl = new SecureStreamSocketImpl(static_cast<StreamSocketImpl*>(streamSocket.impl()), pContext);
 	SecureStreamSocket result(pImpl);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 
@@ -172,7 +178,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket, 
 	SecureStreamSocketImpl* pImpl = new SecureStreamSocketImpl(static_cast<StreamSocketImpl*>(streamSocket.impl()), pContext);
 	SecureStreamSocket result(pImpl);
 	result.useSession(pSession);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 
@@ -182,7 +191,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket, 
 	SecureStreamSocketImpl* pImpl = new SecureStreamSocketImpl(static_cast<StreamSocketImpl*>(streamSocket.impl()), SSLManager::instance().defaultClientContext());
 	SecureStreamSocket result(pImpl);
 	result.setPeerHostName(peerHostName);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 
@@ -192,7 +204,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket, 
 	SecureStreamSocketImpl* pImpl = new SecureStreamSocketImpl(static_cast<StreamSocketImpl*>(streamSocket.impl()), pContext);
 	SecureStreamSocket result(pImpl);
 	result.setPeerHostName(peerHostName);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 
@@ -203,7 +218,10 @@ SecureStreamSocket SecureStreamSocket::attach(const StreamSocket& streamSocket, 
 	SecureStreamSocket result(pImpl);
 	result.setPeerHostName(peerHostName);
 	result.useSession(pSession);
-	pImpl->connectSSL();
+	if (pImpl->context()->isForServerUse())
+      pImpl->acceptSSL();
+	else
+      pImpl->connectSSL();
 	return result;
 }
 


### PR DESCRIPTION
- Allows SecureStreamSocket::attach to be used in server connections
- Move order of condition for isLocalHost in peer certificate verification, to skip DNS lookup if not needed

fixes #539

I created a SSL client and server in Poco, and tested them with a Go client and server, and between them. The communication was successful in all cases.

I also changed the condition order for "isLocalHost", because it makes a DNS lookup, even when not needed.
