### PR TITLE
a small fix on HTTPServerParams:

### DIFF
--- a/Net/include/Poco/Net/HTTPServerParams.h
+++ b/Net/include/Poco/Net/HTTPServerParams.h
@@ -97,7 +97,6 @@ public:
 		/// during a persistent connection, or 0 if
 		/// unlimited connections are allowed.
 
-protected:
 	virtual ~HTTPServerParams();
 		/// Destroys the HTTPServerParams.
 


### PR DESCRIPTION
virtual destructor should be public instead of protected