### PR TITLE
Added new static method to OpenSSLInitializer, disableSSLInitialization()

### DIFF
--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -44,7 +44,7 @@ namespace Crypto {
 
 
 class Crypto_API OpenSSLInitializer
-	/// Initializes the OpenSSL library.
+	/// Initalizes the OpenSSL library.
 	///
 	/// The class ensures the earliest initialization and the
 	/// latest shutdown of the OpenSSL library.
@@ -68,6 +68,8 @@ public:
 	static void enableFIPSMode(bool enabled);
 		// Enable or disable FIPS mode. If FIPS is not available, this method doesn't do anything.
 
+    static void disableSSLInitialization(); // Call if OpenSSL is already being initialized by another component before constructing any OpenSSLInitializers.
+
 protected:
 	enum
 	{
@@ -84,6 +86,8 @@ protected:
 private:
 	static Poco::FastMutex* _mutexes;
 	static Poco::AtomicCounter _rc;
+    static bool _disableSSLInitialization;
+    static bool _setupMultiThreadSupport;
 };
 
 
@@ -109,6 +113,11 @@ inline void OpenSSLInitializer::enableFIPSMode(bool /*enabled*/)
 {
 }
 #endif
+
+inline void OpenSSLInitializer::disableSSLInitialization()
+{
+    _disableSSLInitialization = true;
+}
 
 
 } } // namespace Poco::Crypto

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -87,7 +87,6 @@ private:
 	static Poco::FastMutex* _mutexes;
 	static Poco::AtomicCounter _rc;
     static bool _disableSSLInitialization;
-    static bool _setupMultiThreadSupport;
 };
 
 

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -36,7 +36,7 @@ namespace Crypto {
 
 Poco::FastMutex* OpenSSLInitializer::_mutexes(0);
 Poco::AtomicCounter OpenSSLInitializer::_rc;
-
+bool OpenSSLInitializer::_disableSSLInitialization = false;
 
 OpenSSLInitializer::OpenSSLInitializer()
 {
@@ -64,18 +64,21 @@ void OpenSSLInitializer::initialize()
 #if OPENSSL_VERSION_NUMBER >= 0x0907000L
 		OPENSSL_config(NULL);
 #endif
-		SSL_library_init();
-		SSL_load_error_strings();
-		OpenSSL_add_all_algorithms();
-		
+        if(! _disableSSLInitialization) {
+		    SSL_library_init();
+		    SSL_load_error_strings();
+		    OpenSSL_add_all_algorithms();
+        }
+
 		char seed[SEEDSIZE];
 		RandomInputStream rnd;
 		rnd.read(seed, sizeof(seed));
 		RAND_seed(seed, SEEDSIZE);
 		
-		int nMutexes = CRYPTO_num_locks();
-		_mutexes = new Poco::FastMutex[nMutexes];
-		CRYPTO_set_locking_callback(&OpenSSLInitializer::lock);
+        if(CRYPTO_get_locking_callback() == NULL) {
+    		int nMutexes = CRYPTO_num_locks();
+	    	_mutexes = new Poco::FastMutex[nMutexes];
+    		CRYPTO_set_locking_callback(&OpenSSLInitializer::lock);
 #ifndef POCO_OS_FAMILY_WINDOWS
 // Not needed on Windows (see SF #110: random unhandled exceptions when linking with ssl).
 // https://sourceforge.net/p/poco/bugs/110/
@@ -84,11 +87,12 @@ void OpenSSLInitializer::initialize()
 // "If the application does not register such a callback using CRYPTO_THREADID_set_callback(), 
 //  then a default implementation is used - on Windows and BeOS this uses the system's 
 //  default thread identifying APIs"
-		CRYPTO_set_id_callback(&OpenSSLInitializer::id);
+	    	CRYPTO_set_id_callback(&OpenSSLInitializer::id);
 #endif
-		CRYPTO_set_dynlock_create_callback(&OpenSSLInitializer::dynlockCreate);
-		CRYPTO_set_dynlock_lock_callback(&OpenSSLInitializer::dynlock);
-		CRYPTO_set_dynlock_destroy_callback(&OpenSSLInitializer::dynlockDestroy);
+		    CRYPTO_set_dynlock_create_callback(&OpenSSLInitializer::dynlockCreate);
+		    CRYPTO_set_dynlock_lock_callback(&OpenSSLInitializer::dynlock);
+		    CRYPTO_set_dynlock_destroy_callback(&OpenSSLInitializer::dynlockDestroy);
+        }
 	}
 }
 
@@ -97,15 +101,21 @@ void OpenSSLInitializer::uninitialize()
 {
 	if (--_rc == 0)
 	{
-		EVP_cleanup();
-		ERR_free_strings();
-		CRYPTO_set_locking_callback(0);
+        if(_mutexes != NULL) {
+		    CRYPTO_set_dynlock_create_callback(0);
+		    CRYPTO_set_dynlock_lock_callback(0);
+		    CRYPTO_set_dynlock_destroy_callback(0);
+		    CRYPTO_set_locking_callback(0);
 #ifndef POCO_OS_FAMILY_WINDOWS
-		CRYPTO_set_id_callback(0);
+		    CRYPTO_set_id_callback(0);
 #endif
-		delete [] _mutexes;
-		
-		CONF_modules_free();
+		    delete [] _mutexes;
+		}
+        if(! _disableSSLInitialization) {
+    		EVP_cleanup();
+	    	ERR_free_strings();
+    		CONF_modules_free();
+        }
 	}
 }
 


### PR DESCRIPTION
This allows the caller to inform Poco that the Open SSL library has already been initialized outside of Poco, for example in main(), so it doesn't re-initialize it, and, more importantly, uninitialized it when the last OpenSSLInitializer goes out of scope.