### PR TITLE
Unmask SIGINT when testing termination by signal

### DIFF
--- a/Foundation/testsuite/src/TestApp.cpp
+++ b/Foundation/testsuite/src/TestApp.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv)
 		}
 		else if (arg == "-raise-int")
 		{
+			std::signal(SIGINT, SIG_DFL);
 			std::raise(SIGINT);
 		}
 	}


### PR DESCRIPTION
This will ensure that default signal handler is called (instead of possibly ignoring the signal if it was masked by one of parent processes) and the process is indeed terminated abnormally.

Fixes #1063.