### PR TITLE
Fix #817 - Use std::list instead of std::set for storing elements in Document

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Document.h
+++ b/MongoDB/include/Poco/MongoDB/Document.h
@@ -185,7 +185,7 @@ protected:
 
 inline Document& Document::addElement(Element::Ptr element)
 {
-	_elements.insert(element);
+	_elements.push_back(element);
 	return *this;
 }
 

--- a/MongoDB/include/Poco/MongoDB/Element.h
+++ b/MongoDB/include/Poco/MongoDB/Element.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <set>
+#include <list>
 
 
 namespace Poco {
@@ -76,17 +76,7 @@ inline std::string Element::name() const
 }
 
 
-class ElementComparator
-{
-public:
-	bool operator()(const Element::Ptr& s1, const Element::Ptr& s2)
-	{
-		return s1->name() < s2->name();
-	}
-};
-
-
-typedef std::set<Element::Ptr, ElementComparator> ElementSet;
+typedef std::list<Element::Ptr> ElementSet;
 
 
 template<typename T> 

--- a/MongoDB/samples/SQLToMongo/src/SQLToMongo.cpp
+++ b/MongoDB/samples/SQLToMongo/src/SQLToMongo.cpp
@@ -234,7 +234,7 @@ void sample5(Poco::MongoDB::Connection& connection)
 
 	// When orderby is needed, use 2 separate documents in the query selector
 	cursor.query().selector().addNewDocument("$query").add("birthyear", 1987);
-	cursor.query().selector().addNewDocument("$orderby").add("lastname", 0);
+	cursor.query().selector().addNewDocument("$orderby").add("lastname", -1);
 
 	Poco::MongoDB::ResponseMessage& response = cursor.next(connection);
 	while(1)
@@ -410,7 +410,7 @@ void sample11(Poco::MongoDB::Connection& connection)
 
 	if ( response.hasDocuments() )
 	{
-		std::cout << "Count: " << response.documents()[0]->get<double>("n") << std::endl;
+		std::cout << "Count: " << response.documents()[0]->get<int>("n") << std::endl;
 	}
 }
 

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -120,7 +120,7 @@ void Document::read(BinaryReader& reader)
 		}
 
 		element->read(reader);
-		_elements.insert(element);
+		_elements.push_back(element);
 
 		reader >> type;
 	}

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -410,6 +410,29 @@ void MongoDBTest::testObjectID()
 }
 
 
+void MongoDBTest::testCommand() {
+	Poco::MongoDB::Database db("team");
+	Poco::SharedPtr<Poco::MongoDB::QueryRequest> command = db.createCommand();
+	command->selector().add("create", "fixCol")
+		.add("capped", true)
+		.add("max", 1024*1024)
+		.add("size", 1024);
+
+	Poco::MongoDB::ResponseMessage response;
+	_mongo.sendRequest(*command, response);
+	if ( response.documents().size() > 0 )
+	{
+		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
+		std::cout << doc->toString(2);
+	}
+	else
+	{
+		Poco::MongoDB::Document::Ptr lastError = db.getLastErrorDoc(_mongo);
+		std::cout << "LastError: " << lastError->toString(2) << std::endl;
+		fail("Didn't get a response from the  command");
+	}
+}
+
 CppUnit::Test* MongoDBTest::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("MongoDBTest");
@@ -425,6 +448,7 @@ CppUnit::Test* MongoDBTest::suite()
 	CppUnit_addTest(pSuite, MongoDBTest, testBuildInfo);
 	CppUnit_addTest(pSuite, MongoDBTest, testCursorRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testObjectID);
+	CppUnit_addTest(pSuite, MongoDBTest, testCommand);
 
 	return pSuite;
 }

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -41,6 +41,7 @@ public:
 	void testConnectionPool();
 	void testCursorRequest();
 	void testObjectID();
+	void testCommand();
 	void setUp();
 	void tearDown();
 


### PR DESCRIPTION
This also contains a small fix in the SQLToMongo sample program: $orderby (sample 5) must be -1 or 1.