### PR TITLE
GNU version of strerror_r not available on musl C library

### DIFF
--- a/Foundation/src/Error.cpp
+++ b/Foundation/src/Error.cpp
@@ -69,7 +69,10 @@ namespace Poco {
 		   without -D_GNU_SOURCE is needed, otherwise the GNU version is
 		   preferred.
 		*/
-#if defined _GNU_SOURCE && !POCO_ANDROID
+		/* The GNU version of strerror_r is non-portable and not
+		   available on the musl C library.
+		 */
+#if (defined __GLIBC__ || defined __UCLIBC__) && defined _GNU_SOURCE && !POCO_ANDROID
 		char errmsg[256] = "";
 		return std::string(strerror_r(errorCode, errmsg, 256));
 #elif (_XOPEN_SOURCE >= 600) || POCO_ANDROID


### PR DESCRIPTION
The GNU version of glibc' `strerror_r` is a non-portable extension. The POSIX-compliant version is preferred for portable applications.

When the POSIX and GNU API collides musl always provides the POSIX API. That being the case for `strerror_r` the musl C library supports only the POSIX version, despite of `_GNU_SOURCE`.

NB: Why even care about the GNU version of `strerror_r`? I do not see any benefit here...