### PR TITLE
CMake: Remove odbc32 from SYSLIBS on windows

### DIFF
--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -61,9 +61,6 @@ find_package(Cygwin)
 
 if(WIN32)
   add_definitions( -DPOCO_OS_FAMILY_WINDOWS -DUNICODE -D_UNICODE -D__LCC__)  #__LCC__ define used by MySQL.h
-  if(ENABLE_DATA_ODBC)
-	set(SYSLIBS ${SYSLIBS} odbc32)
-  endif(ENABLE_DATA_ODBC)
 endif(WIN32)
 
 if (UNIX AND NOT ANDROID )


### PR DESCRIPTION
obdc32 is already added to the libraries by FindODBC