### PR TITLE
removing POCO_OS_* declarations from cmake and biicode configuration

### DIFF
--- a/biicode/cmake/biicode.cmake
+++ b/biicode/cmake/biicode.cmake
@@ -24,12 +24,11 @@ endif(POCO_STATIC)
 
 # OS Detection
 if(WIN32)
-  target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE  -DPOCO_OS_FAMILY_WINDOWS -DUNICODE -D_UNICODE)
+  target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE  -DUNICODE -D_UNICODE)
   #set(SYSLIBS iphlpapi gdi32 odbc32)
 endif(WIN32)
 
 if (UNIX AND NOT ANDROID )
-  target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE  -DPOCO_OS_FAMILY_UNIX )
   # Standard 'must be' defines
   if (APPLE)
     target_compile_definitions(${BII_BLOCK_TARGET} INTERFACE  -DPOCO_HAVE_IPv6 -DPOCO_NO_STAT64)

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -40,11 +40,11 @@ if(MSVC)
     else(POCO_MT)
         set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
     endif(POCO_MT)
-      
+
     if (ENABLE_MSVC_MP)
       add_definitions(/MP)
     endif()
-    
+
 else(MSVC)
     # Other compilers then MSVC don't have a static STATIC_POSTFIX at the moment
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
@@ -69,11 +69,10 @@ include(CheckTypeSize)
 find_package(Cygwin)
 
 if(WIN32)
-  add_definitions( -DPOCO_OS_FAMILY_WINDOWS -DUNICODE -D_UNICODE -D__LCC__)  #__LCC__ define used by MySQL.h
+  add_definitions( -DUNICODE -D_UNICODE -D__LCC__)  #__LCC__ define used by MySQL.h
 endif(WIN32)
 
 if (UNIX AND NOT ANDROID )
-  add_definitions( -DPOCO_OS_FAMILY_UNIX )
   # Standard 'must be' defines
   if (APPLE)
     add_definitions( -DPOCO_HAVE_IPv6 -DPOCO_NO_STAT64)
@@ -85,7 +84,6 @@ if (UNIX AND NOT ANDROID )
 endif(UNIX AND NOT ANDROID )
 
 if (CMAKE_SYSTEM MATCHES "SunOS")
-  add_definitions( -DPOCO_OS_FAMILY_UNIX )
   # Standard 'must be' defines
   add_definitions( -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 )
   set(SYSLIBS  pthread socket xnet nsl resolv rt dl)


### PR DESCRIPTION
fixes #960 