### PR TITLE
Fixed one-shot timer and maufunction of long start interval

### DIFF
--- a/Foundation/src/Timer.cpp
+++ b/Foundation/src/Timer.cpp
@@ -184,7 +184,7 @@ void Timer::run()
 		}
 		while (sleep < 0);
 
-		if (_wakeUp.tryWait(sleep > _periodicInterval ? _periodicInterval : sleep))
+		if (_wakeUp.tryWait(sleep))
 		{
 			Poco::FastMutex::ScopedLock lock(_mutex);
 			_nextInvocation.update();


### PR DESCRIPTION
This commit is basically a revert of d39a35378924f762e1eede02ef6e4e33d573b0f0, which was a fix for GH #230. There's a couple of regression bugs found in the patched code which caused one-shot timer failed to work and maulfunction of periodic timer with long start intervals.
- When a one-shot timer was started (`periodicInterval == 0`), it would always timeout immediately regardless of the value of `startInterval`;
- When a periodic timer was started, the first timeout would be triggered prematually when `startInterval` was larger than `periodicInterval`

The reverted fix was aimed to deal with inaccurate timeout introduced by manipulations of system time, however when Poco::Clock was integrated to the timer implementation, Poco::Timer would try to use monotonic timers when possible to make intervals irrevelant with the change of system time. So now this fix might be safely reverted.
