### PR TITLE
Cmake find package poco fixes

### DIFF
--- a/CppParser/cmake/PocoCppParserConfig.cmake
+++ b/CppParser/cmake/PocoCppParserConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoCppParserTargets.cmake")

--- a/Crypto/cmake/PocoCryptoConfig.cmake
+++ b/Crypto/cmake/PocoCryptoConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoCryptoTargets.cmake")

--- a/Data/MySQL/cmake/PocoDataMySQLConfig.cmake
+++ b/Data/MySQL/cmake/PocoDataMySQLConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoData)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoDataMySQLTargets.cmake")

--- a/Data/ODBC/cmake/PocoDataODBCConfig.cmake
+++ b/Data/ODBC/cmake/PocoDataODBCConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoData)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoDataODBCTargets.cmake")

--- a/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake
+++ b/Data/SQLite/cmake/PocoDataSQLiteConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoData)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoDataSQLiteTargets.cmake")

--- a/Data/cmake/PocoDataConfig.cmake
+++ b/Data/cmake/PocoDataConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoDataTargets.cmake")

--- a/JSON/cmake/PocoJSONConfig.cmake
+++ b/JSON/cmake/PocoJSONConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoJSONTargets.cmake")

--- a/MongoDB/cmake/PocoMongoDBConfig.cmake
+++ b/MongoDB/cmake/PocoMongoDBConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoNet)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoMongoDBTargets.cmake")

--- a/Net/cmake/PocoNetConfig.cmake
+++ b/Net/cmake/PocoNetConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoNetTargets.cmake")

--- a/NetSSL_OpenSSL/cmake/PocoNetSSLConfig.cmake
+++ b/NetSSL_OpenSSL/cmake/PocoNetSSLConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoUtil)
 find_dependency(PocoNet)

--- a/NetSSL_Win/cmake/PocoNetSSLWinConfig.cmake
+++ b/NetSSL_Win/cmake/PocoNetSSLWinConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoUtil)
 find_dependency(PocoNet)

--- a/PDF/cmake/PocoPDFConfig.cmake
+++ b/PDF/cmake/PocoPDFConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoPDFTargets.cmake")

--- a/SevenZip/cmake/PocoSevenZipConfig.cmake
+++ b/SevenZip/cmake/PocoSevenZipConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoXML)
 find_dependency(PocoUtil)

--- a/Util/cmake/PocoUtilConfig.cmake
+++ b/Util/cmake/PocoUtilConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoXML)
 find_dependency(PocoJSON)

--- a/XML/cmake/PocoXMLConfig.cmake
+++ b/XML/cmake/PocoXMLConfig.cmake
@@ -1,4 +1,3 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoXMLTargets.cmake")

--- a/Zip/cmake/PocoZipConfig.cmake
+++ b/Zip/cmake/PocoZipConfig.cmake
@@ -1,5 +1,4 @@
 include(CMakeFindDependencyMacro)
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PocoFoundation)
 find_dependency(PocoUtil)
 find_dependency(PocoXML)

--- a/cmake/PocoConfig.cmake.in
+++ b/cmake/PocoConfig.cmake.in
@@ -21,6 +21,10 @@ get_filename_component(_Poco_install_prefix "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE
 
 set(_Poco_NOTFOUND_MESSAGE)
 
+# Let components find each other, but don't overwrite CMAKE_PREFIX_PATH
+set(_Poco_CMAKE_PREFIX_PATH_old ${CMAKE_PREFIX_PATH})
+set(CMAKE_PREFIX_PATH ${_Poco_install_prefix})
+
 foreach(module ${Poco_FIND_COMPONENTS})
     find_package(Poco${module}
         ${_Poco_FIND_PARTS_QUIET}
@@ -38,6 +42,9 @@ foreach(module ${Poco_FIND_COMPONENTS})
     # For backward compatibility set the LIBRARIES variable
     list(APPEND Poco_LIBRARIES "Poco::${module}")
 endforeach()
+
+# Restore the original CMAKE_PREFIX_PATH value
+set(CMAKE_PREFIX_PATH ${_Poco_CMAKE_PREFIX_PATH_old})
 
 if (_Poco_NOTFOUND_MESSAGE)
     set(Poco_NOT_FOUND_MESSAGE "${_Poco_NOTFOUND_MESSAGE}")

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -195,7 +195,7 @@ endmacro()
 macro(POCO_GENERATE_PACKAGE target_name)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/Poco${target_name}ConfigVersion.cmake"
+  "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}ConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
 )


### PR DESCRIPTION
This fixes problems when a project adds a directory to `CMAKE_PREFIX_PATH`, then calls `find_package(Poco ...)` and afterwards calls `find_package()` for another project located in one of the directories of the original `CMAKE_PREFIX_PATH` variable.