### PR TITLE
Return non-zero from ProcessHandle::wait if killed by signal

### DIFF
--- a/Foundation/src/Process_UNIX.cpp
+++ b/Foundation/src/Process_UNIX.cpp
@@ -18,6 +18,7 @@
 #include "Poco/Exception.h"
 #include "Poco/NumberFormatter.h"
 #include "Poco/Pipe.h"
+#include <limits>
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -68,7 +69,12 @@ int ProcessHandleImpl::wait() const
 	while (rc < 0 && errno == EINTR);
 	if (rc != _pid)
 		throw SystemException("Cannot wait for process", NumberFormatter::format(_pid));
-	return WEXITSTATUS(status);
+	if (WIFEXITED(status))
+		return WEXITSTATUS(status);
+	if (WIFSIGNALED(status))
+		return -WTERMSIG(status);
+	// This line should never be reached.
+	return std::numeric_limits<int>::max();
 }
 
 

--- a/Foundation/testsuite/src/ProcessTest.cpp
+++ b/Foundation/testsuite/src/ProcessTest.cpp
@@ -16,6 +16,7 @@
 #include "Poco/Process.h"
 #include "Poco/Pipe.h"
 #include "Poco/PipeStream.h"
+#include <csignal>
 
 
 using Poco::Process;
@@ -190,6 +191,27 @@ void ProcessTest::testIsRunning()
 }
 
 
+void ProcessTest::testSignalExitCode()
+{
+#if defined(POCO_OS_FAMILY_UNIX)
+	std::string name("TestApp");
+	std::string cmd;
+#if defined(_DEBUG)
+	name += "d";
+#endif
+
+	cmd = "./";
+	cmd += name;
+
+	std::vector<std::string> args;
+	args.push_back("-raise-int");
+	ProcessHandle ph = Process::launch(cmd, args, 0, 0, 0);
+	int rc = ph.wait();
+	assert (rc == -SIGINT);
+#endif // defined(POCO_OS_FAMILY_UNIX)
+}
+
+
 void ProcessTest::setUp()
 {
 }
@@ -209,6 +231,7 @@ CppUnit::Test* ProcessTest::suite()
 	CppUnit_addTest(pSuite, ProcessTest, testLaunchRedirectOut);
 	CppUnit_addTest(pSuite, ProcessTest, testLaunchEnv);
 	CppUnit_addTest(pSuite, ProcessTest, testIsRunning);
+	CppUnit_addTest(pSuite, ProcessTest, testSignalExitCode);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/ProcessTest.h
+++ b/Foundation/testsuite/src/ProcessTest.h
@@ -31,6 +31,7 @@ public:
 	void testLaunchRedirectOut();
 	void testLaunchEnv();
 	void testIsRunning();
+	void testSignalExitCode();
 
 	void setUp();
 	void tearDown();

--- a/Foundation/testsuite/src/TestApp.cpp
+++ b/Foundation/testsuite/src/TestApp.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <iostream>
 #include <cstdlib>
+#include <csignal>
 
 
 int main(int argc, char** argv)
@@ -45,6 +46,10 @@ int main(int argc, char** argv)
 				return 0;
 			}
 			else return 1;
+		}
+		else if (arg == "-raise-int")
+		{
+			std::raise(SIGINT);
 		}
 	}
 	return argc - 1;


### PR DESCRIPTION
Currently, `ProcessHandle::wait` (and transitively `Process::wait`) on *NIX return zero if process was terminated as a result of unhandled signal. Check if this is the case and return negative signal number instead to indicate non-graceful process termination.

Note that `waitpid` is also used in VMS implementation, but I don't know whether same change may apply there.