### PR TITLE
fix: android arm64/x86_64 compile error with getdtablesize

### DIFF
--- a/Foundation/src/Process_UNIX.cpp
+++ b/Foundation/src/Process_UNIX.cpp
@@ -200,7 +200,7 @@ ProcessHandleImpl* ProcessImpl::launchByForkExecImpl(const std::string& command,
 		if (outPipe) outPipe->close(Pipe::CLOSE_BOTH);
 		if (errPipe) errPipe->close(Pipe::CLOSE_BOTH);
 		// close all open file descriptors other than stdin, stdout, stderr
-		for (int i = 3; i < getdtablesize(); ++i)
+		for (int i = 3; i < sysconf(_SC_OPEN_MAX); ++i)
 		{
 			close(i);
 		}


### PR DESCRIPTION
https://code.google.com/p/android/issues/detail?id=74387
https://codereview.chromium.org/349323003