### PR TITLE
Poco 1.6.1: collection of improvements

### DIFF
--- a/MongoDB/Makefile
+++ b/MongoDB/Makefile
@@ -14,7 +14,7 @@ objects = Array Binary Connection Cursor DeleteRequest  Database \
 	Document Element GetMoreRequest InsertRequest JavaScriptCode \
 	KillCursorsRequest Message MessageHeader ObjectId QueryRequest \
 	RegularExpression ReplicaSet RequestMessage ResponseMessage \
-	UpdateRequest
+	UpdateRequest UUID
 
 target         = PocoMongoDB
 target_version = $(LIBVERSION)

--- a/MongoDB/include/Poco/MongoDB/Array.h
+++ b/MongoDB/include/Poco/MongoDB/Array.h
@@ -62,7 +62,7 @@ public:
 		/// An empty element will be returned when the element is not found.
 
 	template<typename T>
-	bool isType(int pos)
+	bool isType(int pos) const
 		/// Returns true when the type of the element equals the TypeId of ElementTrait
 	{
 		return Document::isType<T>(Poco::NumberFormatter::format(pos));

--- a/MongoDB/include/Poco/MongoDB/Binary.h
+++ b/MongoDB/include/Poco/MongoDB/Binary.h
@@ -101,16 +101,21 @@ struct ElementTraits<Binary::Ptr>
 template<>
 inline void BSONReader::read<Binary::Ptr>(Binary::Ptr& to)
 {
-	Poco::Int32 size;
-	_reader >> size;
+	// Size and subtype are read in Document when distinguishing UUID and other binary types.
+	// TODO: Is it necessary to add some kind of detection if these attributes were already
+	//       set to instance of Binary?
+	if (0) {
+		Poco::Int32 size;
+		_reader >> size;
 
-	to->buffer().resize(size);
+		to->buffer().resize(size);
 
-	unsigned char subtype;
-	_reader >> subtype;
-	to->subtype(subtype);
-	
-	_reader.readRaw((char*) to->buffer().begin(), size);
+		unsigned char subtype;
+		_reader >> subtype;
+		to->subtype(subtype);
+	}
+	Buffer<unsigned char>& buffer = to->buffer();
+	_reader.readRaw((char*) buffer.begin(), buffer.size());
 }
 
 

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -45,7 +45,7 @@ public:
 	virtual ~Database();
 		/// Destructor
 
-	double count(Connection& connection, const std::string& collectionName) const;
+	Int64 count(Connection& connection, const std::string& collectionName) const;
 		/// Sends a count request for the given collection to MongoDB. When
 		/// the command fails, -1 is returned.
 

--- a/MongoDB/include/Poco/MongoDB/Document.h
+++ b/MongoDB/include/Poco/MongoDB/Document.h
@@ -154,7 +154,7 @@ public:
 		/// An empty element will be returned when the element is not found.
 
 	template<typename T>
-	bool isType(const std::string& name)
+	bool isType(const std::string& name) const
 		/// Returns true when the type of the element equals the TypeId of ElementTrait
 	{
 		Element::Ptr element = get(name);

--- a/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
+++ b/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
@@ -77,9 +77,9 @@ class PooledConnection
 	/// Helper class for borrowing and returning a connection automatically from a pool.
 {
 public:
-	PooledConnection(Poco::ObjectPool<Connection, Connection::Ptr>& pool) : _pool(pool)
+	PooledConnection(Poco::ObjectPool<Connection, Connection::Ptr>& pool, long timeoutMilliseconds = 0) : _pool(pool)
 	{
-		_connection = _pool.borrowObject();
+		_connection = _pool.borrowObject(timeoutMilliseconds);
 	}
 
 	virtual ~PooledConnection()

--- a/MongoDB/include/Poco/MongoDB/UUID.h
+++ b/MongoDB/include/Poco/MongoDB/UUID.h
@@ -1,0 +1,112 @@
+//
+// UUID.h
+//
+// $Id$
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  UUID
+//
+// Definition of the UUID binary class.
+//
+// Copyright (c) 2015, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_UUID_INCLUDED
+#define MongoDB_UUID_INCLUDED
+
+#include "Poco/UUID.h"
+
+#include "Poco/MongoDB/MongoDB.h"
+#include "Poco/MongoDB/Element.h"
+
+namespace Poco {
+namespace MongoDB {
+
+class MongoDB_API UUID
+	/// Implements BSON UUID. It's a wrapper around a Poco::UUID.
+{
+public:
+	typedef SharedPtr<UUID> Ptr;
+
+	static const Poco::Int32    uuidSize;
+	static const unsigned char  uuidSubtypeOld;
+	static const unsigned char  uuidSubtype;
+
+	UUID();
+		/// Constructor
+
+	UUID(const Poco::UUID& uuid);
+		/// Constructor
+
+	virtual ~UUID();
+		/// Destructor
+
+	Poco::UUID&  uuid();
+		/// Returns a reference to the uuid
+
+	std::string toString(int indent = 0) const;
+		/// Returns the string representation of UUID
+
+private:
+
+	Poco::UUID  _uuid;
+};
+
+inline Poco::UUID& UUID::uuid()
+{
+	return _uuid;
+}
+
+// BSON Embedded Document
+// spec: UUID
+template<>
+struct ElementTraits<UUID::Ptr>
+{
+	enum { TypeId = 0x05 };
+
+	static std::string toString(const UUID::Ptr& value, int indent = 0)
+	{
+		return value.isNull() ? "" : value->toString();
+	}
+};
+
+
+template<>
+inline void BSONReader::read<UUID::Ptr>(UUID::Ptr& to)
+{
+	Poco::Int32 size;
+	_reader >> size;
+
+	// TODO: Verify that size is UUID::uuidSize!
+
+	unsigned char subtype;
+	_reader >> subtype;
+	
+	// TODO: Verify that subtype is UUID::uuidSubtype or UUID::uuidSubtypeOld!
+
+	char uuidBuf[UUID::uuidSize];
+	_reader.readRaw(uuidBuf, size);
+	to->uuid().copyFrom(uuidBuf);
+}
+
+
+template<>
+inline void BSONWriter::write<UUID::Ptr>(UUID::Ptr& from)
+{
+	_writer << from->uuidSize;
+	_writer << from->uuidSubtype;
+	char uuidBuf[UUID::uuidSize];
+	from->uuid().copyTo(uuidBuf);
+	_writer.writeRaw(uuidBuf, from->uuidSize);
+}
+
+
+} } // namespace Poco::MongoDB
+
+
+#endif // MongoDB_UUID_INCLUDED

--- a/MongoDB/include/Poco/MongoDB/UUID.h
+++ b/MongoDB/include/Poco/MongoDB/UUID.h
@@ -33,9 +33,9 @@ class MongoDB_API UUID
 public:
 	typedef SharedPtr<UUID> Ptr;
 
-	static const Poco::Int32    uuidSize;
-	static const unsigned char  uuidSubtypeOld;
-	static const unsigned char  uuidSubtype;
+	static const Poco::Int32    uuidSize = (128/8);
+	static const unsigned char  uuidSubtypeOld = 0x03;
+	static const unsigned char  uuidSubtype = 0x04;
 
 	UUID();
 		/// Constructor

--- a/MongoDB/include/Poco/MongoDB/UUID.h
+++ b/MongoDB/include/Poco/MongoDB/UUID.h
@@ -79,18 +79,24 @@ struct ElementTraits<UUID::Ptr>
 template<>
 inline void BSONReader::read<UUID::Ptr>(UUID::Ptr& to)
 {
-	Poco::Int32 size;
-	_reader >> size;
+	// Size and subtype are read in Document when distinguishing UUID and other binary types.
+	// TODO: Is it necessary to add some kind of detection if these attributes were already
+	//       taken into account?
 
-	// TODO: Verify that size is UUID::uuidSize!
+	if (0) {
+		Poco::Int32 size;
+		_reader >> size;
 
-	unsigned char subtype;
-	_reader >> subtype;
-	
-	// TODO: Verify that subtype is UUID::uuidSubtype or UUID::uuidSubtypeOld!
+		// TODO: Verify that size is UUID::uuidSize!
+
+		unsigned char subtype;
+		_reader >> subtype;
+
+		// TODO: Verify that subtype is UUID::uuidSubtype or UUID::uuidSubtypeOld!
+	}
 
 	char uuidBuf[UUID::uuidSize];
-	_reader.readRaw(uuidBuf, size);
+	_reader.readRaw(uuidBuf, UUID::uuidSize);
 	to->uuid().copyFrom(uuidBuf);
 }
 

--- a/MongoDB/src/Array.cpp
+++ b/MongoDB/src/Array.cpp
@@ -59,7 +59,7 @@ std::string Array::toString(int indent) const
 
 		for(int i = 0; i < indent; ++i) oss << ' ';
 
-		oss << (*it)->toString();
+		oss << (*it)->toString(indent);
 	}
 
 	if ( indent > 0 )

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -32,7 +32,7 @@ Database::~Database()
 }
 
 
-double Database::count(Connection& connection, const std::string& collectionName) const
+Int64 Database::count(Connection& connection, const std::string& collectionName) const
 {
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> countRequest = createCountRequest(collectionName);
 
@@ -42,7 +42,16 @@ double Database::count(Connection& connection, const std::string& collectionName
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		return doc->get<double>("n");
+
+		if (doc->isType<double>("n")) {
+			return static_cast<Int64>(doc->get<double>("n"));
+		}
+		else if (doc->isType<Int32>("n")) {
+			return doc->get<Int32>("n");
+		}
+		else if (doc->isType<Int64>("n")) {
+			return doc->get<Int64>("n");
+		}
 	}
 
 	return -1;

--- a/MongoDB/src/UUID.cpp
+++ b/MongoDB/src/UUID.cpp
@@ -1,0 +1,46 @@
+//
+// UUID.cpp
+//
+// $Id$
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  UUID
+//
+// Implementation of the UUID class.
+//
+// Copyright (c) 2015, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/MongoDB/UUID.h"
+
+
+namespace Poco {
+namespace MongoDB {
+
+const Poco::Int32    UUID::uuidSize = 128/8;
+const unsigned char  UUID::uuidSubtypeOld = 0x03;
+const unsigned char  UUID::uuidSubtype = 0x04;
+
+UUID::UUID()
+{
+}
+
+UUID::UUID(const Poco::UUID& uuid) : _uuid(uuid)
+{
+}
+
+UUID::~UUID()
+{
+}
+
+std::string UUID::toString(int indent) const
+{
+	return _uuid.toString();
+}
+
+} } // namespace Poco::MongoDB

--- a/MongoDB/src/UUID.cpp
+++ b/MongoDB/src/UUID.cpp
@@ -22,9 +22,13 @@
 namespace Poco {
 namespace MongoDB {
 
+// Workaround for issue with MS C++ compiler
+// https://connect.microsoft.com/VisualStudio/feedback/details/786583/in-class-static-const-member-initialization-and-lnk2005
+#ifndef _MSC_EXTENSIONS
 const Poco::Int32    UUID::uuidSize;
 const unsigned char  UUID::uuidSubtypeOld;
 const unsigned char  UUID::uuidSubtype;
+#endif
 
 UUID::UUID()
 {

--- a/MongoDB/src/UUID.cpp
+++ b/MongoDB/src/UUID.cpp
@@ -22,9 +22,9 @@
 namespace Poco {
 namespace MongoDB {
 
-const Poco::Int32    UUID::uuidSize = 128/8;
-const unsigned char  UUID::uuidSubtypeOld = 0x03;
-const unsigned char  UUID::uuidSubtype = 0x04;
+const Poco::Int32    UUID::uuidSize;
+const unsigned char  UUID::uuidSubtypeOld;
+const unsigned char  UUID::uuidSubtype;
 
 UUID::UUID()
 {

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -148,9 +148,9 @@ void MongoDBTest::testQueryRequest()
 			bool active = doc->get<bool>("active");
 			assert(!active);
 
-            assert(doc->isType<UUID::Ptr>("an_uuid"));
-            UUID::Ptr dbUuid = doc->get<UUID::Ptr>("an_uuid");
-            assert(dbUuid->uuid() == uuid);
+			assert(doc->isType<UUID::Ptr>("an_uuid"));
+			UUID::Ptr dbUuid = doc->get<UUID::Ptr>("an_uuid");
+			assert(dbUuid->uuid() == uuid);
 
 			std::string id = doc->get("_id")->toString();
 			std::cout << id << std::endl;
@@ -229,8 +229,8 @@ void MongoDBTest::testDBAggregateCommand()
 		.add("_id", "$lastname")
 		.addNewDocument("total_hits").add("$sum", "$hits");
 
-	pipeline->add("step0", match);
-	pipeline->add("step1", group);
+	pipeline->add("0", match);
+	pipeline->add("1", group);
 
 	Database db("team");
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = db.createCommand();

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -21,6 +21,7 @@
 #include "Poco/MongoDB/Database.h"
 #include "Poco/MongoDB/Cursor.h"
 #include "Poco/MongoDB/ObjectId.h"
+#include "Poco/MongoDB/UUID.h"
 
 #include "Poco/Net/NetException.h"
 
@@ -34,6 +35,7 @@ using namespace Poco::MongoDB;
 bool MongoDBTest::_connected = false;
 Poco::MongoDB::Connection MongoDBTest::_mongo;
 
+static Poco::UUID uuid("0489c502-e127-4312-b629-3870c9dddc07");
 
 MongoDBTest::MongoDBTest(const std::string& name): 
 	CppUnit::TestCase("MongoDB"),
@@ -103,6 +105,8 @@ void MongoDBTest::testInsertRequest()
 
 	player->add("unknown", NullValue());
 
+    player->add("an_uuid", UUID::Ptr(new UUID(uuid)));
+
 	Poco::MongoDB::InsertRequest request("team.players");
 	request.documents().push_back(player);
 	_mongo.sendRequest(request);
@@ -141,6 +145,10 @@ void MongoDBTest::testQueryRequest()
 			assert(doc->isType<NullValue>("unknown"));
 			bool active = doc->get<bool>("active");
 			assert(!active);
+
+            assert(doc->isType<UUID::Ptr>("an_uuid"));
+            UUID::Ptr dbUuid = doc->get<UUID::Ptr>("an_uuid");
+            assert(dbUuid->uuid() == uuid);
 
 			std::string id = doc->get("_id")->toString();
 			std::cout << id << std::endl;
@@ -221,7 +229,16 @@ void MongoDBTest::testCountCommand()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		double count = doc->get<double>("n");
+        Poco::Int64 count = -1;
+        if (doc->isType<double>("n")) {
+            count = static_cast<Poco::Int64>(doc->get<double>("n"));
+        }
+        else if (doc->isType<Poco::Int32>("n")) {
+            count = doc->get<Poco::Int32>("n");
+        }
+        else if (doc->isType<Poco::Int64>("n")) {
+            count = doc->get<Poco::Int64>("n");
+        }
 		assert(count == 1);
 	}
 	else
@@ -248,7 +265,16 @@ void MongoDBTest::testDBCountCommand()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		double count = doc->get<double>("n");
+		Poco::Int64 count = -1;
+        if (doc->isType<double>("n")) {
+            count = static_cast<Poco::Int64>(doc->get<double>("n"));
+        }
+        else if (doc->isType<Poco::Int32>("n")) {
+            count = doc->get<Poco::Int32>("n");
+        }
+        else if (doc->isType<Poco::Int64>("n")) {
+            count = doc->get<Poco::Int64>("n");
+        }
 		assert(count == 1);
 	}
 	else
@@ -267,7 +293,7 @@ void MongoDBTest::testDBCount2Command()
 	}
 
 	Poco::MongoDB::Database db("team");
-	double count = db.count(_mongo, "players");
+	int count = db.count(_mongo, "players");
 	assert(count == 1);
 }
 
@@ -390,7 +416,16 @@ void MongoDBTest::testConnectionPool()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		double count = doc->get<double>("n");
+        Poco::Int64 count = -1;
+        if (doc->isType<double>("n")) {
+            count = static_cast<Poco::Int64>(doc->get<double>("n"));
+        }
+        else if (doc->isType<Poco::Int32>("n")) {
+            count = doc->get<Poco::Int32>("n");
+        }
+        else if (doc->isType<Poco::Int64>("n")) {
+            count = doc->get<Poco::Int64>("n");
+        }
 		assert(count == 1);
 	}
 	else

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -33,6 +33,7 @@ public:
 	void testInsertRequest();
 	void testQueryRequest();
 	void testDBQueryRequest();
+	void testDBAggregateCommand();
 	void testCountCommand();
 	void testDBCountCommand();
 	void testDBCount2Command();


### PR DESCRIPTION
1. Allow using const reference to Document and Array without casting away constness to get its type.
2. Add timeout to ObjectPool not to return null immediately if max capacity is exhausted.
3. Pass indentation parameter to array elements
4. Poco::MongoDB::UUID to handle BSON UUID type 0x04
5. Handle different types of "n" attribute in the response from count request.