### PR TITLE
minor change to support cmake2.8 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # ENABLE_{COMPONENT}
 # ENABLE_TESTS
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(Poco)
 

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -202,10 +202,19 @@ write_basic_package_version_file(
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
-export(EXPORT "${target_name}Targets"
-  FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Targets.cmake"
-  NAMESPACE "${PROJECT_NAME}::"
-)
+if ("${CMAKE_VERSION}" VERSION_LESS "3.0.0")
+    if (NOT EXISTS "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Targets.cmake")
+    export(TARGETS "${target_name}" APPEND
+      FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Targets.cmake"
+      NAMESPACE "${PROJECT_NAME}::"
+    )
+    endif ()
+else ()
+    export(EXPORT "${target_name}Targets"
+      FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Targets.cmake"
+      NAMESPACE "${PROJECT_NAME}::"
+    )
+endif ()
 configure_file("cmake/Poco${target_name}Config.cmake"
   "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Config.cmake"
   @ONLY


### PR DESCRIPTION
Reduce cmake version requirement to 2.8.12 (ubuntu trusty), and conditionalize export() in PocoMacros to support 2.8 syntax. This supports building recent versions of poco (1.6.2) using the cmake2.8 series, and using the project config files in a client project under cmake 2.8.

Realizing that cmake2.8 is pretty old now, and cmake3.0 offers many great new features, cmake2.8 is still a default for ubuntu trusty (LTS). Supporting cmake2.8 would allow me to use Poco 1.6.2 as a cmake subproject on ubuntu trusty. Currently, I still use poco 1.5.4 because of the cmake compatibility.

Anyway, far from going backwards, the changes to support this are really quite small, and the resulting project config files even work on a client project using cmake2.8 (provided that there is a copy of CMakeFindDependencyMacro.cmake).

Its there is no interest, I certainty understand -- please close the issue. But I wanted to share this patch just in case there was. Looks like cmake 2.8 was mentioned here: https://github.com/pocoproject/poco/wiki/CMake-Status#todo