### PR TITLE
GH #1050 Foundation: fix gcc -Wshadow warnings

### DIFF
--- a/Foundation/include/Poco/BinaryReader.h
+++ b/Foundation/include/Poco/BinaryReader.h
@@ -162,17 +162,17 @@ class BasicMemoryBinaryReader : public BinaryReader
 	/// A convenient wrapper for using Buffer and MemoryStream with BinaryReader.
 {
 public:
-	BasicMemoryBinaryReader(const Buffer<T>& data, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER):
-		BinaryReader(_istr, byteOrder),
-		_data(data),
-		_istr(data.begin(), data.capacity())
+	BasicMemoryBinaryReader(const Buffer<T>& dataBuffer, StreamByteOrder order = NATIVE_BYTE_ORDER):
+		BinaryReader(_istr, order),
+		_data(dataBuffer),
+		_istr(dataBuffer.begin(), dataBuffer.capacity())
 	{
 	}
 
-	BasicMemoryBinaryReader(const Buffer<T>& data, TextEncoding& encoding, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER):
-		BinaryReader(_istr, encoding, byteOrder),
-		_data(data),
-		_istr(data.begin(), data.capacity())
+	BasicMemoryBinaryReader(const Buffer<T>& dataBuffer, TextEncoding& encoding, StreamByteOrder order = NATIVE_BYTE_ORDER):
+		BinaryReader(_istr, encoding, order),
+		_data(dataBuffer),
+		_istr(dataBuffer.begin(), dataBuffer.capacity())
 	{
 	}
 

--- a/Foundation/include/Poco/BinaryWriter.h
+++ b/Foundation/include/Poco/BinaryWriter.h
@@ -57,10 +57,10 @@ public:
 		LITTLE_ENDIAN_BYTE_ORDER = 3  /// little-endian byte-order
 	};
 	
-	BinaryWriter(std::ostream& ostr, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER);
+	BinaryWriter(std::ostream& ostr, StreamByteOrder order = NATIVE_BYTE_ORDER);
 		/// Creates the BinaryWriter.
 
-	BinaryWriter(std::ostream& ostr, TextEncoding& encoding, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER);
+	BinaryWriter(std::ostream& ostr, TextEncoding& encoding, StreamByteOrder order = NATIVE_BYTE_ORDER);
 		/// Creates the BinaryWriter using the given TextEncoding.
 		///
 		/// Strings will be converted from the currently set global encoding
@@ -171,17 +171,17 @@ class BasicMemoryBinaryWriter: public BinaryWriter
 	/// A convenient wrapper for using Buffer and MemoryStream with BinarWriter.
 {
 public:
-	BasicMemoryBinaryWriter(Buffer<T>& data, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER): 
-		BinaryWriter(_ostr, byteOrder),
-		_data(data),
-		_ostr(data.begin(), data.capacity())
+	BasicMemoryBinaryWriter(Buffer<T>& dataBuffer, StreamByteOrder order = NATIVE_BYTE_ORDER): 
+		BinaryWriter(_ostr, order),
+		_data(dataBuffer),
+		_ostr(dataBuffer.begin(), dataBuffer.capacity())
 	{
 	}
 
-	BasicMemoryBinaryWriter(Buffer<T>& data, TextEncoding& encoding, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER): 
-		BinaryWriter(_ostr, encoding, byteOrder),
-		_data(data),
-		_ostr(data.begin(), data.capacity())
+	BasicMemoryBinaryWriter(Buffer<T>& dataBuffer, TextEncoding& encoding, StreamByteOrder order = NATIVE_BYTE_ORDER): 
+		BinaryWriter(_ostr, encoding, order),
+		_data(dataBuffer),
+		_ostr(dataBuffer.begin(), dataBuffer.capacity())
 	{
 	}
 

--- a/Foundation/include/Poco/Buffer.h
+++ b/Foundation/include/Poco/Buffer.h
@@ -38,16 +38,16 @@ class Buffer
 	/// is needed.
 {
 public:
-	Buffer(std::size_t capacity):
-		_capacity(capacity),
-		_used(capacity),
+	Buffer(std::size_t length):
+		_capacity(length),
+		_used(length),
 		_ptr(0),
 		_ownMem(true)
 		/// Creates and allocates the Buffer.
 	{
-		if (capacity > 0)
+		if (length > 0)
 		{
-			_ptr = new T[capacity];
+			_ptr = new T[length];
 		}
 	}
 

--- a/Foundation/include/Poco/Dynamic/Struct.h
+++ b/Foundation/include/Poco/Dynamic/Struct.h
@@ -62,8 +62,8 @@ public:
 		typedef typename std::map<K, T>::const_iterator MapConstIterator;
 
 		MapConstIterator it = val.begin();
-		MapConstIterator end = val.end();
-		for (; it != end; ++it) _data.insert(ValueType(it->first, Var(it->second)));
+		MapConstIterator itEnd = val.end();
+		for (; it != itEnd; ++it) _data.insert(ValueType(it->first, Var(it->second)));
 	}
 
 	virtual ~Struct()

--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -160,16 +160,16 @@ inline int Exception::code() const
 	POCO_DECLARE_EXCEPTION_CODE(API, CLS, BASE, 0)
 
 #define POCO_IMPLEMENT_EXCEPTION(CLS, BASE, NAME)													\
-	CLS::CLS(int code): BASE(code)																	\
+	CLS::CLS(int otherCode): BASE(otherCode)																	\
 	{																								\
 	}																								\
-	CLS::CLS(const std::string& msg, int code): BASE(msg, code)										\
+	CLS::CLS(const std::string& msg, int otherCode): BASE(msg, otherCode)										\
 	{																								\
 	}																								\
-	CLS::CLS(const std::string& msg, const std::string& arg, int code): BASE(msg, arg, code)		\
+	CLS::CLS(const std::string& msg, const std::string& arg, int otherCode): BASE(msg, arg, otherCode)		\
 	{																								\
 	}																								\
-	CLS::CLS(const std::string& msg, const Poco::Exception& exc, int code): BASE(msg, exc, code)	\
+	CLS::CLS(const std::string& msg, const Poco::Exception& exc, int otherCode): BASE(msg, exc, otherCode)	\
 	{																								\
 	}																								\
 	CLS::CLS(const CLS& exc): BASE(exc)																\

--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -77,33 +77,33 @@ public:
 		///	  Readable event observers are notified, with true value
 		///	  as the argument
 
-	BasicFIFOBuffer(std::size_t size, bool notify = false):
-		_buffer(size),
+	BasicFIFOBuffer(std::size_t bufferSize, bool bufferNotify = false):
+		_buffer(bufferSize),
 		_begin(0),
 		_used(0),
-		_notify(notify),
+		_notify(bufferNotify),
 		_eof(false),
 		_error(false)
 		/// Creates the FIFOBuffer.
 	{
 	}
 
-	BasicFIFOBuffer(T* pBuffer, std::size_t size, bool notify = false):
-		_buffer(pBuffer, size),
+	BasicFIFOBuffer(T* pBuffer, std::size_t bufferSize, bool bufferNotify = false):
+		_buffer(pBuffer, bufferSize),
 		_begin(0),
 		_used(0),
-		_notify(notify),
+		_notify(bufferNotify),
 		_eof(false),
 		_error(false)
 		/// Creates the FIFOBuffer.
 	{
 	}
 
-	BasicFIFOBuffer(const T* pBuffer, std::size_t size, bool notify = false):
-		_buffer(pBuffer, size),
+	BasicFIFOBuffer(const T* pBuffer, std::size_t bufferSize, bool bufferNotify = false):
+		_buffer(pBuffer, bufferSize),
 		_begin(0),
-		_used(size),
-		_notify(notify),
+		_used(bufferSize),
+		_notify(bufferNotify),
 		_eof(false),
 		_error(false)
 		/// Creates the FIFOBuffer.
@@ -154,7 +154,7 @@ public:
 		return length;
 	}
 	
-	std::size_t peek(Poco::Buffer<T>& buffer, std::size_t length = 0) const
+	std::size_t peek(Poco::Buffer<T>& rBuffer, std::size_t length = 0) const
 		/// Peeks into the data currently in the FIFO
 		/// without actually extracting it.
 		/// Resizes the supplied buffer to the size of
@@ -169,8 +169,8 @@ public:
 		Mutex::ScopedLock lock(_mutex);
 		if (!isReadable()) return 0;
 		if (0 == length || length > _used) length = _used;
-		buffer.resize(length);
-		return peek(buffer.begin(), length);
+		rBuffer.resize(length);
+		return peek(rBuffer.begin(), length);
 	}
 	
 	std::size_t read(T* pBuffer, std::size_t length)
@@ -196,7 +196,7 @@ public:
 		return readLen;
 	}
 	
-	std::size_t read(Poco::Buffer<T>& buffer, std::size_t length = 0)
+	std::size_t read(Poco::Buffer<T>& rBuffer, std::size_t length = 0)
 		/// Copies the data currently in the FIFO
 		/// into the supplied buffer.
 		/// Resizes the supplied buffer to the size of
@@ -207,7 +207,7 @@ public:
 		Mutex::ScopedLock lock(_mutex);
 		if (!isReadable()) return 0;
 		std::size_t usedBefore = _used;
-		std::size_t readLen = peek(buffer, length);
+		std::size_t readLen = peek(rBuffer, length);
 		poco_assert (_used >= readLen);
 		_used -= readLen;
 		if (0 == _used) _begin = 0;
@@ -242,8 +242,8 @@ public:
 		}
 
 		std::size_t usedBefore = _used;
-		std::size_t available =  _buffer.size() - _used - _begin;
-		std::size_t len = length > available ? available : length;
+		std::size_t availableBefore =  _buffer.size() - _used - _begin;
+		std::size_t len = length > availableBefore ? availableBefore : length;
 		std::memcpy(begin() + _used, pBuffer, len * sizeof(T));
 		_used += len;
 		poco_assert (_used <= _buffer.size());
@@ -252,7 +252,7 @@ public:
 		return len;
 	}
 
-	std::size_t write(const Buffer<T>& buffer, std::size_t length = 0)
+	std::size_t write(const Buffer<T>& rBuffer, std::size_t length = 0)
 		/// Writes data from supplied buffer to the FIFO buffer.
 		/// If there is no sufficient space for the whole
 		/// buffer to be written, data up to available 
@@ -263,10 +263,10 @@ public:
 		/// 
 		/// Returns the length of data written.
 	{
-		if (length == 0 || length > buffer.size())
-			length = buffer.size();
+		if (length == 0 || length > rBuffer.size())
+			length = rBuffer.size();
 
-		return write(buffer.begin(), length);
+		return write(rBuffer.begin(), length);
 	}
 
 	std::size_t size() const
@@ -499,10 +499,10 @@ public:
 		return !isFull() && isValid() && !_eof;
 	}
 
-	void setNotify(bool notify = true)
+	void setNotify(bool bufferNotify = true)
 		/// Enables/disables notifications.
 	{
-		_notify = notify;
+		_notify = bufferNotify;
 	}
 
 	bool getNotify() const

--- a/Foundation/include/Poco/Manifest.h
+++ b/Foundation/include/Poco/Manifest.h
@@ -118,12 +118,12 @@ public:
 		clear();
 	}
 
-	Iterator find(const std::string& className) const
+	Iterator find(const std::string& rClassName) const
 		/// Returns an iterator pointing to the MetaObject
 		/// for the given class. If the MetaObject cannot
 		/// be found, the iterator points to end().
 	{
-		return Iterator(_metaMap.find(className));
+		return Iterator(_metaMap.find(rClassName));
 	}
 
 	Iterator begin() const

--- a/Foundation/include/Poco/MetaObject.h
+++ b/Foundation/include/Poco/MetaObject.h
@@ -40,7 +40,7 @@ class AbstractMetaObject
 	/// factory for its class.
 {
 public:
-	AbstractMetaObject(const char* name): _name(name)
+	AbstractMetaObject(const char* pName): _name(pName)
 	{
 	}
 

--- a/Foundation/include/Poco/TaskNotification.h
+++ b/Foundation/include/Poco/TaskNotification.h
@@ -126,9 +126,9 @@ class TaskCustomNotification: public TaskNotification
 	/// mechanism between the task and its observer(s).
 {
 public:
-	TaskCustomNotification(Task* pTask, const C& custom):
+	TaskCustomNotification(Task* pTask, const C& rCustom):
 		TaskNotification(pTask),
-		_custom(custom)
+		_custom(rCustom)
 	{
 	}
 

--- a/Foundation/src/AtomicCounter.cpp
+++ b/Foundation/src/AtomicCounter.cpp
@@ -136,9 +136,9 @@ AtomicCounter& AtomicCounter::operator = (const AtomicCounter& counter)
 }
 
 	
-AtomicCounter& AtomicCounter::operator = (AtomicCounter::ValueType value)
+AtomicCounter& AtomicCounter::operator = (AtomicCounter::ValueType valueType)
 {
-	__sync_lock_test_and_set(&_counter, value);
+	__sync_lock_test_and_set(&_counter, valueType);
 	return *this;
 }
 

--- a/Foundation/src/BinaryReader.cpp
+++ b/Foundation/src/BinaryReader.cpp
@@ -24,26 +24,26 @@
 namespace Poco {
 
 
-BinaryReader::BinaryReader(std::istream& istr, StreamByteOrder byteOrder):
+BinaryReader::BinaryReader(std::istream& istr, StreamByteOrder order):
 	_istr(istr),
 	_pTextConverter(0)
 {
 #if defined(POCO_ARCH_BIG_ENDIAN)
-	_flipBytes = (byteOrder == LITTLE_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == LITTLE_ENDIAN_BYTE_ORDER);
 #else
-	_flipBytes = (byteOrder == BIG_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == BIG_ENDIAN_BYTE_ORDER);
 #endif
 }
 
 
-BinaryReader::BinaryReader(std::istream& istr, TextEncoding& encoding, StreamByteOrder byteOrder):
+BinaryReader::BinaryReader(std::istream& istr, TextEncoding& encoding, StreamByteOrder order):
 	_istr(istr),
 	_pTextConverter(new TextConverter(encoding, Poco::TextEncoding::global()))
 {
 #if defined(POCO_ARCH_BIG_ENDIAN)
-	_flipBytes = (byteOrder == LITTLE_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == LITTLE_ENDIAN_BYTE_ORDER);
 #else
-	_flipBytes = (byteOrder == BIG_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == BIG_ENDIAN_BYTE_ORDER);
 #endif
 }
 

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -24,26 +24,26 @@
 namespace Poco {
 
 
-BinaryWriter::BinaryWriter(std::ostream& ostr, StreamByteOrder byteOrder):
+BinaryWriter::BinaryWriter(std::ostream& ostr, StreamByteOrder order):
 	_ostr(ostr),
 	_pTextConverter(0)
 {
 #if defined(POCO_ARCH_BIG_ENDIAN)
-	_flipBytes = (byteOrder == LITTLE_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == LITTLE_ENDIAN_BYTE_ORDER);
 #else
-	_flipBytes = (byteOrder == BIG_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == BIG_ENDIAN_BYTE_ORDER);
 #endif
 }
 
 
-BinaryWriter::BinaryWriter(std::ostream& ostr, TextEncoding& encoding, StreamByteOrder byteOrder):
+BinaryWriter::BinaryWriter(std::ostream& ostr, TextEncoding& encoding, StreamByteOrder order):
 	_ostr(ostr),
 	_pTextConverter(new TextConverter(Poco::TextEncoding::global(), encoding))
 {
 #if defined(POCO_ARCH_BIG_ENDIAN)
-	_flipBytes = (byteOrder == LITTLE_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == LITTLE_ENDIAN_BYTE_ORDER);
 #else
-	_flipBytes = (byteOrder == BIG_ENDIAN_BYTE_ORDER);
+	_flipBytes = (order == BIG_ENDIAN_BYTE_ORDER);
 #endif
 }
 

--- a/Foundation/src/CountingStream.cpp
+++ b/Foundation/src/CountingStream.cpp
@@ -96,21 +96,21 @@ void CountingStreamBuf::setCurrentLineNumber(int line)
 }
 
 
-void CountingStreamBuf::addChars(int chars)
+void CountingStreamBuf::addChars(int charsToAdd)
 {
-	_chars += chars;
+	_chars += charsToAdd;
 }
 
 		
-void CountingStreamBuf::addLines(int lines)
+void CountingStreamBuf::addLines(int linesToAdd)
 {
-	_lines += lines;
+	_lines += linesToAdd;
 }
 
 		
-void CountingStreamBuf::addPos(int pos)
+void CountingStreamBuf::addPos(int posToAdd)
 {
-	_pos += pos;
+	_pos += posToAdd;
 }
 
 
@@ -149,21 +149,21 @@ void CountingIOS::setCurrentLineNumber(int line)
 }
 
 
-void CountingIOS::addChars(int chars)
+void CountingIOS::addChars(int charsToAdd)
 {
-	_buf.addChars(chars);
+	_buf.addChars(charsToAdd);
 }
 
 		
-void CountingIOS::addLines(int lines)
+void CountingIOS::addLines(int linesToAdd)
 {
-	_buf.addLines(lines);
+	_buf.addLines(linesToAdd);
 }
 
 		
-void CountingIOS::addPos(int pos)
+void CountingIOS::addPos(int posToAdd)
 {
-	_buf.addPos(pos);
+	_buf.addPos(posToAdd);
 }
 
 

--- a/Foundation/src/DateTime.cpp
+++ b/Foundation/src/DateTime.cpp
@@ -45,46 +45,46 @@ DateTime::DateTime()
 }
 
 
-DateTime::DateTime(const Timestamp& timestamp):
-	_utcTime(timestamp.utcTime())
+DateTime::DateTime(const Timestamp& rTimestamp):
+	_utcTime(rTimestamp.utcTime())
 {
 	computeGregorian(julianDay());
 	computeDaytime();
 }
 
 	
-DateTime::DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond):
-	_year(year),
-	_month(month),
-	_day(day),
-	_hour(hour),
-	_minute(minute),
-	_second(second),
-	_millisecond(millisecond),
-	_microsecond(microsecond)
+DateTime::DateTime(int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicrosecond):
+	_year(otherYear),
+	_month(otherMonth),
+	_day(otherDay),
+	_hour(otherHour),
+	_minute(otherMinute),
+	_second(otherSecond),
+	_millisecond(otherMillisecond),
+	_microsecond(otherMicrosecond)
 {
-	poco_assert (year >= 0 && year <= 9999);
-	poco_assert (month >= 1 && month <= 12);
-	poco_assert (day >= 1 && day <= daysOfMonth(year, month));
-	poco_assert (hour >= 0 && hour <= 23);
-	poco_assert (minute >= 0 && minute <= 59);
-	poco_assert (second >= 0 && second <= 59);
-	poco_assert (millisecond >= 0 && millisecond <= 999);
-	poco_assert (microsecond >= 0 && microsecond <= 999);
+	poco_assert (_year >= 0 && _year <= 9999);
+	poco_assert (_month >= 1 && _month <= 12);
+	poco_assert (_day >= 1 && _day <= daysOfMonth(_year, _month));
+	poco_assert (_hour >= 0 && _hour <= 23);
+	poco_assert (_minute >= 0 && _minute <= 59);
+	poco_assert (_second >= 0 && _second <= 59);
+	poco_assert (_millisecond >= 0 && _millisecond <= 999);
+	poco_assert (_microsecond >= 0 && _microsecond <= 999);
 	
-	_utcTime = toUtcTime(toJulianDay(year, month, day)) + 10*(hour*Timespan::HOURS + minute*Timespan::MINUTES + second*Timespan::SECONDS + millisecond*Timespan::MILLISECONDS + microsecond);
+	_utcTime = toUtcTime(toJulianDay(_year, _month, _day)) + 10*(_hour*Timespan::HOURS + _minute*Timespan::MINUTES + _second*Timespan::SECONDS + _millisecond*Timespan::MILLISECONDS + _microsecond);
 }
 
 
-DateTime::DateTime(double julianDay):
-	_utcTime(toUtcTime(julianDay))
+DateTime::DateTime(double otherJulianDay):
+	_utcTime(toUtcTime(otherJulianDay))
 {
-	computeGregorian(julianDay);
+	computeGregorian(otherJulianDay);
 }
 
 
-DateTime::DateTime(Timestamp::UtcTimeVal utcTime, Timestamp::TimeDiff diff):
-	_utcTime(utcTime + diff*10)
+DateTime::DateTime(Timestamp::UtcTimeVal otherUtcTime, Timestamp::TimeDiff diff):
+	_utcTime(otherUtcTime + diff*10)
 {
 	computeGregorian(julianDay());
 	computeDaytime();
@@ -128,43 +128,43 @@ DateTime& DateTime::operator = (const DateTime& dateTime)
 }
 
 	
-DateTime& DateTime::operator = (const Timestamp& timestamp)
+DateTime& DateTime::operator = (const Timestamp& otherTimestamp)
 {
-	_utcTime = timestamp.utcTime();
+	_utcTime = otherTimestamp.utcTime();
 	computeGregorian(julianDay());
 	computeDaytime();
 	return *this;
 }
 
 
-DateTime& DateTime::operator = (double julianDay)
+DateTime& DateTime::operator = (double otherJulianDay)
 {
-	_utcTime = toUtcTime(julianDay);
-	computeGregorian(julianDay);
+	_utcTime = toUtcTime(otherJulianDay);
+	computeGregorian(otherJulianDay);
 	return *this;
 }
 
 
-DateTime& DateTime::assign(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond)
+DateTime& DateTime::assign(int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicrosecond)
 {
-	poco_assert (year >= 0 && year <= 9999);
-	poco_assert (month >= 1 && month <= 12);
-	poco_assert (day >= 1 && day <= daysOfMonth(year, month));
-	poco_assert (hour >= 0 && hour <= 23);
-	poco_assert (minute >= 0 && minute <= 59);
-	poco_assert (second >= 0 && second <= 59);
-	poco_assert (millisecond >= 0 && millisecond <= 999);
-	poco_assert (microsecond >= 0 && microsecond <= 999);
+	poco_assert (otherYear >= 0 && otherYear <= 9999);
+	poco_assert (otherMonth >= 1 && otherMonth <= 12);
+	poco_assert (otherDay >= 1 && otherDay <= daysOfMonth(otherYear, otherMonth));
+	poco_assert (otherHour >= 0 && otherHour <= 23);
+	poco_assert (otherMinute >= 0 && otherMinute <= 59);
+	poco_assert (otherSecond >= 0 && otherSecond <= 59);
+	poco_assert (otherMillisecond >= 0 && otherMillisecond <= 999);
+	poco_assert (otherMicrosecond >= 0 && otherMicrosecond <= 999);
 
-	_utcTime     = toUtcTime(toJulianDay(year, month, day)) + 10*(hour*Timespan::HOURS + minute*Timespan::MINUTES + second*Timespan::SECONDS + millisecond*Timespan::MILLISECONDS + microsecond);
-	_year        = year;
-	_month       = month;
-	_day         = day;
-	_hour        = hour;
-	_minute      = minute;
-	_second      = second;
-	_millisecond = millisecond;
-	_microsecond = microsecond;
+	_utcTime     = toUtcTime(toJulianDay(otherYear, otherMonth, otherDay)) + 10*(otherHour*Timespan::HOURS + otherMinute*Timespan::MINUTES + otherSecond*Timespan::SECONDS + otherMillisecond*Timespan::MILLISECONDS + otherMicrosecond);
+	_year        = otherYear;
+	_month       = otherMonth;
+	_day         = otherDay;
+	_hour        = otherHour;
+	_minute      = otherMinute;
+	_second      = otherSecond;
+	_millisecond = otherMillisecond;
+	_microsecond = otherMicrosecond;
 	
 	return *this;
 }
@@ -193,8 +193,8 @@ int DateTime::dayOfWeek() const
 int DateTime::dayOfYear() const
 {
 	int doy = 0;
-	for (int month = 1; month < _month; ++month)
-		doy += daysOfMonth(_year, month);
+	for (int currentMonth = 1; currentMonth < _month; ++currentMonth)
+		doy += daysOfMonth(_year, currentMonth);
 	doy += _day;
 	return doy;
 }
@@ -345,10 +345,10 @@ void DateTime::normalize()
 }
 
 
-void DateTime::computeGregorian(double julianDay)
+void DateTime::computeGregorian(double otherJulianDay)
 {
-	double z    = std::floor(julianDay - 1721118.5);
-	double r    = julianDay - 1721118.5 - z;
+	double z    = std::floor(otherJulianDay - 1721118.5);
+	double r    = otherJulianDay - 1721118.5 - z;
 	double g    = z - 0.25;
 	double a    = std::floor(g / 36524.25);
 	double b    = a - std::floor(a/4);
@@ -392,10 +392,10 @@ void DateTime::computeGregorian(double julianDay)
 void DateTime::computeDaytime()
 {
 	Timespan span(_utcTime/10);
-	int hour = span.hours();
+	int spanHour = span.hours();
 	// Due to double rounding issues, the previous call to computeGregorian()
 	// may have crossed into the next or previous day. We need to correct that.
-	if (hour == 23 && _hour == 0)
+	if (spanHour == 23 && _hour == 0)
 	{
 		_day--;
 		if (_day == 0)
@@ -409,7 +409,7 @@ void DateTime::computeDaytime()
 			_day = daysOfMonth(_year, _month);
 		}
 	}
-	else if (hour == 0 && _hour == 23)
+	else if (spanHour == 0 && _hour == 23)
 	{
 		_day++;
 		if (_day > daysOfMonth(_year, _month))
@@ -423,7 +423,7 @@ void DateTime::computeDaytime()
 			_day = 1;
 		}
 	}
-	_hour        = hour;
+	_hour        = spanHour;
 	_minute      = span.minutes();
 	_second      = span.seconds();
 	_millisecond = span.milliseconds();

--- a/Foundation/src/DirectoryIterator.cpp
+++ b/Foundation/src/DirectoryIterator.cpp
@@ -36,7 +36,7 @@ DirectoryIterator::DirectoryIterator(): _pImpl(0)
 }
 
 	
-DirectoryIterator::DirectoryIterator(const std::string& path): _path(path), _pImpl(new DirectoryIteratorImpl(path))
+DirectoryIterator::DirectoryIterator(const std::string& pathString): _path(pathString), _pImpl(new DirectoryIteratorImpl(pathString))
 {
 	_path.makeDirectory();
 	_path.setFileName(_pImpl->get());
@@ -62,7 +62,7 @@ DirectoryIterator::DirectoryIterator(const File& file): _path(file.path()), _pIm
 }
 
 
-DirectoryIterator::DirectoryIterator(const Path& path): _path(path), _pImpl(new DirectoryIteratorImpl(path.toString()))
+DirectoryIterator::DirectoryIterator(const Path& otherPath): _path(otherPath), _pImpl(new DirectoryIteratorImpl(otherPath.toString()))
 {
 	_path.makeDirectory();
 	_path.setFileName(_pImpl->get());
@@ -101,11 +101,11 @@ DirectoryIterator& DirectoryIterator::operator = (const File& file)
 }
 
 
-DirectoryIterator& DirectoryIterator::operator = (const Path& path)
+DirectoryIterator& DirectoryIterator::operator = (const Path& otherPath)
 {
 	if (_pImpl) _pImpl->release();
-	_pImpl = new DirectoryIteratorImpl(path.toString());
-	_path = path;
+	_pImpl = new DirectoryIteratorImpl(otherPath.toString());
+	_path = otherPath;
 	_path.makeDirectory();
 	_path.setFileName(_pImpl->get());
 	_file = _path;
@@ -113,11 +113,11 @@ DirectoryIterator& DirectoryIterator::operator = (const Path& path)
 }
 
 
-DirectoryIterator& DirectoryIterator::operator = (const std::string& path)
+DirectoryIterator& DirectoryIterator::operator = (const std::string& pathString)
 {
 	if (_pImpl) _pImpl->release();
-	_pImpl = new DirectoryIteratorImpl(path);
-	_path.parseDirectory(path);
+	_pImpl = new DirectoryIteratorImpl(pathString);
+	_path.parseDirectory(pathString);
 	_path.setFileName(_pImpl->get());
 	_file = _path;
 	return *this;

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -53,8 +53,8 @@ namespace Poco {
 class DirectoryWatcherStrategy
 {
 public:
-	DirectoryWatcherStrategy(DirectoryWatcher& owner):
-		_owner(owner)
+	DirectoryWatcherStrategy(DirectoryWatcher& ownerWatcher):
+		_owner(ownerWatcher)
 	{
 	}
 
@@ -263,8 +263,8 @@ private:
 class LinuxDirectoryWatcherStrategy: public DirectoryWatcherStrategy
 {
 public:
-	LinuxDirectoryWatcherStrategy(DirectoryWatcher& owner):
-		DirectoryWatcherStrategy(owner),
+	LinuxDirectoryWatcherStrategy(DirectoryWatcher& ownerWatcher):
+		DirectoryWatcherStrategy(ownerWatcher),
 		_fd(-1),
 		_stopped(false)
 	{
@@ -474,8 +474,8 @@ private:
 class PollingDirectoryWatcherStrategy: public DirectoryWatcherStrategy
 {
 public:
-	PollingDirectoryWatcherStrategy(DirectoryWatcher& owner):
-		DirectoryWatcherStrategy(owner)
+	PollingDirectoryWatcherStrategy(DirectoryWatcher& ownerWatcher):
+		DirectoryWatcherStrategy(ownerWatcher)
 	{
 	}
 	
@@ -519,22 +519,22 @@ private:
 
 
 
-DirectoryWatcher::DirectoryWatcher(const std::string& path, int eventMask, int scanInterval,
+DirectoryWatcher::DirectoryWatcher(const std::string& path, int otherEventMask, int otherScanInterval,
 	bool forceScan) :
 	_directory(path),
-	_eventMask(eventMask),
-	_scanInterval(scanInterval),
+	_eventMask(otherEventMask),
+	_scanInterval(otherScanInterval),
 	_forceScan(forceScan)
 {
 	init();
 }
 
 	
-DirectoryWatcher::DirectoryWatcher(const Poco::File& directory, int eventMask, int scanInterval,
+DirectoryWatcher::DirectoryWatcher(const Poco::File& otherDirectory, int otherEventMask, int otherScanInterval,
 	bool forceScan) :
-	_directory(directory),
-	_eventMask(eventMask),
-	_scanInterval(scanInterval),
+	_directory(otherDirectory),
+	_eventMask(otherEventMask),
+	_scanInterval(otherScanInterval),
 	_forceScan(forceScan)
 {
 	init();

--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -21,17 +21,17 @@
 namespace Poco {
 
 
-Exception::Exception(int code): _pNested(0), _code(code)
+Exception::Exception(int otherCode): _pNested(0), _code(otherCode)
 {
 }
 
 
-Exception::Exception(const std::string& msg, int code): _msg(msg), _pNested(0), _code(code)
+Exception::Exception(const std::string& msg, int otherCode): _msg(msg), _pNested(0), _code(otherCode)
 {
 }
 
 
-Exception::Exception(const std::string& msg, const std::string& arg, int code): _msg(msg), _pNested(0), _code(code)
+Exception::Exception(const std::string& msg, const std::string& arg, int otherCode): _msg(msg), _pNested(0), _code(otherCode)
 {
 	if (!arg.empty())
 	{
@@ -41,7 +41,7 @@ Exception::Exception(const std::string& msg, const std::string& arg, int code): 
 }
 
 
-Exception::Exception(const std::string& msg, const Exception& nested, int code): _msg(msg), _pNested(nested.clone()), _code(code)
+Exception::Exception(const std::string& msg, const Exception& nestedException, int otherCode): _msg(msg), _pNested(nestedException.clone()), _code(otherCode)
 {
 }
 

--- a/Foundation/src/FIFOBufferStream.cpp
+++ b/Foundation/src/FIFOBufferStream.cpp
@@ -33,12 +33,12 @@ FIFOBufferStreamBuf::FIFOBufferStreamBuf():
 }
 
 
-FIFOBufferStreamBuf::FIFOBufferStreamBuf(FIFOBuffer& fifoBuffer):
-	BufferedBidirectionalStreamBuf(fifoBuffer.size() + 4, std::ios::in | std::ios::out),
+FIFOBufferStreamBuf::FIFOBufferStreamBuf(FIFOBuffer& rFifoBuffer):
+	BufferedBidirectionalStreamBuf(rFifoBuffer.size() + 4, std::ios::in | std::ios::out),
 	_pFIFOBuffer(0),
-	_fifoBuffer(fifoBuffer)
+	_fifoBuffer(rFifoBuffer)
 {
-	fifoBuffer.setNotify(true);
+	rFifoBuffer.setNotify(true);
 }
 
 

--- a/Foundation/src/File.cpp
+++ b/Foundation/src/File.cpp
@@ -44,17 +44,17 @@ File::File()
 }
 
 
-File::File(const std::string& path): FileImpl(path)
+File::File(const std::string& rPath): FileImpl(rPath)
 {
 }
 
 
-File::File(const char* path): FileImpl(std::string(path))
+File::File(const char* pPath): FileImpl(std::string(pPath))
 {
 }
 
 
-File::File(const Path& path): FileImpl(path.toString())
+File::File(const Path& rPath): FileImpl(rPath.toString())
 {
 }
 
@@ -76,24 +76,24 @@ File& File::operator = (const File& file)
 }
 
 
-File& File::operator = (const std::string& path)
+File& File::operator = (const std::string& rPath)
 {
-	setPathImpl(path);
+	setPathImpl(rPath);
 	return *this;
 }
 
 
-File& File::operator = (const char* path)
+File& File::operator = (const char* pPath)
 {
-	poco_check_ptr (path);
-	setPathImpl(path);
+	poco_check_ptr (pPath);
+	setPathImpl(pPath);
 	return *this;
 }
 
 
-File& File::operator = (const Path& path)
+File& File::operator = (const Path& rPath)
 {
-	setPathImpl(path.toString());
+	setPathImpl(rPath.toString());
 	return *this;
 }
 
@@ -211,11 +211,11 @@ File& File::setExecutable(bool flag)
 }
 
 	
-void File::copyTo(const std::string& path) const
+void File::copyTo(const std::string& rPath) const
 {
 	Path src(getPathImpl());
-	Path dest(path);
-	File destFile(path);
+	Path dest(rPath);
+	File destFile(rPath);
 	if ((destFile.exists() && destFile.isDirectory()) || dest.isDirectory())
 	{
 		dest.makeDirectory();
@@ -228,9 +228,9 @@ void File::copyTo(const std::string& path) const
 }
 
 
-void File::copyDirectory(const std::string& path) const
+void File::copyDirectory(const std::string& rPath) const
 {
-	File target(path);
+	File target(rPath);
 	target.createDirectories();
 
 	Path src(getPathImpl());
@@ -239,23 +239,23 @@ void File::copyDirectory(const std::string& path) const
 	DirectoryIterator end;
 	for (; it != end; ++it)
 	{
-		it->copyTo(path);
+		it->copyTo(rPath);
 	}
 }
 
 
-void File::moveTo(const std::string& path)
+void File::moveTo(const std::string& rPath)
 {
-	copyTo(path);
+	copyTo(rPath);
 	remove(true);
-	setPathImpl(path);
+	setPathImpl(rPath);
 }
 
 	
-void File::renameTo(const std::string& path)
+void File::renameTo(const std::string& rPath)
 {
-	renameToImpl(path);
-	setPathImpl(path);
+	renameToImpl(rPath);
+	setPathImpl(rPath);
 }
 
 	

--- a/Foundation/src/FileChannel.cpp
+++ b/Foundation/src/FileChannel.cpp
@@ -54,8 +54,8 @@ FileChannel::FileChannel():
 }
 
 
-FileChannel::FileChannel(const std::string& path):
-	_path(path),
+FileChannel::FileChannel(const std::string& rPath):
+	_path(rPath),
 	_times("utc"),
 	_compress(false),
 	_flush(true),

--- a/Foundation/src/LocalDateTime.cpp
+++ b/Foundation/src/LocalDateTime.cpp
@@ -34,30 +34,30 @@ LocalDateTime::LocalDateTime()
 }
 
 
-LocalDateTime::LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond):
-	_dateTime(year, month, day, hour, minute, second, millisecond, microsecond)
+LocalDateTime::LocalDateTime(int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicrosecond):
+	_dateTime(otherYear, otherMonth, otherDay, otherHour, otherMinute, otherSecond, otherMillisecond, otherMicrosecond)
 {
 	determineTzd();
 }
 
 
-LocalDateTime::LocalDateTime(int tzd, int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond):
-	_dateTime(year, month, day, hour, minute, second, millisecond, microsecond),
-	_tzd(tzd)
+LocalDateTime::LocalDateTime(int otherTzd, int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicrosecond):
+	_dateTime(otherYear, otherMonth, otherDay, otherHour, otherMinute, otherSecond, otherMillisecond, otherMicrosecond),
+	_tzd(otherTzd)
 {
 }
 
 
-LocalDateTime::LocalDateTime(double julianDay):
-	_dateTime(julianDay)
+LocalDateTime::LocalDateTime(double otherJulianDay):
+	_dateTime(otherJulianDay)
 {
 	determineTzd(true);
 }
 
 
-LocalDateTime::LocalDateTime(int tzd, double julianDay):
-	_dateTime(julianDay),
-	_tzd(tzd)
+LocalDateTime::LocalDateTime(int otherTzd, double otherJulianDay):
+	_dateTime(otherJulianDay),
+	_tzd(otherTzd)
 {
 	adjustForTzd();
 }
@@ -70,17 +70,17 @@ LocalDateTime::LocalDateTime(const DateTime& dateTime):
 }
 
 
-LocalDateTime::LocalDateTime(int tzd, const DateTime& dateTime):
-	_dateTime(dateTime),
-	_tzd(tzd)
+LocalDateTime::LocalDateTime(int otherTzd, const DateTime& otherDateTime):
+	_dateTime(otherDateTime),
+	_tzd(otherTzd)
 {
 	adjustForTzd();
 }
 
 
-LocalDateTime::LocalDateTime(int tzd, const DateTime& dateTime, bool adjust):
-	_dateTime(dateTime),
-	_tzd(tzd)
+LocalDateTime::LocalDateTime(int otherTzd, const DateTime& otherDateTime, bool adjust):
+	_dateTime(otherDateTime),
+	_tzd(otherTzd)
 {
 	if (adjust)
 		adjustForTzd();
@@ -94,9 +94,9 @@ LocalDateTime::LocalDateTime(const LocalDateTime& dateTime):
 }
 
 
-LocalDateTime::LocalDateTime(Timestamp::UtcTimeVal utcTime, Timestamp::TimeDiff diff, int tzd):
-	_dateTime(utcTime, diff),
-	_tzd(tzd)
+LocalDateTime::LocalDateTime(Timestamp::UtcTimeVal utcTimeVal, Timestamp::TimeDiff diff, int otherTzd):
+	_dateTime(utcTimeVal, diff),
+	_tzd(otherTzd)
 {
 	adjustForTzd();
 }
@@ -118,45 +118,45 @@ LocalDateTime& LocalDateTime::operator = (const LocalDateTime& dateTime)
 }
 
 
-LocalDateTime& LocalDateTime::operator = (const Timestamp& timestamp)
+LocalDateTime& LocalDateTime::operator = (const Timestamp& otherTimestamp)
 {
-	if (timestamp != this->timestamp())
+	if (otherTimestamp != timestamp())
 	{
-		_dateTime = timestamp;
+		_dateTime = otherTimestamp;
 		determineTzd(true);
 	}
 	return *this;
 }
 
 
-LocalDateTime& LocalDateTime::operator = (double julianDay)
+LocalDateTime& LocalDateTime::operator = (double otherJulianDay)
 {
-	_dateTime = julianDay;
+	_dateTime = otherJulianDay;
 	determineTzd(true);
 	return *this;
 }
 
 
-LocalDateTime& LocalDateTime::assign(int year, int month, int day, int hour, int minute, int second, int millisecond, int microseconds)
+LocalDateTime& LocalDateTime::assign(int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicroseconds)
 {
-	_dateTime.assign(year, month, day, hour, minute, second, millisecond, microseconds);
+	_dateTime.assign(otherYear, otherMonth, otherDay, otherHour, otherMinute, otherSecond, otherMillisecond, otherMicroseconds);
 	determineTzd(false);
 	return *this;
 }
 
 
-LocalDateTime& LocalDateTime::assign(int tzd, int year, int month, int day, int hour, int minute, int second, int millisecond, int microseconds)
+LocalDateTime& LocalDateTime::assign(int otherTzd, int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicroseconds)
 {
-	_dateTime.assign(year, month, day, hour, minute, second, millisecond, microseconds);
-	_tzd = tzd;
+	_dateTime.assign(otherYear, otherMonth, otherDay, otherHour, otherMinute, otherSecond, otherMillisecond, otherMicroseconds);
+	_tzd = otherTzd;
 	return *this;
 }
 
 
-LocalDateTime& LocalDateTime::assign(int tzd, double julianDay)
+LocalDateTime& LocalDateTime::assign(int otherTzd, double otherJulianDay)
 {
-	_tzd      = tzd;
-	_dateTime = julianDay;
+	_tzd      = otherTzd;
+	_dateTime = otherJulianDay;
 	adjustForTzd();
 	return *this;
 }
@@ -292,7 +292,7 @@ void LocalDateTime::determineTzd(bool adjust)
 }
 
 
-std::time_t LocalDateTime::dstOffset(int& dstOffset) const
+std::time_t LocalDateTime::dstOffset(int& rDstOffset) const
 {
 	std::time_t local;
 	std::tm     broken;
@@ -310,7 +310,7 @@ std::time_t LocalDateTime::dstOffset(int& dstOffset) const
 	local = std::mktime(&broken);
 #endif
 	
-	dstOffset = (broken.tm_isdst == 1) ? 3600 : 0;
+	rDstOffset = (broken.tm_isdst == 1) ? 3600 : 0;
 	return local;
 }
 

--- a/Foundation/src/LogFile.cpp
+++ b/Foundation/src/LogFile.cpp
@@ -31,7 +31,7 @@
 namespace Poco {
 
 
-LogFile::LogFile(const std::string& path): LogFileImpl(path)
+LogFile::LogFile(const std::string& rPath): LogFileImpl(rPath)
 {
 }
 

--- a/Foundation/src/LogStream.cpp
+++ b/Foundation/src/LogStream.cpp
@@ -25,8 +25,8 @@ namespace Poco {
 //
 
 
-LogStreamBuf::LogStreamBuf(Logger& logger, Message::Priority priority):
-	_logger(logger),
+LogStreamBuf::LogStreamBuf(Logger& rLogger, Message::Priority priority):
+	_logger(rLogger),
 	_priority(priority)
 {
 }
@@ -87,15 +87,15 @@ LogStreamBuf* LogIOS::rdbuf()
 //
 
 
-LogStream::LogStream(Logger& logger, Message::Priority priority):
-	LogIOS(logger, priority),
+LogStream::LogStream(Logger& logger, Message::Priority messagePriority):
+	LogIOS(logger, messagePriority),
 	std::ostream(&_buf)
 {
 }
 
 
-LogStream::LogStream(const std::string& loggerName, Message::Priority priority):
-	LogIOS(Logger::get(loggerName), priority),
+LogStream::LogStream(const std::string& loggerName, Message::Priority messagePriority):
+	LogIOS(Logger::get(loggerName), messagePriority),
 	std::ostream(&_buf)
 {
 }
@@ -210,9 +210,9 @@ LogStream& LogStream::trace(const std::string& message)
 }
 
 
-LogStream& LogStream::priority(Message::Priority priority)
+LogStream& LogStream::priority(Message::Priority messagePriority)
 {
-	_buf.setPriority(priority);
+	_buf.setPriority(messagePriority);
 	return *this;
 }
 

--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -31,7 +31,7 @@ Mutex Logger::_mapMtx;
 const std::string Logger::ROOT;
 
 
-Logger::Logger(const std::string& name, Channel* pChannel, int level): _name(name), _pChannel(pChannel), _level(level)
+Logger::Logger(const std::string& rName, Channel* pChannel, int level): _name(rName), _pChannel(pChannel), _level(level)
 {
 	if (pChannel) pChannel->duplicate();
 }
@@ -69,14 +69,14 @@ void Logger::setLevel(const std::string& level)
 }
 
 
-void Logger::setProperty(const std::string& name, const std::string& value)
+void Logger::setProperty(const std::string& rName, const std::string& rValue)
 {
-	if (name == "channel")
-		setChannel(LoggingRegistry::defaultRegistry().channelForName(value));
-	else if (name == "level")
-		setLevel(value);
+	if (rName == "channel")
+		setChannel(LoggingRegistry::defaultRegistry().channelForName(rValue));
+	else if (rName == "level")
+		setLevel(rValue);
 	else 
-		Channel::setProperty(name, value);
+		Channel::setProperty(rName, rValue);
 }
 
 

--- a/Foundation/src/MD4Engine.cpp
+++ b/Foundation/src/MD4Engine.cpp
@@ -129,11 +129,11 @@ const DigestEngine::Digest& MD4Engine::digest()
 	/* Append length (before padding) */
 	update(bits, 8);
 
-	/* Store state in digest */
-	unsigned char digest[16];
-	encode(digest, _context.state, 16);
+	/* Store state in digestArray */
+	unsigned char digestArray[16];
+	encode(digestArray, _context.state, 16);
 	_digest.clear();
-	_digest.insert(_digest.begin(), digest, digest + sizeof(digest));
+	_digest.insert(_digest.begin(), digestArray, digestArray + sizeof(digestArray));
 
 	/* Zeroize sensitive information. */
 	std::memset(&_context, 0, sizeof (_context));

--- a/Foundation/src/MD5Engine.cpp
+++ b/Foundation/src/MD5Engine.cpp
@@ -129,11 +129,11 @@ const DigestEngine::Digest& MD5Engine::digest()
 	/* Append length (before padding) */
 	update(bits, 8);
 
-	/* Store state in digest */
-	unsigned char digest[16];
-	encode(digest, _context.state, 16);
+	/* Store state in digestArray */
+	unsigned char digestArray[16];
+	encode(digestArray, _context.state, 16);
 	_digest.clear();
-	_digest.insert(_digest.begin(), digest, digest + sizeof(digest));
+	_digest.insert(_digest.begin(), digestArray, digestArray + sizeof(digestArray));
 
 	/* Zeroize sensitive information. */
 	std::memset(&_context, 0, sizeof (_context));

--- a/Foundation/src/MemoryPool.cpp
+++ b/Foundation/src/MemoryPool.cpp
@@ -21,8 +21,8 @@
 namespace Poco {
 
 
-MemoryPool::MemoryPool(std::size_t blockSize, int preAlloc, int maxAlloc):
-	_blockSize(blockSize),
+MemoryPool::MemoryPool(std::size_t blockLength, int preAlloc, int maxAlloc):
+	_blockSize(blockLength),
 	_maxAlloc(maxAlloc),
 	_allocated(preAlloc)
 {

--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -48,7 +48,7 @@ Path::Path(): _absolute(false)
 }
 
 
-Path::Path(bool absolute): _absolute(absolute)
+Path::Path(bool absolutePath): _absolute(absolutePath)
 {
 }
 
@@ -90,39 +90,39 @@ Path::Path(const Path& path):
 }
 
 
-Path::Path(const Path& parent, const std::string& fileName):
-	_node(parent._node), 
-	_device(parent._device),
-	_name(parent._name),
-	_version(parent._version),
-	_dirs(parent._dirs),
-	_absolute(parent._absolute)
+Path::Path(const Path& rParent, const std::string& fileName):
+	_node(rParent._node), 
+	_device(rParent._device),
+	_name(rParent._name),
+	_version(rParent._version),
+	_dirs(rParent._dirs),
+	_absolute(rParent._absolute)
 {	
 	makeDirectory();
 	_name = fileName;
 }
 
 
-Path::Path(const Path& parent, const char* fileName):
-	_node(parent._node), 
-	_device(parent._device),
-	_name(parent._name),
-	_version(parent._version),
-	_dirs(parent._dirs),
-	_absolute(parent._absolute)
+Path::Path(const Path& rParent, const char* fileName):
+	_node(rParent._node), 
+	_device(rParent._device),
+	_name(rParent._name),
+	_version(rParent._version),
+	_dirs(rParent._dirs),
+	_absolute(rParent._absolute)
 {	
 	makeDirectory();
 	_name = fileName;
 }
 
 
-Path::Path(const Path& parent, const Path& relative):
-	_node(parent._node), 
-	_device(parent._device),
-	_name(parent._name),
-	_version(parent._version),
-	_dirs(parent._dirs),
-	_absolute(parent._absolute)
+Path::Path(const Path& rParent, const Path& relative):
+	_node(rParent._node), 
+	_device(rParent._device),
+	_name(rParent._name),
+	_version(rParent._version),
+	_dirs(rParent._dirs),
+	_absolute(rParent._absolute)
 {	
 	resolve(relative);
 }

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -42,9 +42,9 @@ PatternFormatter::PatternFormatter():
 }
 
 
-PatternFormatter::PatternFormatter(const std::string& format):
+PatternFormatter::PatternFormatter(const std::string& rFormat):
 	_localTime(false),
-	_pattern(format)
+	_pattern(rFormat)
 {
 	parsePriorityNames();
 	parsePattern();

--- a/Foundation/src/Process_UNIX.cpp
+++ b/Foundation/src/Process_UNIX.cpp
@@ -207,9 +207,9 @@ ProcessHandleImpl* ProcessImpl::launchByForkExecImpl(const std::string& command,
 		if (outPipe) outPipe->close(Pipe::CLOSE_BOTH);
 		if (errPipe) errPipe->close(Pipe::CLOSE_BOTH);
 		// close all open file descriptors other than stdin, stdout, stderr
-		for (int i = 3; i < sysconf(_SC_OPEN_MAX); ++i)
+		for (int fd = 3; i < sysconf(_SC_OPEN_MAX); ++fd)
 		{
-			close(i);
+			close(fd);
 		}
 
 		execvp(argv[0], &argv[0]);

--- a/Foundation/src/SimpleFileChannel.cpp
+++ b/Foundation/src/SimpleFileChannel.cpp
@@ -40,9 +40,9 @@ SimpleFileChannel::SimpleFileChannel():
 }
 
 
-SimpleFileChannel::SimpleFileChannel(const std::string& path):
-	_path(path),
-	_secondaryPath(path + ".0"),
+SimpleFileChannel::SimpleFileChannel(const std::string& rPath):
+	_path(rPath),
+	_secondaryPath(rPath + ".0"),
 	_limit(0),
 	_flush(true),
 	_pFile(0)
@@ -73,12 +73,12 @@ void SimpleFileChannel::open()
 		File secondary(_secondaryPath);
 		Timestamp pt = primary.exists() ? primary.getLastModified() : 0;
 		Timestamp st = secondary.exists() ? secondary.getLastModified() : 0;
-		std::string path;
+		std::string pathString;
 		if (pt >= st)
-			path = _path;
+			pathString = _path;
 		else
-			path = _secondaryPath;
-		_pFile = new LogFile(path);
+			pathString = _secondaryPath;
+		_pFile = new LogFile(pathString);
 	}
 }
 

--- a/Foundation/src/SortedDirectoryIterator.cpp
+++ b/Foundation/src/SortedDirectoryIterator.cpp
@@ -26,8 +26,8 @@ SortedDirectoryIterator::SortedDirectoryIterator()
 }
 
 
-SortedDirectoryIterator::SortedDirectoryIterator(const std::string& path)
-	: DirectoryIterator(path), _is_finished(false)
+SortedDirectoryIterator::SortedDirectoryIterator(const std::string& rPath)
+	: DirectoryIterator(rPath), _is_finished(false)
 {
 	scan();
 	next();
@@ -50,8 +50,8 @@ SortedDirectoryIterator::SortedDirectoryIterator(const File& file)
 }
 
 
-SortedDirectoryIterator::SortedDirectoryIterator(const Path& path)
-	: DirectoryIterator(path), _is_finished(false)
+SortedDirectoryIterator::SortedDirectoryIterator(const Path& rPath)
+	: DirectoryIterator(rPath), _is_finished(false)
 {
 	scan();
 	next();

--- a/Foundation/src/StreamConverter.cpp
+++ b/Foundation/src/StreamConverter.cpp
@@ -113,10 +113,10 @@ int StreamConverterBuf::writeToDevice(char c)
 				++_errors;
 				return -1;
 			}
-			int n = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
-			if (n == 0) n = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
-			poco_assert_dbg (n <= sizeof(_buffer));
-			_pOstr->write((char*) _buffer, n);
+			int number = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
+			if (number == 0) number = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
+			poco_assert_dbg (number <= sizeof(_buffer));
+			_pOstr->write((char*) _buffer, number);
 			_sequenceLength = 0;
 			_pos = 0;
 		}

--- a/Foundation/src/StringTokenizer.cpp
+++ b/Foundation/src/StringTokenizer.cpp
@@ -25,13 +25,13 @@ namespace Poco {
 StringTokenizer::StringTokenizer(const std::string& str, const std::string& separators, int options)
 {
 	std::string::const_iterator it = str.begin();
-	std::string::const_iterator end = str.end();
+	std::string::const_iterator itEnd = str.end();
 	std::string token;
 	bool doTrim = ((options & TOK_TRIM) != 0);
 	bool ignoreEmpty = ((options & TOK_IGNORE_EMPTY) != 0);
 	bool lastToken = false;
 
-	for (;it != end; ++it)
+	for (;it != itEnd; ++it)
 	{
 		if (separators.find(*it) != std::string::npos) 
 		{

--- a/Foundation/src/Task.cpp
+++ b/Foundation/src/Task.cpp
@@ -22,8 +22,8 @@
 namespace Poco {
 
 
-Task::Task(const std::string& name):
-	_name(name),
+Task::Task(const std::string& rName):
+	_name(rName),
 	_pOwner(0),
 	_progress(0),
 	_state(TASK_IDLE),
@@ -91,11 +91,11 @@ bool Task::sleep(long milliseconds)
 }
 
 
-void Task::setProgress(float progress)
+void Task::setProgress(float taskProgress)
 {
 	FastMutex::ScopedLock lock(_mutex);
 
-	_progress = progress;
+	_progress = taskProgress;
 	if (_pOwner)
 		_pOwner->taskProgress(this, _progress);
 }
@@ -109,9 +109,9 @@ void Task::setOwner(TaskManager* pOwner)
 }
 
 
-void Task::setState(TaskState state)
+void Task::setState(TaskState taskState)
 {
-	_state = state;
+	_state = taskState;
 }
 
 

--- a/Foundation/src/TaskNotification.cpp
+++ b/Foundation/src/TaskNotification.cpp
@@ -79,9 +79,9 @@ TaskFailedNotification::~TaskFailedNotification()
 }
 
 
-TaskProgressNotification::TaskProgressNotification(Task* pTask, float progress):
+TaskProgressNotification::TaskProgressNotification(Task* pTask, float taskProgress):
 	TaskNotification(pTask),
-	_progress(progress)
+	_progress(taskProgress)
 {
 }
 

--- a/Foundation/src/TextBufferIterator.cpp
+++ b/Foundation/src/TextBufferIterator.cpp
@@ -47,18 +47,18 @@ TextBufferIterator::TextBufferIterator(const char* begin, std::size_t size, cons
 }
 
 
-TextBufferIterator::TextBufferIterator(const char* begin, const char* end, const TextEncoding& encoding):
+TextBufferIterator::TextBufferIterator(const char* begin, const char* pEnd, const TextEncoding& encoding):
 	_pEncoding(&encoding),
 	_it(begin),
-	_end(end)
+	_end(pEnd)
 {
 }
 
 
-TextBufferIterator::TextBufferIterator(const char* end):
+TextBufferIterator::TextBufferIterator(const char* pEnd):
 	_pEncoding(0),
-	_it(end),
-	_end(end)
+	_it(pEnd),
+	_end(pEnd)
 {
 }
 

--- a/Foundation/src/TextIterator.cpp
+++ b/Foundation/src/TextIterator.cpp
@@ -36,10 +36,10 @@ TextIterator::TextIterator(const std::string& str, const TextEncoding& encoding)
 }
 
 
-TextIterator::TextIterator(const std::string::const_iterator& begin, const std::string::const_iterator& end, const TextEncoding& encoding):
+TextIterator::TextIterator(const std::string::const_iterator& begin, const std::string::const_iterator& rEnd, const TextEncoding& encoding):
 	_pEncoding(&encoding),
 	_it(begin),
-	_end(end)
+	_end(rEnd)
 {
 }
 
@@ -52,10 +52,10 @@ TextIterator::TextIterator(const std::string& str):
 }
 
 
-TextIterator::TextIterator(const std::string::const_iterator& end):
+TextIterator::TextIterator(const std::string::const_iterator& rEnd):
 	_pEncoding(0),
-	_it(end),
-	_end(end)
+	_it(rEnd),
+	_end(rEnd)
 {
 }
 

--- a/Foundation/src/Thread.cpp
+++ b/Foundation/src/Thread.cpp
@@ -98,9 +98,9 @@ Thread::Thread():
 }
 
 
-Thread::Thread(const std::string& name): 
+Thread::Thread(const std::string& rName): 
 	_id(uniqueId()), 
-	_name(name), 
+	_name(rName), 
 	_pTLS(0),
 	_event()
 {
@@ -190,9 +190,9 @@ void Thread::clearTLS()
 
 std::string Thread::makeName()
 {
-	std::ostringstream name;
-	name << '#' << _id;
-	return name.str();
+	std::ostringstream threadName;
+	threadName << '#' << _id;
+	return threadName.str();
 }
 
 
@@ -203,11 +203,11 @@ int Thread::uniqueId()
 }
 
 
-void Thread::setName(const std::string& name)
+void Thread::setName(const std::string& rName)
 {
 	FastMutex::ScopedLock lock(_mutex);
 
-	_name = name;
+	_name = rName;
 }
 
 

--- a/Foundation/src/ThreadPool.cpp
+++ b/Foundation/src/ThreadPool.cpp
@@ -282,13 +282,13 @@ ThreadPool::ThreadPool(int minCapacity,
 }
 
 
-ThreadPool::ThreadPool(const std::string& name,
+ThreadPool::ThreadPool(const std::string& rName,
 	int minCapacity,
 	int maxCapacity,
 	int idleTime,
 	int stackSize,
 	ThreadAffinityPolicy affinityPolicy):
-	_name(name),
+	_name(rName),
 	_minCapacity(minCapacity), 
 	_maxCapacity(maxCapacity), 
 	_idleTime(idleTime),
@@ -414,9 +414,9 @@ void ThreadPool::start(Runnable& target, int cpu)
 }
 
 
-void ThreadPool::start(Runnable& target, const std::string& name, int cpu)
+void ThreadPool::start(Runnable& target, const std::string& rName, int cpu)
 {
-	getThread()->start(Thread::PRIO_NORMAL, target, name, affinity(cpu));
+	getThread()->start(Thread::PRIO_NORMAL, target, rName, affinity(cpu));
 }
 
 
@@ -426,9 +426,9 @@ void ThreadPool::startWithPriority(Thread::Priority priority, Runnable& target, 
 }
 
 
-void ThreadPool::startWithPriority(Thread::Priority priority, Runnable& target, const std::string& name, int cpu)
+void ThreadPool::startWithPriority(Thread::Priority priority, Runnable& target, const std::string& rName, int cpu)
 {
-	getThread()->start(priority, target, name, affinity(cpu));
+	getThread()->start(priority, target, rName, affinity(cpu));
 }
 
 
@@ -542,9 +542,9 @@ PooledThread* ThreadPool::getThread()
 
 PooledThread* ThreadPool::createThread()
 {
-	std::ostringstream name;
-	name << _name << "[#" << ++_serial << "]";
-	return new PooledThread(name.str(), _stackSize);
+	std::ostringstream threadName;
+	threadName << _name << "[#" << ++_serial << "]";
+	return new PooledThread(threadName.str(), _stackSize);
 }
 
 

--- a/Foundation/src/Timespan.cpp
+++ b/Foundation/src/Timespan.cpp
@@ -40,14 +40,14 @@ Timespan::Timespan(TimeDiff microSeconds):
 }
 
 
-Timespan::Timespan(long seconds, long microSeconds):
-	_span(TimeDiff(seconds)*SECONDS + microSeconds)
+Timespan::Timespan(long otherSeconds, long otherMicroSeconds):
+	_span(TimeDiff(otherSeconds)*SECONDS + otherMicroSeconds)
 {
 }
 
 	
-Timespan::Timespan(int days, int hours, int minutes, int seconds, int microSeconds):
-	_span(TimeDiff(microSeconds) + TimeDiff(seconds)*SECONDS + TimeDiff(minutes)*MINUTES + TimeDiff(hours)*HOURS + TimeDiff(days)*DAYS)
+Timespan::Timespan(int otherDays, int otherHours, int otherMinutes, int otherSeconds, int otherMicroSeconds):
+	_span(TimeDiff(otherMicroSeconds) + TimeDiff(otherSeconds)*SECONDS + TimeDiff(otherMinutes)*MINUTES + TimeDiff(otherHours)*HOURS + TimeDiff(otherDays)*DAYS)
 {
 }
 
@@ -77,16 +77,16 @@ Timespan& Timespan::operator = (TimeDiff microSeconds)
 }
 
 
-Timespan& Timespan::assign(int days, int hours, int minutes, int seconds, int microSeconds)
+Timespan& Timespan::assign(int otherDays, int otherHours, int otherMinutes, int otherSeconds, int otherMicroSeconds)
 {
-	_span = TimeDiff(microSeconds) + TimeDiff(seconds)*SECONDS + TimeDiff(minutes)*MINUTES + TimeDiff(hours)*HOURS + TimeDiff(days)*DAYS;
+	_span = TimeDiff(otherMicroSeconds) + TimeDiff(otherSeconds)*SECONDS + TimeDiff(otherMinutes)*MINUTES + TimeDiff(otherHours)*HOURS + TimeDiff(otherDays)*DAYS;
 	return *this;
 }
 
 
-Timespan& Timespan::assign(long seconds, long microSeconds)
+Timespan& Timespan::assign(long otherSeconds, long otherMicroSeconds)
 {
-	_span = TimeDiff(seconds)*SECONDS + TimeDiff(microSeconds);
+	_span = TimeDiff(otherSeconds)*SECONDS + TimeDiff(otherMicroSeconds);
 	return *this;
 }
 

--- a/Foundation/src/URIStreamFactory.cpp
+++ b/Foundation/src/URIStreamFactory.cpp
@@ -31,8 +31,8 @@ URIStreamFactory::~URIStreamFactory()
 }
 
 
-URIRedirection::URIRedirection(const std::string& uri):
-	_uri(uri)
+URIRedirection::URIRedirection(const std::string& rUri):
+	_uri(rUri)
 {
 }
 

--- a/Foundation/src/UUID.cpp
+++ b/Foundation/src/UUID.cpp
@@ -67,7 +67,7 @@ UUID::UUID(UInt32 timeLow, UInt32 timeMid, UInt32 timeHiAndVersion, UInt16 clock
 }
 
 
-UUID::UUID(const char* bytes, Version version)
+UUID::UUID(const char* bytes, Version uuidVersion)
 {
 	UInt32 i32;
 	UInt16 i16;
@@ -86,7 +86,7 @@ UUID::UUID(const char* bytes, Version version)
 	std::memcpy(_node, bytes, sizeof(_node));
 
 	_timeHiAndVersion &= 0x0FFF;
-	_timeHiAndVersion |= (version << 12);
+	_timeHiAndVersion |= (uuidVersion << 12);
 	_clockSeq &= 0x3FFF;
 	_clockSeq |= 0x8000;
 }

--- a/Foundation/src/diy-fp.h
+++ b/Foundation/src/diy-fp.h
@@ -42,7 +42,7 @@ class DiyFp {
   static const int kSignificandSize = 64;
 
   DiyFp() : f_(0), e_(0) {}
-  DiyFp(uint64_t f, int e) : f_(f), e_(e) {}
+  DiyFp(uint64_t significant, int exponent) : f_(significant), e_(exponent) {}
 
   // this = this - other.
   // The exponents of both numbers must be the same and the significand of this
@@ -76,22 +76,22 @@ class DiyFp {
 
   void Normalize() {
     ASSERT(f_ != 0);
-    uint64_t f = f_;
-    int e = e_;
+    uint64_t significant = f_;
+    int exponent = e_;
 
     // This method is mainly called for normalizing boundaries. In general
     // boundaries need to be shifted by 10 bits. We thus optimize for this case.
     const uint64_t k10MSBits = UINT64_2PART_C(0xFFC00000, 00000000);
-    while ((f & k10MSBits) == 0) {
-      f <<= 10;
-      e -= 10;
+    while ((significant & k10MSBits) == 0) {
+      significant <<= 10;
+      exponent -= 10;
     }
-    while ((f & kUint64MSB) == 0) {
-      f <<= 1;
-      e--;
+    while ((significant & kUint64MSB) == 0) {
+      significant <<= 1;
+      exponent--;
     }
-    f_ = f;
-    e_ = e;
+    f_ = significant;
+    e_ = exponent;
   }
 
   static DiyFp Normalize(const DiyFp& a) {

--- a/Foundation/src/double-conversion.cc
+++ b/Foundation/src/double-conversion.cc
@@ -801,9 +801,9 @@ double StringToDoubleConverter::StringToIeee(
         return junk_string_value_;
       }
     }
-    char sign = '+';
+    char currentSign = '+';
     if (*current == '+' || *current == '-') {
-      sign = static_cast<char>(*current);
+      currentSign = static_cast<char>(*current);
       ++current;
       if (current == end) {
         if (allow_trailing_junk) {
@@ -837,7 +837,7 @@ double StringToDoubleConverter::StringToIeee(
       ++current;
     } while (current != end && *current >= '0' && *current <= '9');
 
-    exponent += (sign == '-' ? -num : num);
+    exponent += (currentSign == '-' ? -num : num);
   }
 
   if (!(allow_trailing_spaces || allow_trailing_junk) && (current != end)) {

--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -158,8 +158,8 @@ template <typename T>
 class Vector {
  public:
   Vector() : start_(NULL), length_(0) {}
-  Vector(T* data, int length) : start_(data), length_(length) {
-    ASSERT(length == 0 || (length > 0 && data != NULL));
+  Vector(T* data, int size) : start_(data), length_(size) {
+    ASSERT(size == 0 || (size > 0 && data != NULL));
   }
 
   // Returns a vector using the same backing storage as this one,
@@ -201,8 +201,8 @@ class Vector {
 // buffer bounds on all operations in debug mode.
 class StringBuilder {
  public:
-  StringBuilder(char* buffer, int size)
-      : buffer_(buffer, size), position_(0) { }
+  StringBuilder(char* buffer, int length)
+      : buffer_(buffer, length), position_(0) { }
 
   ~StringBuilder() { if (!is_finalized()) Finalize(); }
 


### PR DESCRIPTION
http://www.appinf.com/download/CppCodingStyleGuide.pdf indicates that "it", "p" and "r" prefixes are welcome, so in a number of cases I could just fix the warnings by applying those prefixes in case the parameter name was the same as the getter member function name (and one of them needed renaming, so I had to rename the parameter name to avoid API/ABI changes).

```
make Foundation-libexec
```

now succeeds for me with -Wshadow + -Werror, using gcc.