### PR TITLE
Proposed changes for fixing NetSSL_OpenSSL and adding portability function in Sharedmemory

### DIFF
--- a/Foundation/include/Poco/SharedLibrary.h
+++ b/Foundation/include/Poco/SharedLibrary.h
@@ -121,7 +121,7 @@ public:
 	static std::string prefix();
 		/// Returns the platform-specific filename prefix
 		/// for shared libraries.
-		/// Most platforms would return an empty string, but
+		/// Most platforms would return "lib" as prefix, while
 	    /// on Cygwin, the "cyg" prefix will be returned.
 		
 	static std::string suffix();
@@ -130,6 +130,11 @@ public:
 		/// In debug mode, the suffix also includes a
 		/// "d" to specify the debug version of a library.
 		
+	static std::string getOSName(const std::string& name);
+		/// Returns the platform-specific filename 
+		/// for shared libraries by prefixing and suffixing name
+		/// with prefix() and suffix()
+
 private:
 	SharedLibrary(const SharedLibrary&);
 	SharedLibrary& operator = (const SharedLibrary&);

--- a/Foundation/src/SharedLibrary.cpp
+++ b/Foundation/src/SharedLibrary.cpp
@@ -115,5 +115,9 @@ std::string SharedLibrary::suffix()
 	return suffixImpl();
 }
 
+std::string SharedLibrary::getOSName(const std::string& name) 
+{
+	return prefix() + name + suffix();
+}
 
 } // namespace Poco

--- a/Foundation/src/SharedLibrary_HPUX.cpp
+++ b/Foundation/src/SharedLibrary_HPUX.cpp
@@ -85,7 +85,7 @@ const std::string& SharedLibraryImpl::getPathImpl() const
 
 std::string SharedLibraryImpl::prefixImpl()
 {
-	return "";
+	return "lib";
 }
 
 

--- a/Foundation/src/SharedLibrary_UNIX.cpp
+++ b/Foundation/src/SharedLibrary_UNIX.cpp
@@ -104,7 +104,7 @@ std::string SharedLibraryImpl::prefixImpl()
 #if POCO_OS == POCO_OS_CYGWIN
 	return "cyg";
 #else
-	return "";
+	return "lib";
 #endif
 }
 

--- a/NetSSL_OpenSSL/Makefile
+++ b/NetSSL_OpenSSL/Makefile
@@ -7,8 +7,6 @@
 #
 include $(POCO_BASE)/build/rules/global
 
-INCLUDE += -I$(POCO_BASE)/openssl/include
-
 SYSLIBS += -lssl -lcrypto
 
 objects = AcceptCertificateHandler RejectCertificateHandler ConsoleCertificateHandler \

--- a/NetSSL_OpenSSL/Makefile
+++ b/NetSSL_OpenSSL/Makefile
@@ -5,8 +5,9 @@
 #
 # Makefile for Poco NetSSL_OpenSSL
 #
-
 include $(POCO_BASE)/build/rules/global
+
+INCLUDE += -I$(POCO_BASE)/openssl/include
 
 SYSLIBS += -lssl -lcrypto
 

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -333,27 +333,33 @@ void Context::createSSLContext()
 		case SERVER_USE:
 			_pSSLContext = SSL_CTX_new(SSLv23_server_method());
 			break;
+#if defined(SSL_OP_NO_TLSv1) && !defined(OPENSSL_NO_TLS1)
 		case TLSV1_CLIENT_USE:
 			_pSSLContext = SSL_CTX_new(TLSv1_client_method());
 			break;
 		case TLSV1_SERVER_USE:
 			_pSSLContext = SSL_CTX_new(TLSv1_server_method());
 			break;
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-		case TLSV1_1_CLIENT_USE:
-			_pSSLContext = SSL_CTX_new(TLSv1_1_client_method());
-			break;
-		case TLSV1_1_SERVER_USE:
-			_pSSLContext = SSL_CTX_new(TLSv1_1_server_method());
-			break;
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
-		case TLSV1_2_CLIENT_USE:
-			_pSSLContext = SSL_CTX_new(TLSv1_2_client_method());
-			break;
-		case TLSV1_2_SERVER_USE:
-			_pSSLContext = SSL_CTX_new(TLSv1_2_server_method());
-			break;
+#if defined(SSL_OP_NO_TLSv1_1) && !defined(OPENSSL_NO_TLS1)
+/* SSL_OP_NO_TLSv1_1 is defined in ssl.h if the library version supports TLSv1.1.
+ * OPENSSL_NO_TLS1 is defined in opensslconf.h or on the compiler command line
+ * if TLS1.x was removed at OpenSSL library build time via Configure options.
+ */
+        case TLSV1_1_CLIENT_USE:
+            _pSSLContext = SSL_CTX_new(TLSv1_1_client_method());
+            break;
+        case TLSV1_1_SERVER_USE:
+            _pSSLContext = SSL_CTX_new(TLSv1_1_server_method());
+            break;
+#endif
+#if defined(SSL_OP_NO_TLSv1_2) && !defined(OPENSSL_NO_TLS1)
+        case TLSV1_2_CLIENT_USE:
+            _pSSLContext = SSL_CTX_new(TLSv1_2_client_method());
+            break;
+        case TLSV1_2_SERVER_USE:
+            _pSSLContext = SSL_CTX_new(TLSv1_2_server_method());
+            break;
 #endif
 		default:
 			throw Poco::InvalidArgumentException("Invalid or unsupported usage");


### PR DESCRIPTION
Hi

here follow proposed changes for fixing NetSSL_OpenSSL compilation of TLSv1_1 and TLSv1_2.

The SahredLibrary::getOSName(const std::string& name) bring a better portability in SharedMemory for naming the real OS dependent library. For exemple, getOSName("FOO") will return

on Linux/Unix:   libFOO.so
on Cygwin        cygFOO.dll
on Windows      FOO.dll 

so that loading(getOSName("FOO")) will work on all platforms.

May be it would be also interesting to add an paramter asto the suffix function as suffix( const char* version = NULL) so that the version numbering be handled properly.