### PR TITLE
GH #1050 NetSSL_OpenSSL: fix gcc -Wshadow warnings

### DIFF
--- a/Foundation/include/Poco/Optional.h
+++ b/Foundation/include/Poco/Optional.h
@@ -62,9 +62,9 @@ public:
 	{
 	}
 
-	Optional(const C& value): 
+	Optional(const C& rValue):
 		/// Creates a Optional with the given value.
-		_value(value), 
+		_value(rValue),
 		_isSpecified(true)
 	{
 	}
@@ -81,10 +81,10 @@ public:
 	{
 	}
 
-	Optional& assign(const C& value)
+	Optional& assign(const C& rValue)
 		/// Assigns a value to the Optional.
 	{
-		_value  = value;
+		_value  = rValue;
 		_isSpecified = true;
 		return *this;
 	}
@@ -97,9 +97,9 @@ public:
 		return *this;
 	}
 	
-	Optional& operator = (const C& value)
+	Optional& operator = (const C& rValue)
 	{
-		return assign(value);
+		return assign(rValue);
 	}
 
 	Optional& operator = (const Optional& other)

--- a/Net/src/MailMessage.cpp
+++ b/Net/src/MailMessage.cpp
@@ -214,9 +214,9 @@ void MailMessage::addRecipient(const MailRecipient& recipient)
 }
 
 
-void MailMessage::setRecipients(const Recipients& recipients)
+void MailMessage::setRecipients(const Recipients& rRecipients)
 {
-	_recipients.assign(recipients.begin(), recipients.end());
+	_recipients.assign(rRecipients.begin(), rRecipients.end());
 }
 
 
@@ -326,12 +326,12 @@ void MailMessage::addAttachment(const std::string& name, PartSource* pSource, Co
 }
 
 
-void MailMessage::read(std::istream& istr, PartHandler& handler)
+void MailMessage::read(std::istream& istr, PartHandler& rHandler)
 {
 	readHeader(istr);
 	if (isMultipart())
 	{
-		readMultipart(istr, handler);
+		readMultipart(istr, rHandler);
 	}
 	else
 	{

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -41,8 +41,8 @@ Context::Params::Params():
 }
 
 
-Context::Context(Usage usage, const Params& params):
-	_usage(usage),
+Context::Context(Usage contextUsage, const Params& params):
+	_usage(contextUsage),
 	_mode(params.verificationMode),
 	_pSSLContext(0),
 	_extendedCertificateVerification(true)
@@ -52,16 +52,16 @@ Context::Context(Usage usage, const Params& params):
 
 
 Context::Context(
-	Usage usage,
+	Usage contextUsage,
 	const std::string& privateKeyFile, 
 	const std::string& certificateFile,
 	const std::string& caLocation, 
-	VerificationMode verificationMode,
+	VerificationMode mode,
 	int verificationDepth,
 	bool loadDefaultCAs,
 	const std::string& cipherList):
-	_usage(usage),
-	_mode(verificationMode),
+	_usage(contextUsage),
+	_mode(mode),
 	_pSSLContext(0),
 	_extendedCertificateVerification(true)
 {
@@ -69,7 +69,7 @@ Context::Context(
 	params.privateKeyFile = privateKeyFile;
 	params.certificateFile = certificateFile;
 	params.caLocation = caLocation;
-	params.verificationMode = verificationMode;
+	params.verificationMode = mode;
 	params.verificationDepth = verificationDepth;
 	params.loadDefaultCAs = loadDefaultCAs;
 	params.cipherList = cipherList;
@@ -78,20 +78,20 @@ Context::Context(
 
 
 Context::Context(
-	Usage usage,
+	Usage contextUsage,
 	const std::string& caLocation, 
-	VerificationMode verificationMode,
+	VerificationMode mode,
 	int verificationDepth,
 	bool loadDefaultCAs,
 	const std::string& cipherList):
-	_usage(usage),
-	_mode(verificationMode),
+	_usage(contextUsage),
+	_mode(mode),
 	_pSSLContext(0),
 	_extendedCertificateVerification(true)
 {
 	Params params;
 	params.caLocation = caLocation;
-	params.verificationMode = verificationMode;
+	params.verificationMode = mode;
 	params.verificationDepth = verificationDepth;
 	params.loadDefaultCAs = loadDefaultCAs;
 	params.cipherList = cipherList;

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -41,17 +41,17 @@ HTTPSClientSession::HTTPSClientSession():
 }
 
 
-HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket):
-	HTTPClientSession(socket),
-	_pContext(socket.context())
+HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& rSocket):
+	HTTPClientSession(rSocket),
+	_pContext(rSocket.context())
 {
 	setPort(HTTPS_PORT);
 }
 
 
-HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, Session::Ptr pSession):
-	HTTPClientSession(socket),
-	_pContext(socket.context()),
+HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& rSocket, Session::Ptr pSession):
+	HTTPClientSession(rSocket),
+	_pContext(rSocket.context()),
 	_pSession(pSession)
 {
 	setPort(HTTPS_PORT);

--- a/NetSSL_OpenSSL/src/SecureSMTPClientSession.cpp
+++ b/NetSSL_OpenSSL/src/SecureSMTPClientSession.cpp
@@ -24,8 +24,8 @@ namespace Poco {
 namespace Net {
 
 
-SecureSMTPClientSession::SecureSMTPClientSession(const StreamSocket& socket):
-	SMTPClientSession(socket)
+SecureSMTPClientSession::SecureSMTPClientSession(const StreamSocket& rSocket):
+	SMTPClientSession(rSocket)
 {
 }
 

--- a/NetSSL_OpenSSL/src/SecureServerSocket.cpp
+++ b/NetSSL_OpenSSL/src/SecureServerSocket.cpp
@@ -48,18 +48,18 @@ SecureServerSocket::SecureServerSocket(const Socket& socket):
 }
 
 
-SecureServerSocket::SecureServerSocket(const SocketAddress& address, int backlog): 
+SecureServerSocket::SecureServerSocket(const SocketAddress& rAddress, int backlog): 
 	ServerSocket(new SecureServerSocketImpl(SSLManager::instance().defaultServerContext()), true)
 {
-	impl()->bind(address, true);
+	impl()->bind(rAddress, true);
 	impl()->listen(backlog);
 }
 
 
-SecureServerSocket::SecureServerSocket(const SocketAddress& address, int backlog, Context::Ptr pContext): 
+SecureServerSocket::SecureServerSocket(const SocketAddress& rAddress, int backlog, Context::Ptr pContext): 
 	ServerSocket(new SecureServerSocketImpl(pContext), true)
 {
-	impl()->bind(address, true);
+	impl()->bind(rAddress, true);
 	impl()->listen(backlog);
 }
 
@@ -68,8 +68,8 @@ SecureServerSocket::SecureServerSocket(Poco::UInt16 port, int backlog):
 	ServerSocket(new SecureServerSocketImpl(SSLManager::instance().defaultServerContext()), true)
 {
 	IPAddress wildcardAddr;
-	SocketAddress address(wildcardAddr, port);
-	impl()->bind(address, true);
+	SocketAddress socketAddress(wildcardAddr, port);
+	impl()->bind(socketAddress, true);
 	impl()->listen(backlog);
 }
 
@@ -77,8 +77,8 @@ SecureServerSocket::SecureServerSocket(Poco::UInt16 port, int backlog, Context::
 	ServerSocket(new SecureServerSocketImpl(pContext), true)
 {
 	IPAddress wildcardAddr;
-	SocketAddress address(wildcardAddr, port);
-	impl()->bind(address, true);
+	SocketAddress socketAddress(wildcardAddr, port);
+	impl()->bind(socketAddress, true);
 	impl()->listen(backlog);
 }
 

--- a/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
@@ -46,27 +46,27 @@ SocketImpl* SecureServerSocketImpl::acceptConnection(SocketAddress& clientAddr)
 }
 
 
-void SecureServerSocketImpl::connect(const SocketAddress& address)
+void SecureServerSocketImpl::connect(const SocketAddress& rAddress)
 {
 	throw Poco::InvalidAccessException("Cannot connect() a SecureServerSocket");
 }
 
 
-void SecureServerSocketImpl::connect(const SocketAddress& address, const Poco::Timespan& timeout)
-{
-	throw Poco::InvalidAccessException("Cannot connect() a SecureServerSocket");
-}
-	
-
-void SecureServerSocketImpl::connectNB(const SocketAddress& address)
+void SecureServerSocketImpl::connect(const SocketAddress& rAddress, const Poco::Timespan& timeout)
 {
 	throw Poco::InvalidAccessException("Cannot connect() a SecureServerSocket");
 }
 	
 
-void SecureServerSocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SecureServerSocketImpl::connectNB(const SocketAddress& rAddress)
 {
-	_impl.bind(address, reuseAddress);
+	throw Poco::InvalidAccessException("Cannot connect() a SecureServerSocket");
+}
+	
+
+void SecureServerSocketImpl::bind(const SocketAddress& rAddress, bool reuseAddress)
+{
+	_impl.bind(rAddress, reuseAddress);
 	reset(_impl.sockfd());
 }
 
@@ -97,13 +97,13 @@ int SecureServerSocketImpl::receiveBytes(void* buffer, int length, int flags)
 }
 
 
-int SecureServerSocketImpl::sendTo(const void* buffer, int length, const SocketAddress& address, int flags)
+int SecureServerSocketImpl::sendTo(const void* buffer, int length, const SocketAddress& rAddress, int flags)
 {
 	throw Poco::InvalidAccessException("Cannot sendTo() on a SecureServerSocket");
 }
 
 
-int SecureServerSocketImpl::receiveFrom(void* buffer, int length, SocketAddress& address, int flags)
+int SecureServerSocketImpl::receiveFrom(void* buffer, int length, SocketAddress& rAddress, int flags)
 {
 	throw Poco::InvalidAccessException("Cannot receiveFrom() on a SecureServerSocket");
 }

--- a/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
@@ -47,50 +47,50 @@ SecureStreamSocket::SecureStreamSocket(Context::Ptr pContext, Session::Ptr pSess
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress): 
 	StreamSocket(new SecureStreamSocketImpl(SSLManager::instance().defaultClientContext()))
 {
-	connect(address);
+	connect(rAddress);
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, const std::string& hostName): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress, const std::string& hostName): 
 	StreamSocket(new SecureStreamSocketImpl(SSLManager::instance().defaultClientContext()))
 {
 	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
-	connect(address);
+	connect(rAddress);
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, Context::Ptr pContext): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress, Context::Ptr pContext): 
 	StreamSocket(new SecureStreamSocketImpl(pContext))
 {
-	connect(address);
+	connect(rAddress);
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, Context::Ptr pContext, Session::Ptr pSession): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress, Context::Ptr pContext, Session::Ptr pSession): 
 	StreamSocket(new SecureStreamSocketImpl(pContext))
 {
 	useSession(pSession);
-	connect(address);
+	connect(rAddress);
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, const std::string& hostName, Context::Ptr pContext): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress, const std::string& hostName, Context::Ptr pContext): 
 	StreamSocket(new SecureStreamSocketImpl(pContext))
 {
 	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
-	connect(address);
+	connect(rAddress);
 }
 
 
-SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, const std::string& hostName, Context::Ptr pContext, Session::Ptr pSession): 
+SecureStreamSocket::SecureStreamSocket(const SocketAddress& rAddress, const std::string& hostName, Context::Ptr pContext, Session::Ptr pSession): 
 	StreamSocket(new SecureStreamSocketImpl(pContext))
 {
 	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
 	useSession(pSession);
-	connect(address);
+	connect(rAddress);
 }
 
 

--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -64,23 +64,23 @@ void SecureStreamSocketImpl::acceptSSL()
 }
 
 
-void SecureStreamSocketImpl::connect(const SocketAddress& address)
+void SecureStreamSocketImpl::connect(const SocketAddress& rAddress)
 {
-	_impl.connect(address, !_lazyHandshake);
+	_impl.connect(rAddress, !_lazyHandshake);
 	reset(_impl.sockfd());
 }
 
 
-void SecureStreamSocketImpl::connect(const SocketAddress& address, const Poco::Timespan& timeout)
+void SecureStreamSocketImpl::connect(const SocketAddress& rAddress, const Poco::Timespan& timeout)
 {
-	_impl.connect(address, timeout, !_lazyHandshake);
+	_impl.connect(rAddress, timeout, !_lazyHandshake);
 	reset(_impl.sockfd());
 }
 	
 
-void SecureStreamSocketImpl::connectNB(const SocketAddress& address)
+void SecureStreamSocketImpl::connectNB(const SocketAddress& rAddress)
 {
-	_impl.connectNB(address);
+	_impl.connectNB(rAddress);
 	reset(_impl.sockfd());
 }
 
@@ -91,7 +91,7 @@ void SecureStreamSocketImpl::connectSSL()
 }
 	
 
-void SecureStreamSocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SecureStreamSocketImpl::bind(const SocketAddress& rAddress, bool reuseAddress)
 {
 	throw Poco::InvalidAccessException("Cannot bind() a SecureStreamSocketImpl");
 }
@@ -129,13 +129,13 @@ int SecureStreamSocketImpl::receiveBytes(void* buffer, int length, int flags)
 }
 
 
-int SecureStreamSocketImpl::sendTo(const void* buffer, int length, const SocketAddress& address, int flags)
+int SecureStreamSocketImpl::sendTo(const void* buffer, int length, const SocketAddress& rAddress, int flags)
 {
 	throw Poco::InvalidAccessException("Cannot sendTo() on a SecureStreamSocketImpl");
 }
 
 
-int SecureStreamSocketImpl::receiveFrom(void* buffer, int length, SocketAddress& address, int flags)
+int SecureStreamSocketImpl::receiveFrom(void* buffer, int length, SocketAddress& rAddress, int flags)
 {
 	throw Poco::InvalidAccessException("Cannot receiveFrom() on a SecureStreamSocketImpl");
 }

--- a/NetSSL_OpenSSL/src/X509Certificate.cpp
+++ b/NetSSL_OpenSSL/src/X509Certificate.cpp
@@ -111,11 +111,11 @@ bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, c
 						// compare by IP
 						const HostEntry& heData = DNS::resolve(*it);
 						const HostEntry::AddressList& addr = heData.addresses();
-						HostEntry::AddressList::const_iterator it = addr.begin();
+						HostEntry::AddressList::const_iterator itAddr = addr.begin();
 						HostEntry::AddressList::const_iterator itEnd = addr.end();
-						for (; it != itEnd && !ok; ++it)
+						for (; itAddr != itEnd && !ok; ++itAddr)
 						{
-							ok = (*it == ip);
+							ok = (*itAddr == ip);
 						}
 					}
 					else

--- a/XML/src/XMLWriter.cpp
+++ b/XML/src/XMLWriter.cpp
@@ -712,14 +712,14 @@ void XMLWriter::declareNamespaces(const XMLString& namespaceURI, const XMLString
 	bool defaultNameSpaceUsed = false;
 	XMLString defaultNamespaceURI = _namespaces.getURI(std::string());
 	XMLString local;
-	XMLString prefix;
+	XMLString prefixString;
 	XMLString elementNamespaceURI = namespaceURI;
-	Name::split(qname, prefix, local);
+	Name::split(qname, prefixString, local);
 	if (elementNamespaceURI.empty())
-		elementNamespaceURI = _namespaces.getURI(prefix);
+		elementNamespaceURI = _namespaces.getURI(prefixString);
 	if (!elementNamespaceURI.empty())
 	{
-		usedNamespaces[prefix].insert(elementNamespaceURI);
+		usedNamespaces[prefixString].insert(elementNamespaceURI);
 		if (!defaultNamespaceURI.empty() && elementNamespaceURI == defaultNamespaceURI)
 			defaultNameSpaceUsed = true;
 	}
@@ -733,7 +733,7 @@ void XMLWriter::declareNamespaces(const XMLString& namespaceURI, const XMLString
 		XMLString attributeLocal;
 		Name::split(attributeQName, attributePrefix, attributeLocal);
 		if (attributeNamespaceURI.empty())
-			attributeNamespaceURI = _namespaces.getURI(prefix);
+			attributeNamespaceURI = _namespaces.getURI(prefixString);
 		if (!attributeNamespaceURI.empty())
 		{
 			usedNamespaces[attributePrefix].insert(attributeNamespaceURI);


### PR DESCRIPTION
Hi,

Quite similar as the previous ones, this time NetSSL_OpenSSL is now -Wshadow warning-free.

BTW, a related question. :-) 08a748dae166e9aa735ae90fc5d91a420dc132f2 added a nice little new feature on 2015-03-07, still I don't see it in the poco-1.7.1 branch, which has changes from 3 days ago. Is it expected that some changes don't end up in a release branch even after more than a year? ;-)

Thanks.