### PR TITLE
Logger::setLevel(string) - optionally parse log level as number in range 1 to 8

### DIFF
--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -19,6 +19,7 @@
 #include "Poco/LoggingRegistry.h"
 #include "Poco/Exception.h"
 #include "Poco/NumberFormatter.h"
+#include "Poco/NumberParser.h"
 #include "Poco/String.h"
 
 
@@ -432,7 +433,18 @@ int Logger::parseLevel(const std::string& level)
 	else if (icompare(level, "trace") == 0)
 		return Message::PRIO_TRACE;
 	else
-		throw InvalidArgumentException("Not a valid log level", level);
+	{
+		int numLevel;
+		if (Poco::NumberParser::tryParse(level, numLevel))
+		{
+			if (numLevel > 0 && numLevel < 9)
+				return numLevel;
+			else
+				throw InvalidArgumentException("Log level out of range ", level);
+		}
+		else
+			throw InvalidArgumentException("Not a valid log level", level);
+	}
 }
 
 

--- a/Foundation/testsuite/src/LoggerTest.cpp
+++ b/Foundation/testsuite/src/LoggerTest.cpp
@@ -142,6 +142,28 @@ void LoggerTest::testLogger()
 	pChannel->list().clear();
 	root.fatal("fatal");
 	assert (pChannel->list().begin()->getPriority() == Message::PRIO_FATAL);
+	
+	root.setLevel("1");
+	assert (root.getLevel() == Message::PRIO_FATAL);
+	root.setLevel("8");
+	assert (root.getLevel() == Message::PRIO_TRACE);
+	try
+	{
+		root.setLevel("0");
+		assert(0);
+	}
+	catch(Poco::InvalidArgumentException&)
+	{
+	}
+	try
+	{
+		root.setLevel("9");
+		assert(0);
+	}
+	catch(Poco::InvalidArgumentException&)
+	{
+	}
+
 }
 
 


### PR DESCRIPTION
Small extension to Logger::setLevel() behaviour. (Code+Test)
