### PR TITLE
Fix for tcp server that doesn't response after exception

### DIFF
--- a/Net/src/TCPServer.cpp
+++ b/Net/src/TCPServer.cpp
@@ -114,10 +114,10 @@ void TCPServer::run()
 {
 	while (!_stopped)
 	{
-		Poco::Timespan timeout(250000);
-		if (_socket.poll(timeout, Socket::SELECT_READ))
+		try
 		{
-			try
+			const Poco::Timespan timeout(250000);
+			if (_socket.poll(timeout, Socket::SELECT_READ))
 			{
 				StreamSocket ss = _socket.acceptConnection();
 				// enable nodelay per default: OSX really needs that
@@ -129,18 +129,18 @@ void TCPServer::run()
 				}
 				_pDispatcher->enqueue(ss);
 			}
-			catch (Poco::Exception& exc)
-			{
-				ErrorHandler::handle(exc);
-			}
-			catch (std::exception& exc)
-			{
-				ErrorHandler::handle(exc);
-			}
-			catch (...)
-			{
-				ErrorHandler::handle();
-			}
+		}
+		catch (Poco::Exception& exc)
+		{
+			ErrorHandler::handle(exc);
+		}
+		catch (std::exception& exc)
+		{
+			ErrorHandler::handle(exc);
+		}
+		catch (...)
+		{
+			ErrorHandler::handle();
 		}
 	}
 }


### PR DESCRIPTION
Hi all,

I've used your Poco::Net::HTTPServer during stress testing with following settings
1) Load is greater than 1000 queries per second
2) Queries have average processing time more than 0.01 sec.
3) My ulimit for process is 1024
Tcp server in this situation will be able to hang. It happens according to  
Socket::poll(const Poco::Timespan & timeout, int mode). This call can throw exception(I/O error: Too many open files) and end its own thread.  For joining this thread we can set custom error handler on our side, but there will be a few ways to do something (terminate everything or create complicated logic in error handler and in tcp server calling thread).
Does it make sense to catch these exceptions inside while loop (with exceptions from poll)? 
In this case we call error handler inside loop and process next connection after broken. It seems useful for us.

Best regards, Roman.