### PR TITLE
Fix conflicting declaration with unbundled pcre

### DIFF
--- a/Foundation/include/Poco/RegularExpression.h
+++ b/Foundation/include/Poco/RegularExpression.h
@@ -26,7 +26,9 @@
 #include "Poco/Foundation.h"
 #include <vector>
 
-
+#if defined(POCO_UNBUNDLED)
+#include <pcre.h>
+#else
 //
 // Copy these definitions from pcre.h
 // to avoid pulling in the entire header file
@@ -37,7 +39,7 @@ extern "C"
 	typedef struct real_pcre8_or_16 pcre;
 	struct pcre_extra;
 }
-
+#endif
 
 namespace Poco {
 


### PR DESCRIPTION
Building poco 1.6.1 with the `--unbundled` config options fails due to an
conflicting declaration of `pcre`:

```sh
In file included from src/RegularExpression.cpp:21:0:
/usr/include/pcre.h:325:26: error: conflicting declaration ‘typedef struct real_pcre pcre’
 typedef struct real_pcre pcre;
                          ^
In file included from src/RegularExpression.cpp:17:0:
include/Poco/RegularExpression.h:37:34: note: previous declaration as ‘typedef struct real_pcre8_or_16 pcre’
  typedef struct real_pcre8_or_16 pcre;
```