### PR TITLE
tvOS / WatchOS bitcode enabled for simulators

### DIFF
--- a/build/config/AppleTVSimulator
+++ b/build/config/AppleTVSimulator
@@ -8,6 +8,6 @@
 
 TVOS_SDK           = AppleTVSimulator
 POCO_TARGET_OSARCH = x86_64
-OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(TVOS_SDK_BASE) -mtvos-simulator-version-min=$(TVOS_SDK_VERSION_MIN)
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(TVOS_SDK_BASE) -mtvos-simulator-version-min=$(TVOS_SDK_VERSION_MIN) -fembed-bitcode
 
 include $(POCO_BASE)/build/config/AppleTV

--- a/build/config/WatchSimulator
+++ b/build/config/WatchSimulator
@@ -8,6 +8,6 @@
 
 WATCHOS_SDK        = WatchSimulator
 POCO_TARGET_OSARCH = i386
-OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(WATCHOS_SDK_BASE) -mwatchos-simulator-version-min=$(WATCHOS_SDK_VERSION_MIN)
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(WATCHOS_SDK_BASE) -mwatchos-simulator-version-min=$(WATCHOS_SDK_VERSION_MIN) -fembed-bitcode
 
 include $(POCO_BASE)/build/config/WatchOS


### PR DESCRIPTION
Required by default for the platforms.

Added the flags to correctly build the Poco libraries for production with Bitcode.

> For watchOS and tvOS apps, bitcode is required. If you provide bitcode, all apps and frameworks in the app bundle (all targets in the project) need to include bitcode.

--- Related to https://github.com/pocoproject/poco/pull/1029
