### PR TITLE
class Cipher expressively says that it doesn't copy or move

### DIFF
--- a/Crypto/include/Poco/Crypto/Cipher.h
+++ b/Crypto/include/Poco/Crypto/Cipher.h
@@ -99,7 +99,10 @@ public:
 		ENC_BINHEX_NO_LF = 0x82, /// BinHex-encoded output, no linefeeds
 		
 	};
-
+	
+	Cipher(Cipher&&) = delete;
+		/// Expreesively says that Cipher doesn't copy or move.
+		
 	virtual ~Cipher();
 		/// Destroys the Cipher.
 
@@ -128,9 +131,6 @@ protected:
 	Cipher();
 		/// Creates a new Cipher object.
 
-private:
-	Cipher(const Cipher&);
-	Cipher& operator = (const Cipher&);
 };
 
 

--- a/Crypto/src/Cipher.cpp
+++ b/Crypto/src/Cipher.cpp
@@ -31,14 +31,10 @@ namespace Poco {
 namespace Crypto {
 
 
-Cipher::Cipher()
-{
-}
+Cipher::Cipher() = default;
 
 
-Cipher::~Cipher()
-{
-}
+Cipher::~Cipher() = default;
 
 
 std::string Cipher::encryptString(const std::string& str, Encoding encoding)

--- a/Foundation/src/ASCIIEncoding.cpp
+++ b/Foundation/src/ASCIIEncoding.cpp
@@ -49,14 +49,10 @@ const TextEncoding::CharacterMap ASCIIEncoding::_charMap =
 };
 
 
-ASCIIEncoding::ASCIIEncoding()
-{
-}
+ASCIIEncoding::ASCIIEncoding() = default;
 
 
-ASCIIEncoding::~ASCIIEncoding()
-{
-}
+ASCIIEncoding::~ASCIIEncoding() = default;
 
 
 const char* ASCIIEncoding::canonicalName() const


### PR DESCRIPTION
In C++14 we expressively delete what we don't need, and therefore we don't need
to make copy ctor or copy assignment operators private.
And defalted definition of defalt ctor and defaulted definition of destructor works
well so we shouldn't intervene.
