### PR TITLE
Add partition space information to File class

### DIFF
--- a/Foundation/include/Poco/File.h
+++ b/Foundation/include/Poco/File.h
@@ -208,6 +208,15 @@ public:
 		/// Fills the vector with the names of all
 		/// files in the directory.
 
+	FileSize totalSpace() const;
+		/// Returns the total size in bytes of the partition containing this path.
+
+	FileSize usableSpace() const;
+		/// Returns the number of usable free bytes on the partition containing this path.
+
+	FileSize freeSpace() const;
+		/// Returns the number of free bytes on the partition containing this path.
+
 	bool operator == (const File& file) const;
 	bool operator != (const File& file) const;
 	bool operator <  (const File& file) const;

--- a/Foundation/include/Poco/File_UNIX.h
+++ b/Foundation/include/Poco/File_UNIX.h
@@ -58,6 +58,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastErrorImpl(const std::string& path);
 	
 private:

--- a/Foundation/include/Poco/File_VMS.h
+++ b/Foundation/include/Poco/File_VMS.h
@@ -59,6 +59,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastError(const std::string& path);
 	
 private:

--- a/Foundation/include/Poco/File_VX.h
+++ b/Foundation/include/Poco/File_VX.h
@@ -58,6 +58,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastErrorImpl(const std::string& path);
 	
 private:

--- a/Foundation/include/Poco/File_WIN32.h
+++ b/Foundation/include/Poco/File_WIN32.h
@@ -59,6 +59,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastErrorImpl(const std::string& path);
 	
 private:

--- a/Foundation/include/Poco/File_WIN32U.h
+++ b/Foundation/include/Poco/File_WIN32U.h
@@ -59,6 +59,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastErrorImpl(const std::string& path);
 	
 private:

--- a/Foundation/include/Poco/File_WINCE.h
+++ b/Foundation/include/Poco/File_WINCE.h
@@ -59,6 +59,9 @@ protected:
 	void removeImpl();
 	bool createFileImpl();
 	bool createDirectoryImpl();
+	FileSizeImpl totalSpaceImpl() const;
+	FileSizeImpl usableSpaceImpl() const;
+	FileSizeImpl freeSpaceImpl() const;
 	static void handleLastErrorImpl(const std::string& path);
 	
 private:

--- a/Foundation/src/File.cpp
+++ b/Foundation/src/File.cpp
@@ -316,6 +316,24 @@ void File::list(std::vector<std::string>& files) const
 }
 
 
+File::FileSize File::totalSpace() const
+{
+	return totalSpaceImpl();
+}
+
+
+File::FileSize File::usableSpace() const
+{
+	return usableSpaceImpl();
+}
+
+
+File::FileSize File::freeSpace() const
+{
+	return freeSpaceImpl();
+}
+
+
 void File::list(std::vector<File>& files) const
 {
 	files.clear();

--- a/Foundation/src/File_UNIX.cpp
+++ b/Foundation/src/File_UNIX.cpp
@@ -20,6 +20,12 @@
 #include <algorithm>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if defined(POCO_OS_FAMILY_BSD)
+#include <sys/param.h>
+#include <sys/mount.h>
+#else
+#include <sys/statfs.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
@@ -405,6 +411,42 @@ bool FileImpl::createDirectoryImpl()
 	if (mkdir(_path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) != 0) 
 		handleLastErrorImpl(_path);
 	return true;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_blocks * (FileSizeImpl)stats.f_bsize;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_bavail * (FileSizeImpl)stats.f_bsize;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_bfree * (FileSizeImpl)stats.f_bsize;
 }
 
 

--- a/Foundation/src/File_VMS.cpp
+++ b/Foundation/src/File_VMS.cpp
@@ -350,6 +350,36 @@ bool FileImpl::createDirectoryImpl()
 }
 
 
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	// TODO: implement
+	
+	return -1;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	// TODO: implement
+	
+	return -1;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	// TODO: implement
+	
+	return -1;
+}
+
+
 void FileImpl::handleLastErrorImpl(const std::string& path)
 {
 	switch (errno)

--- a/Foundation/src/File_VX.cpp
+++ b/Foundation/src/File_VX.cpp
@@ -330,6 +330,42 @@ bool FileImpl::createDirectoryImpl()
 }
 
 
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_blocks * (FileSizeImpl)stats.f_bsize;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_bavail * (FileSizeImpl)stats.f_bsize;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	struct statfs stats;
+	if (statfs(_path.c_str(), &stats) != 0)
+		handleLastErrorImpl(_path);
+
+	return (FileSizeImpl)stats.f_bfree * (FileSizeImpl)stats.f_bsize;
+}
+
+
 void FileImpl::handleLastErrorImpl(const std::string& path)
 {
 	switch (errno)

--- a/Foundation/src/File_WIN32.cpp
+++ b/Foundation/src/File_WIN32.cpp
@@ -349,6 +349,39 @@ bool FileImpl::createDirectoryImpl()
 }
 
 
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceEx(_path.c_str(), NULL, &space, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceEx(_path.c_str(), &space, NULL, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceEx(_path.c_str(), NULL, NULL, &space))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
 void FileImpl::handleLastErrorImpl(const std::string& path)
 {
 	DWORD err = GetLastError();

--- a/Foundation/src/File_WIN32U.cpp
+++ b/Foundation/src/File_WIN32U.cpp
@@ -357,6 +357,39 @@ bool FileImpl::createDirectoryImpl()
 }
 
 
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), NULL, &space, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), &space, NULL, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), NULL, NULL, &space))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
 void FileImpl::handleLastErrorImpl(const std::string& path)
 {
 	DWORD err = GetLastError();

--- a/Foundation/src/File_WINCE.cpp
+++ b/Foundation/src/File_WINCE.cpp
@@ -348,6 +348,39 @@ bool FileImpl::createDirectoryImpl()
 }
 
 
+FileImpl::FileSizeImpl FileImpl::totalSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), NULL, &space, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::usableSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), &space, NULL, NULL))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
+FileImpl::FileSizeImpl FileImpl::freeSpaceImpl() const
+{
+	poco_assert(!_path.empty());
+
+	ULARGE_INTEGER space;
+	if (!GetDiskFreeSpaceExW(_upath.c_str(), NULL, NULL, &space))
+		handleLastErrorImpl(_path);
+	return space.QuadPart;
+}
+
+
 void FileImpl::handleLastErrorImpl(const std::string& path)
 {
 	switch (GetLastError())

--- a/Foundation/testsuite/src/FileTest.cpp
+++ b/Foundation/testsuite/src/FileTest.cpp
@@ -180,6 +180,33 @@ void FileTest::testFileAttributes1()
 	catch (Exception&)
 	{
 	}
+
+	try
+	{
+		f.totalSpace();
+		failmsg("file does not exist - must throw exception");
+	}
+	catch (Exception&)
+	{
+	}
+
+	try
+	{
+		f.usableSpace();
+		failmsg("file does not exist - must throw exception");
+	}
+	catch (Exception&)
+	{
+	}
+
+	try
+	{
+		f.freeSpace();
+		failmsg("file does not exist - must throw exception");
+	}
+	catch (Exception&)
+	{
+	}
 }
 
 
@@ -314,6 +341,15 @@ void FileTest::testSize()
 	assert (f.getSize() > 0);
 	f.setSize(0);
 	assert (f.getSize() == 0);
+}
+
+
+void FileTest::testSpace()
+{
+	File f(Path::home());
+	assert(f.totalSpace() > 0);
+	assert(f.usableSpace() > 0);
+	assert(f.freeSpace() > 0);
 }
 
 
@@ -525,6 +561,7 @@ CppUnit::Test* FileTest::suite()
 	CppUnit_addTest(pSuite, FileTest, testCompare);
 	CppUnit_addTest(pSuite, FileTest, testSwap);
 	CppUnit_addTest(pSuite, FileTest, testSize);
+	CppUnit_addTest(pSuite, FileTest, testSpace);
 	CppUnit_addTest(pSuite, FileTest, testDirectory);
 	CppUnit_addTest(pSuite, FileTest, testCopy);
 	CppUnit_addTest(pSuite, FileTest, testMove);

--- a/Foundation/testsuite/src/FileTest.h
+++ b/Foundation/testsuite/src/FileTest.h
@@ -33,6 +33,7 @@ public:
 	void testCompare();
 	void testSwap();
 	void testSize();
+	void testSpace();
 	void testDirectory();
 	void testCopy();
 	void testMove();


### PR DESCRIPTION
This is my first try to contribute some new functionality to Poco. I'm looking forward for any feedback. I'm only able to build on Windows Desktop, OSX, iOS and Linux. For WINCE, VMS and VX I could only guess what a correct implementation would look like.

Add `File::totalSpaceImpl()`, `File::usableSpaceImpl()` and `File::freeSpaceImpl()` to retrieve total, available and usable space in the filesystem for the specified path.

- [X] Implement and test WIN32 implementation
- [x] Implement UNIX implementation
  - [X] Initial implementation
  - [x] Verify correct includes for `statfs()` based on platform
- [ ] Implement VMS
- [ ] Implement VX (might already be correct)
