### PR TITLE
Move select implementation from Socket to SocketImpl.

### DIFF
--- a/Net/include/Poco/Net/Socket.h
+++ b/Net/include/Poco/Net/Socket.h
@@ -305,7 +305,6 @@ protected:
 		/// Returns the socket descriptor for this socket.
 
 private:
-
 	SocketImpl* _pImpl;
 };
 

--- a/Net/include/Poco/Net/Socket.h
+++ b/Net/include/Poco/Net/Socket.h
@@ -305,6 +305,12 @@ protected:
 		/// Returns the socket descriptor for this socket.
 
 private:
+	typedef SocketImpl::SocketImplList SocketImplList;
+
+	static void SocketListToSocketImplList(const SocketList& socketList, SocketImplList& socketImplList);
+
+	static void SocketImplListToSocketList(SocketImplList& socketImplList, SocketList& socketList);
+
 	SocketImpl* _pImpl;
 };
 

--- a/Net/include/Poco/Net/Socket.h
+++ b/Net/include/Poco/Net/Socket.h
@@ -306,22 +306,6 @@ protected:
 
 private:
 
-#if defined(POCO_HAVE_FD_POLL)
-class FDCompare
-	/// Utility functor used to compare socket file descriptors.
-	/// Used in poll() member function.
-{
-public:
-	FDCompare(int fd): _fd(fd) { }
-	inline bool operator()(const Socket& socket) const
-	{ return socket.sockfd() == _fd; }
-
-private:
-	FDCompare();
-	int _fd;
-};
-#endif
-
 	SocketImpl* _pImpl;
 };
 

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -468,7 +468,7 @@ private:
 #elif defined(POCO_HAVE_FD_POLL)
 	typedef std::vector<pollfd> PollFd;
 
-	static void fillPollFd(SocketImplList& socketImplList, int event, PollFd& pollFd);
+	static void fillPollFd(const SocketImplList& socketImplList, int event, PollFd& pollFd);
 
 	static void doPoll(PollFd& pollFd, const Poco::Timespan& timeout);
 
@@ -490,7 +490,7 @@ private:
 #else
 	static void fillFDSet(const SocketImplList& socketImplList, fd_set* fdSet, int* nfd);
 
-	static int doSelect(fd_set* fdRead, fd_set* fdWrite, fd_set* fdExcept, int nfd, const Poco::Timespan& timeout);
+	static void doSelect(fd_set* fdRead, fd_set* fdWrite, fd_set* fdExcept, int nfd, const Poco::Timespan& timeout);
 
 	static void collectReadyFd(const SocketImplList& socketImplList, fd_set* fdSet, SocketImplList& readyList);
 #endif

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -505,6 +505,7 @@ private:
 	bool          _isBrokenTimeout;
 	
 	friend class Socket;
+	friend class SecureSocketImpl;
 };
 
 

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -27,6 +27,8 @@
 #include "Poco/Timespan.h"
 #if defined(POCO_HAVE_FD_EPOLL)
 #include <sys/epoll.h>
+#elif defined(POCO_HAVE_FD_POLL)
+#include <poll.h>
 #endif
 #include <vector>
 
@@ -464,6 +466,14 @@ private:
 
 	static void epollEventToSocketImplList(epoll_event* event, int size, SocketImplList& readList, SocketImplList& writeList, SocketImplList& exceptList);
 #elif defined(POCO_HAVE_FD_POLL)
+	typedef std::vector<pollfd> PollFd;
+
+	static void fillPollFd(SocketImplList& socketImplList, int event, PollFd& pollFd);
+
+	static void doPoll(PollFd& pollFd, const Poco::Timespan& timeout);
+
+	static void collectReadyFd(const PollFd& pollFd, const SocketImplList& readList, const SocketImplList& writeList, const SocketImplList& exceptList, SocketImplList& readyReadList, SocketImplList& readyWriteList, SocketImplList& readyExceptList);
+
 class FDCompare
 	/// Utility functor used to compare socket file descriptors.
 	/// Used in poll() member function.

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -505,7 +505,6 @@ private:
 	bool          _isBrokenTimeout;
 	
 	friend class Socket;
-	friend class SecureSocketImpl;
 };
 
 

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -25,6 +25,9 @@
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/RefCountedObject.h"
 #include "Poco/Timespan.h"
+#if defined(POCO_HAVE_FD_EPOLL)
+#include <sys/epoll.h>
+#endif
 #include <vector>
 
 
@@ -451,7 +454,15 @@ protected:
 
 private:
 #if defined(POCO_HAVE_FD_EPOLL)
+	typedef std::vector<epoll_event> EpollEvent;
 
+	static void fillEpollEvent(SocketImplList& socketImplList, int event, EpollEvent& epollEvent);
+
+	static void addEpollEventToWatch(EpollEvent& epollEvent, int fd);
+
+	static int doEpollWait(int fd, epoll_event* eventsOut, int size, const Poco::Timespan& timeout);
+
+	static void epollEventToSocketImplList(epoll_event* event, int size, SocketImplList& readList, SocketImplList& writeList, SocketImplList& exceptList);
 #elif defined(POCO_HAVE_FD_POLL)
 class FDCompare
 	/// Utility functor used to compare socket file descriptors.

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -458,7 +458,7 @@ private:
 #if defined(POCO_HAVE_FD_EPOLL)
 	typedef std::vector<epoll_event> EpollEvent;
 
-	static void fillEpollEvent(SocketImplList& socketImplList, int event, EpollEvent& epollEvent);
+	static void fillEpollEvent(const SocketImplList& socketImplList, int event, EpollEvent& epollEvent);
 
 	static void addEpollEventToWatch(EpollEvent& epollEvent, int fd);
 

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -450,7 +450,9 @@ protected:
 		/// Throws an appropriate exception for the given error code.
 
 private:
-#if defined(POCO_HAVE_FD_POLL)
+#if defined(POCO_HAVE_FD_EPOLL)
+
+#elif defined(POCO_HAVE_FD_POLL)
 class FDCompare
 	/// Utility functor used to compare socket file descriptors.
 	/// Used in poll() member function.
@@ -464,6 +466,12 @@ private:
 	FDCompare();
 	int _fd;
 };
+#else
+	static void fillFDSet(const SocketImplList& socketImplList, fd_set* fdSet, int* nfd);
+
+	static int doSelect(fd_set* fdRead, fd_set* fdWrite, fd_set* fdExcept, int nfd, const Poco::Timespan& timeout);
+
+	static void collectReadyFd(const SocketImplList& socketImplList, fd_set* fdSet, SocketImplList& readyList);
 #endif
 
 	SocketImpl(const SocketImpl&);

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -462,7 +462,7 @@ private:
 
 	static void addEpollEventToWatch(EpollEvent& epollEvent, int fd);
 
-	static int doEpollWait(int fd, epoll_event* eventsOut, int size, const Poco::Timespan& timeout);
+	static int doEpollWait(int fd, epoll_event* eventOut, int size, const Poco::Timespan& timeout);
 
 	static void epollEventToSocketImplList(epoll_event* event, int size, SocketImplList& readList, SocketImplList& writeList, SocketImplList& exceptList);
 #elif defined(POCO_HAVE_FD_POLL)

--- a/Net/src/Socket.cpp
+++ b/Net/src/Socket.cpp
@@ -17,14 +17,6 @@
 #include "Poco/Net/Socket.h"
 #include "Poco/Net/StreamSocketImpl.h"
 #include "Poco/Timestamp.h"
-#include <algorithm>
-#include <string.h> // FD_SET needs memset on some platforms, so we can't use <cstring>
-#if defined(POCO_HAVE_FD_EPOLL)
-#include <sys/epoll.h>
-#elif defined(POCO_HAVE_FD_POLL)
-#include "Poco/SharedPtr.h"
-#include <poll.h>
-#endif
 
 
 namespace Poco {
@@ -73,323 +65,50 @@ Socket::~Socket()
 
 int Socket::select(SocketList& readList, SocketList& writeList, SocketList& exceptList, const Poco::Timespan& timeout)
 {
-#if defined(POCO_HAVE_FD_EPOLL)
+	typedef SocketImpl::SocketImplList sockImpList;
+	sockImpList sockImpReadList;
+	sockImpList sockImpWriteList;
+	sockImpList sockeImpExceptList;
 
-	int epollSize = readList.size() + writeList.size() + exceptList.size();
-	if (epollSize == 0) return 0;
-
-	int epollfd = -1;
+	for (SocketList::const_iterator it = readList.begin(); it != readList.end(); ++it)
 	{
-		struct epoll_event eventsIn[epollSize];
-		memset(eventsIn, 0, sizeof(eventsIn));
-		struct epoll_event* eventLast = eventsIn;
-		for (SocketList::iterator it = readList.begin(); it != readList.end(); ++it)
-		{
-			poco_socket_t sockfd = it->sockfd();
-			if (sockfd != POCO_INVALID_SOCKET)
-			{
-				struct epoll_event* e = eventsIn;
-				for (; e != eventLast; ++e)
-				{
-					if (reinterpret_cast<Socket*>(e->data.ptr)->sockfd() == sockfd)
-						break;
-				}
-				if (e == eventLast)
-				{
-					e->data.ptr = &(*it);
-					++eventLast;
-				}
-				e->events |= EPOLLIN;
-			}
-		}
-
-		for (SocketList::iterator it = writeList.begin(); it != writeList.end(); ++it)
-		{
-			poco_socket_t sockfd = it->sockfd();
-			if (sockfd != POCO_INVALID_SOCKET)
-			{
-				struct epoll_event* e = eventsIn;
-				for (; e != eventLast; ++e)
-				{
-					if (reinterpret_cast<Socket*>(e->data.ptr)->sockfd() == sockfd)
-						break;
-				}
-				if (e == eventLast)
-				{
-					e->data.ptr = &(*it);
-					++eventLast;
-				}
-				e->events |= EPOLLOUT;
-			}
-		}
-
-		for (SocketList::iterator it = exceptList.begin(); it != exceptList.end(); ++it)
-		{
-			poco_socket_t sockfd = it->sockfd();
-			if (sockfd != POCO_INVALID_SOCKET)
-			{
-				struct epoll_event* e = eventsIn;
-				for (; e != eventLast; ++e)
-				{
-					if (reinterpret_cast<Socket*>(e->data.ptr)->sockfd() == sockfd)
-						break;
-				}
-				if (e == eventLast)
-				{
-					e->data.ptr = &(*it);
-					++eventLast;
-				}
-				e->events |= EPOLLERR;
-			}
-		}
-
-		epollSize = eventLast - eventsIn;
-		epollfd = epoll_create(epollSize);
-		if (epollfd < 0)
-		{
-			char buf[1024];
-			strerror_r(errno, buf, sizeof(buf));
-			SocketImpl::error(std::string("Can't create epoll queue: ") + buf);
-		}
-
-		for (struct epoll_event* e = eventsIn; e != eventLast; ++e)
-		{
-			poco_socket_t sockfd = reinterpret_cast<Socket*>(e->data.ptr)->sockfd();
-			if (sockfd != POCO_INVALID_SOCKET)
-			{
-				if (epoll_ctl(epollfd, EPOLL_CTL_ADD, sockfd, e) < 0)
-				{
-					char buf[1024];
-					strerror_r(errno, buf, sizeof(buf));
-					::close(epollfd);
-					SocketImpl::error(std::string("Can't insert socket to epoll queue: ") + buf);
-				}
-			}
-		}
+		if (it->sockfd() != POCO_INVALID_SOCKET) sockImpReadList.push_back(it->impl());
+	}
+	for (SocketList::const_iterator it = writeList.begin(); it != writeList.end(); ++it)
+	{
+		if (it->sockfd() != POCO_INVALID_SOCKET) sockImpWriteList.push_back(it->impl());
+	}
+	for (SocketList::const_iterator it = exceptList.begin(); it != exceptList.end(); ++it)
+	{
+		if (it->sockfd() != POCO_INVALID_SOCKET) sockeImpExceptList.push_back(it->impl());
 	}
 
-	struct epoll_event eventsOut[epollSize];
-	memset(eventsOut, 0, sizeof(eventsOut));
-
-	Poco::Timespan remainingTime(timeout);
-	int rc;
-	do
-	{
-		Poco::Timestamp start;
-		rc = epoll_wait(epollfd, eventsOut, epollSize, remainingTime.totalMilliseconds());
-		if (rc < 0 && SocketImpl::lastError() == POCO_EINTR)
-		{
- 			Poco::Timestamp end;
-			Poco::Timespan waited = end - start;
-			if (waited < remainingTime)
-				remainingTime -= waited;
-			else
-				remainingTime = 0;
-		}
-	}
-	while (rc < 0 && SocketImpl::lastError() == POCO_EINTR);
-
-	::close(epollfd);
-	if (rc < 0) SocketImpl::error();
+	SocketImpl::select(sockImpReadList, sockImpWriteList, sockeImpExceptList, timeout);
 
  	SocketList readyReadList;
 	SocketList readyWriteList;
 	SocketList readyExceptList;
-	for (int n = 0; n < rc; ++n)
+
+	for (sockImpList::iterator it = sockImpReadList.begin(); it != sockImpReadList.end(); ++it)
 	{
-		if (eventsOut[n].events & EPOLLERR)
-			readyExceptList.push_back(*reinterpret_cast<Socket*>(eventsOut[n].data.ptr));
-		if (eventsOut[n].events & EPOLLIN)
-			readyReadList.push_back(*reinterpret_cast<Socket*>(eventsOut[n].data.ptr));
-		if (eventsOut[n].events & EPOLLOUT)
-			readyWriteList.push_back(*reinterpret_cast<Socket*>(eventsOut[n].data.ptr));
+		readyReadList.push_back(Socket(*it));
+		(*it)->duplicate();
 	}
+	for (sockImpList::iterator it = sockImpWriteList.begin(); it != sockImpWriteList.end(); ++it)
+	{
+		readyWriteList.push_back(Socket(*it));
+		(*it)->duplicate();
+	}
+	for (sockImpList::iterator it = sockeImpExceptList.begin(); it != sockeImpExceptList.end(); ++it)
+	{
+		readyExceptList.push_back(Socket(*it));
+		(*it)->duplicate();
+	}
+
 	std::swap(readList, readyReadList);
 	std::swap(writeList, readyWriteList);
 	std::swap(exceptList, readyExceptList);
 	return readList.size() + writeList.size() + exceptList.size();
-
-#elif defined(POCO_HAVE_FD_POLL)
-	typedef Poco::SharedPtr<pollfd, Poco::ReferenceCounter, Poco::ReleaseArrayPolicy<pollfd> > SharedPollArray;
-
-	nfds_t nfd = readList.size() + writeList.size() + exceptList.size();
-	if (0 == nfd) return 0;
-
-	SharedPollArray pPollArr = new pollfd[nfd];
-
-	int idx = 0;
-	for (SocketList::iterator it = readList.begin(); it != readList.end(); ++it)
-	{
-		pPollArr[idx].fd = int(it->sockfd());
-		pPollArr[idx++].events |= POLLIN;
-	}
-
-	SocketList::iterator begR = readList.begin();
-	SocketList::iterator endR = readList.end();
-	for (SocketList::iterator it = writeList.begin(); it != writeList.end(); ++it)
-	{
-		SocketList::iterator pos = std::find(begR, endR, *it);
-		if (pos != endR) 
-		{
-			pPollArr[pos-begR].events |= POLLOUT;
-			--nfd;
-		}
-		else
-		{
-			pPollArr[idx].fd = int(it->sockfd());
-			pPollArr[idx++].events |= POLLOUT;
-		}
-	}
-
-	SocketList::iterator begW = writeList.begin();
-	SocketList::iterator endW = writeList.end();
-	for (SocketList::iterator it = exceptList.begin(); it != exceptList.end(); ++it)
-	{
-		SocketList::iterator pos = std::find(begR, endR, *it);
-		if (pos != endR) --nfd;
-		else
-		{
-			SocketList::iterator pos = std::find(begW, endW, *it);
-			if (pos != endW) --nfd;
-			else pPollArr[idx++].fd = int(it->sockfd());
-		}
-	}
-
-	Poco::Timespan remainingTime(timeout);
-	int rc;
-	do
-	{
-		Poco::Timestamp start;
-		rc = ::poll(pPollArr, nfd, timeout.totalMilliseconds());
-		if (rc < 0 && SocketImpl::lastError() == POCO_EINTR)
-		{
-			Poco::Timestamp end;
-			Poco::Timespan waited = end - start;
-			if (waited < remainingTime) remainingTime -= waited;
-			else remainingTime = 0;
-		}
-	}
-	while (rc < 0 && SocketImpl::lastError() == POCO_EINTR);
-	if (rc < 0) SocketImpl::error();
-
-	SocketList readyReadList;
-	SocketList readyWriteList;
-	SocketList readyExceptList;
-
-	SocketList::iterator begE = exceptList.begin();
-	SocketList::iterator endE = exceptList.end();
-	for (int idx = 0; idx < nfd; ++idx)
-	{
-		SocketList::iterator slIt = std::find_if(begR, endR, Socket::FDCompare(pPollArr[idx].fd));
-		if (POLLIN & pPollArr[idx].revents && slIt != endR) readyReadList.push_back(*slIt);
-		slIt = std::find_if(begW, endW, Socket::FDCompare(pPollArr[idx].fd));
-		if (POLLOUT & pPollArr[idx].revents && slIt != endW) readyWriteList.push_back(*slIt);
-		slIt = std::find_if(begE, endE, Socket::FDCompare(pPollArr[idx].fd));
-		if (POLLERR & pPollArr[idx].revents && slIt != endE) readyExceptList.push_back(*slIt);
-	}
-	std::swap(readList, readyReadList);
-	std::swap(writeList, readyWriteList);
-	std::swap(exceptList, readyExceptList);
-	return readList.size() + writeList.size() + exceptList.size();
-
-#else
-
-	fd_set fdRead;
-	fd_set fdWrite;
-	fd_set fdExcept;
-	int nfd = 0;
-	FD_ZERO(&fdRead);
-	for (SocketList::const_iterator it = readList.begin(); it != readList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (int(fd) > nfd)
-				nfd = int(fd);
-			FD_SET(fd, &fdRead);
-		}
-	}
-	FD_ZERO(&fdWrite);
-	for (SocketList::const_iterator it = writeList.begin(); it != writeList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (int(fd) > nfd)
-				nfd = int(fd);
-			FD_SET(fd, &fdWrite);
-		}
-	}
-	FD_ZERO(&fdExcept);
-	for (SocketList::const_iterator it = exceptList.begin(); it != exceptList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (int(fd) > nfd)
-				nfd = int(fd);
-			FD_SET(fd, &fdExcept);
-		}
-	}
-	if (nfd == 0) return 0;
-	Poco::Timespan remainingTime(timeout);
-	int rc;
-	do
-	{
-		struct timeval tv;
-		tv.tv_sec  = (long) remainingTime.totalSeconds();
-		tv.tv_usec = (long) remainingTime.useconds();
-		Poco::Timestamp start;
-		rc = ::select(nfd + 1, &fdRead, &fdWrite, &fdExcept, &tv);
-		if (rc < 0 && SocketImpl::lastError() == POCO_EINTR)
-		{
-			Poco::Timestamp end;
-			Poco::Timespan waited = end - start;
-			if (waited < remainingTime)
-				remainingTime -= waited;
-			else
-				remainingTime = 0;
-		}
-	}
-	while (rc < 0 && SocketImpl::lastError() == POCO_EINTR);
-	if (rc < 0) SocketImpl::error();
-	
-	SocketList readyReadList;
-	for (SocketList::const_iterator it = readList.begin(); it != readList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (FD_ISSET(fd, &fdRead))
-				readyReadList.push_back(*it);
-		}
-	}
-	std::swap(readList, readyReadList);
-	SocketList readyWriteList;
-	for (SocketList::const_iterator it = writeList.begin(); it != writeList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (FD_ISSET(fd, &fdWrite))
-				readyWriteList.push_back(*it);
-		}
-	}
-	std::swap(writeList, readyWriteList);
-	SocketList readyExceptList;
-	for (SocketList::const_iterator it = exceptList.begin(); it != exceptList.end(); ++it)
-	{
-		poco_socket_t fd = it->sockfd();
-		if (fd != POCO_INVALID_SOCKET)
-		{
-			if (FD_ISSET(fd, &fdExcept))
-				readyExceptList.push_back(*it);
-		}
-	}
-	std::swap(exceptList, readyExceptList);	
-	return rc; 
-
-#endif // POCO_HAVE_FD_EPOLL
 }
 
 

--- a/Net/src/Socket.cpp
+++ b/Net/src/Socket.cpp
@@ -16,7 +16,6 @@
 
 #include "Poco/Net/Socket.h"
 #include "Poco/Net/StreamSocketImpl.h"
-#include "Poco/Timestamp.h"
 
 
 namespace Poco {

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -21,11 +21,6 @@
 #include "Poco/Timestamp.h"
 #include <algorithm>
 #include <string.h> // FD_SET needs memset on some platforms, so we can't use <cstring>
-#if defined(POCO_HAVE_FD_EPOLL)
-#include <sys/epoll.h>
-#elif defined(POCO_HAVE_FD_POLL)
-#include <poll.h>
-#endif
 
 
 #if defined(sun) || defined(__sun) || defined(__sun__)
@@ -1075,7 +1070,7 @@ void SocketImpl::error(int code, const std::string& arg)
 
 
 #if defined(POCO_HAVE_FD_EPOLL)
-void SocketImpl::fillEpollEvent(SocketImplList& socketImplList, int event, EpollEvent& epollEvent)
+void SocketImpl::fillEpollEvent(const SocketImplList& socketImplList, int event, EpollEvent& epollEvent)
 {
 	for (SocketImplList::const_iterator sIt = socketImplList.begin(); sIt != socketImplList.end(); ++sIt)
 	{
@@ -1093,9 +1088,7 @@ void SocketImpl::fillEpollEvent(SocketImplList& socketImplList, int event, Epoll
 
 		if (eIt == epollEvent.end())
 		{
-			struct epoll_event e = { 0 };
-			e.data.ptr = *sIt;
-			e.events |= event;
+			struct epoll_event e = { event, *sIt };
 			epollEvent.push_back(e);
 		}
 		else eIt->events |= event;

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -752,12 +752,9 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 	SocketImplList sockImpWriteList;
 	SocketImplList sockeImpExceptList;
 
-	if (mode & SELECT_READ)
-		sockImpReadList.push_back(this);
-	if (mode & SELECT_WRITE)
-		sockImpWriteList.push_back(this);
-	if (mode & SELECT_ERROR)
-		sockeImpExceptList.push_back(this);
+	if (mode & SELECT_READ)  sockImpReadList.push_back(this);
+	if (mode & SELECT_WRITE) sockImpWriteList.push_back(this);
+	if (mode & SELECT_ERROR) sockeImpExceptList.push_back(this);
 
 	return select(sockImpReadList, sockImpWriteList, sockeImpExceptList, timeout) > 0;
 }

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -1082,6 +1082,7 @@ void SocketImpl::fillEpollEvent(const SocketImplList& socketImplList, int event,
 	}	
 }
 
+
 void SocketImpl::addEpollEventToWatch(EpollEvent& epollEvent, int fd)
 {
 	for (EpollEvent::iterator it = epollEvent.begin(); it != epollEvent.end(); ++it)
@@ -1134,6 +1135,8 @@ void SocketImpl::epollEventToSocketImplList(epoll_event* event, int size, Socket
 			exceptList.push_back(reinterpret_cast<SocketImpl*>(event[n].data.ptr));
 	}
 }
+
+
 #elif defined(POCO_HAVE_FD_POLL)
 void SocketImpl::fillPollFd(const SocketImplList& socketImplList, int event, PollFd& pollFd)
 {
@@ -1164,6 +1167,7 @@ void SocketImpl::fillPollFd(const SocketImplList& socketImplList, int event, Pol
 		}
 	}
 }
+
 
 void SocketImpl::doPoll(PollFd& pollFd, const Poco::Timespan& timeout)
 {
@@ -1206,6 +1210,8 @@ void SocketImpl::collectReadyFd(const PollFd& pollFd, const SocketImplList& read
 		if (POLLERR & it->revents && sIt != endE) readyExceptList.push_back(*sIt);
 	}
 }
+
+
 #else
 void SocketImpl::fillFDSet(const SocketImplList& socketImplList, fd_set* fdSet, int* nfd)
 {
@@ -1221,6 +1227,7 @@ void SocketImpl::fillFDSet(const SocketImplList& socketImplList, fd_set* fdSet, 
 		}
 	}
 }
+
 
 void SocketImpl::collectReadyFd(const SocketImplList& socketImplList, fd_set* fdSet, SocketImplList& readyList)
 {
@@ -1256,6 +1263,8 @@ void SocketImpl::doSelect(fd_set* fdRead, fd_set* fdWrite, fd_set* fdExcept, int
 	while (rc < 0 && lastError() == POCO_EINTR);
 	if (rc < 0) error();
 }
+
+
 #endif
 
 


### PR DESCRIPTION
1. Move the select implementation from Socket to SocketImpl, so poll can reuse the code.
2. Extract each select implementation to several small-functions.
