### PR TITLE
Foundation: fix memory leaks in Logger sample

### DIFF
--- a/Foundation/samples/Logger/src/Logger.cpp
+++ b/Foundation/samples/Logger/src/Logger.cpp
@@ -14,6 +14,7 @@
 
 
 #include "Poco/Logger.h"
+#include "Poco/AutoPtr.h"
 #include "Poco/PatternFormatter.h"
 #include "Poco/FormattingChannel.h"
 #include "Poco/ConsoleChannel.h"
@@ -22,6 +23,7 @@
 
 
 using Poco::Logger;
+using Poco::AutoPtr;
 using Poco::PatternFormatter;
 using Poco::FormattingChannel;
 using Poco::ConsoleChannel;
@@ -33,12 +35,16 @@ int main(int argc, char** argv)
 {
 	// set up two channel chains - one to the
 	// console and the other one to a log file.
-	FormattingChannel* pFCConsole = new FormattingChannel(new PatternFormatter("%s: %p: %t"));
-	pFCConsole->setChannel(new ConsoleChannel);
+	AutoPtr<PatternFormatter> pPatternFormatter(new PatternFormatter("%s: %p: %t"));
+	AutoPtr<FormattingChannel> pFCConsole(new FormattingChannel(pPatternFormatter));
+	AutoPtr<ConsoleChannel> pConsoleChannel(new ConsoleChannel());
+	pFCConsole->setChannel(pConsoleChannel);
 	pFCConsole->open();
 	
-	FormattingChannel* pFCFile = new FormattingChannel(new PatternFormatter("%Y-%m-%d %H:%M:%S.%c %N[%P]:%s:%q:%t"));
-	pFCFile->setChannel(new FileChannel("sample.log"));
+	AutoPtr<PatternFormatter> pPatternFormatter2(new PatternFormatter("%Y-%m-%d %H:%M:%S.%c %N[%P]:%s:%q:%t"));
+	AutoPtr<FormattingChannel> pFCFile(new FormattingChannel(pPatternFormatter2));
+	AutoPtr<FileChannel> pFileChannel(new FileChannel("sample.log"));
+	pFCFile->setChannel(pFileChannel);
 	pFCFile->open();
 
 	// create two Logger objects - one for
@@ -60,6 +66,7 @@ int main(int argc, char** argv)
 	poco_warning_f2(consoleLogger, "A warning message with arguments: %d, %d", 1, 2);
 	
 	Logger::get("ConsoleLogger").error("Another error message");
+	Logger::shutdown();
 	
 	return 0;
 }


### PR DESCRIPTION
At least valgrind now doesn't point out leaks anymore.