### PR TITLE
Somewhere along the line the syntax of the CMake Poco::Data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,3 @@ cmake-build/
 ###################
 *.bak
 
-buildx64.txt
-
-buildx642.txt

--- a/Data/PostgreSQL/CMakeLists.txt
+++ b/Data/PostgreSQL/CMakeLists.txt
@@ -18,7 +18,7 @@ set_target_properties( "${LIBNAME}"
     DEFINE_SYMBOL PostgreSQL_EXPORTS
     )
 
-target_link_libraries( "${LIBNAME}" Foundation Data ${POSTGRESQL_LIBRARY})
+target_link_libraries( "${LIBNAME}" Foundation Data ${POSTGRESQL_LIB})
 target_include_directories( "${LIBNAME}"
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/Data/PostgreSQL/Makefile
+++ b/Data/PostgreSQL/Makefile
@@ -8,29 +8,9 @@
 
 include $(POCO_BASE)/build/rules/global
 
-ifndef POCO_POSTGRESQL_INCLUDE
-POCO_POSTGRESQL_INCLUDE = /usr/include/postgresql
-endif
+INCLUDE += -I/usr/include/postgresql -I/usr/local/include/postgresql -I/usr/local/postgresql/include -I/opt/postgresql/include
 
-ifndef POCO_POSTGRESQL_LIB
-ifeq (0, $(shell test -d /usr/lib/$(OSARCH)-linux-gnu; echo $$?))
-POCO_POSTGRESQL_LIB = /usr/lib/$(OSARCH)-linux-gnu
-else ifeq (0, $(shell test -d /usr/lib64; echo $$?))
-POCO_POSTGRESQL_LIB = /usr/lib64
-else
-POCO_POSTGRESQL_LIB = /usr/lib
-endif
-endif
-
-ifeq ($(LINKMODE),STATIC)
-LIBLINKEXT = .a
-else
-LIBLINKEXT = $(SHAREDLIBLINKEXT)
-endif
-
-INCLUDE += -I$(POCO_POSTGRESQL_INCLUDE)
-
-SYSLIBS += -L$(POCO_POSTGRESQL_LIB) -lpq
+SYSLIBS += -L/usr/lib$(LIB64SUFFIX)/postgresql -L/usr/local/lib$(LIB64SUFFIX)/postgresql -L/usr/local/postgresql/lib$(LIB64SUFFIX) -L/opt/postgresql/lib$(LIB64SUFFIX) -lpq
 
 objects = Extractor Binder SessionImpl Connector \
 	PostgreSQLStatementImpl PostgreSQLException \

--- a/README
+++ b/README
@@ -91,6 +91,7 @@ libraries) being installed to build properly:
 - Data/ODBC requires ODBC 
   (Microsoft ODBC on Windows, unixODBC or iODBC on Unix/Linux)
 - Data/MySQL requires the MySQL client.
+- Data/PostgreSQL requires the PostgreSQL client.
 
 Most Unix/Linux systems already have OpenSSL preinstalled. If your system 
 does not have OpenSSL, please get it from http://www.openssl.org or 
@@ -110,13 +111,15 @@ to build the ODBC connector (which is the default). On Windows
 platforms, ODBC should be readily available if you have the 
 Windows SDK. On Unix/Linux platforms, you can use iODBC 
 (preinstalled on Mac OS X) or unixODBC. For the MySQL connector, 
-the MySQL client libraries and header files are required.
+the MySQL client libraries and header files are required. For the 
+PostgreSQL connector, the PostgreSQL client libraries and header 
+files are required.
 
-The Data/ODBC and Data/MySQL Makefiles will search for the ODBC 
-and MySQL headers and libraries in various places. Nevertheless, 
-the Makefiles may not be able to find the headers and libraries. 
-In this case, please edit the Makefile in Data/ODBC and/or Data/MySQL 
-accordingly.
+The Data/ODBC, Data/MySQL, DataPostgreSQL Makefiles will search
+for the ODBC, MySQL and PostgreSQL headers and libraries in various
+places. Nevertheless, the Makefiles may not be able to find the
+headers and libraries. In this case, please edit the Makefile 
+in Data/ODBC and/or Data/MySQL and/or Data/PostgreSQL accordingly.
 
 
 BUILDING ON WINDOWS
@@ -200,11 +203,12 @@ to configure --prefix=<path>):
 > sudo gmake -s install
 
 You can omit certain components from the build. For example, you might
-want to omit Data/ODBC or Data/MySQL if you do not have the corresponding
-third-party libraries (iodbc or unixodbc, mysqlclient) installed
-on your system. To do this, use the --omit argument to configure:
+want to omit Data/ODBC or Data/MySQL or Data/PostgreSQL if you do not
+have the corresponding third-party libraries (iodbc, unixodbc,
+mysqlclient or libpq ) installed on your system. To do this, use
+the --omit argument to configure:
 
-> ./configure --omit=Data/ODBC,Data/MySQL
+> ./configure --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL
 
 
 To build on Mac OS X 10.3 with GCC 3, do the following:

--- a/biicode/cmake/PostgreSQL.cmake
+++ b/biicode/cmake/PostgreSQL.cmake
@@ -1,0 +1,2 @@
+target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE -DTHREADSAFE)
+target_link_libraries( ${BII_BLOCK_TARGET} INTERFACE ${POSTGRESQL_LIB})

--- a/doc/00200-GettingStarted.page
+++ b/doc/00200-GettingStarted.page
@@ -100,6 +100,7 @@ libraries) being installed to build properly:
   - Data/ODBC requires ODBC 
     (Microsoft ODBC on Windows, unixODBC or iODBC on Unix/Linux)
   - Data/MySQL requires the MySQL client.
+  - Data/PostgreSQL requires the PostgreSQL client.
 
 
 !OpenSSL
@@ -143,11 +144,11 @@ necessary libraries and header files. For example, on Ubuntu, type
 
 to install the iODBC library and header files.
 
-The Data/ODBC and Data/MySQL Makefiles will search for the ODBC and
-MySQL headers and libraries in various places. Nevertheless, the
-Makefiles may not be able to find the headers and libraries. In this
-case, please edit the Makefile in Data/ODBC and/or Data/MySQL
-accordingly.
+The Data/ODBC, Data/MySQL and Data/PostgreSQL Makefiles will search
+for the ODBC, MySQL and PostgreSQL headers and libraries in various
+places. Nevertheless, the Makefiles may not be able to find the 
+headers and libraries. In this case, please edit the Makefile in
+Data/ODBC and/or Data/MySQL and/or Data/PostgreSQL accordingly.
 
 
 !MySQL Client
@@ -159,6 +160,16 @@ installer to install the necessary files. On Unix/Linux platforms, use
 the package management system of your choice to install the necessary
 files. Alternatively, you can of course build MySQL yourself from
 source.
+
+!PostgreSQL Client
+
+The Data library requires the [[http://postgresql.org PostgreSQL]]
+client libraries and header files if you want to build the PostgreSQL
+connector (which is the default). On Windows platforms, use the
+PostgreSQL graphical installer to install the necessary files. On
+Unix/Linux platforms, use the package management system of your 
+choice to install the necessary files. Alternatively, you can of
+course build PostgreSQL yourself from source.
 
 
 !!Building On Windows
@@ -250,11 +261,12 @@ to configure <[--prefix=<path>]>):
 ----
 
 You can omit certain components from the build. For example, you might
-want to omit Data/ODBC or Data/MySQL if you do not have the corresponding
-third-party libraries (iodbc or unixodbc, mysqlclient) installed
-on your system. To do this, use the <[--omit]> argument to configure:
+want to omit Data/ODBC or Data/MySQL or Data/PostgreSQL if you do 
+not have the corresponding third-party libraries (iodbc or unixodbc,
+mysqlclient or libpq) installed on your system. To do this, use the 
+<[--omit]> argument to configure:
 
-    $ ./configure --omit=Data/ODBC,Data/MySQL
+    $ ./configure --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL
 ----
 
 <*IMPORTANT: Make sure that the path to the build directory does not

--- a/release/spec/all.release
+++ b/release/spec/all.release
@@ -4,6 +4,7 @@ Data
 Data/SQLite
 Data/ODBC
 Data/MySQL
+Data/PostgreSQL
 MongoDB
 Zip
 PageCompiler

--- a/release/spec/world.release
+++ b/release/spec/world.release
@@ -4,6 +4,7 @@ Data
 Data/SQLite
 Data/ODBC
 Data/MySQL
+Data/PostgreSQL
 MongoDB
 Zip
 PageCompiler


### PR DESCRIPTION
changed.

1) CMake config files for PostgreSQL now updated to same syntax as
other Poco::Data databases and verified as working under MacOSX 10.10.5
(PG 9.4), Ubuntu Linux 15.04 (PG 9.3) and Windows 7 (PG 9.3).

2) Updated PostgreSQL Makefile to be similar to other Poco::Data
Makefiles

3) fixed .gitignore to remove references to local files.

4) Added support for biked

5) Updated doc text files to mention PostgreSQL and same fashion as
MySQL

6) Added support in release (???) directory for PostgreSQL