### PR TITLE
Better C++11 compiler detection

### DIFF
--- a/Foundation/include/Poco/Format.h
+++ b/Foundation/include/Poco/Format.h
@@ -23,7 +23,9 @@
 #include "Poco/Foundation.h"
 #include "Poco/Any.h"
 #include <vector>
+#if defined(POCO_ENABLE_CPP11)
 #include <type_traits>
+#endif
 
 
 namespace Poco {

--- a/Foundation/include/Poco/Platform_POSIX.h
+++ b/Foundation/include/Poco/Platform_POSIX.h
@@ -61,8 +61,8 @@
 	#define POCO_ENABLE_CPP11
 #endif
 
-// Enable C++11 support for Clang 3.4
-#if defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4)) && !defined(POCO_ENABLE_CPP11) && !defined(POCO_DISABLE_CPP11)
+// Enable C++11 support for Clang 3.3
+#if defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 3)) && !defined(POCO_ENABLE_CPP11) && !defined(POCO_DISABLE_CPP11)
 	#define POCO_ENABLE_CPP11
 #endif
 

--- a/Foundation/include/Poco/Platform_POSIX.h
+++ b/Foundation/include/Poco/Platform_POSIX.h
@@ -61,8 +61,8 @@
 	#define POCO_ENABLE_CPP11
 #endif
 
-// Enable C++11 support for Clang 3.3
-#if defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 3)) && !defined(POCO_ENABLE_CPP11) && !defined(POCO_DISABLE_CPP11)
+// Enable C++11 support for Clang 3.4
+#if defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4)) && !defined(POCO_ENABLE_CPP11) && !defined(POCO_DISABLE_CPP11)
 	#define POCO_ENABLE_CPP11
 #endif
 

--- a/build/config/Darwin-clang
+++ b/build/config/Darwin-clang
@@ -50,10 +50,10 @@ SHAREDLIBLINKEXT = .dylib
 # Compiler and Linker Flags
 #
 CFLAGS          = $(ARCHFLAGS)
-CXXFLAGS        = $(ARCHFLAGS) -std=c++11 -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
-LINKFLAGS       = $(ARCHFLAGS) -stdlib=libc++
-SHLIBFLAGS      = $(ARCHFLAGS) -stdlib=libc++
-DYLIBFLAGS      = $(ARCHFLAGS) -stdlib=libc++
+CXXFLAGS        = $(ARCHFLAGS) -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
+LINKFLAGS       = $(ARCHFLAGS)
+SHLIBFLAGS      = $(ARCHFLAGS)
+DYLIBFLAGS      = $(ARCHFLAGS)
 STATICOPT_CC    =
 STATICOPT_CXX   =
 STATICOPT_LINK  =
@@ -80,4 +80,4 @@ SYSLIBS  = -L$(OPENSSL_DIR)/lib -ldl
 #
 # C++11/14 detection
 #
-include $(POCO_BASE)/build/script/cpp11-clang
+include $(POCO_BASE)/build/script/cpp11-appleclang

--- a/build/config/Linux-clang
+++ b/build/config/Linux-clang
@@ -69,3 +69,8 @@ SYSFLAGS = -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=6
 # System Specific Libraries
 #
 SYSLIBS  = -lpthread -ldl -lrt
+
+#
+# C++11/14 detection
+#
+include $(POCO_BASE)/build/script/cpp11-clang

--- a/build/script/cpp11-appleclang
+++ b/build/script/cpp11-appleclang
@@ -1,0 +1,18 @@
+#! /bin/sh
+#
+# $Id: //poco/1.4/build/script/cpp11-appleclang#1 $
+#
+# cpp11-appleclang
+#
+# Detect compatible AppleClang version and add c++11/14 flags
+#
+
+CLANGVERSION   := $(shell $(CXX) -E -dM - < /dev/null | grep __apple_build_version__ | sed -e 's/^.* //g')
+
+# C++14 needs AppleClang 500.x
+ifeq ($(shell test $(CLANGVERSION) -gt 5000274 && echo 1), 1)
+	CXXFLAGS += -std=c++1y
+# C++11 needs AppleClang 503.x
+else ifeq ($(shell test $(CLANGVERSION) -gt 5030037 && echo 1), 1)
+	CXXFLAGS += -std=c++0x
+endif

--- a/build/script/cpp11-appleclang
+++ b/build/script/cpp11-appleclang
@@ -10,9 +10,9 @@
 CLANGVERSION   := $(shell $(CXX) -E -dM - < /dev/null | grep __apple_build_version__ | sed -e 's/^.* //g')
 
 # C++14 needs AppleClang 500.x
-ifeq ($(shell test $(CLANGVERSION) -gt 5000274 && echo 1), 1)
+ifeq ($(shell test $(CLANGVERSION) -ge 5000275 && echo 1), 1)
 	CXXFLAGS += -std=c++1y
 # C++11 needs AppleClang 503.x
-else ifeq ($(shell test $(CLANGVERSION) -gt 5030037 && echo 1), 1)
+else ifeq ($(shell test $(CLANGVERSION) -ge 5030038 && echo 1), 1)
 	CXXFLAGS += -std=c++0x
 endif

--- a/build/script/cpp11-clang
+++ b/build/script/cpp11-clang
@@ -14,7 +14,7 @@ CLANGVERSION := $(CLANGMAJOR)$(CLANGMINOR)$(CLANGPATCH)
 # C++14 needs Clang 3.4
 ifeq ($(shell test $(CLANGVERSION) -gt 339 && echo 1), 1)
 	CXXFLAGS += -std=c++1y
-# C++11 needs Clang 3.3
-else ifeq ($(shell test $(CLANGVERSION) -gt 329 && echo 1), 1)
-#	CXXFLAGS += -std=c++0x
+# C++11 needs Clang 3.4 (3.3 has compile problem in Linux)
+else ifeq ($(shell test $(CLANGVERSION) -gt 339 && echo 1), 1)
+	CXXFLAGS += -std=c++0x
 endif

--- a/build/script/cpp11-clang
+++ b/build/script/cpp11-clang
@@ -7,13 +7,14 @@
 # Detect compatible Clang version and add c++11/14 flags
 #
 
-APPLE_CLANGVERSION := $(subst .,,$(shell clang --version | grep ^Apple | sed 's/^.* //g' | sed 's/(clang\-\(.*\))/\1/g' | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/' ))
-
-# C++14 needs AppleClang 503.x
-ifeq ($(shell test $(APPLE_CLANGVERSION) -gt 5030038 && echo 1), 1)
-	CXXFLAGS += -std=c++14
-# C++11 needs AppleClang 500.x
-else ifeq ($(shell test $(APPLE_CLANGVERSION) -gt 5000275 && echo 1), 1)
-	CXXFLAGS += -std=c++11
+CLANGMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_major__ | sed -e 's/^.* //g'i)
+CLANGMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_minor__ | sed -e 's/^.* //g'i)
+CLANGPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_patchlevel__ | sed -e 's/^.* //g'i)
+CLANGVERSION := $(CLANGMAJOR)$(CLANGMINOR)$(CLANGPATCH)
+# C++14 needs Clang 3.4
+ifeq ($(shell test $(CLANGVERSION) -gt 339 && echo 1), 1)
+	CXXFLAGS += -std=c++1y
+# C++11 needs Clang 3.3
+else ifeq ($(shell test $(CLANGVERSION) -gt 329 && echo 1), 1)
+#	CXXFLAGS += -std=c++0x
 endif
-

--- a/build/script/cpp11-clang
+++ b/build/script/cpp11-clang
@@ -11,10 +11,11 @@ CLANGMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_major__ | sed
 CLANGMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_minor__ | sed -e 's/^.* //g'i)
 CLANGPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __clang_patchlevel__ | sed -e 's/^.* //g'i)
 CLANGVERSION := $(CLANGMAJOR)$(CLANGMINOR)$(CLANGPATCH)
+
 # C++14 needs Clang 3.4
-ifeq ($(shell test $(CLANGVERSION) -gt 339 && echo 1), 1)
+ifeq ($(shell test $(CLANGVERSION) -ge 340 && echo 1), 1)
 	CXXFLAGS += -std=c++1y
-# C++11 needs Clang 3.4 (3.3 has compile problem in Linux)
-else ifeq ($(shell test $(CLANGVERSION) -gt 339 && echo 1), 1)
+# C++11 needs Clang 3.3
+else ifeq ($(shell test $(CLANGVERSION) -ge 330 && echo 1), 1)
 	CXXFLAGS += -std=c++0x
 endif

--- a/build/script/cpp11-gcc
+++ b/build/script/cpp11-gcc
@@ -26,10 +26,11 @@ GNUMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.
 GNUMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g'i)
 GNUPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g'i)
 GCCVERSION := $(GNUMAJOR)$(GNUMINOR)$(GNUPATCH)
+
 # C++14 needs GCC 4.9.2
-ifeq ($(shell test $(GCCVERSION) -gt 491 && echo 1), 1)
+ifeq ($(shell test $(GCCVERSION) -ge 492 && echo 1), 1)
 	CXXFLAGS += -std=c++14
 # C++11 needs GCC 4.8.1
-else ifeq ($(shell test $(GCCVERSION) -gt 480 && echo 1), 1)
+else ifeq ($(shell test $(GCCVERSION) -ge 481 && echo 1), 1)
 	CXXFLAGS += -std=c++0x
 endif

--- a/build/script/cpp11-gcc
+++ b/build/script/cpp11-gcc
@@ -31,5 +31,5 @@ ifeq ($(shell test $(GCCVERSION) -gt 491 && echo 1), 1)
 	CXXFLAGS += -std=c++14
 # C++11 needs GCC 4.8.1
 else ifeq ($(shell test $(GCCVERSION) -gt 480 && echo 1), 1)
-	CXXFLAGS += -std=c++11
+	CXXFLAGS += -std=c++0x
 endif


### PR DESCRIPTION
* Use separate C++11 flag detection for AppleClang
* Fix Format.h for non-C++11 compilers
* Use -ge for compiler version comparison

Compiled on OSX Yosemite (AppleClang 700+), and on Linux with GCC 4.6, 4.8, 4.9 and 5.1.
Clang on Linux has incompatibilites with GCC headers on C++11 mode, so couldn't be tested.