### PR TITLE
MySQL: allow to override search paths

### DIFF
--- a/Data/MySQL/Makefile
+++ b/Data/MySQL/Makefile
@@ -8,8 +8,18 @@
 
 include $(POCO_BASE)/build/rules/global
 
-SYSLIBS += -L/usr/local/lib$(LIB64SUFFIX)/mysql -L/usr/lib$(LIB64SUFFIX)/mysql -L/usr/mysql/lib$(LIB64SUFFIX) -L/usr/mysql/lib$(LIB64SUFFIX)/mysql -L/usr/local/mysql/lib$(LIB64SUFFIX) -lmysqlclient
-INCLUDE += -I/usr/local/include/mysql/ -I/usr/include/mysql/ -I/usr/mysql/include/mysql -I/usr/local/mysql/include
+MYSQL_LIBDIR ?= /usr/local/lib$(LIB64SUFFIX)/mysql \
+		/usr/lib$(LIB64SUFFIX)/mysql \
+		/usr/mysql/lib$(LIB64SUFFIX) \
+		/usr/mysql/lib$(LIB64SUFFIX)/mysql \
+		/usr/local/mysql/lib$(LIB64SUFFIX)
+MYSQL_INCDIR ?= /usr/local/include/mysql/ \
+		/usr/include/mysql/ \
+		/usr/mysql/include/mysql \
+		/usr/local/mysql/include
+
+SYSLIBS += $(foreach dir,$(MYSQL_LIBDIR),-L$(dir)) -lmysqlclient
+INCLUDE += $(foreach dir,$(MYSQL_INCDIR),-I$(dir))
 SYSFLAGS += -DTHREADSAFE -DNO_TCL
 
 objects = Binder Extractor SessionImpl Connector \


### PR DESCRIPTION
The default search paths for the MySQL library and header files are for hosts only and do not allow cross-compilation of poco against a target MySQL.

Allow to pass the paths through the build environment by setting `MYSQL_LIBDIR` and `MYSQL_INCDIR`.