### PR TITLE
Only escape string values in Poco::JSON::Stringifier::stringify()

### DIFF
--- a/JSON/src/Stringifier.cpp
+++ b/JSON/src/Stringifier.cpp
@@ -62,10 +62,14 @@ void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int inde
 		if (any.type() == typeid(char)) formatString(value, out);
 		else out << value;
 	}
-	else
+	else if (any.isString())
 	{
 		std::string value = any.convert<std::string>();
 		formatString(value, out);
+	}
+	else
+	{
+		out << any.convert<std::string>();
 	}
 }
 


### PR DESCRIPTION
As the Poco::JSON implementation uses Dynamic::Var, it allows to create specialized implementations of VarHolder to place other types somewhere into a JSON object. This allows for efficient storage and serialization, since there is no need to first convert a specialized class into a JSON::Object structure and then serialize it. Instead, the class can implement the `convert<std::string>()`  method to build a JSON string out of the class members.

This patch should not change the behaviour of Stringifier while only using the Poco::JSON classes.