### PR TITLE
CMake Fix for non MSVC Installs

### DIFF
--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -251,8 +251,10 @@ install(
     INCLUDES DESTINATION include
     )
 
+if (MSVC)
 # install the targets pdb
-POCO_INSTALL_PDB(${target_name})
+  POCO_INSTALL_PDB(${target_name})
+endif()
   
 endmacro()
 
@@ -264,9 +266,6 @@ endmacro()
 #
 #    This is an internal macro meant only to be used by POCO_INSTALL.
 macro(POCO_INSTALL_PDB target_name)
-    if (NOT MSVC)
-        return()
-    endif()
 
     get_property(type TARGET ${target_name} PROPERTY TYPE)
     if ("${type}" STREQUAL "SHARED_LIBRARY" OR "${type}" STREQUAL "EXECUTABLE")


### PR DESCRIPTION
The return function is causing Data/CMakeLists.txt to exit early,
before it can they include sub directories i.e Data/MySQL Data/ODBC  Data/SQLite

http://www.cmake.org/cmake/help/v3.0/command/return.html