### PR TITLE
Refactory BinaryReader and BinaryWriter

### DIFF
--- a/Foundation/include/Poco/BinaryReader.h
+++ b/Foundation/include/Poco/BinaryReader.h
@@ -23,6 +23,7 @@
 #include "Poco/Foundation.h"
 #include "Poco/Buffer.h"
 #include "Poco/MemoryStream.h"
+#include "Poco/ByteOrder.h"
 #include <vector>
 #include <istream>
 
@@ -151,6 +152,32 @@ public:
 		/// Returns the number of available bytes in the stream.
 
 private:
+	template<typename T>
+	BinaryReader& read(T& value, bool flipBytes)
+	{
+		_istr.read((char*) &value, sizeof(value));
+		if (flipBytes) value = ByteOrder::flipBytes(value);
+		return *this;
+	}
+
+	template<typename T>
+	void read7BitEncoded(T& value)
+	{
+		char c;
+		value = 0;
+		int s = 0;
+		do
+		{
+			c = 0;
+			_istr.read(&c, 1);
+			T x = (c & 0x7F);
+			x <<= s;
+			value += x;
+			s += 7;
+		}
+		while (c & 0x80);
+	}
+
 	std::istream&  _istr;
 	bool           _flipBytes; 
 	TextConverter* _pTextConverter;

--- a/Foundation/include/Poco/BinaryWriter.h
+++ b/Foundation/include/Poco/BinaryWriter.h
@@ -189,6 +189,8 @@ private:
 		while (value);
 	}
 
+	BinaryWriter& write(const char* value, std::size_t length);
+
 	std::ostream&  _ostr;
 	bool           _flipBytes;
 	TextConverter* _pTextConverter;

--- a/Foundation/include/Poco/BinaryWriter.h
+++ b/Foundation/include/Poco/BinaryWriter.h
@@ -23,6 +23,7 @@
 #include "Poco/Foundation.h"
 #include "Poco/Buffer.h"
 #include "Poco/MemoryStream.h"
+#include "Poco/ByteOrder.h"
 #include <vector>
 #include <ostream>
 
@@ -160,6 +161,34 @@ public:
 		/// either BIG_ENDIAN_BYTE_ORDER or LITTLE_ENDIAN_BYTE_ORDER.
 
 private:
+	template<typename T>
+	BinaryWriter& write(T value, bool flipBytes)
+	{
+		if (flipBytes)
+		{
+			T fValue = ByteOrder::flipBytes(value);
+			_ostr.write((const char*) &fValue, sizeof(fValue));
+		}
+		else
+		{
+			_ostr.write((const char*) &value, sizeof(value));
+		}
+		return *this;
+	}
+
+	template<typename T>
+	void write7BitEncoded(T value)
+	{
+		do
+		{
+			unsigned char c = (unsigned char) (value & 0x7F);
+			value >>= 7;
+			if (value) c |= 0x80;
+			_ostr.write((const char*) &c, 1);
+		}
+		while (value);
+	}
+
 	std::ostream&  _ostr;
 	bool           _flipBytes;
 	TextConverter* _pTextConverter;

--- a/Foundation/include/Poco/ByteOrder.h
+++ b/Foundation/include/Poco/ByteOrder.h
@@ -24,7 +24,6 @@
 #include <stdlib.h> // builtins
 #endif
 
-
 namespace Poco {
 
 
@@ -38,6 +37,8 @@ public:
 	static UInt16 flipBytes(UInt16 value);
 	static Int32 flipBytes(Int32 value);
 	static UInt32 flipBytes(UInt32 value);
+	static float flipBytes(float value);
+	static double flipBytes(double value);
 #if defined(POCO_HAVE_INT64)
 	static Int64 flipBytes(Int64 value);
 	static UInt64 flipBytes(UInt64 value);
@@ -96,6 +97,21 @@ public:
 	static Int64 fromNetwork(Int64 value);
 	static UInt64 fromNetwork (UInt64 value);
 #endif
+
+private:
+	template<typename T>
+	static T flip(T value)
+	{
+		T           flip     = value;
+		std::size_t halfSize = sizeof(T) / 2;
+		char*       flipP    = reinterpret_cast<char*>(&flip);
+
+		for (std::size_t i = 0; i < halfSize; i++)
+		{
+			std::swap(flipP[i], flipP[sizeof(T) - i - 1]);
+		}
+		return flip;
+	}
 };
 
 
@@ -149,6 +165,18 @@ inline UInt32 ByteOrder::flipBytes(UInt32 value)
 inline Int32 ByteOrder::flipBytes(Int32 value)
 {
 	return Int32(flipBytes(UInt32(value)));
+}
+
+
+inline float ByteOrder::flipBytes(float value)
+{
+	return flip(value);
+}
+
+
+inline double ByteOrder::flipBytes(double value)
+{
+	return flip(value);
 }
 
 

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -15,7 +15,6 @@
 
 
 #include "Poco/BinaryWriter.h"
-#include "Poco/ByteOrder.h"
 #include "Poco/TextEncoding.h"
 #include "Poco/TextConverter.h"
 #include <cstring>
@@ -56,161 +55,81 @@ BinaryWriter::~BinaryWriter()
 
 BinaryWriter& BinaryWriter::operator << (bool value)
 {
-	_ostr.write((const char*) &value, sizeof(value));
-	return *this;
+	return write(value, false);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (char value)
 {
-	_ostr.write((const char*) &value, sizeof(value));
-	return *this;
+	return write(value, false);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (unsigned char value)
 {
-	_ostr.write((const char*) &value, sizeof(value));
-	return *this;
+	return write(value, false);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (signed char value)
 {
-	_ostr.write((const char*) &value, sizeof(value));
-	return *this;
+	return write(value, false);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (short value)
 {
-	if (_flipBytes)
-	{
-		short fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (unsigned short value)
 {
-	if (_flipBytes)
-	{
-		unsigned short fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (int value)
 {
-	if (_flipBytes)
-	{
-		int fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (unsigned int value)
 {
-	if (_flipBytes)
-	{
-		unsigned int fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (long value)
 {
-	if (_flipBytes)
-	{
 #if defined(POCO_LONG_IS_64_BIT)
-		long fValue = ByteOrder::flipBytes((Int64) value);
+	return write((Int64) value, _flipBytes);
 #else
-		long fValue = ByteOrder::flipBytes((Int32) value);
+	return write((Int32) value, _flipBytes);
 #endif
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
 }
 
 
 BinaryWriter& BinaryWriter::operator << (unsigned long value)
 {
-	if (_flipBytes)
-	{
 #if defined(POCO_LONG_IS_64_BIT)
-		long fValue = ByteOrder::flipBytes((UInt64) value);
+	return write((UInt64) value, _flipBytes);
 #else
-		long fValue = ByteOrder::flipBytes((UInt32) value);
+	return write((UInt32) value, _flipBytes);
 #endif
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
 }
 
 
 BinaryWriter& BinaryWriter::operator << (float value)
 {
-	if (_flipBytes)
-	{
-		const char* ptr = (const char*) &value;
-		ptr += sizeof(value);
-		for (unsigned i = 0; i < sizeof(value); ++i)
-			_ostr.write(--ptr, 1);
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (double value)
 {
-	if (_flipBytes)
-	{
-		const char* ptr = (const char*) &value;
-		ptr += sizeof(value);
-		for (unsigned i = 0; i < sizeof(value); ++i)
-			_ostr.write(--ptr, 1);
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	return write(value, _flipBytes);
 }
 
 
@@ -219,31 +138,13 @@ BinaryWriter& BinaryWriter::operator << (double value)
 
 BinaryWriter& BinaryWriter::operator << (Int64 value)
 {
-	if (_flipBytes)
-	{
-		Int64 fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (UInt64 value)
 {
-	if (_flipBytes)
-	{
-		UInt64 fValue = ByteOrder::flipBytes(value);
-		_ostr.write((const char*) &fValue, sizeof(fValue));
-	}
-	else
-	{
-		_ostr.write((const char*) &value, sizeof(value));
-	}
-	return *this;
+	write(value, _flipBytes);
 }
 
 
@@ -252,21 +153,7 @@ BinaryWriter& BinaryWriter::operator << (UInt64 value)
 
 BinaryWriter& BinaryWriter::operator << (const std::string& value)
 {
-	if (_pTextConverter)
-	{
-		std::string converted;
-		_pTextConverter->convert(value, converted);
-		UInt32 length = (UInt32) converted.size();
-		write7BitEncoded(length);
-		_ostr.write(converted.data(), length);
-	}
-	else
-	{
-		UInt32 length = (UInt32) value.size();
-		write7BitEncoded(length);
-		_ostr.write(value.data(), length);
-	}
-	return *this;
+	return *this << value.c_str();
 }
 
 
@@ -294,14 +181,7 @@ BinaryWriter& BinaryWriter::operator << (const char* value)
 
 void BinaryWriter::write7BitEncoded(UInt32 value)
 {
-	do
-	{
-		unsigned char c = (unsigned char) (value & 0x7F);
-		value >>= 7;
-		if (value) c |= 0x80;
-		_ostr.write((const char*) &c, 1);
-	}
-	while (value);
+	write7BitEncoded<UInt32>(value);
 }
 
 
@@ -310,14 +190,7 @@ void BinaryWriter::write7BitEncoded(UInt32 value)
 
 void BinaryWriter::write7BitEncoded(UInt64 value)
 {
-	do
-	{
-		unsigned char c = (unsigned char) (value & 0x7F);
-		value >>= 7;
-		if (value) c |= 0x80;
-		_ostr.write((const char*) &c, 1);
-	}
-	while (value);
+	write7BitEncoded<UInt64>(value);
 }
 
 

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -153,29 +153,13 @@ BinaryWriter& BinaryWriter::operator << (UInt64 value)
 
 BinaryWriter& BinaryWriter::operator << (const std::string& value)
 {
-	return *this << value.c_str();
+	return write(value.c_str(), value.length());
 }
 
 
 BinaryWriter& BinaryWriter::operator << (const char* value)
 {
-	poco_check_ptr (value);
-	
-	if (_pTextConverter)
-	{
-		std::string converted;
-		_pTextConverter->convert(value, static_cast<int>(std::strlen(value)), converted);
-		UInt32 length = (UInt32) converted.size();
-		write7BitEncoded(length);
-		_ostr.write(converted.data(), length);
-	}
-	else
-	{
-		UInt32 length = static_cast<UInt32>(std::strlen(value));
-		write7BitEncoded(length);
-		_ostr.write(value, length);
-	}
-	return *this;
+	return write(value, std::strlen(value));
 }
 
 
@@ -220,6 +204,28 @@ void BinaryWriter::writeBOM()
 void BinaryWriter::flush()
 {
 	_ostr.flush();
+}
+
+
+BinaryWriter& BinaryWriter::write(const char* value, std::size_t length)
+{
+	poco_check_ptr (value);
+	
+	if (_pTextConverter)
+	{
+		std::string converted;
+		_pTextConverter->convert(value, static_cast<int>(length), converted);
+		UInt32 convertedLength = (UInt32) converted.length();
+		write7BitEncoded(convertedLength);
+		_ostr.write(converted.data(), convertedLength);
+	}
+	else
+	{
+		UInt32 lengthUInt32 = static_cast<UInt32>(length);
+		write7BitEncoded(lengthUInt32);
+		_ostr.write(value, lengthUInt32);
+	}
+	return *this;	
 }
 
 

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -138,13 +138,13 @@ BinaryWriter& BinaryWriter::operator << (double value)
 
 BinaryWriter& BinaryWriter::operator << (Int64 value)
 {
-	write(value, _flipBytes);
+	return write(value, _flipBytes);
 }
 
 
 BinaryWriter& BinaryWriter::operator << (UInt64 value)
 {
-	write(value, _flipBytes);
+	return write(value, _flipBytes);
 }
 
 

--- a/Foundation/testsuite/src/ByteOrderTest.cpp
+++ b/Foundation/testsuite/src/ByteOrderTest.cpp
@@ -67,6 +67,46 @@ void ByteOrderTest::testByteOrderFlip()
 		flip = ByteOrder::flipBytes(flip);
 		assert (flip == norm);
 	}
+	{
+		unsigned char  c     = 0x00;
+		float          norm  = 0;
+		unsigned char* normP = reinterpret_cast<unsigned char*>(&norm);
+		for (unsigned i = 0; i < sizeof(float); i++)
+		{
+			normP[i] |= c;
+			c += 0x11;
+		}
+
+		float          flip  = ByteOrder::flipBytes(norm);
+		unsigned char* flipP = reinterpret_cast<unsigned char*>(&flip);
+		for (unsigned i = 0; i < sizeof(float); i++)
+		{
+			assert(normP[i] == flipP[sizeof(float) - 1 - i]);
+		}
+
+		flip = ByteOrder::flipBytes(flip);
+		assert (flip == norm);
+	}
+	{
+		unsigned char  c     = 0x00;
+		double         norm  = 0;
+		unsigned char* normP = reinterpret_cast<unsigned char*>(&norm);
+		for (unsigned i = 0; i < sizeof(double); i++)
+		{
+			normP[i] |= c;
+			c += 0x11;
+		}
+
+		double         flip  = ByteOrder::flipBytes(norm);
+		unsigned char* flipP = reinterpret_cast<unsigned char*>(&flip);
+		for (unsigned i = 0; i < sizeof(double); i++)
+		{
+			assert(normP[i] == flipP[sizeof(double) - 1 - i]);
+		}
+
+		flip = ByteOrder::flipBytes(flip);
+		assert (flip == norm);
+	}
 	#if defined(POCO_HAVE_INT64)
 	{
 		Int64 norm = (Int64(0x8899AABB) << 32) + 0xCCDDEEFF;


### PR DESCRIPTION
1. move flipBytes(float/double) to ByteOrder.
2. remove redundant code from BinaryWriter and BinaryReader.