### PR TITLE
Issue #585: use OSAtomicAdd32 which was available since iPhone 2.0 inste...

### DIFF
--- a/Foundation/include/Poco/AtomicCounter.h
+++ b/Foundation/include/Poco/AtomicCounter.h
@@ -193,26 +193,26 @@ inline AtomicCounter::ValueType AtomicCounter::value() const
 
 inline AtomicCounter::ValueType AtomicCounter::operator ++ () // prefix
 {
-	return OSAtomicIncrement32(&_counter);
+	return OSAtomicAdd32(1, &_counter);
 }
 
 	
 inline AtomicCounter::ValueType AtomicCounter::operator ++ (int) // postfix
 {
-	ValueType result = OSAtomicIncrement32(&_counter);
+	ValueType result = OSAtomicAdd32(1, &_counter);
 	return --result;
 }
 
 
 inline AtomicCounter::ValueType AtomicCounter::operator -- () // prefix
 {
-	return OSAtomicDecrement32(&_counter);
+	return OSAtomicAdd32(-1, &_counter);
 }
 
 	
 inline AtomicCounter::ValueType AtomicCounter::operator -- (int) // postfix
 {
-	ValueType result = OSAtomicDecrement32(&_counter);
+	ValueType result = OSAtomicAdd32(-1, &_counter);
 	return ++result;
 }
 


### PR DESCRIPTION
...ad of OSAtomicIncrement32 and OSAtomicDecrement32, which is iPhone 7.1+
