### PR TITLE
tvOS / WatchOS bitcode enabled

### DIFF
--- a/build/config/AppleTV
+++ b/build/config/AppleTV
@@ -31,7 +31,7 @@ TVOS_SDK_VERSION_MIN ?= $(patsubst %.sdk,%,$(patsubst $(TVOS_SDK_ROOT_DIR)%,%,$(
 POCO_TARGET_OSNAME     ?= $(TVOS_SDK)
 POCO_TARGET_OSARCH     ?= arm64
 TOOL_PREFIX            ?= $(shell xcode-select -print-path)/Platforms/$(TVOS_SDK).platform/Developer/usr/bin
-OSFLAGS                ?= -arch $(POCO_TARGET_OSARCH) -isysroot $(TVOS_SDK_BASE) -mtvos-version-min=$(TVOS_SDK_VERSION_MIN)
+OSFLAGS                ?= -arch $(POCO_TARGET_OSARCH) -isysroot $(TVOS_SDK_BASE) -mtvos-version-min=$(TVOS_SDK_VERSION_MIN) -fembed-bitcode
 
 #
 # Tools

--- a/build/config/WatchOS
+++ b/build/config/WatchOS
@@ -31,7 +31,7 @@ WATCHOS_SDK_VERSION_MIN ?= $(patsubst %.sdk,%,$(patsubst $(WATCHOS_SDK_ROOT_DIR)
 POCO_TARGET_OSNAME     ?= $(WATCHOS_SDK)
 POCO_TARGET_OSARCH     ?= armv7k
 TOOL_PREFIX            ?= $(shell xcode-select -print-path)/Platforms/$(WATCHOS_SDK).platform/Developer/usr/bin
-OSFLAGS                ?= -arch $(POCO_TARGET_OSARCH) -isysroot $(WATCHOS_SDK_BASE) -mwatchos-version-min=$(WATCHOS_SDK_VERSION_MIN)
+OSFLAGS                ?= -arch $(POCO_TARGET_OSARCH) -isysroot $(WATCHOS_SDK_BASE) -mwatchos-version-min=$(WATCHOS_SDK_VERSION_MIN) -fembed-bitcode
 
 #
 # Tools


### PR DESCRIPTION
Required by default for the platforms.

Added the flags to correctly build the Poco libraries for production with Bitcode.

> For watchOS and tvOS apps, bitcode is required. If you provide bitcode, all apps and frameworks in the app bundle (all targets in the project) need to include bitcode.