### PR TITLE
Fix for issue #1265.

### DIFF
--- a/Foundation/src/File.cpp
+++ b/Foundation/src/File.cpp
@@ -46,6 +46,7 @@ File::File()
 
 File::File(const std::string& rPath): FileImpl(rPath)
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
 }
 
 
@@ -78,6 +79,8 @@ File& File::operator = (const File& file)
 
 File& File::operator = (const std::string& rPath)
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
+
 	setPathImpl(rPath);
 	return *this;
 }
@@ -213,6 +216,8 @@ File& File::setExecutable(bool flag)
 	
 void File::copyTo(const std::string& rPath) const
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
+
 	Path src(getPathImpl());
 	Path dest(rPath);
 	File destFile(rPath);
@@ -230,6 +235,8 @@ void File::copyTo(const std::string& rPath) const
 
 void File::copyDirectory(const std::string& rPath) const
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
+
 	File target(rPath);
 	target.createDirectories();
 
@@ -246,6 +253,8 @@ void File::copyDirectory(const std::string& rPath) const
 
 void File::moveTo(const std::string& rPath)
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
+
 	copyTo(rPath);
 	remove(true);
 	setPathImpl(rPath);
@@ -254,6 +263,8 @@ void File::moveTo(const std::string& rPath)
 	
 void File::renameTo(const std::string& rPath)
 {
+	poco_assert( std::char_traits<char>::length(rPath.data()) == rPath.size() );
+
 	renameToImpl(rPath);
 	setPathImpl(rPath);
 }

--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -55,12 +55,14 @@ Path::Path(bool absolutePath): _absolute(absolutePath)
 
 Path::Path(const std::string& path)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
 	assign(path);
 }
 
 
 Path::Path(const std::string& path, Style style)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
 	assign(path, style);
 }
 
@@ -98,6 +100,7 @@ Path::Path(const Path& rParent, const std::string& fileName):
 	_dirs(rParent._dirs),
 	_absolute(rParent._absolute)
 {	
+	poco_assert( std::char_traits<char>::length(fileName.data()) == fileName.size() );
 	makeDirectory();
 	_name = fileName;
 }
@@ -141,6 +144,7 @@ Path& Path::operator = (const Path& path)
 	
 Path& Path::operator = (const std::string& path)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
 	return assign(path);
 }
 
@@ -257,6 +261,8 @@ std::string Path::toString(Style style) const
 
 bool Path::tryParse(const std::string& path)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
+
 	try
 	{
 		Path p;
@@ -273,6 +279,8 @@ bool Path::tryParse(const std::string& path)
 
 bool Path::tryParse(const std::string& path, Style style)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
+
 	try
 	{
 		Path p;
@@ -289,6 +297,8 @@ bool Path::tryParse(const std::string& path, Style style)
 
 Path& Path::parseDirectory(const std::string& path)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
+
 	assign(path);
 	return makeDirectory();
 }
@@ -296,6 +306,8 @@ Path& Path::parseDirectory(const std::string& path)
 
 Path& Path::parseDirectory(const std::string& path, Style style)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
+
 	assign(path, style);
 	return makeDirectory();
 }
@@ -436,6 +448,8 @@ Path& Path::resolve(const Path& path)
 
 Path& Path::setNode(const std::string& node)
 {
+	poco_assert( std::char_traits<char>::length(node.data()) == node.size() );
+
 	_node     = node;
 	_absolute = _absolute || !node.empty();
 	return *this;
@@ -444,6 +458,8 @@ Path& Path::setNode(const std::string& node)
 	
 Path& Path::setDevice(const std::string& device)
 {
+	poco_assert( std::char_traits<char>::length(device.data()) == device.size() );
+
 	_device   = device;
 	_absolute = _absolute || !device.empty();
 	return *this;
@@ -474,6 +490,8 @@ const std::string& Path::operator [] (int n) const
 	
 Path& Path::pushDirectory(const std::string& dir)
 {
+	poco_assert( std::char_traits<char>::length(dir.data()) == dir.size() );
+
 	if (!dir.empty() && dir != ".")
 	{
 #if defined(POCO_OS_FAMILY_VMS)
@@ -521,6 +539,8 @@ Path& Path::popFrontDirectory()
 	
 Path& Path::setFileName(const std::string& name)
 {
+	poco_assert( std::char_traits<char>::length(name.data()) == name.size() );
+
 	_name = name;
 	return *this;
 }
@@ -528,6 +548,8 @@ Path& Path::setFileName(const std::string& name)
 
 Path& Path::setBaseName(const std::string& name)
 {
+	poco_assert( std::char_traits<char>::length(name.data()) == name.size() );
+
 	std::string ext = getExtension();
 	_name = name;
 	if (!ext.empty())
@@ -551,6 +573,8 @@ std::string Path::getBaseName() const
 
 Path& Path::setExtension(const std::string& extension)
 {
+	poco_assert( std::char_traits<char>::length(extension.data()) == extension.size() );
+
 	_name = getBaseName();
 	if (!extension.empty())
 	{
@@ -658,6 +682,7 @@ std::string Path::null()
 	
 std::string Path::expand(const std::string& path)
 {
+	poco_assert( std::char_traits<char>::length(path.data()) == path.size() );
 	return PathImpl::expandImpl(path);
 }
 
@@ -670,6 +695,8 @@ void Path::listRoots(std::vector<std::string>& roots)
 
 bool Path::find(StringVec::const_iterator it, StringVec::const_iterator end, const std::string& name, Path& path)
 {
+	poco_assert( std::char_traits<char>::length(name.data()) == name.size() );
+
 	while (it != end)
 	{
 #if defined(WIN32)

--- a/Foundation/testsuite/src/PathTest.cpp
+++ b/Foundation/testsuite/src/PathTest.cpp
@@ -1451,7 +1451,10 @@ void PathTest::testRobustness()
 	{
 		int len = r.next(1024);
 		std::string s;
-		for (int j = 0; j < len; ++j) s += r.nextChar();
+		while(s.size() < len) {
+			char c = r.nextChar();
+			if( c!= 0 ) s += c;
+		}
 		try
 		{
 			Path p(s, Path::PATH_WINDOWS);


### PR DESCRIPTION
The fix purpose to add the following assertion :
`poco_assert( std::char_traits<char>::length(path.data()) == path.size() );`

The `std::char_traits<char>::length` considers the null-terminated sequence, while the `std::string::size` considers the total number of symbols of the string.

The assertion ensures the sizes are the same.

Hoping it helps,
Thank you for considering my pull-request =)

Have a great day.
