### PR TITLE
remove un-needed headers

### DIFF
--- a/Net/src/WebSocket.cpp
+++ b/Net/src/WebSocket.cpp
@@ -20,7 +20,6 @@
 #include "Poco/Net/HTTPServerResponse.h"
 #include "Poco/Net/HTTPClientSession.h"
 #include "Poco/Net/NetException.h"
-#include "Poco/Buffer.h"
 #include "Poco/MemoryStream.h"
 #include "Poco/NullStream.h"
 #include "Poco/BinaryWriter.h"
@@ -29,7 +28,6 @@
 #include "Poco/String.h"
 #include "Poco/Random.h"
 #include "Poco/StreamCopier.h"
-#include "Poco/Buffer.h"
 #include <sstream>
 
 


### PR DESCRIPTION
These files were there multiple times and may be just a simple aesthetic problem.
They are included in [WebSocket.h](https://github.com/tml1024/poco/blob/develop/Net/include/Poco/Net/WebSocket.h)