### PR TITLE
Enhancing error message to show correct way to setup libodbc path

### DIFF
--- a/Data/ODBC/ODBC.make
+++ b/Data/ODBC/ODBC.make
@@ -58,6 +58,6 @@ COMMONFLAGS += -DPOCO_IODBC -I/usr/include/iodbc
 COMMONFLAGS += -Wno-deprecated-declarations
 
 else
-$(error No ODBC library found. Please install unixODBC or iODBC or specify POCO_ODBC_LIB and try again)
+$(error No ODBC library found. Please install unixODBC or iODBC or specify POCO_ODBC_LIB or set the correct libodbc library path by using --odbc-lib as option to 'configure' script and try again)
 endif
 


### PR DESCRIPTION
While running make on poco I got below error message which was confusing since I had installed unixodbc on my Ubuntu 14.10. 

make[1]: Entering directory '/home/m1016632/github/poco/Data/ODBC'
ODBC.make:61: *** No ODBC library found. Please install unixODBC or iODBC or specify POCO_ODBC_LIB and try again.  Stop.
make[1]: Leaving directory '/home/m1016632/github/poco/Data/ODBC'
Makefile:191: recipe for target 'Data/ODBC-libexec' failed
make: *** [Data/ODBC-libexec] Error 2

m1016632@A2ML04601L:~/github/poco$ ls -l /usr/lib/i386-linux-gnu/libodbc*
-rw-r--r-- 1 root root 866062 May  1  2014 /usr/lib/i386-linux-gnu/libodbc.a
-rw-r--r-- 1 root root  98954 May  1  2014 /usr/lib/i386-linux-gnu/libodbccr.a
lrwxrwxrwx 1 root root     18 May  1  2014 /usr/lib/i386-linux-gnu/libodbccr.so -> libodbccr.so.2.0.0
lrwxrwxrwx 1 root root     14 May  1  2014 /usr/lib/i386-linux-gnu/libodbccr.so.1 -> libodbccr.so.2
lrwxrwxrwx 1 root root     18 May  1  2014 /usr/lib/i386-linux-gnu/libodbccr.so.2 -> libodbccr.so.2.0.0
-rw-r--r-- 1 root root  38332 May  1  2014 /usr/lib/i386-linux-gnu/libodbccr.so.2.0.0
-rw-r--r-- 1 root root 215466 May  1  2014 /usr/lib/i386-linux-gnu/libodbcinst.a
lrwxrwxrwx 1 root root     22 Apr  9  2014 /usr/lib/i386-linux-gnu/libodbcinstQ4.so.1 -> libodbcinstQ4.so.1.1.1
-rw-r--r-- 1 root root 705000 Apr  9  2014 /usr/lib/i386-linux-gnu/libodbcinstQ4.so.1.1.1
lrwxrwxrwx 1 root root     20 May  1  2014 /usr/lib/i386-linux-gnu/libodbcinst.so -> libodbcinst.so.2.0.0
lrwxrwxrwx 1 root root     16 May  1  2014 /usr/lib/i386-linux-gnu/libodbcinst.so.1 -> libodbcinst.so.2
lrwxrwxrwx 1 root root     20 May  1  2014 /usr/lib/i386-linux-gnu/libodbcinst.so.2 -> libodbcinst.so.2.0.0
-rw-r--r-- 1 root root  75312 May  1  2014 /usr/lib/i386-linux-gnu/libodbcinst.so.2.0.0
lrwxrwxrwx 1 root root     16 May  1  2014 /usr/lib/i386-linux-gnu/libodbc.so -> libodbc.so.2.0.0
lrwxrwxrwx 1 root root     12 May  1  2014 /usr/lib/i386-linux-gnu/libodbc.so.1 -> libodbc.so.2
lrwxrwxrwx 1 root root     16 May  1  2014 /usr/lib/i386-linux-gnu/libodbc.so.2 -> libodbc.so.2.0.0
-rw-r--r-- 1 root root 445968 May  1  2014 /usr/lib/i386-linux-gnu/libodbc.so.2.0.0

I did a little debugging and found that 'uname -m' was returning i686 but the location of libodbc libraries was '/usr/lib/i386-linux-gnu'. This was confusing. Later I setup correct path in  --odbc-lib and I was able to successfully build poco. I'm enhacing error message so that the user knows about --odbc-lib option to setup correct libodbc path. Hope this helps!

--Raju Kadam