### PR TITLE
XML, CMake: Remove expat CPP sources from globbed C++ source file list.

### DIFF
--- a/XML/CMakeLists.txt
+++ b/XML/CMakeLists.txt
@@ -1,8 +1,13 @@
 set(LIBNAME "XML")
 set(POCO_LIBNAME "Poco${LIBNAME}")
 
+# Expat CPP sources to be excluded from globbed SRCS_G
+# They are added back on the list if POCO_UNBUNDLED is not set
+set(EXPAT_CPP "${CMAKE_CURRENT_SOURCE_DIR}/src/xmlparse.cpp")
+
 # Sources
 file(GLOB SRCS_G "src/*.cpp")
+list(REMOVE_ITEM SRCS_G ${EXPAT_CPP})
 POCO_SOURCES_AUTO( SRCS ${SRCS_G})
 
 # Headers


### PR DESCRIPTION
List of C++ source files for libXML when building with CMake always contained an expat C++ source file xmlparser.cpp.

This file is now removed from default globbed source list and only added if POCO_UNBUNDLED is not set.

Fixes #1167 