### PR TITLE
Fix for BasicFIFOBuffer next()-based writing

### DIFF
--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -352,6 +352,11 @@ public:
 	T* begin()
 		/// Returns the pointer to the beginning of the buffer.
 	{
+		if (_begin != 0)
+		{
+			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
+			_begin = 0;
+		}
 		return _buffer.begin();
 	}
 
@@ -360,6 +365,12 @@ public:
 	{
 		if (available() == 0)
 			throw InvalidAccessException("Buffer is full.");
+
+		if (_begin != 0)
+		{
+			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
+			_begin = 0;
+		}
 
 		return _buffer.begin() + _used;
 	}

--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -284,7 +284,7 @@ public:
 	std::size_t available() const
 		/// Returns the size of the available portion of the buffer.
 	{
-		return _buffer.size() - _used;
+		return size() - _used;
 	}
 
 	void drain(std::size_t length = 0)
@@ -361,6 +361,9 @@ public:
 		Mutex::ScopedLock lock(_mutex);
 		if (_begin != 0)
 		{
+			// Move the data to the start of the buffer so begin() and next()
+			// always return consistent pointers with each other and allow writing
+			// to the end of the buffer.
 			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
 			_begin = 0;
 		}
@@ -371,16 +374,7 @@ public:
 		/// Returns the pointer to the next available position in the buffer.
 	{
 		Mutex::ScopedLock lock(_mutex);
-		if (available() == 0)
-			throw InvalidAccessException("Buffer is full.");
-
-		if (_begin != 0)
-		{
-			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
-			_begin = 0;
-		}
-
-		return _buffer.begin() + _used;
+		return begin() + _used;
 	}
 
 	T& operator [] (std::size_t index)

--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -344,6 +344,12 @@ public:
 		if (!isWritable())
 			throw Poco::InvalidAccessException("Buffer not writable.");
 
+		if (_buffer.size() - (_begin + _used) < length)
+		{
+			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
+			_begin = 0;
+		}
+
 		std::size_t usedBefore = _used;
 		_used += length;
 		if (_notify) notify(usedBefore);
@@ -352,6 +358,7 @@ public:
 	T* begin()
 		/// Returns the pointer to the beginning of the buffer.
 	{
+		Mutex::ScopedLock lock(_mutex);
 		if (_begin != 0)
 		{
 			std::memmove(_buffer.begin(), _buffer.begin() + _begin, _used * sizeof(T));
@@ -363,6 +370,7 @@ public:
 	T* next()
 		/// Returns the pointer to the next available position in the buffer.
 	{
+		Mutex::ScopedLock lock(_mutex);
 		if (available() == 0)
 			throw InvalidAccessException("Buffer is full.");
 

--- a/Foundation/testsuite/Makefile-Driver
+++ b/Foundation/testsuite/Makefile-Driver
@@ -39,7 +39,8 @@ objects = ActiveMethodTest ActivityTest ActiveDispatcherTest \
 	HashSetTest HashMapTest SharedMemoryTest \
 	UniqueExpireCacheTest UniqueExpireLRUCacheTest UnicodeConverterTest \
 	TuplesTest NamedTuplesTest TypeListTest VarTest DynamicTestSuite FileStreamTest \
-	MemoryStreamTest ObjectPoolTest DirectoryWatcherTest DirectoryIteratorsTest
+	MemoryStreamTest ObjectPoolTest DirectoryWatcherTest \
+	DirectoryIteratorsTest BufferTestSuite BasicFIFOBufferTest
 
 target         = testrunner
 target_version = 1

--- a/Foundation/testsuite/src/BasicFIFOBufferTest.cpp
+++ b/Foundation/testsuite/src/BasicFIFOBufferTest.cpp
@@ -14,6 +14,7 @@
 #include "CppUnit/TestCaller.h"
 #include "CppUnit/TestSuite.h"
 #include "Poco/FIFOBuffer.h"
+#include <iostream>
 #include <memory>
 #include <cstring>
 
@@ -38,6 +39,7 @@ void BasicFIFOBufferTest::testNextWrite()
 	BasicFIFOBuffer<char> buffer(128);
 	buffer.write(text.data(), text.size());
 	char c_buffer[buffer.size()];
+	std::memset(c_buffer, 0, buffer.size());
 	
 	buffer.read(c_buffer, 4);
 

--- a/Foundation/testsuite/src/BasicFIFOBufferTest.cpp
+++ b/Foundation/testsuite/src/BasicFIFOBufferTest.cpp
@@ -1,0 +1,85 @@
+//
+// BasicFIFOBufferTest.cpp
+//
+// $Id: //poco/1.4/Foundation/testsuite/src/BasicFIFOBufferTest.cpp#1 $
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "BasicFIFOBufferTest.h"
+#include "CppUnit/TestCaller.h"
+#include "CppUnit/TestSuite.h"
+#include "Poco/FIFOBuffer.h"
+#include <memory>
+#include <cstring>
+
+// NOTE: using for certain namespace
+using Poco::BasicFIFOBuffer;
+using std::memcpy;
+
+BasicFIFOBufferTest::BasicFIFOBufferTest(const std::string& name): CppUnit::TestCase(name)
+{
+}
+
+
+BasicFIFOBufferTest::~BasicFIFOBufferTest()
+{
+}
+
+
+void BasicFIFOBufferTest::testNextWrite()
+{
+	// String length is 88 characters.
+	std::string text("The Quick Brown Dog Jumps Over The Lazy Fox.");
+	BasicFIFOBuffer<char> buffer(128);
+	buffer.write(text.data(), text.size());
+	char c_buffer[buffer.size()];
+	
+	buffer.read(c_buffer, 4);
+
+	assert(std::string(c_buffer, 4) == std::string("The "));
+	
+	buffer.peek(c_buffer, buffer.used());
+	assert(std::string(c_buffer, buffer.used()) ==
+			std::string("Quick Brown Dog Jumps Over The Lazy Fox."));
+
+	memcpy(buffer.next(), "The ", 4);
+	buffer.advance(4);
+
+	buffer.peek(c_buffer, buffer.used());
+
+	assert(std::string("Quick Brown Dog Jumps Over The Lazy Fox.The ") == std::string(c_buffer, buffer.used()));
+
+	/*
+	std::istringstream istr("foo");
+	std::ostringstream ostr;
+	TeeInputStream tis(istr);
+	tis.addStream(ostr);
+	std::string s;
+	tis >> s;
+	assert (ostr.str() == "foo");
+	*/
+}
+
+void BasicFIFOBufferTest::setUp()
+{
+}
+
+
+void BasicFIFOBufferTest::tearDown()
+{
+}
+
+
+CppUnit::Test* BasicFIFOBufferTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("BasicFIFOBufferTest");
+
+	CppUnit_addTest(pSuite, BasicFIFOBufferTest, testNextWrite);
+
+	return pSuite;
+}

--- a/Foundation/testsuite/src/BasicFIFOBufferTest.h
+++ b/Foundation/testsuite/src/BasicFIFOBufferTest.h
@@ -1,0 +1,40 @@
+//
+// BasicFIFOBufferTest.h
+//
+// $Id: //poco/1.6/Foundation/testsuite/src/BasicFIFOBufferTest.h#1 $
+//
+// Definition of the BasicFIFOBufferTest class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef BasicFIFOBufferTest_INCLUDED
+#define BasicFIFOBufferTest_INCLUDED
+
+
+#include "Poco/Foundation.h"
+#include "CppUnit/TestCase.h"
+
+
+class BasicFIFOBufferTest: public CppUnit::TestCase
+{
+public:
+	BasicFIFOBufferTest(const std::string& name);
+	~BasicFIFOBufferTest();
+
+	void testNextWrite();
+
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+
+private:
+};
+
+
+#endif // BasicFIFOBufferTest_INCLUDED

--- a/Foundation/testsuite/src/BufferTestSuite.cpp
+++ b/Foundation/testsuite/src/BufferTestSuite.cpp
@@ -1,0 +1,24 @@
+//
+// BufferTestSuite.cpp
+//
+// $Id: //poco/1.4/Foundation/testsuite/src/BufferTestSuite.cpp#1 $
+//
+// Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "BufferTestSuite.h"
+#include "BasicFIFOBufferTest.h"
+
+
+CppUnit::Test* BufferTestSuite::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("BufferTestSuite");
+
+	pSuite->addTest(BasicFIFOBufferTest::suite());
+
+	return pSuite;
+}

--- a/Foundation/testsuite/src/BufferTestSuite.h
+++ b/Foundation/testsuite/src/BufferTestSuite.h
@@ -1,0 +1,29 @@
+//
+// BufferTestSuite.h
+//
+// $Id: //poco/1.6/Foundation/testsuite/src/BufferTestSuite.h#1 $
+//
+// Definition of the BufferTestSuite class.
+//
+// Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef BufferTestSuite_INCLUDED
+#define BufferTestSuite_INCLUDED
+
+
+#include "CppUnit/TestSuite.h"
+
+
+class BufferTestSuite
+{
+public:
+	static CppUnit::Test* suite();
+};
+
+
+#endif // BufferTestSuite_INCLUDED

--- a/Foundation/testsuite/src/FoundationTestSuite.cpp
+++ b/Foundation/testsuite/src/FoundationTestSuite.cpp
@@ -30,6 +30,7 @@
 #include "EventTestSuite.h"
 #include "CacheTestSuite.h"
 #include "HashingTestSuite.h"
+#include "BufferTestSuite.h"
 
 
 CppUnit::Test* FoundationTestSuite::suite()
@@ -39,6 +40,7 @@ CppUnit::Test* FoundationTestSuite::suite()
 	pSuite->addTest(CoreTestSuite::suite());
 	pSuite->addTest(DateTimeTestSuite::suite());
 	pSuite->addTest(StreamsTestSuite::suite());
+	pSuite->addTest(BufferTestSuite::suite());
 	pSuite->addTest(CryptTestSuite::suite());
 	pSuite->addTest(NotificationsTestSuite::suite());
 	pSuite->addTest(ThreadingTestSuite::suite());


### PR DESCRIPTION
This is the first pull request I've ever made, so let me know where I can improve.

This should fix issues with the StreamSocket implementation writing to a BasicFIFOBuffer derivative using the next() function to retreive a pointer to the first unused byte after the existing data. I couldn't think of a cleaner way other than just moving the memory to the front of the buffer otherwise weird stuff could happen with pointers, or 'iterators' if you prefer becoming invalid, so there's a chance for a small performance hit if you're not going to actually write to the end of the buffer.

I was told to make a test case, so I went and made a test suite for the BasicFIFOBuffer and included it in the commits(I hope this wasn't going too far, and hopefully I integrated it with the build properly):

```
// String length is 88 characters.
std::string text("The Quick Brown Dog Jumps Over The Lazy Fox.");
BasicFIFOBuffer<char> buffer(128);
buffer.write(text.data(), text.size());
char c_buffer[buffer.size()];
std::memset(c_buffer, 0, buffer.size());

buffer.read(c_buffer, 4);

assert(std::string(c_buffer, 4) == std::string("The "));

buffer.peek(c_buffer, buffer.used());
assert(std::string(c_buffer, buffer.used()) ==
std::string("Quick Brown Dog Jumps Over The Lazy Fox."));

memcpy(buffer.next(), "The ", 4);
buffer.advance(4);

buffer.peek(c_buffer, buffer.used());

assert(std::string("Quick Brown Dog Jumps Over The Lazy Fox.The ") == std::string(c_buffer, buffer.used()));
```