### PR TITLE
add POCO_EXPORT_CLASS_INTERFACE to ClassLibrary.h

### DIFF
--- a/Foundation/include/Poco/ClassLibrary.h
+++ b/Foundation/include/Poco/ClassLibrary.h
@@ -76,13 +76,34 @@ extern "C"	\
 			Poco::Manifest<_Base>* pManifest = static_cast<_Manifest*>(pManifest_);
 
 
+#define POCO_BEGIN_MANIFEST_IMPL_WITH_ONE_ARG(fnName, base, arg1) \
+	bool fnName(Poco::ManifestBase* pManifest_)										\
+	{																				\
+		typedef base _Base;															\
+		typedef Poco::Manifest<_Base, arg1> _Manifest;								\
+		std::string requiredType(typeid(_Manifest).name());							\
+		std::string actualType(pManifest_->className());							\
+		if (requiredType == actualType)												\
+		{																			\
+			Poco::Manifest<_Base, arg1>* pManifest = static_cast<_Manifest*>(pManifest_);
+
+
 #define POCO_BEGIN_MANIFEST(base) \
 	POCO_BEGIN_MANIFEST_IMPL(pocoBuildManifest, base)
+
+
+#define POCO_BEGIN_MANIFEST_WITH_ONE_ARG(base, arg1) \
+	POCO_BEGIN_MANIFEST_IMPL_WITH_ONE_ARG(pocoBuildManifest, base, arg1)
 
 
 #define POCO_BEGIN_NAMED_MANIFEST(name, base)	\
 	POCO_DECLARE_NAMED_MANIFEST(name)			\
 	POCO_BEGIN_MANIFEST_IMPL(POCO_JOIN(pocoBuildManifest, name), base)
+
+
+#define POCO_BEGIN_NAMED_MANIFEST_WITH_ONE_ARG(name, base, arg1)	\
+	POCO_DECLARE_NAMED_MANIFEST(name)			\
+	POCO_BEGIN_MANIFEST_IMPL_WITH_ONE_ARG(POCO_JOIN(pocoBuildManifest, name), base, arg1)
 
 
 #define POCO_END_MANIFEST \
@@ -95,9 +116,16 @@ extern "C"	\
 #define POCO_EXPORT_CLASS(cls) \
     pManifest->insert(new Poco::MetaObject<cls, _Base>(#cls));
 
+#define POCO_EXPORT_CLASS_WITH_ONE_ARG(cls, arg1) \
+    pManifest->insert(new Poco::MetaObject<cls, _Base, arg1>(#cls));
+
 
 #define POCO_EXPORT_CLASS_INTERFACE(cls, itf) \
     pManifest->insert(new Poco::MetaObject<cls, _Base>(itf));
+
+
+#define POCO_EXPORT_CLASS_INTERFACE_WITH_ONE_ARG(cls, itf, arg1) \
+    pManifest->insert(new Poco::MetaObject<cls, _Base, arg1>(itf));
 
 
 #define POCO_EXPORT_SINGLETON(cls) \

--- a/Foundation/include/Poco/ClassLibrary.h
+++ b/Foundation/include/Poco/ClassLibrary.h
@@ -96,6 +96,10 @@ extern "C"	\
     pManifest->insert(new Poco::MetaObject<cls, _Base>(#cls));
 
 
+#define POCO_EXPORT_CLASS_INTERFACE(cls, itf) \
+    pManifest->insert(new Poco::MetaObject<cls, _Base>(itf));
+
+
 #define POCO_EXPORT_SINGLETON(cls) \
 	pManifest->insert(new Poco::MetaSingleton<cls, _Base>(#cls));
 

--- a/Foundation/include/Poco/ClassLoader.h
+++ b/Foundation/include/Poco/ClassLoader.h
@@ -32,7 +32,11 @@
 namespace Poco {
 
 
+#ifdef POCO_ENABLE_CPP11
+template <class Base, class... Type>
+#else
 template <class Base>
+#endif
 class ClassLoader
 	/// The ClassLoader loads C++ classes from shared libraries
 	/// at runtime. It must be instantiated with a root class
@@ -53,8 +57,13 @@ class ClassLoader
 	/// library.
 {
 public:
+#ifdef POCO_ENABLE_CPP11
+	typedef AbstractMetaObject<Base, Type...> Meta;
+	typedef Manifest<Base, Type...> Manif;
+#else
 	typedef AbstractMetaObject<Base> Meta;
 	typedef Manifest<Base> Manif;
+#endif
 	typedef void (*InitializeLibraryFunc)();
 	typedef void (*UninitializeLibraryFunc)();
 	typedef bool (*BuildManifestFunc)(ManifestBase*);
@@ -269,13 +278,23 @@ public:
 			throw NotFoundException(className);
 	}
 	
+#ifdef POCO_ENABLE_CPP11
+	Base* create(const std::string& className, Type... type) const
+	/// Creates an instance of the given class.
+		/// Throws a NotFoundException if the class
+		/// is not known.
+	{
+		return classFor(className).create(type...);
+	}
+#else
 	Base* create(const std::string& className) const
-		/// Creates an instance of the given class.
+	/// Creates an instance of the given class.
 		/// Throws a NotFoundException if the class
 		/// is not known.
 	{
 		return classFor(className).create();
 	}
+#endif
 	
 	Base& instance(const std::string& className) const
 		/// Returns a reference to the sole instance of

--- a/Foundation/include/Poco/Manifest.h
+++ b/Foundation/include/Poco/Manifest.h
@@ -42,7 +42,11 @@ public:
 };
 
 
+#ifdef POCO_ENABLE_CPP11
+template <class B, class... A>
+#else
 template <class B>
+#endif
 class Manifest: public ManifestBase
 	/// A Manifest maintains a list of all classes
 	/// contained in a dynamically loadable class
@@ -52,7 +56,11 @@ class Manifest: public ManifestBase
 	/// iterate over all the classes in a Manifest.
 {
 public:
+#ifdef POCO_ENABLE_CPP11
+	typedef AbstractMetaObject<B, A...> Meta;
+#else
 	typedef AbstractMetaObject<B> Meta;
+#endif
 	typedef std::map<std::string, const Meta*> MetaMap;
 
 	class Iterator

--- a/Foundation/include/Poco/MetaObject.h
+++ b/Foundation/include/Poco/MetaObject.h
@@ -29,7 +29,11 @@
 namespace Poco {
 
 
+#ifdef POCO_ENABLE_CPP11
+template <class B, typename... A>
+#else
 template <class B>
+#endif
 class AbstractMetaObject
 	/// A MetaObject stores some information
 	/// about a C++ class. The MetaObject class
@@ -57,10 +61,16 @@ public:
 		return _name;
 	}
 
+#ifdef POCO_ENABLE_CPP11
+	virtual B* create(A... a) const = 0;
+		/// Create a new instance of a class.
+		/// Cannot be used for singletons.
+#else
 	virtual B* create() const = 0;
 		/// Create a new instance of a class.
 		/// Cannot be used for singletons.
-		
+#endif
+
 	virtual B& instance() const = 0;
 		/// Returns a reference to the only instance
 		/// of the class. Used for singletons only.
@@ -123,8 +133,13 @@ private:
 };
 
 
+#ifdef POCO_ENABLE_CPP11
+template <class C, class B, class... A>
+class MetaObject: public AbstractMetaObject<B, A...>
+#else
 template <class C, class B>
 class MetaObject: public AbstractMetaObject<B>
+#endif
 	/// A MetaObject stores some information
 	/// about a C++ class. The MetaObject class
 	/// is used by the Manifest class.
@@ -132,7 +147,11 @@ class MetaObject: public AbstractMetaObject<B>
 	/// factory for its class.
 {
 public:
+#ifdef POCO_ENABLE_CPP11
+	MetaObject(const char* name): AbstractMetaObject<B,A...>(name)
+#else
 	MetaObject(const char* name): AbstractMetaObject<B>(name)
+#endif
 	{
 	}
 
@@ -140,10 +159,17 @@ public:
 	{
 	}
 
+#ifdef POCO_ENABLE_CPP11
+	B* create(A... a) const
+	{
+		return new C(a...);
+	}
+#else
 	B* create() const
 	{
 		return new C;
 	}
+#endif
 	
 	B& instance() const
 	{

--- a/Foundation/testsuite/src/ClassLoaderTest.cpp
+++ b/Foundation/testsuite/src/ClassLoaderTest.cpp
@@ -191,6 +191,34 @@ void ClassLoaderTest::testClassLoader3()
 	assertNullPtr (cl.findManifest(path));
 }
 
+#ifdef POCO_ENABLE_CPP11
+void ClassLoaderTest::testClassLoader4()
+{
+	std::string path = "TestLibrary";
+	path.append(SharedLibrary::suffix());
+
+	ClassLoader<TestPluginWithOneArg, int> cl;
+	cl.loadLibrary(path, "TestPluginWithOneArg");
+
+	assert (cl.begin() != cl.end());
+	assertNotNullPtr (cl.findClass("PluginD"));
+	assert (cl.manifestFor(path).size() == 1);
+
+
+	TestPluginWithOneArg* pPluginD;
+	pPluginD = cl.classFor("PluginD").create(2);
+	assert (pPluginD->name() == "PluginD");
+	assert (pPluginD->no() == 2);
+	delete pPluginD;
+
+	pPluginD = cl.create("PluginD", 4);
+	assert (pPluginD->name() == "PluginD");
+	assert (pPluginD->no() == 4);
+	delete pPluginD;
+
+	cl.unloadLibrary(path);
+}
+#endif
 
 void ClassLoaderTest::setUp()
 {
@@ -209,6 +237,8 @@ CppUnit::Test* ClassLoaderTest::suite()
 	CppUnit_addTest(pSuite, ClassLoaderTest, testClassLoader1);
 	CppUnit_addTest(pSuite, ClassLoaderTest, testClassLoader2);
 	CppUnit_addTest(pSuite, ClassLoaderTest, testClassLoader3);
-
+#ifdef POCO_ENABLE_CPP11
+	CppUnit_addTest(pSuite, ClassLoaderTest, testClassLoader4);
+#endif
 	return pSuite;
 }

--- a/Foundation/testsuite/src/ClassLoaderTest.h
+++ b/Foundation/testsuite/src/ClassLoaderTest.h
@@ -29,7 +29,9 @@ public:
 	void testClassLoader1();
 	void testClassLoader2();
 	void testClassLoader3();
-
+#ifdef POCO_ENABLE_CPP11
+	void testClassLoader4();
+#endif
 	void setUp();
 	void tearDown();
 

--- a/Foundation/testsuite/src/TestLibrary.cpp
+++ b/Foundation/testsuite/src/TestLibrary.cpp
@@ -71,6 +71,29 @@ public:
 	}
 };
 
+class PluginD: public TestPluginWithOneArg
+{
+public:
+	PluginD(int no) : _no(no)
+	{
+	}
+
+	~PluginD()
+	{
+	}
+
+	std::string name() const
+	{
+		return "PluginD";
+	}
+	int no() const
+	{
+		return _no;
+	}
+private:
+	int _no;
+};
+
 
 POCO_BEGIN_MANIFEST(TestPlugin)
 	POCO_EXPORT_CLASS(PluginA)
@@ -78,6 +101,12 @@ POCO_BEGIN_MANIFEST(TestPlugin)
 	POCO_EXPORT_SINGLETON(PluginC)
 POCO_END_MANIFEST
 
+
+#ifdef POCO_ENABLE_CPP11
+POCO_BEGIN_NAMED_MANIFEST_WITH_ONE_ARG(TestPluginWithOneArg, TestPluginWithOneArg, int)
+	POCO_EXPORT_CLASS_WITH_ONE_ARG(PluginD, int)
+POCO_END_MANIFEST
+#endif
 
 void pocoInitializeLibrary()
 {

--- a/Foundation/testsuite/src/TestPlugin.cpp
+++ b/Foundation/testsuite/src/TestPlugin.cpp
@@ -21,3 +21,12 @@ TestPlugin::TestPlugin()
 TestPlugin::~TestPlugin()
 {
 }
+
+TestPluginWithOneArg::TestPluginWithOneArg()
+{
+}
+
+
+TestPluginWithOneArg::~TestPluginWithOneArg()
+{
+}

--- a/Foundation/testsuite/src/TestPlugin.h
+++ b/Foundation/testsuite/src/TestPlugin.h
@@ -27,5 +27,15 @@ public:
 	virtual std::string name() const = 0;
 };
 
+#ifdef POCO_ENABLE_CPP11
+class TestPluginWithOneArg
+{
+public:
+	TestPluginWithOneArg();
+	virtual ~TestPluginWithOneArg();
+	virtual std::string name() const = 0;
+	virtual int no() const = 0;
+};
+#endif
 
 #endif // TestPlugin_INCLUDED


### PR DESCRIPTION
add POCO_EXPORT_CLASS_INTERFACE so that the same interface be implemented by many different libraries while having a unique name in the IoC controller.
Signed-off-by: FrancisANDRE <zosrothko@orange.fr>