### PR TITLE
Guard SQLITE_BUSY_SNAPSHOT which is not available in older SQLite rel…

### DIFF
--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -168,7 +168,9 @@ void Utility::throwException(int rc, const std::string& addErrMsg)
 		throw ExecutionAbortedException(std::string("Callback routine requested an abort"), addErrMsg);
 	case SQLITE_BUSY:
 	case SQLITE_BUSY_RECOVERY:
+#if defined(SQLITE_BUSY_SNAPSHOT)
 	case SQLITE_BUSY_SNAPSHOT:
+#endif
 		throw DBLockedException(std::string("The database file is locked"), addErrMsg);
 	case SQLITE_LOCKED:
 		throw TableLockedException(std::string("A table in the database is locked"), addErrMsg);


### PR DESCRIPTION
…eases

When building POCO unbundled with older versions of SQLite (such as on RHEL7)
SQLITE_BUSY_SNAPSHOT is not defined, so #ifdef guard it.