### PR TITLE
PatternFormatter Priority Name Enhancement

### DIFF
--- a/Foundation/include/Poco/PatternFormatter.h
+++ b/Foundation/include/Poco/PatternFormatter.h
@@ -116,9 +116,10 @@ public:
 
 	static const std::string PROP_PATTERN;
 	static const std::string PROP_TIMES;
+	static const std::string PROP_PRIORITY_NAMES;
 
 protected:
-	static const std::string& getPriorityName(int);
+	const std::string& getPriorityName(int);
 		/// Returns a string for the given priority value.
 	
 private:
@@ -139,9 +140,13 @@ private:
 		/// which contains the message key, any text that needs to be written first
 		/// a property in case of %[] and required length.
 
+	void parsePriorityNames();
+
 	std::vector<PatternAction> _patternActions;
 	bool _localTime;
 	std::string _pattern;
+        std::string _priorityNames;
+        std::string _priorities[9];
 };
 
 

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -24,6 +24,7 @@
 #include "Poco/Timezone.h"
 #include "Poco/Environment.h"
 #include "Poco/NumberParser.h"
+#include "Poco/StringTokenizer.h"
 
 
 namespace Poco {
@@ -31,11 +32,13 @@ namespace Poco {
 
 const std::string PatternFormatter::PROP_PATTERN = "pattern";
 const std::string PatternFormatter::PROP_TIMES   = "times";
+const std::string PatternFormatter::PROP_PRIORITY_NAMES = "priorityNames";
 
 
 PatternFormatter::PatternFormatter():
 	_localTime(false)
 {
+	parsePriorityNames();
 }
 
 
@@ -43,6 +46,7 @@ PatternFormatter::PatternFormatter(const std::string& format):
 	_localTime(false),
 	_pattern(format)
 {
+	parsePriorityNames();
 	parsePattern();
 }
 
@@ -204,6 +208,11 @@ void PatternFormatter::setProperty(const std::string& name, const std::string& v
 	{
 		_localTime = (value == "local");
 	}
+	else if (name == PROP_PRIORITY_NAMES) 
+	{
+		_priorityNames = value;
+		parsePriorityNames();
+	}
 	else 
 	{
 		Formatter::setProperty(name, value);
@@ -217,6 +226,8 @@ std::string PatternFormatter::getProperty(const std::string& name) const
 		return _pattern;
 	else if (name == PROP_TIMES)
 		return _localTime ? "local" : "UTC";
+	else if (name == PROP_PRIORITY_NAMES)
+		return _priorityNames;
 	else
 		return Formatter::getProperty(name);
 }
@@ -238,11 +249,20 @@ namespace
 	};
 }
 
+	void PatternFormatter::parsePriorityNames()
+	{
+		for (int i = 0; i <= 8; i++)
+			_priorities[i] = priorities[i];
+		StringTokenizer st (_priorityNames, ".", StringTokenizer::TOK_TRIM);
+		if (st.count() == 8)
+		for (int i = 1; i <= 8; i++)
+			_priorities[i] = st[i-1];
+	}
 
 const std::string& PatternFormatter::getPriorityName(int prio)
 {
 	poco_assert (1 <= prio && prio <= 8);	
-	return priorities[prio];
+	return _priorities[prio];
 }
 
 


### PR DESCRIPTION
Added a property to allow the user to specify the actual names for the priorities that will go into the log. This was required for our app to conform to RFC 5424.

The property is called "priorityNames".

It should contain a list of 8 names, separated by a period. For example:

"Fatal.Critical.Error.Warning.Notice.Information.Debug.Trace"