### PR TITLE
* Fix for Zip file loading not setting containing file offsets

### DIFF
--- a/Zip/src/ZipFileInfo.cpp
+++ b/Zip/src/ZipFileInfo.cpp
@@ -95,6 +95,7 @@ void ZipFileInfo::parse(std::istream& inp, bool assumeHeaderRead)
 	_crc32 = getCRCFromHeader();
 	_compressedSize = getCompressedSizeFromHeader();
 	_uncompressedSize = getUncompressedSizeFromHeader();
+	_localHeaderOffset = getOffsetFromHeader();
 	parseDateTime();
 	Poco::UInt16 len = getFileNameLength();
 	Poco::Buffer<char> buf(len);

--- a/Zip/testsuite/src/ZipTest.cpp
+++ b/Zip/testsuite/src/ZipTest.cpp
@@ -81,6 +81,21 @@ void ZipTest::testDecompressSingleFile()
 }
 
 
+void ZipTest::testDecompressSingleFileInDir()
+{
+	std::string testFile = getTestFile("test.zip");
+	std::ifstream inp(testFile.c_str(), std::ios::binary);
+	assert (inp.good());
+	ZipArchive arch(inp);
+	ZipArchive::FileHeaders::const_iterator it = arch.findHeader("testdir/testfile.txt");
+	assert (it != arch.headerEnd());
+	ZipInputStream zipin (inp, it->second);
+	std::ostringstream out(std::ios::binary);
+	Poco::StreamCopier::copyStream(zipin, out);
+	assert(!out.str().empty());
+}
+
+
 void ZipTest::testCrcAndSizeAfterData()
 {
 	std::string testFile = getTestFile("data.zip");
@@ -234,6 +249,7 @@ CppUnit::Test* ZipTest::suite()
 
 	CppUnit_addTest(pSuite, ZipTest, testSkipSingleFile);
 	CppUnit_addTest(pSuite, ZipTest, testDecompressSingleFile);
+	CppUnit_addTest(pSuite, ZipTest, testDecompressSingleFileInDir);
 	CppUnit_addTest(pSuite, ZipTest, testDecompress);
 	CppUnit_addTest(pSuite, ZipTest, testDecompressFlat);
 	CppUnit_addTest(pSuite, ZipTest, testCrcAndSizeAfterData);

--- a/Zip/testsuite/src/ZipTest.h
+++ b/Zip/testsuite/src/ZipTest.h
@@ -29,6 +29,7 @@ public:
 
 	void testSkipSingleFile();
 	void testDecompressSingleFile();
+	void testDecompressSingleFileInDir();
 	void testDecompress();
 	void testCrcAndSizeAfterData();
 	void testCrcAndSizeAfterDataWithArchive();


### PR DESCRIPTION
The local header offset wasn't being loaded on the constructor.

Fixes #840 
