### PR TITLE
Replace std::auto_ptr with std::unique_ptr

### DIFF
--- a/ApacheConnector/src/ApacheConnector.cpp
+++ b/ApacheConnector/src/ApacheConnector.cpp
@@ -174,21 +174,21 @@ extern "C" int ApacheConnector_handler(request_rec *r)
 		if ((rv = ap_setup_client_block(r, REQUEST_CHUNKED_DECHUNK))) 
 			return rv; 
 
-		std::auto_ptr<ApacheServerRequest> pRequest(new ApacheServerRequest(
+		std::unique_ptr<ApacheServerRequest> pRequest(new ApacheServerRequest(
 			&rec, 
 			r->connection->local_ip, 
 			r->connection->local_addr->port,
 			r->connection->remote_ip, 
 			r->connection->remote_addr->port));
 
-		std::auto_ptr<ApacheServerResponse> pResponse(new ApacheServerResponse(pRequest.get()));
+		std::unique_ptr<ApacheServerResponse> pResponse(new ApacheServerResponse(pRequest.get()));
 
 		// add header information to request
 		rec.copyHeaders(*pRequest);
 		
 		try
 		{
-			std::auto_ptr<HTTPRequestHandler> pHandler(app.factory().createRequestHandler(*pRequest));
+			std::unique_ptr<HTTPRequestHandler> pHandler(app.factory().createRequestHandler(*pRequest));
 
 			if (pHandler.get())
 			{				

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # Setup C/C++ compiler options
 #################################################################################
 
+# setup c++11 support
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 if(NOT MSVC_IDE)
   if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/CppUnit/include/CppUnit/TestCaller.h
+++ b/CppUnit/include/CppUnit/TestCaller.h
@@ -81,7 +81,7 @@ protected:
 
 private:
 	TestMethod             _test;
-	std::auto_ptr<Fixture> _fixture;
+	std::unique_ptr<Fixture> _fixture;
 };
 
 

--- a/Foundation/include/Poco/DynamicFactory.h
+++ b/Foundation/include/Poco/DynamicFactory.h
@@ -89,7 +89,7 @@ public:
 
 		FastMutex::ScopedLock lock(_mutex);
 
-		std::auto_ptr<AbstractFactory> ptr(pAbstractFactory);
+		std::unique_ptr<AbstractFactory> ptr(pAbstractFactory);
 		typename FactoryMap::iterator it = _map.find(className);
 		if (it == _map.end())
 			_map[className] = ptr.release();

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -59,7 +59,7 @@ void pad(std::string& str, int precision, int width, char prefix = ' ', char dec
 	std::string::size_type frac = str.length() - decSepPos - 1;
 
 	std::string::size_type ePos = str.find_first_of("eE");
-	std::auto_ptr<std::string> eStr;
+	std::unique_ptr<std::string> eStr;
 	if (ePos != std::string::npos)
 	{
 		eStr.reset(new std::string(str.substr(ePos, std::string::npos)));

--- a/Foundation/testsuite/src/DynamicFactoryTest.cpp
+++ b/Foundation/testsuite/src/DynamicFactoryTest.cpp
@@ -68,8 +68,8 @@ void DynamicFactoryTest::testDynamicFactory()
 	
 	assert (!dynFactory.isClass("C"));
 	
-	std::auto_ptr<A> a(dynamic_cast<A*>(dynFactory.createInstance("A")));
-	std::auto_ptr<B> b(dynamic_cast<B*>(dynFactory.createInstance("B")));
+	std::unique_ptr<A> a(dynamic_cast<A*>(dynFactory.createInstance("A")));
+	std::unique_ptr<B> b(dynamic_cast<B*>(dynFactory.createInstance("B")));
 	
 	assertNotNull(a.get());
 	assertNotNull(b.get());
@@ -89,7 +89,7 @@ void DynamicFactoryTest::testDynamicFactory()
 	
 	try
 	{
-		std::auto_ptr<B> b(dynamic_cast<B*>(dynFactory.createInstance("B")));
+		std::unique_ptr<B> b(dynamic_cast<B*>(dynFactory.createInstance("B")));
 		fail("unregistered - must throw");
 	}
 	catch (Poco::NotFoundException&)

--- a/Foundation/testsuite/src/LoggingFactoryTest.cpp
+++ b/Foundation/testsuite/src/LoggingFactoryTest.cpp
@@ -113,7 +113,7 @@ void LoggingFactoryTest::testBuiltins()
 
 void LoggingFactoryTest::testCustom()
 {
-	std::auto_ptr<LoggingFactory> fact(new LoggingFactory);
+	std::unique_ptr<LoggingFactory> fact(new LoggingFactory);
 	
 	fact->registerChannelClass("CustomChannel", new Instantiator<CustomChannel, Channel>);
 	fact->registerFormatterClass("CustomFormatter", new Instantiator<CustomFormatter, Formatter>);

--- a/Net/samples/download/src/download.cpp
+++ b/Net/samples/download/src/download.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 	try
 	{
 		URI uri(argv[1]);
-		std::auto_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
+		std::unique_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
 		StreamCopier::copyStream(*pStr.get(), std::cout);
 	}
 	catch (Exception& exc)

--- a/Net/src/HTTPServerConnection.cpp
+++ b/Net/src/HTTPServerConnection.cpp
@@ -78,7 +78,7 @@ void HTTPServerConnection::run()
 					response.set("Server", server);
 				try
 				{
-					std::auto_ptr<HTTPRequestHandler> pHandler(_pFactory->createRequestHandler(request));
+					std::unique_ptr<HTTPRequestHandler> pHandler(_pFactory->createRequestHandler(request));
 					if (pHandler.get())
 					{
 						if (request.expectContinue())

--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -110,7 +110,7 @@ void TCPServerDispatcher::run()
 			TCPConnectionNotification* pCNf = dynamic_cast<TCPConnectionNotification*>(pNf.get());
 			if (pCNf)
 			{
-				std::auto_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
+				std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
 				poco_check_ptr(pConnection.get());
 				beginConnection();
 				pConnection->start();

--- a/Net/testsuite/src/FTPStreamFactoryTest.cpp
+++ b/Net/testsuite/src/FTPStreamFactoryTest.cpp
@@ -81,7 +81,7 @@ void FTPStreamFactoryTest::testDownload()
 	uri.setPort(server.port());
 	uri.setPath("/test.txt;type=a");
 	FTPStreamFactory sf;
-	std::auto_ptr<std::istream> pStr(sf.open(uri));
+	std::unique_ptr<std::istream> pStr(sf.open(uri));
 
 	std::ostringstream dataStr;
 	StreamCopier::copyStream(*pStr.get(), dataStr);
@@ -119,7 +119,7 @@ void FTPStreamFactoryTest::testList()
 	uri.setPort(server.port());
 	uri.setPath("/usr/guest/data;type=d");
 	FTPStreamFactory sf;
-	std::auto_ptr<std::istream> pStr(sf.open(uri));
+	std::unique_ptr<std::istream> pStr(sf.open(uri));
 
 	std::ostringstream dataStr;
 	StreamCopier::copyStream(*pStr.get(), dataStr);
@@ -157,7 +157,7 @@ void FTPStreamFactoryTest::testUserInfo()
 	uri.setPath("/test.txt;type=a");
 	uri.setUserInfo("user:secret");
 	FTPStreamFactory sf;
-	std::auto_ptr<std::istream> pStr(sf.open(uri));
+	std::unique_ptr<std::istream> pStr(sf.open(uri));
 
 	std::ostringstream dataStr;
 	StreamCopier::copyStream(*pStr.get(), dataStr);
@@ -196,7 +196,7 @@ void FTPStreamFactoryTest::testPasswordProvider()
 	uri.setPath("/test.txt;type=a");
 	uri.setUserInfo("user");
 	FTPStreamFactory sf;
-	std::auto_ptr<std::istream> pStr(sf.open(uri));
+	std::unique_ptr<std::istream> pStr(sf.open(uri));
 
 	std::ostringstream dataStr;
 	StreamCopier::copyStream(*pStr.get(), dataStr);
@@ -226,7 +226,7 @@ void FTPStreamFactoryTest::testMissingPasswordProvider()
 	try
 	{
 		FTPStreamFactory sf;
-		std::auto_ptr<std::istream> pStr(sf.open(uri));
+		std::unique_ptr<std::istream> pStr(sf.open(uri));
 		fail("no password provider - must throw");
 	}
 	catch (FTPException&)

--- a/Net/testsuite/src/HTTPStreamFactoryTest.cpp
+++ b/Net/testsuite/src/HTTPStreamFactoryTest.cpp
@@ -46,7 +46,7 @@ void HTTPStreamFactoryTest::testNoRedirect()
 	HTTPStreamFactory factory;
 	URI uri("http://localhost/large");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPTestServer::LARGE_BODY);
@@ -59,7 +59,7 @@ void HTTPStreamFactoryTest::testEmptyPath()
 	HTTPStreamFactory factory;
 	URI uri("http://localhost");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPTestServer::SMALL_BODY);
@@ -73,7 +73,7 @@ void HTTPStreamFactoryTest::testRedirect()
 	opener.registerStreamFactory("http", new HTTPStreamFactory);
 	URI uri("http://localhost/redirect");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(opener.open(uri));
+	std::unique_ptr<std::istream> pStr(opener.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPTestServer::LARGE_BODY);
@@ -85,7 +85,7 @@ void HTTPStreamFactoryTest::testProxy()
 	HTTPTestServer server;
 	HTTPStreamFactory factory("localhost", server.port());
 	URI uri("http://www.somehost.com/large");
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPTestServer::LARGE_BODY);

--- a/Net/testsuite/src/WebSocketTest.cpp
+++ b/Net/testsuite/src/WebSocketTest.cpp
@@ -51,7 +51,7 @@ namespace
 			try
 			{
 				WebSocket ws(request, response);
-				std::auto_ptr<char> pBuffer(new char[_bufSize]);
+				std::unique_ptr<char> pBuffer(new char[_bufSize]);
 				int flags;
 				int n;
 				do

--- a/NetSSL_OpenSSL/samples/download/src/download.cpp
+++ b/NetSSL_OpenSSL/samples/download/src/download.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
 	try
 	{
 		URI uri(argv[1]);
-		std::auto_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
+		std::unique_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
 		StreamCopier::copyStream(*pStr.get(), std::cout);
 	}
 	catch (Exception& exc)

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSStreamFactoryTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSStreamFactoryTest.cpp
@@ -49,7 +49,7 @@ void HTTPSStreamFactoryTest::testNoRedirect()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost/large");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::LARGE_BODY);
@@ -62,7 +62,7 @@ void HTTPSStreamFactoryTest::testEmptyPath()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::SMALL_BODY);
@@ -75,7 +75,7 @@ void HTTPSStreamFactoryTest::testRedirect()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost/redirect");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::LARGE_BODY);
@@ -90,7 +90,7 @@ void HTTPSStreamFactoryTest::testProxy()
 		Application::instance().config().getInt("testsuite.proxy.port")
 	);
 	URI uri("https://secure.appinf.com/public/poco/NetSSL.txt");
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str().length() > 0);

--- a/NetSSL_OpenSSL/testsuite/src/WebSocketTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/WebSocketTest.cpp
@@ -51,7 +51,7 @@ namespace
 			try
 			{
 				WebSocket ws(request, response);
-				std::auto_ptr<char> pBuffer(new char[_bufSize]);
+				std::unique_ptr<char> pBuffer(new char[_bufSize]);
 				int flags;
 				int n;
 				do

--- a/NetSSL_Win/samples/download/src/download.cpp
+++ b/NetSSL_Win/samples/download/src/download.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
 	try
 	{
 		URI uri(argv[1]);
-		std::auto_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
+		std::unique_ptr<std::istream> pStr(URIStreamOpener::defaultOpener().open(uri));
 		StreamCopier::copyStream(*pStr.get(), std::cout);
 	}
 	catch (Exception& exc)

--- a/NetSSL_Win/testsuite/src/HTTPSStreamFactoryTest.cpp
+++ b/NetSSL_Win/testsuite/src/HTTPSStreamFactoryTest.cpp
@@ -49,7 +49,7 @@ void HTTPSStreamFactoryTest::testNoRedirect()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost/large");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::LARGE_BODY);
@@ -62,7 +62,7 @@ void HTTPSStreamFactoryTest::testEmptyPath()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::SMALL_BODY);
@@ -75,7 +75,7 @@ void HTTPSStreamFactoryTest::testRedirect()
 	HTTPSStreamFactory factory;
 	URI uri("https://localhost/redirect");
 	uri.setPort(server.port());
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str() == HTTPSTestServer::LARGE_BODY);
@@ -90,7 +90,7 @@ void HTTPSStreamFactoryTest::testProxy()
 		Application::instance().config().getInt("testsuite.proxy.port")
 	);
 	URI uri("https://secure.appinf.com/public/poco/NetSSL.txt");
-	std::auto_ptr<std::istream> pStr(factory.open(uri));
+	std::unique_ptr<std::istream> pStr(factory.open(uri));
 	std::ostringstream ostr;
 	StreamCopier::copyStream(*pStr.get(), ostr);
 	assert (ostr.str().length() > 0);

--- a/PageCompiler/src/PageCompiler.cpp
+++ b/PageCompiler/src/PageCompiler.cpp
@@ -285,7 +285,7 @@ protected:
 			p.setBaseName(clazz);
 		}
 
-		std::auto_ptr<CodeWriter> pCodeWriter(createCodeWriter(page, clazz));
+		std::unique_ptr<CodeWriter> pCodeWriter(createCodeWriter(page, clazz));
 
 		if (!_outputDir.empty())
 		{

--- a/PocoDoc/src/PocoDoc.cpp
+++ b/PocoDoc/src/PocoDoc.cpp
@@ -263,7 +263,7 @@ protected:
 	void parse(const std::string& file)
 	{
 		logger().information("Preprocessing " + file);
-		std::auto_ptr<Preprocessor> pPreProc(preprocess(file));
+		std::unique_ptr<Preprocessor> pPreProc(preprocess(file));
 		
 		logger().information("Parsing " + file);
 		if (pPreProc->stream().good())


### PR DESCRIPTION
This should solve issue #619.

This pull requests also contains a little change to the CMakeLists.txt file. It adds the "-std=c++" switch to CMAKE_CXX_FLAGS to enable c++11 compiler support. I don't know if this is right in the toplevel CMakeLists file, please let me know if it should be done in the approriate subfiles.