### PR TITLE
Add getInteger / Fix #1078

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Binary.h
+++ b/MongoDB/include/Poco/MongoDB/Binary.h
@@ -26,6 +26,7 @@
 #include "Poco/Buffer.h"
 #include "Poco/StreamCopier.h"
 #include "Poco/MemoryStream.h"
+#include "Poco/UUID.h"
 #include <sstream>
 
 
@@ -45,6 +46,9 @@ public:
 	Binary(Poco::Int32 size, unsigned char subtype);
 		/// Constructor
 
+	Binary(const UUID& uuid);
+		/// Constructor for setting a UUID in a binary element
+
 	virtual ~Binary();
 		/// Destructor
 
@@ -59,6 +63,10 @@ public:
 
 	std::string toString(int indent = 0) const;
 		/// Returns the binary encoded in Base64
+
+	UUID uuid() const;
+		/// Returns the UUID when the binary subtype is 0x04.
+		/// Otherwise BadCastException will be thrown
 
 private:
 	Buffer<unsigned char> _buffer;
@@ -109,7 +117,7 @@ inline void BSONReader::read<Binary::Ptr>(Binary::Ptr& to)
 	unsigned char subtype;
 	_reader >> subtype;
 	to->subtype(subtype);
-	
+
 	_reader.readRaw((char*) to->buffer().begin(), size);
 }
 

--- a/MongoDB/include/Poco/MongoDB/Document.h
+++ b/MongoDB/include/Poco/MongoDB/Document.h
@@ -153,6 +153,12 @@ public:
 		/// Returns the element with the given name.
 		/// An empty element will be returned when the element is not found.
 
+	Int64 getInteger(const std::string& name) const;
+		/// Returns an integer. Useful when MongoDB returns int32, int64
+		/// or double for a number (count for example). This method will always
+		/// return an Int64. When the element is not found, a
+		/// NotFoundException will be thrown.
+
 	template<typename T>
 	bool isType(const std::string& name) const
 		/// Returns true when the type of the element equals the TypeId of ElementTrait

--- a/MongoDB/src/Binary.cpp
+++ b/MongoDB/src/Binary.cpp
@@ -33,6 +33,13 @@ Binary::Binary(Poco::Int32 size, unsigned char subtype) : _buffer(size), _subtyp
 }
 
 
+Binary::Binary(const UUID& uuid) : _buffer(128 / 8), _subtype(0x04)
+{
+    unsigned char szUUID[16];
+    uuid.copyTo((char*) szUUID);
+    _buffer.assign(szUUID, 16);
+}
+
 Binary::~Binary()
 {
 }
@@ -47,5 +54,15 @@ std::string Binary::toString(int indent) const
 	return oss.str();
 }
 
+UUID Binary::uuid() const
+{
+	if ( _subtype == 0x04 && _buffer.size() == 16 )
+	{
+		UUID uuid;
+		uuid.copyFrom((const char*) _buffer.begin());
+		return uuid;
+	}
+	throw BadCastException("Invalid subtype");
+}
 
 } } // namespace Poco::MongoDB

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -42,16 +42,7 @@ Int64 Database::count(Connection& connection, const std::string& collectionName)
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-
-		if (doc->isType<double>("n")) {
-			return static_cast<Int64>(doc->get<double>("n"));
-		}
-		else if (doc->isType<Int32>("n")) {
-			return doc->get<Int32>("n");
-		}
-		else if (doc->isType<Int64>("n")) {
-			return doc->get<Int64>("n");
-		}
+		return doc->getInteger("n");
 	}
 
 	return -1;

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -52,6 +52,28 @@ Element::Ptr Document::get(const std::string& name) const
 	return element;
 }
 
+Int64 Document::getInteger(const std::string& name) const
+{
+	Element::Ptr element = get(name);
+	if ( element.isNull() ) throw NotFoundException(name);
+
+	if ( ElementTraits<double>::TypeId == element->type() )
+	{
+		ConcreteElement<double>* concrete = dynamic_cast<ConcreteElement<double>* >(element.get());
+		if ( concrete != NULL ) return concrete->value();
+	}
+	else if ( ElementTraits<Int32>::TypeId == element->type() )
+	{
+		ConcreteElement<Int32>* concrete = dynamic_cast<ConcreteElement<Int32>* >(element.get());
+		if ( concrete != NULL ) return concrete->value();
+	}
+	else if ( ElementTraits<Int64>::TypeId == element->type() )
+	{
+		ConcreteElement<Int64>* concrete = dynamic_cast<ConcreteElement<Int64>* >(element.get());
+		if ( concrete != NULL ) return concrete->value();
+	}
+	throw BadCastException("Invalid type mismatch!");
+}
 
 void Document::read(BinaryReader& reader)
 {
@@ -184,7 +206,7 @@ void Document::write(BinaryWriter& writer)
 			element->write(tempWriter);
 		}
 		tempWriter.flush();
-		
+
 		Poco::Int32 len = static_cast<Poco::Int32>(5 + sstream.tellp()); /* 5 = sizeof(len) + 0-byte */
 		writer << len;
 		writer.writeRaw(sstream.str());

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -174,8 +174,8 @@ void MongoDBTest::testCountCommand()
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
 		std::cout << doc->toString() << std::endl;
-		double count = doc->get<double>("n");
-		assert(count == 1);
+
+		assert(doc->getInteger("n") == 1);
 	}
 	else
 	{
@@ -195,8 +195,7 @@ void MongoDBTest::testDBCountCommand()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		double count = doc->get<double>("n");
-		assert(count == 1);
+		assert(doc->getInteger("n") == 1);
 	}
 	else
 	{
@@ -314,8 +313,7 @@ void MongoDBTest::testConnectionPool()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		double count = doc->get<double>("n");
-		assert(count == 1);
+		assert(doc->getInteger("n") == 1);
 	}
 	else
 	{

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -21,8 +21,10 @@
 #include "Poco/MongoDB/Database.h"
 #include "Poco/MongoDB/Cursor.h"
 #include "Poco/MongoDB/ObjectId.h"
+#include "Poco/MongoDB/Binary.h"
 
 #include "Poco/Net/NetException.h"
+#include "Poco/UUIDGenerator.h"
 
 #include "MongoDBTest.h"
 #include "CppUnit/TestCaller.h"
@@ -68,7 +70,6 @@ void MongoDBTest::testInsertRequest()
 	player->add("active", false);
 
 	Poco::DateTime now;
-	std::cout << now.day() << " " << now.hour() << ":" << now.minute() << ":" << now.second() << std::endl;
 	player->add("lastupdated", now.timestamp());
 
 	player->add("unknown", NullValue());
@@ -107,7 +108,6 @@ void MongoDBTest::testQueryRequest()
 			assert(!active);
 
 			std::string id = doc->get("_id")->toString();
-			std::cout << id << std::endl;
 		}
 		catch(Poco::NotFoundException& nfe)
 		{
@@ -146,7 +146,6 @@ void MongoDBTest::testDBQueryRequest()
 			assert(doc->isType<NullValue>("unknown"));
 
 			std::string id = doc->get("_id")->toString();
-			std::cout << id << std::endl;
 		}
 		catch(Poco::NotFoundException& nfe)
 		{
@@ -173,8 +172,6 @@ void MongoDBTest::testCountCommand()
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		std::cout << doc->toString() << std::endl;
-
 		assert(doc->getInteger("n") == 1);
 	}
 	else
@@ -234,7 +231,6 @@ void MongoDBTest::testCursorRequest()
 	_mongo->sendRequest(*insertRequest);
 
 	Poco::Int64 count = db.count(*_mongo, "numbers");
-	std::cout << "count= " << count << std::endl;
 	assert(count == 10000);
 
 	Poco::MongoDB::Cursor cursor("team", "numbers");
@@ -248,7 +244,6 @@ void MongoDBTest::testCursorRequest()
 			break;
 		response = cursor.next(*_mongo);
 	}
-	std::cout << "n= " << n << std::endl;
 	assert(n == 10000);
 
 	Poco::MongoDB::QueryRequest drop("team.$cmd");
@@ -257,11 +252,6 @@ void MongoDBTest::testCursorRequest()
 
 	Poco::MongoDB::ResponseMessage responseDrop;
 	_mongo->sendRequest(drop, responseDrop);
-
-	if ( responseDrop.documents().size() > 0 )
-	{
-		std::cout << responseDrop.documents()[0]->toString(2) << std::endl;
-	}
 }
 
 
@@ -343,15 +333,62 @@ void MongoDBTest::testCommand() {
 	if ( response.documents().size() > 0 )
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-		std::cout << doc->toString(2);
 	}
 	else
 	{
 		Poco::MongoDB::Document::Ptr lastError = db.getLastErrorDoc(*_mongo);
-		std::cout << "LastError: " << lastError->toString(2) << std::endl;
-		fail("Didn't get a response from the  command");
+		fail(lastError->toString(2));
 	}
 }
+
+void MongoDBTest::testUUID()
+{
+	Poco::MongoDB::Document::Ptr club = new Poco::MongoDB::Document();
+	club->add("name", std::string("Barcelona"));
+
+	Poco::UUIDGenerator generator;
+	Poco::UUID uuid = generator.create();
+	Poco::MongoDB::Binary::Ptr uuidBinary = new Poco::MongoDB::Binary(uuid);
+	club->add("uuid", uuidBinary);
+
+	Poco::MongoDB::InsertRequest request("team.club");
+	request.documents().push_back(club);
+
+	_mongo->sendRequest(request);
+
+	Poco::MongoDB::QueryRequest queryReq("team.club");
+	queryReq.selector().add("name" , std::string("Barcelona"));
+
+	Poco::MongoDB::ResponseMessage response;
+	_mongo->sendRequest(queryReq, response);
+
+	if ( response.documents().size() > 0 )
+	{
+		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
+
+		try
+		{
+			std::string name = doc->get<std::string>("name");
+			assert(name.compare("Barcelona") == 0);
+
+			Poco::MongoDB::Binary::Ptr uuidBinary = doc->get<Binary::Ptr>("uuid");
+			assert(uuid == uuidBinary->uuid());
+		}
+		catch(Poco::NotFoundException& nfe)
+		{
+			fail(nfe.message() + " not found.");
+		}
+	}
+	else
+	{
+		fail("No document returned");
+	}
+
+	Poco::MongoDB::DeleteRequest delRequest("team.club");
+	delRequest.selector().add("name", std::string("Barcelona"));
+	_mongo->sendRequest(delRequest);
+}
+
 
 CppUnit::Test* MongoDBTest::suite()
 {
@@ -368,6 +405,7 @@ CppUnit::Test* MongoDBTest::suite()
 
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("MongoDBTest");
 
+	CppUnit_addTest(pSuite, MongoDBTest, testBuildInfo);
 	CppUnit_addTest(pSuite, MongoDBTest, testInsertRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testQueryRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testDBQueryRequest);
@@ -376,10 +414,10 @@ CppUnit::Test* MongoDBTest::suite()
 	CppUnit_addTest(pSuite, MongoDBTest, testDBCount2Command);
 	CppUnit_addTest(pSuite, MongoDBTest, testConnectionPool);
 	CppUnit_addTest(pSuite, MongoDBTest, testDeleteRequest);
-	CppUnit_addTest(pSuite, MongoDBTest, testBuildInfo);
 	CppUnit_addTest(pSuite, MongoDBTest, testCursorRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testObjectID);
 	CppUnit_addTest(pSuite, MongoDBTest, testCommand);
+	CppUnit_addTest(pSuite, MongoDBTest, testUUID);
 
 	return pSuite;
 }

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -42,6 +42,7 @@ public:
 	void testCursorRequest();
 	void testObjectID();
 	void testCommand();
+	void testUUID();
 	void setUp();
 	void tearDown();
 


### PR DESCRIPTION
getInteger will always return Int64. This method can be used when MongoDB returns a double, int32 or int64 and you don't know which type it will be (count is an example).