### PR TITLE
Adding Timestamp::raw

### DIFF
--- a/Foundation/include/Poco/Timestamp.h
+++ b/Foundation/include/Poco/Timestamp.h
@@ -106,6 +106,9 @@ public:
 	bool isElapsed(TimeDiff interval) const;
 		/// Returns true iff the given interval has passed
 		/// since the time denoted by the timestamp.
+
+   TimeVal raw() const;
+      /// Returns the raw time value.
 	
 	static Timestamp fromEpochTime(std::time_t t);
 		/// Creates a timestamp from a std::time_t.
@@ -241,6 +244,11 @@ inline Timestamp::TimeVal Timestamp::resolution()
 inline void swap(Timestamp& s1, Timestamp& s2)
 {
 	s1.swap(s2);
+}
+
+inline Timestamp::TimeVal Timestamp::raw() const
+{
+   return _ts;
 }
 
 


### PR DESCRIPTION
Returns the raw value, (the internal representation) of the timestamp. Currently equivalent to epochMicroseconds, but much clearer to use.
Useful when storing to a database for instance.
