### PR TITLE
parse attachments' name and filename

### DIFF
--- a/Net/src/MailMessage.cpp
+++ b/Net/src/MailMessage.cpp
@@ -98,28 +98,27 @@ namespace
 				NameValueCollection::ConstIterator end = header.end();
 				PartSource* pPS = _pMsg->createPartStore(tmp, 
 					header[MailMessage::HEADER_CONTENT_TYPE], 
-					getFileNameFromDisp(it->second));
+					getAttrFromHeader(header[MailMessage::HEADER_CONTENT_DISPOSITION], "filename"));
 				poco_check_ptr (pPS);
 				for (; it != end; ++it)
 				{
 					if (MailMessage::HEADER_CONTENT_DISPOSITION == it->first)
 					{
 						if (it->second == "inline") _pMsg->addContent(pPS, cte);
-						else _pMsg->addAttachment("", pPS, cte);
+						else _pMsg->addAttachment(getAttrFromHeader(header[MailMessage::HEADER_CONTENT_TYPE], "name"), pPS, cte);
 					}
-					
 					pPS->headers().set(it->first, it->second);
 				}
 			}
 		}
 		
 	private:
-		std::string getFileNameFromDisp(const std::string& str)
+		std::string getAttrFromHeader(const std::string& str, const std::string& attrName)
 		{
 			StringTokenizer st(str, ";=", StringTokenizer::TOK_IGNORE_EMPTY | StringTokenizer::TOK_TRIM);
 			StringTokenizer::Iterator it = st.begin();
 			StringTokenizer::Iterator end = st.end();
-			for (; it != end; ++it) { if (*it == "filename") break; }
+			for (; it != end; ++it) { if (*it == attrName) break; }
 			if (it != end)
 			{
 				++it;

--- a/Net/testsuite/src/MailMessageTest.cpp
+++ b/Net/testsuite/src/MailMessageTest.cpp
@@ -431,6 +431,42 @@ void MailMessageTest::testReadMultiPart()
 }
 
 
+void MailMessageTest::testReadMultiPartWithAttachmentNames()
+{
+	std::istringstream istr(
+		"Content-Type: multipart/mixed; boundary=MIME_boundary_01234567\r\n"
+		"Date: Thu, 1 Jan 1970 00:00:00 GMT\r\n"
+		"From: poco@appinf.com\r\n"
+		"Mime-Version: 1.0\r\n"
+		"Subject: Test Message\r\n"
+		"To: John Doe <john.doe@no.where>\r\n"
+		"\r\n"
+		"\r\n"
+		"--MIME_boundary_01234567\r\n"
+		"Content-Disposition: inline\r\n"
+		"Content-Transfer-Encoding: 8bit\r\n"
+		"Content-Type: text/plain\r\n"
+		"\r\n"
+		"Hello World!\r\n"
+		"\r\n"
+		"--MIME_boundary_01234567\r\n"
+		"Content-Disposition: attachment; filename=sample.dat\r\n"
+		"Content-Transfer-Encoding: base64\r\n"
+		"Content-Type: application/octet-stream; name=sample\r\n"
+		"\r\n"
+		"VGhpcyBpcyBzb21lIGJpbmFyeSBkYXRhLiBSZWFsbHku\r\n"
+		"--MIME_boundary_01234567--\r\n"
+	);
+	
+	MailMessage message;
+	message.read(istr);
+	
+	assert (message.parts().size() == 2);
+	assert (message.parts()[1].name == "sample");
+	assert (message.parts()[1].pSource->filename() == "sample.dat");
+}
+
+
 void MailMessageTest::testReadMultiPartDefaultTransferEncoding()
 {
 	std::istringstream istr(

--- a/Net/testsuite/src/MailMessageTest.h
+++ b/Net/testsuite/src/MailMessageTest.h
@@ -37,6 +37,7 @@ public:
 	void testReadQP();
 	void testRead8Bit();
 	void testReadMultiPart();
+	void testReadMultiPartWithAttachmentNames();
 	void testReadMultiPartDefaultTransferEncoding();
 	void testEncodeWord();
 


### PR DESCRIPTION
Parse attachments' name and filename from Content-Type and Content-Disposition headers, respectively.