### PR TITLE
Database::count() can parse different types of 'n' attribute in result.

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -45,7 +45,7 @@ public:
 	virtual ~Database();
 		/// Destructor
 
-	int count(Connection& connection, const std::string& collectionName) const;
+	Int64 count(Connection& connection, const std::string& collectionName) const;
 		/// Sends a count request for the given collection to MongoDB. When
 		/// the command fails, -1 is returned.
 

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -23,7 +23,7 @@ namespace Poco {
 namespace MongoDB {
 
 
-Database::Database( const std::string& db) : _dbname(db)
+Database::Database(const std::string& db) : _dbname(db)
 {
 }
 
@@ -32,7 +32,7 @@ Database::~Database()
 }
 
 
-int Database::count(Connection& connection, const std::string& collectionName) const
+Int64 Database::count(Connection& connection, const std::string& collectionName) const
 {
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> countRequest = createCountRequest(collectionName);
 
@@ -42,7 +42,16 @@ int Database::count(Connection& connection, const std::string& collectionName) c
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		return doc->get<int>("n");
+
+		if (doc->isType<double>("n")) {
+			return static_cast<Int64>(doc->get<double>("n"));
+		}
+		else if (doc->isType<Int32>("n")) {
+			return doc->get<Int32>("n");
+		}
+		else if (doc->isType<Int64>("n")) {
+			return doc->get<Int64>("n");
+		}
 	}
 
 	return -1;

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -268,7 +268,7 @@ void MongoDBTest::testDBCount2Command()
 	}
 
 	Poco::MongoDB::Database db("team");
-	int count = db.count(_mongo, "players");
+	Poco::Int64 count = db.count(_mongo, "players");
 	assert(count == 1);
 }
 
@@ -306,7 +306,7 @@ void MongoDBTest::testCursorRequest()
 	}
 	_mongo.sendRequest(*insertRequest);
 
-	int count = db.count(_mongo, "numbers");
+	Poco::Int64 count = db.count(_mongo, "numbers");
 	std::cout << "count= " << count << std::endl;
 	assert(count == 10000);
 


### PR DESCRIPTION
This is the enhancement for Database::count from @matejk (pull request #838)