### PR TITLE
Use .profile instead of .bashrc

### DIFF
--- a/Foundation/testsuite/src/PathTest.cpp
+++ b/Foundation/testsuite/src/PathTest.cpp
@@ -1511,15 +1511,15 @@ void PathTest::testForDirectory()
 void PathTest::testExpand()
 {
 #if defined(POCO_OS_FAMILY_UNIX)
-	std::string s = Path::expand("~/.bashrc");
-	assert (s == Path::expand("$HOME/.bashrc"));
-	assert (s == Environment::get("HOME") + "/.bashrc" || 
-	        s == Environment::get("HOME") + "//.bashrc");
+	std::string s = Path::expand("~/.profile");
+	assert (s == Path::expand("$HOME/.profile"));
+	assert (s == Environment::get("HOME") + "/.profile" || 
+	        s == Environment::get("HOME") + "//.profile");
 	Path p(s);
-	s = Path::expand("$HOME/.bashrc");
-	assert (s == Path::expand("~/.bashrc"));
-	s = Path::expand("${HOME}/.bashrc");
-	assert (s == Path::expand("~/.bashrc"));
+	s = Path::expand("$HOME/.profile");
+	assert (s == Path::expand("~/.profile"));
+	s = Path::expand("${HOME}/.profile");
+	assert (s == Path::expand("~/.profile"));
 #elif defined(POCO_OS_FAMILY_WINDOWS)
 	std::string s = Path::expand("%TMP%\\foo");
 	assert (s == Environment::get("TMP") + "\\foo");


### PR DESCRIPTION
On Ubuntu, PathTest::testExpand()  fails because launchpad -- the automatic building environment--  is using /bin/sh