### PR TITLE
Crypto: Add any digest to  key generation.

### DIFF
--- a/Crypto/include/Poco/Crypto/CipherKey.h
+++ b/Crypto/include/Poco/Crypto/CipherKey.h
@@ -47,6 +47,16 @@ class Crypto_API CipherKey
 	///     std::string salt("asdff8723lasdf(**923412");
 	///     CipherKey key("aes-256", password, salt);
 	///
+	/// You may also control the digest and the number of iterations used to generate the key
+	/// by specifying the specific values. Here we create a key with the same data as before,
+	/// except that we use 100 iterations instead of DEFAULT_ITERATION_COUNT, and sha1 instead of
+	/// the default md5:
+	///
+	///     std::string password = "secret";
+	///     std::string salt("asdff8723lasdf(**923412");
+	///     std::string digest ("sha1");
+	///     CipherKey key("aes-256", password, salt, 100, digest);
+	///
 {
 public:
 	typedef CipherKeyImpl::Mode Mode;
@@ -63,9 +73,10 @@ public:
 	CipherKey(const std::string& name, 
 		const std::string& passphrase, 
 		const std::string& salt = "",
-		int iterationCount = DEFAULT_ITERATION_COUNT);
+		int iterationCount = DEFAULT_ITERATION_COUNT,
+		const std::string& digest = "md5");
 		/// Creates a new CipherKeyImpl object using the given
-		/// cipher name, passphrase, salt value and iteration count.
+		/// cipher name, passphrase, salt value, iteration count and digest.
 
 	CipherKey(const std::string& name, 
 		const ByteVec& key, 

--- a/Crypto/include/Poco/Crypto/CipherKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/CipherKeyImpl.h
@@ -53,17 +53,19 @@ public:
 		MODE_OFB			/// Output feedback
 	};
 
-	CipherKeyImpl(const std::string& name, 
-		const std::string& passphrase, 
+	CipherKeyImpl(const std::string& name,
+		const std::string& passphrase,
 		const std::string& salt,
-		int iterationCount);
+		int iterationCount,
+		const std::string &digest);
 		/// Creates a new CipherKeyImpl object, using
 		/// the given cipher name, passphrase, salt value
 		/// and iteration count.
 
 	CipherKeyImpl(const std::string& name, 
 		const ByteVec& key, 
-		const ByteVec& iv);
+		const ByteVec& iv
+	);
 		/// Creates a new CipherKeyImpl object, using the 
 		/// given cipher name, key and initialization vector.
 
@@ -118,6 +120,7 @@ private:
 
 private:
 	const EVP_CIPHER*  _pCipher;
+	const EVP_MD*      _pDigest;
 	std::string	       _name;
 	ByteVec		       _key;
 	ByteVec		       _iv;

--- a/Crypto/src/CipherKey.cpp
+++ b/Crypto/src/CipherKey.cpp
@@ -21,8 +21,9 @@ namespace Poco {
 namespace Crypto {
 
 
-CipherKey::CipherKey(const std::string& name, const std::string& passphrase,  const std::string& salt, int iterationCount):
-	_pImpl(new CipherKeyImpl(name, passphrase, salt, iterationCount))
+CipherKey::CipherKey(const std::string& name, const std::string& passphrase,  const std::string& salt, int iterationCount,
+	const std::string &digest):
+	_pImpl(new CipherKeyImpl(name, passphrase, salt, iterationCount, digest))
 {
 }
 

--- a/Crypto/testsuite/src/CryptoTest.h
+++ b/Crypto/testsuite/src/CryptoTest.h
@@ -33,9 +33,11 @@ public:
 
 	void testEncryptDecrypt();
 	void testEncryptDecryptWithSalt();
+    void testEncryptDecryptWithSaltSha1();
 	void testEncryptDecryptDESECB();
 	void testStreams();
 	void testPassword();
+    void testPasswordSha1();
 	void testEncryptInterop();
 	void testDecryptInterop();
 	void testCertificate();


### PR DESCRIPTION
See #912. This pull request adds the possibility to add a custom digest for key generation in symmetric ciphers.

A question though: how is memory management done? The _pCipher pointer is not directly deleted, I would assume because it is delivered by the function EVP_get_cipherbyname(), and this pointer would be deleted by the OpenSSLInitializer::uninitialize() method? I have to admit this is a bit obscure to me, why not use RAII in all the cipher classes?