### PR TITLE
improvment in running tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ RemotingNG
 XSD
 stage/
 releases/
+Zip/testsuite/data*.bin
 
 
 # openssl binaries #

--- a/Foundation/src/Process_UNIX.cpp
+++ b/Foundation/src/Process_UNIX.cpp
@@ -207,7 +207,7 @@ ProcessHandleImpl* ProcessImpl::launchByForkExecImpl(const std::string& command,
 		if (outPipe) outPipe->close(Pipe::CLOSE_BOTH);
 		if (errPipe) errPipe->close(Pipe::CLOSE_BOTH);
 		// close all open file descriptors other than stdin, stdout, stderr
-		for (int fd = 3; i < sysconf(_SC_OPEN_MAX); ++fd)
+		for (int fd = 3; fd < sysconf(_SC_OPEN_MAX); ++fd)
 		{
 			close(fd);
 		}

--- a/NetSSL_OpenSSL/testsuite/src/Driver.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/Driver.cpp
@@ -14,6 +14,7 @@
 
 #include "CppUnit/TestRunner.h"
 #include "NetSSLTestSuite.h"
+#include "Poco/Path.h"
 #include "Poco/Util/Application.h"
 #include "Poco/Net/HTTPStreamFactory.h"
 #include "Poco/Net/HTTPSStreamFactory.h"
@@ -52,7 +53,17 @@ public:
 protected:
 	void initialize(Poco::Util::Application& self)
 	{
-		loadConfiguration(); // load default configuration files, if present
+		std::string pocoBase(Poco::Environment::get("POCO_BASE"));
+		if (pocoBase.empty())
+			throw Poco::LogicException("POCO_BASE should be defined");
+		
+		Poco::Path configPath(pocoBase);
+		configPath.makeDirectory();
+		configPath.pushDirectory("NetSSL_OpenSSL");
+		configPath.pushDirectory("testsuite");
+		configPath.setFileName("TestSuite.xml");
+
+		loadConfiguration(configPath.toString()); 
 		Poco::Util::Application::initialize(self);
 	}
 	

--- a/NetSSL_OpenSSL/testsuite/src/Driver.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/Driver.cpp
@@ -53,6 +53,7 @@ public:
 protected:
 	void initialize(Poco::Util::Application& self)
 	{
+#ifdef POCO_OS_FAMILY_UNIX
 		std::string pocoBase(Poco::Environment::get("POCO_BASE"));
 		if (pocoBase.empty())
 			throw Poco::LogicException("POCO_BASE should be defined");
@@ -64,6 +65,9 @@ protected:
 		configPath.setFileName("TestSuite.xml");
 
 		loadConfiguration(configPath.toString()); 
+#else
+		loadConfiguration(); 
+#endif
 		Poco::Util::Application::initialize(self);
 	}
 	

--- a/build/script/runtests2.cmd
+++ b/build/script/runtests2.cmd
@@ -4,8 +4,11 @@ rem $Id$
 rem
 rem A script for running the POCO testsuites.
 rem
-rem usage: runtests2 [64]
+rem usage: runtests2 [64] [component [test]]
 rem
+rem component   : the component under test
+rem test        : the test as part of the component
+
 rem If the environment variable EXCLUDE_TESTS is set, containing
 rem a space-separated list of project names (as found in the
 rem components file), these tests will be skipped.
@@ -15,19 +18,27 @@ setlocal EnableDelayedExpansion
 
 set TESTRUNNER=TestSuite.exe
 set TESTRUNNERARGS=-all
+set TESTCOMPONENTS='findstr /R "." components'
 set BINDIR=bin
 
 if "%1"=="64" (
   set BINDIR=bin64
+  shift
+)
+if not "%1" == "" (
+  set TESTCOMPONENTS="%1"
+  if not "%2" == "" (
+    set TESTRUNNERARGS=%2
+  )
 )
 
 set runs=0
 set failures=0
 set failedTests=
 set status=0
-set excluded=0
 
-for /f %%C in ('findstr /R "." components') do (
+
+for /f %%C in ( %TESTCOMPONENTS% ) do (
   set excluded=0
   for %%X in (%EXCLUDE_TESTS%) do (
     if "%%X"=="%%C" (

--- a/build_cmake.cmd
+++ b/build_cmake.cmd
@@ -1,19 +1,16 @@
-# POCO_STATIC=1 - for static build
-# POCO_UNBUNDLED - for no built-in version of libs
-# CMAKE_INSTALL_PREFIX=path - for install path
+rem usage
+rem build_cmake ( Debug | Release )
+
+rem -DPOCO_STATIC=1 - for static build
+rem -DPOCO_UNBUNDLED - for no built-in version of libs
+rem -DCMAKE_INSTALL_PREFIX=path - for install path
 
 mkdir cmake-build
 cd cmake-build
 
-cmake ../. -DCMAKE_BUILD_TYPE=Debug -G"NMake Makefiles JOM" %1 %2 %3 %4 %5
-jom /j3
-jom install
-
 del CMakeCache.txt
-
-cmake ../. -DCMAKE_BUILD_TYPE=Release -G"NMake Makefiles JOM" %1 %2 %3 %4 %5
-jom /j3
-jom install
-
+cmake ../. -DCMAKE_BUILD_TYPE=%1 -G"NMake Makefiles JOM"  -DENABLE_TESTS=ON -DENABLE_SAMPLE=ON %2 %3 %4 %5
+jom /i /j3
+jom /i install
 
 cd ..

--- a/buildwin.cmd
+++ b/buildwin.cmd
@@ -123,6 +123,7 @@ if "%BUILD_TOOL%"=="msbuild" (
   set CONFIGSW=/p:Configuration=
   set EXTRASW=/m
   set USEENV=/p:UseEnv=true
+  set BUILD_TOOL_FLAGS=/clp:NoSummary /nologo  /v:minimal  
 )
 if not "%BUILD_TOOL%"=="msbuild" (
   set ACTIONSW=/
@@ -335,72 +336,72 @@ echo ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 echo.
 
 if %DEBUG_SHARED%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !PROJECT_FILE! 
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !PROJECT_FILE! 
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
   )
 )
 if %RELEASE_SHARED%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !PROJECT_FILE! 
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !PROJECT_FILE! 
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
   )
 )
 if %DEBUG_STATIC_MT%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !PROJECT_FILE!
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !PROJECT_FILE!
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
   )
 )
 if %RELEASE_STATIC_MT%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !PROJECT_FILE! 
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !PROJECT_FILE! 
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
   )
 )
 if %DEBUG_STATIC_MD%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !PROJECT_FILE! 
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !PROJECT_FILE! 
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
   )
 )
 if %RELEASE_STATIC_MD%==1 (
-  !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !PROJECT_FILE!
+  !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !PROJECT_FILE!
   if ERRORLEVEL 1 exit /b 1
   echo. && echo. && echo.
   if %TESTS%==tests (
     if exist !TEST_PROJECT_FILE! (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !TEST_PROJECT_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !TEST_PROJECT_FILE!
       if ERRORLEVEL 1 exit /b 1
       echo. && echo. && echo.
     )
@@ -440,32 +441,32 @@ for /f %%G in ('findstr /R "." components') do (
     set SOLUTION_FILE=samples%PLATFORM_SUFFIX%_%VS_VERSION%.sln
 
     if %DEBUG_SHARED%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !SOLUTION_FILE! 
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_shared %PLATFORMSW% !SOLUTION_FILE! 
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )
     if %RELEASE_SHARED%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !SOLUTION_FILE! 
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_shared %PLATFORMSW% !SOLUTION_FILE! 
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )
     if %DEBUG_STATIC_MT%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !SOLUTION_FILE! 
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_mt %PLATFORMSW% !SOLUTION_FILE! 
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )
     if %RELEASE_STATIC_MT%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !SOLUTION_FILE! 
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_mt %PLATFORMSW% !SOLUTION_FILE! 
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )
     if %DEBUG_STATIC_MD%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !SOLUTION_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%debug_static_md %PLATFORMSW% !SOLUTION_FILE!
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )
     if %RELEASE_STATIC_MD%==1 (
-      !BUILD_TOOL! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !SOLUTION_FILE!
+      !BUILD_TOOL! !BUILD_TOOL_FLAGS! %USEENV% %EXTRASW% %ACTIONSW%%ACTION% %CONFIGSW%release_static_md %PLATFORMSW% !SOLUTION_FILE!
       if ERRORLEVEL 1 goto buildfailed
       echo. && echo. && echo.
     )

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -47,7 +47,7 @@ Param
   [string] $omit,
   
   [Parameter()]
-  [ValidateSet('msbuild', 'devenv')]
+  [ValidateSet('msbuild', 'devenv', 'vcexpress', 'wdexpress')]
   [string] $tool = 'msbuild',
 
   [Parameter()]
@@ -204,6 +204,8 @@ function Process-Input
 function Build-MSBuild([string] $vsProject)
 {
   Write-Host "Build-MSBuild ==> $vsProject"
+  [string]$flags = '/clp:NoSummary /nologo /v:minimal'
+  
   if ($linkmode -eq 'all')
   {
     $linkModeArr = 'shared', 'static_mt', 'static_md'
@@ -217,14 +219,14 @@ function Build-MSBuild([string] $vsProject)
         {
           $projectConfig = "$cfg"
           $projectConfig += "_$mode"
-          Invoke-Expression "msbuild $vsProject /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
+          Invoke-Expression "msbuild $vsProject $flags /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
         }
       }
       else #config
       {
         $projectConfig = "$config"
         $projectConfig += "_$mode"
-        Invoke-Expression "msbuild $vsProject /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
+        Invoke-Expression "msbuild $vsProject $flags /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
       }
     }
   }
@@ -237,14 +239,14 @@ function Build-MSBuild([string] $vsProject)
       {
         $projectConfig = "$cfg"
         $projectConfig += "_$linkmode"
-        Invoke-Expression "msbuild $vsProject /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
+        Invoke-Expression "msbuild $vsProject $flags /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
       }
     }
     else #config
     {
       $projectConfig = "$config"
       $projectConfig += "_$linkmode"
-      Invoke-Expression "msbuild $vsProject /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
+      Invoke-Expression "msbuild $vsProject $flags /t:$action /p:Configuration=$projectConfig /p:Platform=$platform /p:useenv=true"
     }
   }
 }

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -48,6 +48,8 @@ if(MSVC)
 else(MSVC)
     # Other compilers then MSVC don't have a static STATIC_POSTFIX at the moment
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
+    set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}   -D_DEBUG")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 endif(MSVC)
 
 # Add a d postfix to the debug libraries
@@ -72,22 +74,27 @@ if(WIN32)
   add_definitions( -DUNICODE -D_UNICODE -D__LCC__)  #__LCC__ define used by MySQL.h
 endif(WIN32)
 
-if (UNIX AND NOT ANDROID )
-  # Standard 'must be' defines
-  if (APPLE)
-    add_definitions( -DPOCO_HAVE_IPv6 -DPOCO_NO_STAT64)
-    set(SYSLIBS  dl)
-  else (APPLE)
-    add_definitions( -D_REENTRANT -D_THREAD_SAFE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 )
-    if (QNX)
-      add_definitions( -DPOCO_HAVE_FD_POLL)
-      set(SYSLIBS  m socket)
-    else (QNX)
-      add_definitions( -D_XOPEN_SOURCE=500 -DPOCO_HAVE_FD_EPOLL)
-      set(SYSLIBS  pthread dl rt)
-    endif (QNX)
-  endif (APPLE)
-endif(UNIX AND NOT ANDROID )
+if (CYGWIN)
+  add_definitions(-DPOCO_NO_FPENVIRONMENT -DPOCO_NO_WSTRING)
+  add_definitions(-D_XOPEN_SOURCE=500 -D__BSD_VISIBLE)
+else (CYGWIN)
+	if (UNIX AND NOT ANDROID )
+	  # Standard 'must be' defines
+	  if (APPLE)
+	    add_definitions( -DPOCO_HAVE_IPv6 -DPOCO_NO_STAT64)
+	    set(SYSLIBS  dl)
+	  else (APPLE)
+	    add_definitions( -D_REENTRANT -D_THREAD_SAFE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 )
+	    if (QNX)
+	      add_definitions( -DPOCO_HAVE_FD_POLL)
+	      set(SYSLIBS  m socket)
+	    else (QNX)
+	      add_definitions( -D_XOPEN_SOURCE=500 -DPOCO_HAVE_FD_EPOLL)
+	      set(SYSLIBS  pthread dl rt)
+	    endif (QNX)
+	  endif (APPLE)
+	endif(UNIX AND NOT ANDROID )
+endif (CYGWIN)
 
 if (CMAKE_SYSTEM MATCHES "SunOS")
   # Standard 'must be' defines
@@ -99,10 +106,6 @@ if (CMAKE_COMPILER_IS_MINGW)
   add_definitions(-DWC_NO_BEST_FIT_CHARS=0x400  -DPOCO_WIN32_UTF8)
   add_definitions(-D_WIN32 -DMINGW32 -DWINVER=0x500 -DODBCVER=0x0300 -DPOCO_THREAD_STACK_SIZE)
 endif (CMAKE_COMPILER_IS_MINGW)
-
-if (CYGWIN)
-#    add_definitions(-DWC_NO_BEST_FIT_CHARS=0x400  -DPOCO_WIN32_UTF8)
-endif (CYGWIN)
 
 # SunPro C++
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -12,7 +12,8 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
 		$ENV{MYSQL_DIR}/include
 		$ENV{ProgramFiles}/MySQL/*/include
 		${BINDIR32}/MySQL/include
-		$ENV{SystemDrive}/MySQL/*/include)
+        ${BINDIR32}/MySQL/*/include
+        $ENV{SystemDrive}/MySQL/*/include)
 
 if (WIN32)
 	if (CMAKE_BUILD_TYPE STREQUAL Debug)
@@ -24,13 +25,16 @@ if (WIN32)
 		add_definitions(-DDBUG_OFF)
 	endif (CMAKE_BUILD_TYPE STREQUAL Debug)
 
-	find_library(MYSQL_LIB NAMES mysqlclient
+	find_library(MYSQL_LIB NAMES mysqlclient.lib
 				 PATHS
 				 $ENV{MYSQL_DIR}/lib/${libsuffixDist}
 				 $ENV{MYSQL_DIR}/libmysql/${libsuffixBuild}
 				 $ENV{MYSQL_DIR}/client/${libsuffixBuild}
 				 $ENV{ProgramFiles}/MySQL/*/lib/${libsuffixDist}
 				 ${BINDIR32}/MySQL/lib
+				 ${BINDIR32}/MySQL/*/lib/vs12
+				 ${BINDIR32}/MySQL/*/lib/vs11
+				 ${BINDIR32}/MySQL/*/lib/vs10
 				 $ENV{SystemDrive}/MySQL/*/lib/${libsuffixDist})
 else (WIN32)
 	find_library(MYSQL_LIB NAMES mysqlclient_r

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -261,6 +261,37 @@ endif()
   
 endmacro()
 
+#===============================================================================
+# Macros for simplified installation of package not following the Poco standard as CppUnit
+#
+#  SIMPLE_INSTALL - Install the given target
+#    Usage: SIMPLE_INSTALL(target_name)
+#      INPUT:
+#           target_name             the name of the target. e.g. CppUnit
+#    Example: SIMPLE_INSTALL(Foundation)
+macro(SIMPLE_INSTALL target_name)
+install(
+    DIRECTORY include
+    DESTINATION include
+    COMPONENT Devel
+    PATTERN ".svn" EXCLUDE
+    )
+
+install(
+    TARGETS "${target_name}" EXPORT "${target_name}Targets"
+    LIBRARY DESTINATION lib${LIB_SUFFIX}
+    ARCHIVE DESTINATION lib${LIB_SUFFIX}
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+    )
+
+if (MSVC)
+# install the targets pdb
+  POCO_INSTALL_PDB(${target_name})
+endif()
+  
+endmacro()
+
 #  POCO_INSTALL_PDB - Install the given target's companion pdb file (if present)
 #    Usage: POCO_INSTALL_PDB(target_name)
 #      INPUT:

--- a/release/spec/all.release
+++ b/release/spec/all.release
@@ -1,6 +1,5 @@
 Crypto
 NetSSL_OpenSSL
-NetSSL_Win
 Data
 Data/SQLite
 Data/ODBC

--- a/release/spec/world.release
+++ b/release/spec/world.release
@@ -1,6 +1,5 @@
 Crypto
 NetSSL_OpenSSL
-NetSSL_Win
 Data
 Data/SQLite
 Data/ODBC


### PR DESCRIPTION
Hi

This PR is covering  the following points:
1/ For a UNIX_FAMILY platform, use of POCO_BASE for finding out the configuration file of the testsuite of NetSSL_OpenSSL
2/ Add a filter on runtests2.cmd on Windows.
2/ Limit verbosity of msbuild at minimal

It is worthwhile to note that now, one can build Poco in a separate directory and run the tests from $POCO_BASE. This can be applied to multiple parallele branches. Here a sample

git clone https://github.com/pocoproject/poco.git poco
cd poco
git checkout MyBranch
mkdir MyBranch
cd MyBranch
../configure --everything
make -s -j4
cd ..
. env.sh
export POCO_BUILD=`pwd`/MyBranch
./build/script/runtests.sh
