### PR TITLE
PostgreSQL

### DIFF
--- a/Data/PostgreSQL/testsuite/Makefile
+++ b/Data/PostgreSQL/testsuite/Makefile
@@ -8,30 +8,9 @@
 
 include $(POCO_BASE)/build/rules/global
 
-ifndef POCO_POSTGRESQL_INCLUDE
-POCO_POSTGRESQL_INCLUDE = /usr/include/postgresql
-endif
+INCLUDE += -I/usr/include/postgresql -I/usr/local/include/postgresql -I/usr/local/postgresql/include -I/opt/postgresql/include
 
-ifndef POCO_POSTGRESQL_LIB
-ifeq (0, $(shell test -d /usr/lib/$(OSARCH)-linux-gnu; echo $$?))
-POCO_POSTGRESQL_LIB = /usr/lib/$(OSARCH)-linux-gnu
-else ifeq (0, $(shell test -d /usr/lib64; echo $$?))
-POCO_POSTGRESQL_LIB = /usr/lib64
-else
-POCO_POSTGRESQL_LIB = /usr/lib
-endif
-endif
-
-ifeq ($(LINKMODE),STATIC)
-LIBLINKEXT = .a
-else
-LIBLINKEXT = $(SHAREDLIBLINKEXT)
-endif
-
-INCLUDE += -I./../include
-INCLUDE += -I$(POCO_POSTGRESQL_INCLUDE)
-
-SYSLIBS += -L$(POCO_POSTGRESQL_LIB) -lpq
+SYSLIBS += -L/usr/lib$(LIB64SUFFIX)/postgresql -L/usr/local/lib$(LIB64SUFFIX)/postgresql -L/usr/local/postgresql/lib$(LIB64SUFFIX) -L/opt/postgresql/lib$(LIB64SUFFIX) -lpq
 
 # Note: linking order is important, do not change it.
 SYSLIBS += -lz -lpthread -ldl

--- a/Data/src/StatementImpl.cpp
+++ b/Data/src/StatementImpl.cpp
@@ -355,8 +355,10 @@ void StatementImpl::makeExtractors(std::size_t count, const Position& position)
 				addInternalExtract<std::string>(mc, position.value()); break;
 			case MetaColumn::FDT_WSTRING:
 				addInternalExtract<Poco::UTF16String>(mc, position.value()); break;
-			case MetaColumn::FDT_BLOB:   
-				addInternalExtract<BLOB>(mc, position.value()); break;
+            case MetaColumn::FDT_BLOB:
+                addInternalExtract<BLOB>(mc, position.value()); break;
+            case MetaColumn::FDT_CLOB:
+                addInternalExtract<CLOB>(mc, position.value()); break;
 			case MetaColumn::FDT_DATE:
 				addInternalExtract<Date>(mc, position.value()); break;
 			case MetaColumn::FDT_TIME:


### PR DESCRIPTION
The extractor creation loop used in Poco::Data::RecordSets was missing
a case for Poco::Data::CLOB results from database queries