### PR TITLE
Added preprocessor guards for "define"s.

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -23,7 +23,9 @@
 // Define to enable Windows Unicode (UTF-8) support
 // NOTE: As of POCO C++ Libraries release 1.6.0, compiling POCO
 // without POCO_WIN32_UTF8 defined on Windows is deprecated.
+#ifndef POCO_WIN32_UTF8
 #define POCO_WIN32_UTF8
+#endif
 
 
 // Define to enable C++11 support
@@ -35,10 +37,10 @@
 
 
 // Define to disable automatic initialization
-// Defining this will disable ALL automatic 
+// Defining this will disable ALL automatic
 // initialization framework-wide (e.g. Net
 // on Windows, all Data back-ends, etc).
-// 
+//
 // #define POCO_NO_AUTOMATIC_LIB_INIT
 
 
@@ -77,20 +79,23 @@
 // #define POCO_THREAD_PRIORITY_MAX 31
 
 
-// Define to disable small object optimization. If not 
+// Define to disable small object optimization. If not
 // defined, Any and Dynamic::Var (and similar optimization
-// candidates) will be auto-allocated on the stack in 
+// candidates) will be auto-allocated on the stack in
 // cases when value holder fits into POCO_SMALL_OBJECT_SIZE
 // (see below).
-// 
+//
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!! NOTE: Any/Dynamic::Var SOO will NOT work reliably   !!!
 // !!! without C++11 (std::aligned_storage in particular). !!!
 // !!! Only comment this out if your compiler has support  !!!
 // !!! for std::aligned_storage.                           !!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-// 
+//
+#ifndef POCO_NO_SOO
 #define POCO_NO_SOO
+#endif
+
 
 
 // Small object size in bytes. When assigned to Any or Var,
@@ -115,7 +120,7 @@
 
 
 // No automatic registration of FileChannel in
-// LoggingFactory - avoids FileChannel and friends 
+// LoggingFactory - avoids FileChannel and friends
 // being linked to executable.
 // #define POCO_NO_FILECHANNEL
 
@@ -141,13 +146,13 @@
 // #define POCO_UTIL_NO_INIFILECONFIGURATION
 
 
-// No support for JSON configuration in 
+// No support for JSON configuration in
 // Poco::Util::Application. Avoids linking of JSON
 // library and saves a few 100 Kbytes.
 // #define POCO_UTIL_NO_JSONCONFIGURATION
 
 
-// No support for XML configuration in 
+// No support for XML configuration in
 // Poco::Util::Application. Avoids linking of XML
 // library and saves a few 100 Kbytes.
 // #define POCO_UTIL_NO_XMLCONFIGURATION


### PR DESCRIPTION
Many projects have already defined these flags. Redefining them causes a warning. 