### PR TITLE
  Update OpenSSL initialize to use alse not deprecated code

### DIFF
--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -87,7 +87,12 @@ void OpenSSLInitializer::initialize()
 // "If the application does not register such a callback using CRYPTO_THREADID_set_callback(), 
 //  then a default implementation is used - on Windows and BeOS this uses the system's 
 //  default thread identifying APIs"
-	    	CRYPTO_set_id_callback(&OpenSSLInitializer::id);
+#ifndef OPENSSL_NO_DEPRECATED
+		    CRYPTO_set_id_callback(&OpenSSLInitializer::id);
+#else
+		    CRYPTO_THREADID tid;
+		    CRYPTO_THREADID_set_numeric(&tid, OpenSSLInitializer::id());
+#endif /* OPENSSL_NO_DEPRECATED */
 #endif
 		    CRYPTO_set_dynlock_create_callback(&OpenSSLInitializer::dynlockCreate);
 		    CRYPTO_set_dynlock_lock_callback(&OpenSSLInitializer::dynlock);
@@ -107,7 +112,12 @@ void OpenSSLInitializer::uninitialize()
 		    CRYPTO_set_dynlock_destroy_callback(0);
 		    CRYPTO_set_locking_callback(0);
 #ifndef POCO_OS_FAMILY_WINDOWS
+#ifndef OPENSSL_NO_DEPRECATED
 		    CRYPTO_set_id_callback(0);
+#else
+		    CRYPTO_THREADID tid;
+		    CRYPTO_THREADID_set_numeric(&tid, 0);
+#endif /* OPENSSL_NO_DEPRECATED */
 #endif
 		    delete [] _mutexes;
 		}

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -65,9 +65,6 @@ find_package(Cygwin)
 
 if(WIN32)
   add_definitions( -DPOCO_OS_FAMILY_WINDOWS -DUNICODE -D_UNICODE -D__LCC__)  #__LCC__ define used by MySQL.h
-  if(ENABLE_DATA_ODBC)
-	set(SYSLIBS ${SYSLIBS} odbc32)
-  endif(ENABLE_DATA_ODBC)
 endif(WIN32)
 
 if (UNIX AND NOT ANDROID )


### PR DESCRIPTION
OpenSSL's 1.0.2a `CRYPTO_set_id_callback` [is deprecated](https://github.com/openssl/openssl/blob/master/include/openssl/crypto.h#L450) and it is not defined if OpenSSL is compiled with `no-deprecated` option.

It's used directly `CRYPTO_THREADID_set_numeric` because, as stated [here](https://www.openssl.org/docs/crypto/threads.html), 
> should use CRYPTO_THREADID_set_numeric() if thread IDs are numeric

and `OpenSSLInitializer::id` returns an [unsigned long](https://github.com/pocoproject/poco/blob/develop/Crypto/src/OpenSSLInitializer.cpp#L132).

This patch use OpenSSL symbol to check and use OpenSSL compiled with deprecated code and with newer and not deprecated ones.