### PR TITLE
Adding ostream operator for Poco::Net::IPAddress

### DIFF
--- a/Net/include/Poco/Net/NetworkInterface.h
+++ b/Net/include/Poco/Net/NetworkInterface.h
@@ -343,6 +343,7 @@ inline bool NetworkInterface::operator == (const NetworkInterface& other) const
 
 
 Net_API std::ostream& operator<<(std::ostream& os, const Poco::Net::NetworkInterface::MACAddress& mac);
+Net_API std::ostream& operator<<(std::ostream& os, const Poco::Net::IPAddress& ipAddress);
 
 
 #endif // POCO_NET_HAS_INTERFACE

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -56,6 +56,13 @@ std::ostream& operator<<(std::ostream& os, const Poco::Net::NetworkInterface::MA
 	return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const Poco::Net::IPAddress& ipAddress)
+{
+    os << ipAddress.toString();
+
+    return os;
+}
+
 
 namespace Poco {
 namespace Net {

--- a/Net/testsuite/src/NetworkInterfaceTest.cpp
+++ b/Net/testsuite/src/NetworkInterfaceTest.cpp
@@ -65,11 +65,11 @@ void NetworkInterfaceTest::testMap()
 			std::cout << std::endl << "----------" << std::endl;
 			std::cout << "Address " << counter << std::endl;
 			std::cout << "----------" << std::endl;
-			std::cout << "Address:     " << ipIt->get<NetworkInterface::IP_ADDRESS>().toString() << std::endl;
+			std::cout << "Address:     " << ipIt->get<NetworkInterface::IP_ADDRESS>() << std::endl;
 			IPAddress addr = ipIt->get<NetworkInterface::SUBNET_MASK>();
-			if (!addr.isWildcard()) std::cout << "Subnet:      " << addr.toString() << " (/" << addr.prefixLength() << ")" << std::endl;
+			if (!addr.isWildcard()) std::cout << "Subnet:      " << addr << " (/" << addr.prefixLength() << ")" << std::endl;
 			addr = ipIt->get<NetworkInterface::BROADCAST_ADDRESS>();
-			if (!addr.isWildcard()) std::cout << "Broadcast:   " << addr.toString() << std::endl;
+			if (!addr.isWildcard()) std::cout << "Broadcast:   " << addr << std::endl;
 		}
 
 		std::cout << "=============" << std::endl << std::endl;
@@ -100,11 +100,11 @@ void NetworkInterfaceTest::testList()
 		List::const_iterator ipEnd = ipList.end();
 		for (int counter = 0; ipIt != ipEnd; ++ipIt, ++counter)
 		{
-			std::cout << "IP Address:  " << ipIt->get<NetworkInterface::IP_ADDRESS>().toString() << std::endl;
+			std::cout << "IP Address:  " << ipIt->get<NetworkInterface::IP_ADDRESS>() << std::endl;
 			IPAddress addr = ipIt->get<NetworkInterface::SUBNET_MASK>();
-			if (!addr.isWildcard()) std::cout << "Subnet:      " << ipIt->get<NetworkInterface::SUBNET_MASK>().toString() << " (/" << ipIt->get<NetworkInterface::SUBNET_MASK>().prefixLength() << ")" << std::endl;
+			if (!addr.isWildcard()) std::cout << "Subnet:      " << ipIt->get<NetworkInterface::SUBNET_MASK>() << " (/" << ipIt->get<NetworkInterface::SUBNET_MASK>().prefixLength() << ")" << std::endl;
 			addr = ipIt->get<NetworkInterface::BROADCAST_ADDRESS>();
-			if (!addr.isWildcard()) std::cout << "Broadcast:   " << ipIt->get<NetworkInterface::BROADCAST_ADDRESS>().toString() << std::endl;
+			if (!addr.isWildcard()) std::cout << "Broadcast:   " << ipIt->get<NetworkInterface::BROADCAST_ADDRESS>() << std::endl;
 		}
 
 		std::cout << "==============" << std::endl << std::endl;
@@ -180,7 +180,7 @@ void NetworkInterfaceTest::testMapIpOnly()
 	{
 		assert(it->second.supportsIPv4() || it->second.supportsIPv6());
 		std::cout << "Interface: (" << it->second.index() << ")" << std::endl;
-		std::cout << "Address:    " << it->second.address().toString() << std::endl;
+		std::cout << "Address:    " << it->second.address() << std::endl;
 		NetworkInterface::MACAddress mac(it->second.macAddress());
 		if (!mac.empty() && (it->second.type() != NetworkInterface::NI_TYPE_SOFTWARE_LOOPBACK))
 			std::cout << "MAC Address:" << mac << std::endl;


### PR DESCRIPTION
I found that there is no ostream operator for Poco::Net::IPAddress. Hence adding the same which will result in less typing :). I have modified NetworkInterfaceTest.cpp to ensure ostream operator is called. I also ran NetworkInterfaceTest after re-building the project and it passed successfully.