### PR TITLE
HashTable/SimpleHashTable DEBUG pre-processor fix

### DIFF
--- a/Foundation/include/Poco/HashTable.h
+++ b/Foundation/include/Poco/HashTable.h
@@ -327,7 +327,7 @@ public:
 		UInt32 numZeroEntries = 0;
 		UInt32 maxEntriesPerHash = 0;
 		std::vector<UInt32> detailedEntriesPerHash;
-	#ifdef DEBUG
+	#ifdef HASH_DEBUG
 		UInt32 totalSize = 0;
 	#endif
 		for (UInt32 i = 0; i < _maxCapacity; ++i)
@@ -340,7 +340,7 @@ public:
 					maxEntriesPerHash = size;
 				if (details)
 					detailedEntriesPerHash.push_back(size);
-	#ifdef DEBUG
+	#ifdef HASH_DEBUG
 				totalSize += size;
 	#endif
 			}
@@ -351,7 +351,7 @@ public:
 					detailedEntriesPerHash.push_back(0);
 			}
 		}
-	#ifdef DEBUG
+	#ifdef HASH_DEBUG
 		poco_assert_dbg(totalSize == numberOfEntries);
 	#endif
 		return HashStatistic(_maxCapacity, numberOfEntries, numZeroEntries, maxEntriesPerHash, detailedEntriesPerHash);

--- a/Foundation/include/Poco/SimpleHashTable.h
+++ b/Foundation/include/Poco/SimpleHashTable.h
@@ -369,7 +369,7 @@ public:
 				UInt32 size = 1;
 				if (details)
 					detailedEntriesPerHash.push_back(size);
-	#ifdef DEBUG
+	#ifdef HASH_DEBUG
 				totalSize += size;
 	#endif
 			}


### PR DESCRIPTION
Fix for `DEBUG` in the Poco HashTable headers.

Changes `DEBUG` to `HASH_DEBUG`

Fixes: https://github.com/pocoproject/poco/issues/544
