### PR TITLE
Options: allow to set option as hidden

### DIFF
--- a/Util/include/Poco/Util/Option.h
+++ b/Util/include/Poco/Util/Option.h
@@ -149,6 +149,9 @@ public:
 		/// The Option takes ownership of the Validator and
 		/// deletes it when it's no longer needed.
 
+    Option& hidden(bool hide);
+        /// Should the option be displayed to the user?
+
 	const std::string& shortName() const;
 		/// Returns the short name of the option.
 		
@@ -194,6 +197,9 @@ public:
 	AbstractConfiguration* config() const;
 		/// Returns the configuration, if specified, or NULL otherwise.
 		
+    bool hidden() const;
+        /// Return whether the option is displayed to the user on help
+
 	bool matchesShort(const std::string& option) const;
 		/// Returns true if the given option string matches the
 		/// short name.
@@ -242,6 +248,7 @@ private:
 	Validator*  _pValidator;
 	AbstractOptionCallback* _pCallback;
 	AbstractConfiguration*  _pConfig;
+    bool _hidden;
 };
 
 
@@ -325,6 +332,12 @@ inline Validator* Option::validator() const
 inline AbstractConfiguration* Option::config() const
 {
 	return _pConfig;
+}
+
+
+inline bool Option::hidden() const
+{
+	return _hidden;
 }
 
 

--- a/Util/src/HelpFormatter.cpp
+++ b/Util/src/HelpFormatter.cpp
@@ -126,6 +126,10 @@ int HelpFormatter::calcIndent() const
 	int indent = 0;
 	for (OptionSet::Iterator it = _options.begin(); it != _options.end(); ++it)
 	{
+        if (it->hidden())
+        {
+            continue;
+        }
 		int shortLen = (int) it->shortName().length();
 		int fullLen  = (int) it->fullName().length();
 		int n = 0;
@@ -155,6 +159,10 @@ void HelpFormatter::formatOptions(std::ostream& ostr) const
 	int optWidth = calcIndent();
 	for (OptionSet::Iterator it = _options.begin(); it != _options.end(); ++it)
 	{
+        if (it->hidden())
+        {
+            continue;
+        }
 		formatOption(ostr, *it, optWidth);
 		if (_indent < optWidth)
 		{

--- a/Util/src/Option.cpp
+++ b/Util/src/Option.cpp
@@ -53,7 +53,7 @@ Option::Option(const Option& option):
 	_binding(option._binding),
 	_pValidator(option._pValidator),
 	_pCallback(option._pCallback),
-	_pConfig(option._pConfig)
+	_pConfig(option._pConfig),
 	_hidden(option._hidden)
 {
 	if (_pValidator) _pValidator->duplicate();

--- a/Util/src/Option.cpp
+++ b/Util/src/Option.cpp
@@ -35,7 +35,8 @@ Option::Option():
 	_argRequired(false),
 	_pValidator(0),
 	_pCallback(0),
-	_pConfig(0)
+	_pConfig(0),
+	_hidden(false)
 {
 }
 
@@ -53,6 +54,7 @@ Option::Option(const Option& option):
 	_pValidator(option._pValidator),
 	_pCallback(option._pCallback),
 	_pConfig(option._pConfig)
+	_hidden(option._hidden)
 {
 	if (_pValidator) _pValidator->duplicate();
 	if (_pCallback) _pCallback = _pCallback->clone();
@@ -68,7 +70,8 @@ Option::Option(const std::string& fullName, const std::string& shortName):
 	_argRequired(false),
 	_pValidator(0),
 	_pCallback(0),
-	_pConfig(0)
+	_pConfig(0),
+	_hidden(false)
 {
 }
 
@@ -82,7 +85,8 @@ Option::Option(const std::string& fullName, const std::string& shortName, const 
 	_argRequired(false),
 	_pValidator(0),
 	_pCallback(0),
-	_pConfig(0)
+	_pConfig(0),
+	_hidden(false)
 {
 }
 
@@ -97,7 +101,8 @@ Option::Option(const std::string& fullName, const std::string& shortName, const 
 	_argRequired(argRequired),
 	_pValidator(0),
 	_pCallback(0),
-	_pConfig(0)
+	_pConfig(0),
+	_hidden(false)
 {
 }
 
@@ -135,6 +140,7 @@ void Option::swap(Option& option)
 	std::swap(_pValidator, option._pValidator);
 	std::swap(_pCallback, option._pCallback);
 	std::swap(_pConfig, option._pConfig);
+	std::swap(_hidden, option._hidden);
 }
 
 	
@@ -223,6 +229,13 @@ Option& Option::validator(Validator* pValidator)
 {
 	if (_pValidator) _pValidator->release();
 	_pValidator = pValidator;
+	return *this;
+}
+
+
+Option& Option::hidden(bool hide)
+{
+    _hidden = hide;
 	return *this;
 }
 


### PR DESCRIPTION
hidden options shall not be displayed to user on the help invocation

this can be useful when the option name is refactored but the old
usage is required to be preserved to prevent regression

Issue: Allow a program option to hide in the usage help display #609
