### PR TITLE
Poco 1.6.2: fixes for producing the Poco-1.6.2 documentation on Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ lib64/
 pocomsg.h
 
 # Eclipse generated files #
-######################
+###########################
 .project
 .cproject
 .settings
@@ -113,3 +113,8 @@ cmake-build/
 # Temporary files #
 ###################
 *.bak
+
+# mkdoc & mkrelease #
+#####################
+stage/
+releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       compiler: gcc
       script:
         - sudo apt-get install -qq -y software-properties-common
-        - sudo add-apt-repository ppa:george-edison55/cmake-3.x
+        - sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
         - sudo apt-get update -qq
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ cache:
 
 before_install:
   # we need a recent version of CMake
-  - sudo apt-get purge cmake
+  - sudo apt-get autoremove
+  - sudo apt-get clean
   - sudo add-apt-repository -y ppa:andykimpe/cmake3
   - sudo apt-get update
+  - sudo apt-get install -y cmake
   - sudo apt-get install -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 
 
 services:
@@ -43,9 +45,6 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -y software-properties-common
-        - sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-        - sudo apt-get update
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -qq -y cmake3 --no-check-certificate
         # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 
     - env:    TEST_NAME="gcc-4.8 (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -qq -y cmake3 --no-check-certificate
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         - sudo apt-get update -qq
         - sudo apt-get install -qq -y g++-4.8
@@ -60,19 +60,19 @@ matrix:
     - env:    TEST_NAME="clang (CMake)"
       compiler: clang
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -qq -y cmake3 --no-check-certificate
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -qq -y cmake3 --no-check-certificate
         - export CC="arm-linux-gnueabi-gcc"
         - export CXX="arm-linux-gnueabi-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -qq -y cmake3 --no-check-certificate
         - export CC="arm-linux-gnueabihf-gcc"
         - export CXX="arm-linux-gnueabihf-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install software-properties-common
+        - sudo apt-get install -qq -y software-properties-common
         - sudo add-apt-repository ppa:george-edison55/cmake-3.x
-        - sudo apt-get update
+        - sudo apt-get update -qq
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ before_install:
   # we need a recent version of CMake
   - sudo apt-get autoremove
   - sudo apt-get clean
-  - sudo add-apt-repository -y ppa:andykimpe/cmake3
-  - sudo apt-get update
-  - sudo apt-get install -y cmake
   - sudo apt-get install -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 
 
 services:
@@ -45,8 +42,6 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get autoremove
-        - sudo apt-get clean
         - sudo add-apt-repository -y ppa:andykimpe/cmake3
         - sudo apt-get install -y cmake
         - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
 
 before_install:
   # we need a recent version of CMake
+  - sudo apt-get purge -qq cmake
   - sudo add-apt-repository -y ppa:andykimpe/cmake3
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
       script:
         - sudo add-apt-repository -y ppa:andykimpe/cmake3
         - sudo apt-get install -y cmake
+        - type cmake
         - cmake --version
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-    - sudo apt-get autoremove
-    - sudo apt-get clean
-    - sudo add-apt-repository -y ppa:andykimpe/cmake3
-    - sudo apt-get update
-    - sudo apt-get install -y cmake
+        - sudo apt-get autoremove
+        - sudo apt-get clean
+        - sudo add-apt-repository -y ppa:andykimpe/cmake3
+        - sudo apt-get update
+        - sudo apt-get install -y cmake
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,16 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3 --no-check-certificate
-        # disable tests, gcc-4.6 gets an internal compiler error
+        - sudo apt-get install software-properties-common
+        - sudo add-apt-repository ppa:george-edison55/cmake-3.x
+        - sudo apt-get update
+      # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 
     - env:    TEST_NAME="gcc-4.8 (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3 --no-check-certificate
+        - sudo apt-get install -qq -y cmake3
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         - sudo apt-get update -qq
         - sudo apt-get install -qq -y g++-4.8
@@ -60,19 +62,19 @@ matrix:
     - env:    TEST_NAME="clang (CMake)"
       compiler: clang
       script:
-        - sudo apt-get install -qq -y cmake3 --no-check-certificate
+        - sudo apt-get install -qq -y cmake3
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3 --no-check-certificate
+        - sudo apt-get install -qq -y cmake3
         - export CC="arm-linux-gnueabi-gcc"
         - export CXX="arm-linux-gnueabi-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3 --no-check-certificate
+        - sudo apt-get install -qq -y cmake3
         - export CC="arm-linux-gnueabihf-gcc"
         - export CXX="arm-linux-gnueabihf-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ matrix:
         - sudo apt-get autoremove
         - sudo apt-get clean
         - sudo add-apt-repository -y ppa:andykimpe/cmake3
-        - sudo apt-get update
         - sudo apt-get install -y cmake
         - cmake --version
       # disable tests, gcc-4.6 gets an internal compiler error

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ cache:
 
 before_install:
   # we need a recent version of CMake
-  - sudo apt-get purge -qq cmake
+  - sudo apt-get purge cmake
   - sudo add-apt-repository -y ppa:andykimpe/cmake3
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 
+  - sudo apt-get update
+  - sudo apt-get install -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 
 
 services:
   - mongodb
@@ -43,19 +43,19 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y software-properties-common
+        - sudo apt-get install -y software-properties-common
         - sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-        - sudo apt-get update -qq
+        - sudo apt-get update
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 
     - env:    TEST_NAME="gcc-4.8 (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -y cmake3
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq -y g++-4.8
+        - sudo apt-get update
+        - sudo apt-get install -y g++-4.8
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..
@@ -63,19 +63,19 @@ matrix:
     - env:    TEST_NAME="clang (CMake)"
       compiler: clang
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -y cmake3
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -y cmake3
         - export CC="arm-linux-gnueabi-gcc"
         - export CXX="arm-linux-gnueabi-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
+        - sudo apt-get install -y cmake3
         - export CC="arm-linux-gnueabihf-gcc"
         - export CXX="arm-linux-gnueabihf-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,11 @@ matrix:
     - env:    TEST_NAME="gcc (CMake)"
       compiler: gcc
       script:
+    - sudo apt-get autoremove
+    - sudo apt-get clean
+    - sudo add-apt-repository -y ppa:andykimpe/cmake3
+    - sudo apt-get update
+    - sudo apt-get install -y cmake
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
         - sudo add-apt-repository -y ppa:andykimpe/cmake3
         - sudo apt-get update
         - sudo apt-get install -y cmake
+        - cmake --version
       # disable tests, gcc-4.6 gets an internal compiler error
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 

--- a/Net/samples/Mail/Makefile
+++ b/Net/samples/Mail/Makefile
@@ -12,6 +12,6 @@ objects = Mail
 
 target         = Mail
 target_version = 1
-target_libs    = PocoUtil PocoNet PocoXML PocoFoundation
+target_libs    = PocoUtil PocoNet PocoJSON PocoXML PocoFoundation
 
 include $(POCO_BASE)/build/rules/exec

--- a/Net/samples/Ping/Makefile
+++ b/Net/samples/Ping/Makefile
@@ -12,7 +12,7 @@ objects = Ping
 
 target         = Ping
 target_version = 1
-target_libs    = PocoUtil PocoJSON PocoNet PocoXML PocoFoundation
+target_libs    = PocoUtil PocoJSON PocoNet PocoJSON PocoXML PocoFoundation
 
 include $(POCO_BASE)/build/rules/exec
 

--- a/Net/samples/dict/Makefile
+++ b/Net/samples/dict/Makefile
@@ -12,6 +12,6 @@ objects = dict
 
 target         = dict
 target_version = 1
-target_libs    = PocoUtil PocoNet PocoXML PocoFoundation
+target_libs    = PocoUtil PocoNet PocoXML PocoJSON PocoFoundation
 
 include $(POCO_BASE)/build/rules/exec

--- a/Net/samples/download/Makefile
+++ b/Net/samples/download/Makefile
@@ -12,6 +12,6 @@ objects = download
 
 target         = download
 target_version = 1
-target_libs    = PocoUtil PocoNet PocoXML PocoFoundation
+target_libs    = PocoUtil PocoNet PocoJSON PocoXML PocoFoundation
 
 include $(POCO_BASE)/build/rules/exec

--- a/Net/samples/httpget/Makefile
+++ b/Net/samples/httpget/Makefile
@@ -12,6 +12,6 @@ objects = httpget
 
 target         = httpget
 target_version = 1
-target_libs    = PocoUtil PocoNet PocoXML PocoFoundation
+target_libs    = PocoUtil PocoNet PocoXML PocoJSON PocoFoundation
 
 include $(POCO_BASE)/build/rules/exec

--- a/PocoDoc/cfg/mkdoc-poco.xml
+++ b/PocoDoc/cfg/mkdoc-poco.xml
@@ -12,7 +12,7 @@
 				*_*.h,
 				expat*.h,
 				zconf.h,
-				zlib.h,
+				zlib.h
 			</exclude>
 		</files>
 		<pages>
@@ -32,6 +32,7 @@
 			<options>
 				${Includes},
 				-I/usr/local/mysql/include,
+				-I/usr/include/mysql,
 				-D_DEBUG,
 				-E,
 				-C,

--- a/PocoDoc/cfg/mkdocumentation.xml
+++ b/PocoDoc/cfg/mkdocumentation.xml
@@ -33,6 +33,7 @@
 			<options>
 				${Includes},
 				-I/usr/local/mysql/include,
+				-I/usr/include/mysql,
 				-D_DEBUG,
 				-E,
 				-C,

--- a/build/config/CYGWIN
+++ b/build/config/CYGWIN
@@ -64,7 +64,7 @@ RELEASEOPT_LINK =
 #
 # System Specific Flags
 #
-SYSFLAGS = -D_XOPEN_SOURCE=500
+SYSFLAGS = -D_XOPEN_SOURCE=500 -D__BSD_VISIBLE
 
 #
 # System Specific Libraries

--- a/release/script/mkdoc
+++ b/release/script/mkdoc
@@ -84,6 +84,11 @@ if [ $osname = "Darwin" ] ; then
 	osarch=`basename $archpath`
 fi
 
+if [ ${osname:0:6} = "CYGWIN" ] ; then
+	osname="CYGWIN"
+	export PATH=$tools/lib/$osname/$osarch:$PATH
+fi
+
 export PATH=$tools/PocoDoc/bin/$osname/$osarch:$PATH
 echo PATH=$PATH
 

--- a/release/script/mkdocumentation
+++ b/release/script/mkdocumentation
@@ -123,6 +123,7 @@ echo "PocoDoc.output=$docPath" >>$build/PocoDoc.ini
 echo "PocoDoc.version=$docVersion" >> $build/PocoDoc.ini
 echo "Includes=$includes" >> $build/PocoDoc.ini
 
+echo "PocoDoc --config=$docConfig --config=$build/PocoDoc.ini"
 PocoDoc --config=$docConfig --config=$build/PocoDoc.ini
 
 cd $dist

--- a/release/script/mkrelease
+++ b/release/script/mkrelease
@@ -289,10 +289,11 @@ echo 'cleans: $(filter-out $(foreach f,$(OMIT),$f%),$(cleans))' >>${target}/Make
 
 for comp in $comps ;
 do
-	if [ "`grep -c POCO_LICENSING "${POCO_BASE}/${comp}/Makefile"`" != 0 ] ; then
-		dependencies=$licensingDep
-	else
-		dependencies=""
+	dependencies=""
+	if [ -f "${POCO_BASE}/${comp}/Makefile" ] ; then
+		if [ "`grep -c POCO_LICENSING "${POCO_BASE}/${comp}/Makefile"`" != 0 ] ; then
+			dependencies=$licensingDep
+		fi
 	fi
 	if [ -f "${POCO_BASE}/${comp}/dependencies" ] ; then
 		for dep in `cat "${POCO_BASE}/${comp}/dependencies"` ;

--- a/release/spec/all.release
+++ b/release/spec/all.release
@@ -1,5 +1,6 @@
 Crypto
 NetSSL_OpenSSL
+NetSSL_Win
 Data
 Data/SQLite
 Data/ODBC

--- a/release/spec/world.release
+++ b/release/spec/world.release
@@ -1,5 +1,6 @@
 Crypto
 NetSSL_OpenSSL
+NetSSL_Win
 Data
 Data/SQLite
 Data/ODBC


### PR DESCRIPTION
Hi

These fixes makes PocoDoc working on a Cygwin platform for the poco-1.6.2 release, and thus permits to produce a packaged Windows msi installer with the documentation.

The fixes related to Net samples are needed for building a rpm on Fedora with the samples