### PR TITLE
Prevent possible data race in access to PooledThread::_idle

### DIFF
--- a/Foundation/src/ThreadPool.cpp
+++ b/Foundation/src/ThreadPool.cpp
@@ -128,6 +128,7 @@ void PooledThread::start(Thread::Priority priority, Runnable& target, const std:
 
 inline bool PooledThread::idle()
 {
+	FastMutex::ScopedLock lock(_mutex);
 	return _idle;
 }
 


### PR DESCRIPTION
I have a project using Poco ThreadPools, and I use Helgrind to detect data races.

This gives me the following output:
==4393== Possible data race during read of size 1 at 0x808E968 by thread #1
==4393== Locks held: 2, at addresses 0x808A668 0x80C6A68
==4393==    at 0x502F77A: Poco::PooledThread::idle() (ThreadPool.cpp:131)
==4393==    by 0x502F3D6: Poco::ThreadPool::getThread() (ThreadPool.cpp:451)
==4393==    by 0x502ED2E: Poco::ThreadPool::startWithPriority(Poco::Thread::Priority, Poco::Runnable&) (ThreadPool.cpp:359)
==4393==    by 0x5032031: Poco::Timer::start(Poco::AbstractTimerCallback const&, Poco::Thread::Priority, Poco::ThreadPool&) (Timer.cpp:84)
==4393==    by 0x5031E83: Poco::Timer::start(Poco::AbstractTimerCallback const&) (Timer.cpp:51)
==4393==    [ ... ]
==4393== 
==4393== This conflicts with a previous write of size 1 by thread #3
==4393== Locks held: 1, at address 0x808EB68
==4393==    at 0x502E4F2: Poco::PooledThread::run() (ThreadPool.cpp:220)
==4393==    by 0x502B8A0: Poco::(anonymous namespace)::RunnableHolder::run() (Thread.cpp:57)
==4393==    by 0x502B576: Poco::ThreadImpl::runnableEntry(void*) (Thread_POSIX.cpp:344)
==4393==    by 0x4C2F056: mythread_wrapper (hg_intercepts.c:234)
==4393==    by 0x6E910A3: start_thread (pthread_create.c:309)
==4393==    by 0x6BC5CCC: clone (clone.S:111)

The offending function is PooledThread::idle(), which accesses _idle without acquiring _mutex.
