### PR TITLE
Fixed ODBC WString size handling.

### DIFF
--- a/Data/ODBC/src/Preparator.cpp
+++ b/Data/ODBC/src/Preparator.cpp
@@ -152,7 +152,8 @@ std::size_t Preparator::maxDataSize(std::size_t pos) const
 		sz = mc.length();
 
 		// accomodate for terminating zero (non-bulk only!)
-		if (!isBulk() && ODBCMetaColumn::FDT_STRING == mc.type()) ++sz;
+		MetaColumn::ColumnDataType type = mc.type();
+		if (!isBulk() && ((ODBCMetaColumn::FDT_WSTRING == type) || (ODBCMetaColumn::FDT_STRING == type))) ++sz;
 	}
 	catch (StatementException&) { }
 


### PR DESCRIPTION
This fixes a bug where Poco would return a string 1 character shorter than is actually in the DB (when the string in the DB uses the full length of a CHAR(N) or VARCHAR(N) column).

Test case:
MySQL 5.1 ODBC driver, database with table A, column B defined as CHAR(4), open session to the DB `session`.

``` cpp
string b = "1234";
session << "INSERT INTO A (B) VALUES (?)", bind(b), now;
session << "SELECT B FROM A", into(b), now;
assert(b == "1234");  // Fails; Poco returns b == "123"
```
