### PR TITLE
Fix compiler warnings with Clang/XLC

### DIFF
--- a/Foundation/include/Poco/NamedEvent_UNIX.h
+++ b/Foundation/include/Poco/NamedEvent_UNIX.h
@@ -44,8 +44,6 @@ private:
 #if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX)
 	sem_t* _sem;
 #else
-	int _lockfd; // lock file descriptor
-	int _semfd;  // file used to identify semaphore
 	int _semid;  // semaphore id
 #endif
 };

--- a/Foundation/include/Poco/NamedMutex_UNIX.h
+++ b/Foundation/include/Poco/NamedMutex_UNIX.h
@@ -47,8 +47,6 @@ private:
 #if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX)
 	sem_t* _sem;
 #else
-	int _lockfd; // lock file descriptor
-	int _semfd;  // file used to identify semaphore
 	int _semid;  // semaphore id
 #endif
 };

--- a/MongoDB/include/Poco/MongoDB/GetMoreRequest.h
+++ b/MongoDB/include/Poco/MongoDB/GetMoreRequest.h
@@ -58,7 +58,6 @@ protected:
 	void buildRequest(BinaryWriter& writer);
 
 private:
-	Int32 _flags;
 	std::string _fullCollectionName;
 	Int32 _numberToReturn;
 	Int64 _cursorID;

--- a/Redis/include/Poco/Redis/AsyncReader.h
+++ b/Redis/include/Poco/Redis/AsyncReader.h
@@ -67,10 +67,8 @@ private:
 	AsyncReader(const AsyncReader&);
 	AsyncReader& operator = (const AsyncReader&);
 
-
-	Activity<AsyncReader> _activity;
-
 	Client& _client;
+	Activity<AsyncReader> _activity;
 };
 
 


### PR DESCRIPTION
This pull request fixes some warnings that both Clang and XLC emits regarding some unused variables and class member initialization issues.