### PR TITLE
Add mysql_stmt_store_result

### DIFF
--- a/Data/MySQL/src/StatementExecutor.cpp
+++ b/Data/MySQL/src/StatementExecutor.cpp
@@ -95,6 +95,9 @@ void StatementExecutor::execute()
 
 	if (mysql_stmt_execute(_pHandle) != 0)
 		throw StatementException("mysql_stmt_execute error", _pHandle, _query);
+		
+	if (mysql_stmt_store_result(_pHandle) != 0)
+		throw StatementException("mysql_stmt_store_result", _pHandle, _query);
 
 	_state = STMT_EXECUTED;
 


### PR DESCRIPTION
If MySQL connection is lost after statement execution and before / during fetching the result.
Will segfault due to mysqlclient library referencing a null pointer.

Using mysql_stmt_store_result prevents this from happening and gives us extra error handling.
Downside is higher clientside memory usage
https://dev.mysql.com/doc/refman/5.0/en/mysql-stmt-store-result.html