### PR TITLE
MongoDB: disable unwanted release of resources in PooledConnection

### DIFF
--- a/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
+++ b/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
@@ -86,7 +86,10 @@ public:
 	{
 		try
 		{
-			_pool.returnObject(_connection);
+			if (_connection)
+			{
+				_pool.returnObject(_connection);
+			}
 		}
 		catch (...)
 		{
@@ -99,7 +102,24 @@ public:
 		return _connection;
 	}
 
+#if defined(POCO_ENABLE_CPP11)
+	// Disable copy to prevent unwanted release of resources: C++11 way
+    PooledConnection(const PooledConnection&) = delete;
+    PooledConnection& operator=(const PooledConnection&) = delete;
+
+    // Enable move semantics
+    PooledConnection(PooledConnection&& other) = default;
+    PooledConnection& operator=(PooledConnection&&) = default;
+#endif
+
 private:
+
+#if ! defined(POCO_ENABLE_CPP11)
+	// Disable copy to prevent unwanted release of resources: pre C++11 way
+    PooledConnection(const PooledConnection&);
+    PooledConnection& operator=(const PooledConnection&);
+#endif
+
 	Poco::ObjectPool<Connection, Connection::Ptr>& _pool;
 	Connection::Ptr _connection;
 };


### PR DESCRIPTION
Using copy ctor or assignment operator could release the connection when not desired.

Disabled copy semantics.

Added move semantics if C++11 functionality is enabled.

Fixes: #860