### PR TITLE
Fully support cross-compiling with Linux GNU build system using OSARCH_64BITS=[0,1]

### DIFF
--- a/build/config/Linux
+++ b/build/config/Linux
@@ -39,14 +39,14 @@ SHAREDLIBLINKEXT = .so
 # Compiler and Linker Flags
 #
 CFLAGS          = 
-CFLAGS32        =
-CFLAGS64        =
+CFLAGS32        = -m32
+CFLAGS64        = -m64
 CXXFLAGS        = -Wall -Wno-sign-compare
-CXXFLAGS32      =
-CXXFLAGS64      =
+CXXFLAGS32      = -m32
+CXXFLAGS64      = -m64
 LINKFLAGS       =
-LINKFLAGS32     =
-LINKFLAGS64     =
+LINKFLAGS32     = -m32
+LINKFLAGS64     = -m64
 STATICOPT_CC    =
 STATICOPT_CXX   =
 STATICOPT_LINK  = -static

--- a/build/config/Linux
+++ b/build/config/Linux
@@ -69,3 +69,15 @@ SYSFLAGS = -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=6
 # System Specific Libraries
 #
 SYSLIBS  = -lpthread -ldl -lrt
+
+#
+# Auto-detect architecture if not specified
+#
+ifndef OSARCH_64BITS
+  LBITS := $(shell getconf LONG_BIT)
+  ifeq ($(LBITS),64)
+    OSARCH_64BITS = 1
+  else
+    OSARCH_64BITS = 0
+  endif
+endif

--- a/build/rules/lib
+++ b/build/rules/lib
@@ -61,13 +61,13 @@ $(LIB_RELEASE_STATIC): $(foreach o,$(objects),$(OBJPATH_RELEASE_STATIC)/$(o).o)
 
 $(LIB_DEBUG_SHARED): $(foreach o,$(objects),$(OBJPATH_DEBUG_SHARED)/$(o).o)
 	@echo "** Building shared library (debug)" $@
-	$(SHLIB) $(SHLIBFLAGS) $^ $(LIBRARY) $(TARGET_LIBS_DEBUG) $(SYSLIBS)
+	$(SHLIB) $(LINKFLAGS) $(SHLIBFLAGS) $^ $(LIBRARY) $(TARGET_LIBS_DEBUG) $(SYSLIBS)
 	$(SHLIBLN) $(LIB_DEBUG_SHARED) $(LIB_DEBUG_SHARED_LINK)
 	$(postbuild)
 
 $(LIB_RELEASE_SHARED): $(foreach o,$(objects),$(OBJPATH_RELEASE_SHARED)/$(o).o)
 	@echo "** Building shared library (release)" $@
-	$(SHLIB) $(SHLIBFLAGS) $^ $(LIBRARY) $(TARGET_LIBS_RELEASE) $(SYSLIBS)
+	$(SHLIB) $(LINKFLAGS) $(SHLIBFLAGS) $^ $(LIBRARY) $(TARGET_LIBS_RELEASE) $(SYSLIBS)
 	$(SHLIBLN) $(LIB_RELEASE_SHARED) $(LIB_RELEASE_SHARED_LINK)
 	$(STRIPCMD)
 	$(postbuild)


### PR DESCRIPTION
Building POCO on a Linux host with an architecture different from the host system's (e. g. using `--cflags="-m32"`), dynamic linking of the POCO libraries fails. This patch adds the proper compiler and linker flags to the Linux configuration (including auto.detection of the host's arch if not specified), and passes `LINKFLAGS` to the dynamic linker command line.

Note: The build/rules/global script always adds either `*FLAGS32` or `*FLAGS64` to the flags list, and defaults to the 32-bit variant if `OSARCH_64BITS` is undefined. I left the file unchanged to avoid possible problems with other OS configurations.

This patch will fix issue #894 