### PR TITLE
Added NotificationQueue::remove function

### DIFF
--- a/Foundation/include/Poco/NotificationQueue.h
+++ b/Foundation/include/Poco/NotificationQueue.h
@@ -125,6 +125,10 @@ public:
 	void clear();
 		/// Removes all notifications from the queue.
 		
+	bool remove(Notification::Ptr pNotification);
+		/// Removes a notification from the queue.
+		/// Returns true if remove succeeded, false otherwise
+
 	bool hasIdleThreads() const;	
 		/// Returns true if the queue has at least one thread waiting 
 		/// for a notification.

--- a/Foundation/src/NotificationQueue.cpp
+++ b/Foundation/src/NotificationQueue.cpp
@@ -179,6 +179,19 @@ void NotificationQueue::clear()
 }
 
 
+bool NotificationQueue::remove(Notification::Ptr pNotification)
+{
+	FastMutex::ScopedLock lock(_mutex);
+	NfQueue::iterator it = std::find(_nfQueue.begin(), _nfQueue.end(), pNotification);
+	if (it == _nfQueue.end())
+	{
+		return false;
+	}
+	_nfQueue.erase(it);
+	return true;
+}
+
+
 bool NotificationQueue::hasIdleThreads() const
 {
 	FastMutex::ScopedLock lock(_mutex);

--- a/Foundation/testsuite/src/NotificationQueueTest.cpp
+++ b/Foundation/testsuite/src/NotificationQueueTest.cpp
@@ -190,6 +190,29 @@ void NotificationQueueTest::testDefaultQueue()
 }
 
 
+void NotificationQueueTest::testQueueRemove()
+{
+	NotificationQueue queue;
+	Notification::Ptr frontNotification = new QTestNotification("front");
+	Notification::Ptr middleNotification = new QTestNotification("middle");
+	Notification::Ptr backNotification = new QTestNotification("back");
+	queue.enqueueNotification(frontNotification);
+	queue.enqueueNotification(new QTestNotification("dummy"));
+	queue.enqueueNotification(middleNotification);
+	queue.enqueueNotification(new QTestNotification("dummy"));
+	queue.enqueueNotification(backNotification);
+	assert (queue.size() == 5);
+	assert (queue.remove(frontNotification));
+	assert (queue.size() == 4);
+	assert (queue.remove(middleNotification));
+	assert (queue.size() == 3);
+	assert (queue.remove(backNotification));
+	assert (queue.size() == 2);
+	assert (!queue.remove(backNotification));
+	assert (queue.size() == 2);
+}
+
+
 void NotificationQueueTest::setUp()
 {
 	_handled.clear();
@@ -227,6 +250,7 @@ CppUnit::Test* NotificationQueueTest::suite()
 	CppUnit_addTest(pSuite, NotificationQueueTest, testWaitDequeue);
 	CppUnit_addTest(pSuite, NotificationQueueTest, testThreads);
 	CppUnit_addTest(pSuite, NotificationQueueTest, testDefaultQueue);
+	CppUnit_addTest(pSuite, NotificationQueueTest, testQueueRemove);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/NotificationQueueTest.h
+++ b/Foundation/testsuite/src/NotificationQueueTest.h
@@ -34,6 +34,7 @@ public:
 	void testWaitDequeue();
 	void testThreads();
 	void testDefaultQueue();
+	void testQueueRemove();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
As discussed in #803.
This includes appropriate tests, which pass on my Mac 10.4 machine.