### PR TITLE
add 'log' to SYSLIBS when compiling Foundation for android

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -104,6 +104,10 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
 	set_target_properties( "${LIBNAME}" PROPERTIES LINK_FLAGS "-library=stlport4")
 endif (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
 
+if(ANDROID)
+	set(SYSLIBS ${SYSLIBS} log)
+endif(ANDROID)
+
 # TODO: Why is this here?
 add_definitions( -DPCRE_STATIC)
 


### PR DESCRIPTION
This should help with #814 .

Without it you get the following error.
```
Linking CXX shared library ../lib/libPocoFoundation.so
CMakeFiles/Foundation.dir/src/AndroidLogChannel.cpp.o:AndroidLogChannel.cpp:function Poco::AndroidLogChannel::log(Poco::Message const&): error: undefined reference to '__android_log_print'
collect2: error: ld returned 1 exit status
make[2]: *** [lib/libPocoFoundation.so] Error 1
make[1]: *** [Foundation/CMakeFiles/Foundation.dir/all] Error 2
make: *** [all] Error 2
```

I was able to get the android build to work with cmake using the toolchain found https://github.com/taka-no-me/android-cmake .