### PR TITLE
do not guess mingw include/link dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,6 @@ endif(CMAKE_SYSTEM MATCHES "SunOS")
 if (CMAKE_COMPILER_IS_MINGW)
   add_definitions(-DWC_NO_BEST_FIT_CHARS=0x400  -DPOCO_WIN32_UTF8)
   add_definitions(-mno-cygwin -D_WIN32 -DMINGW32 -DWINVER=0x500 -DODBCVER=0x0300 -DPOCO_THREAD_STACK_SIZE -DFoundation_Config_INCLUDED )
-  link_directories(/usr/local/lib /usr/lib)
-  include_directories(/usr/local/include /usr/include)
 endif (CMAKE_COMPILER_IS_MINGW)
 
 if (CYGWIN)


### PR DESCRIPTION
let cmake do the job as we dont want mingw headers to conflict with system headers and libs, they are provided in a separate tree