### PR TITLE
Improved support for MinGW-w64

### DIFF
--- a/Foundation/include/Poco/FPEnvironment_WIN32.h
+++ b/Foundation/include/Poco/FPEnvironment_WIN32.h
@@ -43,6 +43,12 @@
 #	define _SW_DENORMAL 0x00080000 // denormal status bit
 #endif
 
+#ifdef __MINGW32__
+    #define _RC_CHOP 0x00000300
+    #define _RC_UP 0x00000200
+    #define _RC_DOWN 0x00000100
+    #define _RC_NEAR 0x00000000
+#endif
 
 namespace Poco {
 
@@ -94,49 +100,81 @@ private:
 //
 inline bool FPEnvironmentImpl::isInfiniteImpl(float value)
 {
+#ifdef __MINGW32__
+        return isfinite(value) == 0;
+#else
 	return _finite(value) == 0;
+#endif
 }
 
 
 inline bool FPEnvironmentImpl::isInfiniteImpl(double value)
 {
-	return _finite(value) == 0;
+#ifdef __MINGW32__
+        return isfinite(value) == 0;
+#else
+        return _finite(value) == 0;
+#endif
 }
 
 
 inline bool FPEnvironmentImpl::isInfiniteImpl(long double value)
 {
-	return _finite(value) == 0;
+#ifdef __MINGW32__
+        return isfinite(value) == 0;
+#else
+        return _finite(value) == 0;
+#endif
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(float value)
 {
-	return _isnan(value) != 0;
+#ifdef __MINGW32__
+        return isnan(value) != 0;
+#else
+        return _isnan(value) != 0;
+#endif
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(double value)
 {
-	return _isnan(value) != 0;
+#ifdef __MINGW32__
+        return isnan(value) != 0;
+#else
+        return _isnan(value) != 0;
+#endif
 }
 
 
 inline bool FPEnvironmentImpl::isNaNImpl(long double value)
 {
-	return _isnan(value) != 0;
+#ifdef __MINGW32__
+        return isnan(value) != 0;
+#else
+        return _isnan(value) != 0;
+#endif
 }
 
 
 inline float FPEnvironmentImpl::copySignImpl(float target, float source)
 {
-	return float(_copysign(target, source));
+#ifdef __MINGW32__
+        return float(copysign(target, source));
+#else
+        return float(_copysign(target, source));
+#endif
 }
 
 
 inline double FPEnvironmentImpl::copySignImpl(double target, double source)
 {
-	return _copysign(target, source);
+#ifdef __MINGW32__
+        return copysign(target, source);
+#else
+        return _copysign(target, source);
+#endif
 }
 
 


### PR DESCRIPTION
Added following #defines which is not defined in MinGW header:
    #define _RC_CHOP 0x00000300
    #define _RC_UP 0x00000200
    #define _RC_DOWN 0x00000100
    #define _RC_NEAR 0x00000000

Use isfinite(), instead of _finite(), for isInfiniteImpl().
Use isnan(), instead of _isnan(), for isNaNImpl().
Use copysign(), instead of _copysign(), for copySignImpl().