### PR TITLE
cmake improvements for msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ option(POCO_UNBUNDLED
 if(MSVC)
     option(POCO_MT
       "Set to OFF|ON (default is OFF) to control build of POCO as /MT instead of /MD" OFF)
+
+    option(ENABLE_MSVC_MP
+      "Set to OFF|ON (default is OFF) to control parallel build of POCO with MSVC" OFF)
 endif()
 
 # Uncomment from next two lines to force static or dynamic library, default is autodetection

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -40,6 +40,11 @@ if(MSVC)
     else(POCO_MT)
         set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
     endif(POCO_MT)
+      
+    if (ENABLE_MSVC_MP)
+      add_definitions(/MP)
+    endif()
+    
 else(MSVC)
     # Other compilers then MSVC don't have a static STATIC_POSTFIX at the moment
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -250,4 +250,31 @@ install(
     RUNTIME DESTINATION bin
     INCLUDES DESTINATION include
     )
+
+# install the targets pdb
+POCO_INSTALL_PDB(${target_name})
+  
+endmacro()
+
+#  POCO_INSTALL_PDB - Install the given target's companion pdb file (if present)
+#    Usage: POCO_INSTALL_PDB(target_name)
+#      INPUT:
+#           target_name             the name of the target. e.g. Foundation for PocoFoundation
+#    Example: POCO_INSTALL_PDB(Foundation)
+#
+#    This is an internal macro meant only to be used by POCO_INSTALL.
+macro(POCO_INSTALL_PDB target_name)
+    if (NOT MSVC)
+        return()
+    endif()
+
+    get_property(type TARGET ${target_name} PROPERTY TYPE)
+    if ("${type}" STREQUAL "SHARED_LIBRARY" OR "${type}" STREQUAL "EXECUTABLE")
+        install(
+            FILES $<TARGET_PDB_FILE:${target_name}>
+            DESTINATION bin
+            COMPONENT Devel
+            OPTIONAL
+            )
+    endif()
 endmacro()


### PR DESCRIPTION
I made two small but important improvements for the cmake build using Visual Studio. 

The first enhancement is to add a cmake option ``ENABLE_MSVC_MP``. When ON, this option uses the /MP compiler flag for MSVC. This change required adding the option to the top-level ``CMakeLists.txt`` and then using the option in ``cmake/DefinePlatformSpecifc.cmake``. I have the default setting OFF, so it will not adversely affect anyone's current build scripts. But by enabling it, build speed scales to the number of cores used, which means on my 8-core laptop, poco builds 8 times faster when using this option. 

The second enhancement is to install the pdb files using the macro ``POCO_INSTALL_PDB`` added to the file ``cmake/PocoMacros.cmake``. Including pdb files in a development installation makes it much easier for other developers to reuse a build of poco. 

I hope you find this pull request useful.