### PR TITLE
Named substring support

### DIFF
--- a/Foundation/include/Poco/RegularExpression.h
+++ b/Foundation/include/Poco/RegularExpression.h
@@ -25,6 +25,7 @@
 
 #include "Poco/Foundation.h"
 #include <vector>
+#include <map>
 
 
 //
@@ -91,8 +92,10 @@ public:
 	{
 		std::string::size_type offset; /// zero based offset (std::string::npos if subexpr does not match)
 		std::string::size_type length; /// length of substring
+		std::string name;              /// name of group
 	};
 	typedef std::vector<Match> MatchVec;
+	typedef std::map<int, std::string> GroupMap;
 	
 	RegularExpression(const std::string& pattern, int options = 0, bool study = true);
 		/// Creates a regular expression and parses the given pattern.
@@ -212,6 +215,8 @@ private:
 	pcre*       _pcre;
 	pcre_extra* _extra;
 	
+	GroupMap _groups;
+
 	static const int OVEC_SIZE;
 	
 	RegularExpression();

--- a/Foundation/src/RegularExpression.cpp
+++ b/Foundation/src/RegularExpression.cpp
@@ -24,7 +24,6 @@
 #include "pcre.h"
 #endif
 
-
 namespace Poco {
 
 
@@ -35,6 +34,10 @@ RegularExpression::RegularExpression(const std::string& pattern, int options, bo
 {
 	const char* error;
 	int offs;
+	unsigned nmcount;
+	unsigned nmentrysz;
+	unsigned char* nmtbl;
+
 	_pcre = pcre_compile(pattern.c_str(), options, &error, &offs, 0);
 	if (!_pcre)
 	{
@@ -44,6 +47,18 @@ RegularExpression::RegularExpression(const std::string& pattern, int options, bo
 	}
 	if (study)
 		_extra = pcre_study(_pcre, 0, &error);
+
+	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMECOUNT, &nmcount);
+	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMEENTRYSIZE, &nmentrysz);
+	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMETABLE, &nmtbl);
+
+	for (int i = 0; i < nmcount; i++)
+	{
+		unsigned char* group = nmtbl + 2 + (nmentrysz * i);
+		int n = pcre_get_stringnumber(_pcre, (char*) group);
+		_groups[n] = std::string((char*) group);
+	}
+
 }
 
 
@@ -116,8 +131,17 @@ int RegularExpression::match(const std::string& subject, std::string::size_type 
 	for (int i = 0; i < rc; ++i)
 	{
 		Match m;
+		GroupMap::const_iterator it;
+
 		m.offset = ovec[i*2] < 0 ? std::string::npos : ovec[i*2] ;
 		m.length = ovec[i*2 + 1] - m.offset;
+
+		it = _groups.find(i);
+		if (it != _groups.end())
+		{
+			m.name = (*it).second;
+		}
+
 		matches.push_back(m);
 	}
 	return rc;

--- a/Foundation/testsuite/src/RegularExpressionTest.cpp
+++ b/Foundation/testsuite/src/RegularExpressionTest.cpp
@@ -264,6 +264,16 @@ void RegularExpressionTest::testError()
 	}
 }
 
+void RegularExpressionTest::testGroup()
+{
+	RegularExpression::MatchVec matches;
+	RegularExpression re("(?P<group1>[a-z]+) (?P<group2>[0-9]+)");
+	assert (re.match("abcd 1234", 0, matches) == 3);
+	assert (matches[0].name == "");
+	assert (matches[1].name == "group1");
+	assert (matches[2].name == "group2");
+}
+
 
 void RegularExpressionTest::setUp()
 {
@@ -294,6 +304,7 @@ CppUnit::Test* RegularExpressionTest::suite()
 	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst3);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst4);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testError);
+	CppUnit_addTest(pSuite, RegularExpressionTest, testGroup);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/RegularExpressionTest.h
+++ b/Foundation/testsuite/src/RegularExpressionTest.h
@@ -41,6 +41,7 @@ public:
 	void testSubst3();
 	void testSubst4();
 	void testError();
+	void testGroup();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Hello,

Regular expressions are very limited in C++11 using ECMAScript syntax. POCO is more powerful using PCRE but it has not support for substrings names.

See man pages:
pcre_get_named_substring
pcre_fullinfo

I have added a field in Match structure to support group name when calling match() method with a MatchVec parameter:

# Code example:
```c++
#include <iostream>
#include <string>
#include <cstring>
#include <cstdlib>
#include <Poco/RegularExpression.h>

using namespace std;
using namespace Poco;

int main(int argc, char* argv[])
{
	if (argc != 3)
		return -1;

	RegularExpression::MatchVec matches;
	RegularExpression regex(argv[1]);

	regex.match(argv[2], 0, matches);
	if (matches.size() > 0)
	{
		cout << "String found" << endl;

		for (auto match : matches)
		{
			char* matchedStr = strndup(argv[2] + match.offset, match.length);
			cout << "    Group name: " << match.name << " => " << matchedStr << endl;
			free(matchedStr);
		}
	}
	else
	{
		cout << "String not found" << endl;
	}

	return 0;
}
```
## Execution:
```
david@ubuntu:~/workspace/test$ g++ -o regexp -std=c++11 regexp.cpp -lPocoFoundation
david@ubuntu:~/workspace/test$ ./regexp "Hello (?P<name>\S+) (?P<surname>\S+)" "Hello David Moran"
String found
    Group name:  => Hello David Moran
    Group name: name => David
    Group name: surname => Moran
david@ubuntu:~/workspace/test$ 
```

Regards