### PR TITLE
GNU Make/c++11: computing the version of gcc: use predefined constant instead of --version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 
   - sudo apt-get install -qq -y sloccount cppcheck 
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
   - sudo apt-get install -qq -y g++-4.8
 
 services:
@@ -30,8 +31,6 @@ notifications:
 env:
   global: 
     TEST_NAME=""
-    CC="gcc-4.8"
-    CXX="g++-4.8"
     
 
 before_script:
@@ -43,6 +42,8 @@ matrix:
     - env:    TEST_NAME="gcc (make) bundled"
       compiler: gcc
       script:
+        - export CC="gcc-4.8"
+        - export CXX="g++-4.8"
         - ./configure --everything && make -s -j2
         - travis_wait 30 ./travis/runtests.sh
     
@@ -50,6 +51,8 @@ matrix:
       compiler: gcc
       script:
         - sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev
+        - export CC="gcc-4.8"
+        - export CXX="g++-4.8"
         - ./configure --everything --unbundled && make -s -j2
         - travis_wait 30 ./travis/runtests.sh
     
@@ -68,6 +71,8 @@ matrix:
       compiler: gcc
       script:
         # disable tests, gcc-4.6 gets an internal compiler error
+        - export CC="gcc-4.8"
+        - export CXX="g++-4.8"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=OFF .. && make -j2 && cd ..
 
     - env:    TEST_NAME="gcc-4.8 (CMake)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ services:
 notifications:
   slack: 
     rooms:
-      - pocoproject:ItIUZvs8aJGyPdaKxIKMnS1t
-      - kampbell:v4ARuptk0ETzwUsKDdV6Gspb#travis
+      - pocoproject:ItIUZvs8aJGyPdaKxIKMnS1t#travis
 
 env:
   global: 
@@ -44,7 +43,8 @@ matrix:
       script:
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
-        - ./configure --everything && make -s -j2
+        - ${CXX} -version
+        - ./configure --everything && make -j2
         - travis_wait 30 ./travis/runtests.sh
     
     - env:    TEST_NAME="gcc (make) unbundled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       script:
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
-        - ${CXX} -version
+        - ${CXX} --version
         - ./configure --everything && make -j2
         - travis_wait 30 ./travis/runtests.sh
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev libsqlite3-dev 
   - sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 
   - sudo apt-get install -qq -y sloccount cppcheck 
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get install -qq -y g++-4.8
 
 services:
   - mongodb
@@ -26,7 +28,11 @@ notifications:
       - kampbell:v4ARuptk0ETzwUsKDdV6Gspb#travis
 
 env:
-  global: TEST_NAME=""
+  global: 
+    TEST_NAME=""
+    CC="gcc-4.8"
+    CXX="g++-4.8"
+    
 
 before_script:
  - echo ${TEST_NAME}
@@ -67,9 +73,6 @@ matrix:
     - env:    TEST_NAME="gcc-4.8 (CMake)"
       compiler: gcc
       script:
-        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq -y g++-4.8
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..

--- a/build/config/Linux
+++ b/build/config/Linux
@@ -15,8 +15,8 @@ LINKMODE ?= SHARED
 #
 # Define Tools
 #
-CC      = ${CROSS_COMPILE}gcc
-CXX     = ${CROSS_COMPILE}g++
+CC      ?= ${CROSS_COMPILE}gcc
+CXX     ?= ${CROSS_COMPILE}g++
 LINK    = $(CXX)
 LIB     = ${CROSS_COMPILE}ar -cr
 RANLIB  = ${CROSS_COMPILE}ranlib

--- a/build/script/cpp11-gcc
+++ b/build/script/cpp11-gcc
@@ -22,11 +22,10 @@
 #
 
 
-GNUMAJOR   := $(shell gcc -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.* //g'i)
-GNUMINOR   := $(shell gcc -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g'i)
-GNUPATCH   := $(shell gcc -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g'i)
+GNUMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.* //g'i)
+GNUMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g'i)
+GNUPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g'i)
 GCCVERSION := $(GNUMAJOR)$(GNUMINOR)$(GNUPATCH)
-$(info GCCVERSION=$(GCCVERSION))
 # C++14 needs GCC 4.9.2
 ifeq ($(shell test $(GCCVERSION) -gt 491 && echo 1), 1)
 	CXXFLAGS += -std=c++14

--- a/build/script/cpp11-gcc
+++ b/build/script/cpp11-gcc
@@ -26,6 +26,7 @@ GNUMAJOR   := $(shell gcc -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.* /
 GNUMINOR   := $(shell gcc -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g'i)
 GNUPATCH   := $(shell gcc -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g'i)
 GCCVERSION := $(GNUMAJOR)$(GNUMINOR)$(GNUPATCH)
+$(info GCCVERSION=$(GCCVERSION))
 # C++14 needs GCC 4.9.2
 ifeq ($(shell test $(GCCVERSION) -gt 491 && echo 1), 1)
 	CXXFLAGS += -std=c++14


### PR DESCRIPTION
Hi

One should use  gcc predefined constants `__GNUC__`,   `__GNUC_MINOR__`  and `__GNUC_PATCHLEVEL__ ` instead of --version... See embedded comments.