### PR TITLE
GH #1050 Foundation-tests: fix gcc -Wshadow warnings

### DIFF
--- a/Foundation/include/Poco/Dynamic/Pair.h
+++ b/Foundation/include/Poco/Dynamic/Pair.h
@@ -59,7 +59,7 @@ public:
 	}
 
 	template <typename T>
-	Pair(const K& first, const T& second): _data(std::make_pair(first, second))
+	Pair(const K& rFirst, const T& rSecond): _data(std::make_pair(rFirst, rSecond))
 		/// Creates pair from two values.
 	{
 	}

--- a/Foundation/include/Poco/HashTable.h
+++ b/Foundation/include/Poco/HashTable.h
@@ -334,14 +334,14 @@ public:
 		{
 			if (_entries[i])
 			{
-				UInt32 size = (UInt32)_entries[i]->size();
-				poco_assert_dbg(size != 0);
-				if (size > maxEntriesPerHash)
-					maxEntriesPerHash = size;
+				UInt32 entrySize = (UInt32)_entries[i]->size();
+				poco_assert_dbg(entrySize != 0);
+				if (entrySize > maxEntriesPerHash)
+					maxEntriesPerHash = entrySize;
 				if (details)
-					detailedEntriesPerHash.push_back(size);
+					detailedEntriesPerHash.push_back(entrySize);
 	#ifdef _DEBUG
-				totalSize += size;
+				totalSize += entrySize;
 	#endif
 			}
 			else

--- a/Foundation/include/Poco/LRUCache.h
+++ b/Foundation/include/Poco/LRUCache.h
@@ -37,8 +37,8 @@ class LRUCache: public AbstractCache<TKey, TValue, LRUStrategy<TKey, TValue>, TM
 	/// An LRUCache implements Least Recently Used caching. The default size for a cache is 1024 entries.
 {
 public:
-	LRUCache(long size = 1024):
-		AbstractCache<TKey, TValue, LRUStrategy<TKey, TValue>, TMutex, TEventMutex>(LRUStrategy<TKey, TValue>(size))
+	LRUCache(long cacheSize = 1024):
+		AbstractCache<TKey, TValue, LRUStrategy<TKey, TValue>, TMutex, TEventMutex>(LRUStrategy<TKey, TValue>(cacheSize))
 	{
 	}
 

--- a/Foundation/include/Poco/MetaObject.h
+++ b/Foundation/include/Poco/MetaObject.h
@@ -132,7 +132,7 @@ class MetaObject: public AbstractMetaObject<B>
 	/// factory for its class.
 {
 public:
-	MetaObject(const char* name): AbstractMetaObject<B>(name)
+	MetaObject(const char* pName): AbstractMetaObject<B>(pName)
 	{
 	}
 
@@ -164,7 +164,7 @@ class MetaSingleton: public AbstractMetaObject<B>
 	/// the single instance of its class. 
 { 
 public: 
-	MetaSingleton(const char* name): AbstractMetaObject<B>(name) 
+	MetaSingleton(const char* pName): AbstractMetaObject<B>(pName)
 	{
 	}
 	

--- a/Foundation/include/Poco/ObjectPool.h
+++ b/Foundation/include/Poco/ObjectPool.h
@@ -168,28 +168,28 @@ class ObjectPool
 	///   - If the object is not valid, it is destroyed immediately.
 {
 public:
-	ObjectPool(std::size_t capacity, std::size_t peakCapacity):
+	ObjectPool(std::size_t objectCapacity, std::size_t peakObjectCapacity):
 		/// Creates a new ObjectPool with the given capacity
 		/// and peak capacity.
 		///
 		/// The PoolableObjectFactory must have a public default constructor.
-		_capacity(capacity),
-		_peakCapacity(peakCapacity),
+		_capacity(objectCapacity),
+		_peakCapacity(peakObjectCapacity),
 		_size(0)
 	{
-		poco_assert (capacity <= peakCapacity);
+		poco_assert (objectCapacity <= peakObjectCapacity);
 	}
 	
-	ObjectPool(const F& factory, std::size_t capacity, std::size_t peakCapacity):
+	ObjectPool(const F& factory, std::size_t objectCapacity, std::size_t peakObjectCapacity):
 		/// Creates a new ObjectPool with the given PoolableObjectFactory,
 		/// capacity and peak capacity. The PoolableObjectFactory must have
 		/// a public copy constructor.
 		_factory(factory),
-		_capacity(capacity),
-		_peakCapacity(peakCapacity),
+		_capacity(objectCapacity),
+		_peakCapacity(peakObjectCapacity),
 		_size(0)
 	{
-		poco_assert (capacity <= peakCapacity);
+		poco_assert (objectCapacity <= peakObjectCapacity);
 	}
 	
 	~ObjectPool()

--- a/Foundation/include/Poco/RecursiveDirectoryIterator.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIterator.h
@@ -59,7 +59,7 @@ class RecursiveDirectoryIterator
 	///     * SiblingsFirstRecursiveDirectoryIterator.
 	///
 	/// The depth of traversal can be limited by constructor
-	/// parameter maxDepth (which sets the infinite depth by default).
+	/// parameter maxTraversalDepth (which sets the infinite depth by default).
 {
 public:
 	typedef RecursiveDirectoryIterator<TTravStr> MyType;
@@ -75,9 +75,9 @@ public:
 	{
 	}
 
-	RecursiveDirectoryIterator(const std::string& path, UInt16 maxDepth = D_INFINITE)
+	RecursiveDirectoryIterator(const std::string& rPath, UInt16 maxTraversalDepth = D_INFINITE)
 		/// Creates a recursive directory iterator for the given path.
-		: _pImpl(new ImplType(path, maxDepth)), _path(Path(_pImpl->get())), _file(_path)
+		: _pImpl(new ImplType(rPath, maxTraversalDepth)), _path(Path(_pImpl->get())), _file(_path)
 	{
 	}
 
@@ -87,22 +87,22 @@ public:
 	{
 	}
 
-	RecursiveDirectoryIterator(const DirectoryIterator& iterator, UInt16 maxDepth = D_INFINITE):
+	RecursiveDirectoryIterator(const DirectoryIterator& iterator, UInt16 maxTraversalDepth = D_INFINITE):
 		/// Creates a recursive directory iterator for the path of
 		/// non-recursive directory iterator.
-		_pImpl(new ImplType(iterator->path(), maxDepth)), _path(Path(_pImpl->get())), _file(_path)
+		_pImpl(new ImplType(iterator->path(), maxTraversalDepth)), _path(Path(_pImpl->get())), _file(_path)
 	{
 	}
 
-	RecursiveDirectoryIterator(const File& file, UInt16 maxDepth = D_INFINITE):
+	RecursiveDirectoryIterator(const File& file, UInt16 maxTraversalDepth = D_INFINITE):
 		/// Creates a recursive directory iterator for the given path.
-		_pImpl(new ImplType(file.path(), maxDepth)), _path(Path(_pImpl->get())), _file(_path)
+		_pImpl(new ImplType(file.path(), maxTraversalDepth)), _path(Path(_pImpl->get())), _file(_path)
 	{
 	}
 
-	RecursiveDirectoryIterator(const Path& path, UInt16 maxDepth = D_INFINITE):
+	RecursiveDirectoryIterator(const Path& rPath, UInt16 maxTraversalDepth = D_INFINITE):
 		/// Creates a recursive directory iterator for the given path.
-		_pImpl(new ImplType(path.toString(), maxDepth)), _path(Path(_pImpl->get())), _file(_path)
+		_pImpl(new ImplType(rPath.toString(), maxTraversalDepth)), _path(Path(_pImpl->get())), _file(_path)
 	{
 	}
 
@@ -163,21 +163,21 @@ public:
 	}
 
 
-	MyType& operator = (const Path& path)
+	MyType& operator = (const Path& rPath)
 	{
 		if (_pImpl)
 			_pImpl->release();
-		_pImpl = new ImplType(path.toString());
+		_pImpl = new ImplType(rPath.toString());
 		_path = Path(_pImpl->get());
 		_file = _path;
 		return *this;
 	}
 
-	MyType& operator = (const std::string& path)
+	MyType& operator = (const std::string& rPath)
 	{
 		if (_pImpl)
 			_pImpl->release();
-		_pImpl = new ImplType(path);
+		_pImpl = new ImplType(rPath);
 		_path = Path(_pImpl->get());
 		_file = _path;
 		return *this;

--- a/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
+++ b/Foundation/include/Poco/RecursiveDirectoryIteratorImpl.h
@@ -42,8 +42,8 @@ public:
 		D_INFINITE = 0 /// Special value for infinite traverse depth.
 	};
 
-	RecursiveDirectoryIteratorImpl(const std::string& path, UInt16 maxDepth = D_INFINITE)
-		: _maxDepth(maxDepth), _traverseStrategy(std::ptr_fun(depthFun), _maxDepth), _isFinished(false), _rc(1)
+	RecursiveDirectoryIteratorImpl(const std::string& path, UInt16 maxTraversalDepth = D_INFINITE)
+		: _maxDepth(maxTraversalDepth), _traverseStrategy(std::ptr_fun(depthFun), _maxDepth), _isFinished(false), _rc(1)
 	{
 		_itStack.push(DirectoryIterator(path));
 		_current = _itStack.top()->path();

--- a/Foundation/include/Poco/SimpleHashTable.h
+++ b/Foundation/include/Poco/SimpleHashTable.h
@@ -58,7 +58,7 @@ public:
 
 	typedef std::vector<HashEntry*> HashTableVector;
 
-	SimpleHashTable(UInt32 capacity = 251): _entries(capacity, 0), _size(0), _capacity(capacity)
+	SimpleHashTable(UInt32 tableCapacity = 251): _entries(tableCapacity, 0), _size(0), _capacity(tableCapacity)
 		/// Creates the SimpleHashTable.
 	{
 	}
@@ -366,11 +366,11 @@ public:
 			if (_entries[i])
 			{
 				maxEntriesPerHash = 1;
-				UInt32 size = 1;
+				UInt32 entrySize = 1;
 				if (details)
-					detailedEntriesPerHash.push_back(size);
+					detailedEntriesPerHash.push_back(entrySize);
 	#ifdef _DEBUG
-				totalSize += size;
+				totalSize += entrySize;
 	#endif
 			}
 			else

--- a/Foundation/include/Poco/ValidArgs.h
+++ b/Foundation/include/Poco/ValidArgs.h
@@ -30,8 +30,8 @@ template <class TKey>
 class ValidArgs
 {
 public:
-	ValidArgs(const TKey& key):
-		_key(key), 
+	ValidArgs(const TKey& rKey):
+		_key(rKey), 
 		_isValid(true)
 	{
 	}

--- a/Foundation/testsuite/src/DynamicFactoryTest.cpp
+++ b/Foundation/testsuite/src/DynamicFactoryTest.cpp
@@ -89,7 +89,7 @@ void DynamicFactoryTest::testDynamicFactory()
 	
 	try
 	{
-		std::auto_ptr<B> b(dynamic_cast<B*>(dynFactory.createInstance("B")));
+		std::auto_ptr<B> pB(dynamic_cast<B*>(dynFactory.createInstance("B")));
 		fail("unregistered - must throw");
 	}
 	catch (Poco::NotFoundException&)

--- a/Foundation/testsuite/src/FileChannelTest.cpp
+++ b/Foundation/testsuite/src/FileChannelTest.cpp
@@ -60,10 +60,10 @@ FileChannelTest::~FileChannelTest()
 
 void FileChannelTest::testRotateBySize()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "2 K");
 		pChannel->open();
 		Message msg("source", "This is a log file entry", Message::PRIO_INFORMATION);
@@ -71,28 +71,28 @@ void FileChannelTest::testRotateBySize()
 		{
 			pChannel->log(msg);
 		}
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
-		f = name + ".1";
+		f = fileName + ".1";
 		assert (f.exists());
-		f = name + ".2";
+		f = fileName + ".2";
 		assert (!f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateByAge()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "2 seconds");
 		pChannel->open();
 		Message msg("source", "This is a log file entry", Message::PRIO_INFORMATION);
@@ -101,26 +101,26 @@ void FileChannelTest::testRotateByAge()
 			pChannel->log(msg);
 			Thread::sleep(300);
 		}
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
-		f = name + ".1";
+		f = fileName + ".1";
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeDayUTC()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "utc");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<DateTime>(DAY_HOUR_MIN));
 		pChannel->open();
@@ -132,24 +132,24 @@ void FileChannelTest::testRotateAtTimeDayUTC()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeDayLocal()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "local");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<LocalDateTime>(DAY_HOUR_MIN));
 		pChannel->open();
@@ -161,24 +161,24 @@ void FileChannelTest::testRotateAtTimeDayLocal()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeHourUTC()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "utc");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<DateTime>(HOUR_MIN));
 		pChannel->open();
@@ -190,24 +190,24 @@ void FileChannelTest::testRotateAtTimeHourUTC()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeHourLocal()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "local");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<LocalDateTime>(HOUR_MIN));
 		pChannel->open();
@@ -219,24 +219,24 @@ void FileChannelTest::testRotateAtTimeHourLocal()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeMinUTC()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "utc");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<DateTime>(MIN));
 		pChannel->open();
@@ -248,24 +248,24 @@ void FileChannelTest::testRotateAtTimeMinUTC()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testRotateAtTimeMinLocal()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_TIMES, "local");
 		pChannel->setProperty(FileChannel::PROP_ROTATION, rotation<LocalDateTime>(MIN));
 		pChannel->open();
@@ -277,24 +277,24 @@ void FileChannelTest::testRotateAtTimeMinLocal()
 			Thread::sleep(1000);
 		}
 		pChannel->log(msg);
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testArchive()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "2 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->open();
@@ -303,24 +303,24 @@ void FileChannelTest::testArchive()
 		{
 			pChannel->log(msg);
 		}
-		File f(name + ".0");
+		File f(fileName + ".0");
 		assert (f.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::testCompress()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "1 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->setProperty(FileChannel::PROP_COMPRESS, "true");
@@ -331,26 +331,26 @@ void FileChannelTest::testCompress()
 			pChannel->log(msg);
 		}
 		Thread::sleep(3000); // allow time for background compression
-		File f0(name + ".0.gz");
+		File f0(fileName + ".0.gz");
 		assert (f0.exists());
-		File f1(name + ".1.gz");
+		File f1(fileName + ".1.gz");
 		assert (f1.exists());
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::purgeAge(const std::string& pa)
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "1 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->setProperty(FileChannel::PROP_PURGEAGE, pa);
@@ -360,11 +360,11 @@ void FileChannelTest::purgeAge(const std::string& pa)
 		{
 			pChannel->log(msg);
 		}
-		File f0(name + ".0");
+		File f0(fileName + ".0");
 		assert(f0.exists());
-		File f1(name + ".1");
+		File f1(fileName + ".1");
 		assert(f1.exists());
-		File f2(name + ".2");
+		File f2(fileName + ".2");
 		assert(f2.exists());
 		
 		Thread::sleep(5000);
@@ -377,20 +377,20 @@ void FileChannelTest::purgeAge(const std::string& pa)
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::noPurgeAge(const std::string& npa)
 {
-	std::string name = filename();
+	std::string fileName = filename();
 
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "1 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->setProperty(FileChannel::PROP_PURGEAGE, npa);
@@ -400,11 +400,11 @@ void FileChannelTest::noPurgeAge(const std::string& npa)
 		{
 			pChannel->log(msg);
 		}
-		File f0(name + ".0");
+		File f0(fileName + ".0");
 		assert(f0.exists());
-		File f1(name + ".1");
+		File f1(fileName + ".1");
 		assert(f1.exists());
-		File f2(name + ".2");
+		File f2(fileName + ".2");
 		assert(f2.exists());
 
 		Thread::sleep(5000);
@@ -417,10 +417,10 @@ void FileChannelTest::noPurgeAge(const std::string& npa)
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
@@ -442,10 +442,10 @@ void FileChannelTest::testPurgeAge()
 
 void FileChannelTest::purgeCount(const std::string& pc)
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "1 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->setProperty(FileChannel::PROP_PURGECOUNT, pc);
@@ -456,27 +456,27 @@ void FileChannelTest::purgeCount(const std::string& pc)
 			pChannel->log(msg);
 			Thread::sleep(50);
 		}
-		File f0(name + ".0");
+		File f0(fileName + ".0");
 		assert(f0.exists());
-		File f1(name + ".1");
+		File f1(fileName + ".1");
 		assert(f1.exists());
-		File f2(name + ".2");
+		File f2(fileName + ".2");
 		assert(!f2.exists());
 	} catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
 void FileChannelTest::noPurgeCount(const std::string& npc)
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 		pChannel->setProperty(FileChannel::PROP_ROTATION, "1 K");
 		pChannel->setProperty(FileChannel::PROP_ARCHIVE, "number");
 		pChannel->setProperty(FileChannel::PROP_PURGECOUNT, npc);
@@ -487,18 +487,18 @@ void FileChannelTest::noPurgeCount(const std::string& npc)
 			pChannel->log(msg);
 			Thread::sleep(50);
 		}
-		File f0(name + ".0");
+		File f0(fileName + ".0");
 		assert(f0.exists());
-		File f1(name + ".1");
+		File f1(fileName + ".1");
 		assert(f1.exists());
-		File f2(name + ".2");
+		File f2(fileName + ".2");
 		assert(f2.exists());
 	} catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
@@ -520,8 +520,8 @@ void FileChannelTest::testPurgeCount()
 
 void FileChannelTest::testWrongPurgeOption()
 {
-	std::string name = filename();
-	AutoPtr<FileChannel> pChannel = new FileChannel(name);
+	std::string fileName = filename();
+	AutoPtr<FileChannel> pChannel = new FileChannel(fileName);
 	pChannel->setProperty(FileChannel::PROP_PURGEAGE, "5 seconds");
 
 	try
@@ -542,7 +542,7 @@ void FileChannelTest::testWrongPurgeOption()
 		assert(pChannel->getProperty(FileChannel::PROP_PURGEAGE) == "5 seconds");
 	}
 
-	remove(name);
+	remove(fileName);
 }
 
 
@@ -569,11 +569,11 @@ void FileChannelTest::remove(const std::string& baseName)
 		}
 		++it;
 	}
-	for (std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it)
+	for (std::vector<std::string>::iterator itFiles = files.begin(); itFiles != files.end(); ++itFiles)
 	{
 		try
 		{
-			File f(*it);
+			File f(*itFiles);
 			f.remove();
 		} catch (...)
 		{
@@ -584,10 +584,10 @@ void FileChannelTest::remove(const std::string& baseName)
 
 std::string FileChannelTest::filename() const
 {
-	std::string name = "log_";
-	name.append(DateTimeFormatter::format(Timestamp(), "%Y%m%d%H%M%S"));
-	name.append(".log");
-	return name;
+	std::string ret = "log_";
+	ret.append(DateTimeFormatter::format(Timestamp(), "%Y%m%d%H%M%S"));
+	ret.append(".log");
+	return ret;
 }
 
 
@@ -595,7 +595,7 @@ template <class DT>
 std::string FileChannelTest::rotation(TimeRotation rtype) const
 {
 	DT now;
-	std::string rotation;
+	std::string ret;
 
 	int day  = now.dayOfWeek();
 	int min  = now.minute();
@@ -615,20 +615,20 @@ std::string FileChannelTest::rotation(TimeRotation rtype) const
 	switch (rtype)
 	{
 	case DAY_HOUR_MIN: // day,hh:m,
-		rotation = DateTimeFormat::WEEKDAY_NAMES[day];
-		rotation += ',' + NumberFormatter::format0(hour, 2) + ':' + NumberFormatter::format0(min, 2);
+		ret = DateTimeFormat::WEEKDAY_NAMES[day];
+		ret += ',' + NumberFormatter::format0(hour, 2) + ':' + NumberFormatter::format0(min, 2);
 		break;
 	case HOUR_MIN: // hh:mm
-		rotation = NumberFormatter::format0(hour, 2) + ':' + NumberFormatter::format0(min, 2);
+		ret = NumberFormatter::format0(hour, 2) + ':' + NumberFormatter::format0(min, 2);
 		break;
 	case MIN: // mm
-		rotation = ':' + NumberFormatter::format0(min, 2);
+		ret = ':' + NumberFormatter::format0(min, 2);
 		break;
 	default:
-		rotation = "";
+		ret = "";
 		break;
 	}
-	return rotation;
+	return ret;
 }
 
 

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -50,13 +50,13 @@ void NDCTest::testNDC()
 
 void NDCTest::testNDCScope()
 {
-	poco_ndc("item1");
+	Poco::NDCScope item1("item1", __LINE__, __FILE__);
 	assert (NDC::current().depth() == 1);
 	{
-		poco_ndc("item2");
+		Poco::NDCScope item2("item2", __LINE__, __FILE__);
 		assert (NDC::current().depth() == 2);
 		{
-			poco_ndc("item3");
+			Poco::NDCScope item3("item3", __LINE__, __FILE__);
 			assert (NDC::current().depth() == 3);
 			NDC::current().dump(std::cout);
 		}

--- a/Foundation/testsuite/src/NotificationQueueTest.cpp
+++ b/Foundation/testsuite/src/NotificationQueueTest.cpp
@@ -32,7 +32,7 @@ namespace
 	class QTestNotification: public Notification
 	{
 	public:
-		QTestNotification(const std::string& data): _data(data)
+		QTestNotification(const std::string& rData): _data(rData)
 		{
 		}
 		~QTestNotification()

--- a/Foundation/testsuite/src/PathTest.cpp
+++ b/Foundation/testsuite/src/PathTest.cpp
@@ -1451,7 +1451,7 @@ void PathTest::testRobustness()
 	{
 		int len = r.next(1024);
 		std::string s;
-		for (int i = 0; i < len; ++i) s += r.nextChar();
+		for (int j = 0; j < len; ++j) s += r.nextChar();
 		try
 		{
 			Path p(s, Path::PATH_WINDOWS);

--- a/Foundation/testsuite/src/PriorityNotificationQueueTest.cpp
+++ b/Foundation/testsuite/src/PriorityNotificationQueueTest.cpp
@@ -32,7 +32,7 @@ namespace
 	class QTestNotification: public Notification
 	{
 	public:
-		QTestNotification(const std::string& data): _data(data)
+		QTestNotification(const std::string& rData): _data(rData)
 		{
 		}
 		~QTestNotification()

--- a/Foundation/testsuite/src/ProcessTest.cpp
+++ b/Foundation/testsuite/src/ProcessTest.cpp
@@ -39,18 +39,18 @@ ProcessTest::~ProcessTest()
 
 void ProcessTest::testLaunch()
 {
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #elif defined(_WIN32_WCE)
 	cmd = "\\";
-	cmd += name;
+	cmd += testName;
 	cmd += ".EXE";
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -66,14 +66,14 @@ void ProcessTest::testLaunch()
 void ProcessTest::testLaunchRedirectIn()
 {
 #if !defined(_WIN32_WCE)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -92,14 +92,14 @@ void ProcessTest::testLaunchRedirectIn()
 void ProcessTest::testLaunchRedirectOut()
 {
 #if !defined(_WIN32_WCE)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -120,14 +120,14 @@ void ProcessTest::testLaunchRedirectOut()
 void ProcessTest::testLaunchEnv()
 {
 #if !defined(_WIN32_WCE)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -150,14 +150,14 @@ void ProcessTest::testLaunchEnv()
 void ProcessTest::testIsRunning()
 {
 #if !defined(_WIN32_WCE)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -180,14 +180,14 @@ void ProcessTest::testIsRunning()
 void ProcessTest::testIsRunningAllowsForTermination()
 {
 #if !defined(_WIN32_WCE)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 #if defined(POCO_OS_FAMILY_UNIX)
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 #else
-	cmd = name;
+	cmd = testName;
 #endif
 
 	std::vector<std::string> args;
@@ -201,11 +201,11 @@ void ProcessTest::testIsRunningAllowsForTermination()
 void ProcessTest::testSignalExitCode()
 {
 #if defined(POCO_OS_FAMILY_UNIX)
-	std::string name("TestApp");
+	std::string testName("TestApp");
 	std::string cmd;
 
 	cmd = "./";
-	cmd += name;
+	cmd += testName;
 
 	std::vector<std::string> args;
 	args.push_back("-raise-int");

--- a/Foundation/testsuite/src/SimpleFileChannelTest.cpp
+++ b/Foundation/testsuite/src/SimpleFileChannelTest.cpp
@@ -45,10 +45,10 @@ SimpleFileChannelTest::~SimpleFileChannelTest()
 
 void SimpleFileChannelTest::testRotate()
 {
-	std::string name = filename();
+	std::string fileName = filename();
 	try
 	{
-		AutoPtr<SimpleFileChannel> pChannel = new SimpleFileChannel(name);
+		AutoPtr<SimpleFileChannel> pChannel = new SimpleFileChannel(fileName);
 		pChannel->setProperty(SimpleFileChannel::PROP_ROTATION, "2 K");
 		pChannel->open();
 		Message msg("source", "This is a log file entry", Message::PRIO_INFORMATION);
@@ -56,18 +56,18 @@ void SimpleFileChannelTest::testRotate()
 		{
 			pChannel->log(msg);
 		}
-		File f(name);
+		File f(fileName);
 		assert (f.exists());
-		f = name + ".0";
+		f = fileName + ".0";
 		assert (f.exists());
 		assert (f.getSize() >= 2048);
 	}
 	catch (...)
 	{
-		remove(name);
+		remove(fileName);
 		throw;
 	}
-	remove(name);
+	remove(fileName);
 }
 
 
@@ -94,11 +94,11 @@ void SimpleFileChannelTest::remove(const std::string& baseName)
 		}
 		++it;
 	}
-	for (std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it)
+	for (std::vector<std::string>::iterator itFiles = files.begin(); itFiles != files.end(); ++itFiles)
 	{
 		try
 		{
-			File f(*it);
+			File f(*itFiles);
 			f.remove();
 		}
 		catch (...)
@@ -110,10 +110,10 @@ void SimpleFileChannelTest::remove(const std::string& baseName)
 
 std::string SimpleFileChannelTest::filename() const
 {
-	std::string name = "log_";
-	name.append(DateTimeFormatter::format(Timestamp(), "%Y%m%d%H%M%S"));
-	name.append(".log");
-	return name;
+	std::string ret = "log_";
+	ret.append(DateTimeFormatter::format(Timestamp(), "%Y%m%d%H%M%S"));
+	ret.append(".log");
+	return ret;
 }
 
 

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -80,8 +80,8 @@ void StringTest::testTrimLeft()
 		std::string s = "abc";
 		assert (trimLeft(s) == "abc");
 	}
-		std::string s = " abc ";
-		assert (trimLeft(s) == "abc ");
+		std::string s2 = " abc ";
+		assert (trimLeft(s2) == "abc ");
 	{
 	std::string s = "  ab c ";
 	assert (trimLeft(s) == "ab c ");

--- a/Foundation/testsuite/src/TaskManagerTest.cpp
+++ b/Foundation/testsuite/src/TaskManagerTest.cpp
@@ -209,7 +209,7 @@ namespace
 	class CustomTaskObserver
 	{
 	public:
-		CustomTaskObserver(const C& custom): _custom(custom)
+		CustomTaskObserver(const C& rCustom): _custom(rCustom)
 		{
 		}
 		

--- a/Foundation/testsuite/src/TimedNotificationQueueTest.cpp
+++ b/Foundation/testsuite/src/TimedNotificationQueueTest.cpp
@@ -28,7 +28,7 @@ namespace
 	class QTestNotification: public Notification
 	{
 	public:
-		QTestNotification(const std::string& data): _data(data)
+		QTestNotification(const std::string& rData): _data(rData)
 		{
 		}
 		~QTestNotification()

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -2511,13 +2511,13 @@ void VarTest::testEmpty()
 
 	try
 	{
-		int i = da;
+		int j = da;
 		fail ("must fail");
 	} catch (InvalidAccessException&) { }
 
 	try
 	{
-		int i = da.extract<int>();
+		int j = da.extract<int>();
 		fail ("must fail");
 	} catch (InvalidAccessException&) { }
 }


### PR DESCRIPTION
As in, quarter of the changes are in public headers, just detected while building the tests.