### PR TITLE
fix ODBC: losing input data in case PD_IN_OUT paramater type 

### DIFF
--- a/Data/ODBC/src/Binder.cpp
+++ b/Data/ODBC/src/Binder.cpp
@@ -238,6 +238,8 @@ void Binder::bind(std::size_t pos, const UTF16String& val, Direction dir, const 
 		getColumnOrParameterSize(pos, size);
 		CharT* pChar = (CharT*)std::calloc(size, 1);
 		pVal = (SQLPOINTER)pChar;
+		if (isInOutBound(dir))
+			std::wcscpy(pChar,val.c_str());
 		_outParams.insert(ParamMap::value_type(pVal, size));
 		_utf16Strings.insert(UTF16StringMap::value_type(pChar, const_cast<UTF16String*>(&val)));
 	}

--- a/Data/ODBC/src/Binder.cpp
+++ b/Data/ODBC/src/Binder.cpp
@@ -179,6 +179,10 @@ void Binder::bind(std::size_t pos, const std::string& val, Direction dir, const 
 	{
 		getColumnOrParameterSize(pos, size);
 		char* pChar = (char*) std::calloc(size, sizeof(char));
+
+		if (isInOutBound(dir))
+			std::strcpy(pChar,val.c_str());
+
 		pVal = (SQLPOINTER) pChar;
 		_outParams.insert(ParamMap::value_type(pVal, size));
 		_strings.insert(StringMap::value_type(pChar, const_cast<std::string*>(&val)));

--- a/Data/ODBC/testsuite/src/ODBCOracleTest.cpp
+++ b/Data/ODBC/testsuite/src/ODBCOracleTest.cpp
@@ -338,6 +338,20 @@ void ODBCOracleTest::testStoredProcedureAny()
 	}
 }
 
+void ODBCOracleTest::testStoredProcedureAnyString()
+{
+	Any sInOut = std::string("Hello");
+
+	*_pSession << "CREATE OR REPLACE "
+		"PROCEDURE storedProcedure(inParam IN OUT VARCHAR2) IS "
+		" BEGIN inParam := inParam||' world!'; "
+		"END storedProcedure;" , now;
+
+	*_pSession << "{call storedProcedure(?)}", io(sInOut), now;
+	assert("Hello world!" == AnyCast<std::string>(sInOut));
+	*_pSession << "DROP PROCEDURE storedProcedure;", now;
+}
+
 
 void ODBCOracleTest::testStoredProcedureDynamicAny()
 {
@@ -916,6 +930,7 @@ CppUnit::Test* ODBCOracleTest::suite()
 		CppUnit_addTest(pSuite, ODBCOracleTest, testStoredProcedure);
 		CppUnit_addTest(pSuite, ODBCOracleTest, testCursorStoredProcedure);
 		CppUnit_addTest(pSuite, ODBCOracleTest, testStoredProcedureAny);
+		CppUnit_addTest(pSuite, ODBCOracleTest, testStoredProcedureAnyString);
 		CppUnit_addTest(pSuite, ODBCOracleTest, testStoredProcedureDynamicAny);
 		CppUnit_addTest(pSuite, ODBCOracleTest, testStoredFunction);
 		CppUnit_addTest(pSuite, ODBCOracleTest, testCursorStoredFunction);

--- a/Data/ODBC/testsuite/src/ODBCOracleTest.h
+++ b/Data/ODBC/testsuite/src/ODBCOracleTest.h
@@ -45,6 +45,7 @@ public:
 	void testStoredFunction();
 	void testCursorStoredFunction();
 	void testStoredProcedureAny();
+	void testStoredProcedureAnyString();
 	void testStoredProcedureDynamicAny();
 	void testAutoTransaction();
 

--- a/Data/include/Poco/Data/AbstractBinder.h
+++ b/Data/include/Poco/Data/AbstractBinder.h
@@ -407,6 +407,9 @@ public:
 
 	static bool isInBound(Direction dir);
 		/// Returns true if direction is in bound;
+
+	static bool isInOutBound(Direction dir);
+	/// Returns true if direction is in and out bound;
 };
 
 
@@ -424,6 +427,10 @@ inline bool AbstractBinder::isOutBound(Direction dir)
 	return PD_OUT == dir || PD_IN_OUT == dir;
 }
 
+inline bool AbstractBinder::isInOutBound(Direction dir)
+{
+	return PD_IN_OUT == dir;
+}
 
 inline bool AbstractBinder::isInBound(Direction dir)
 {


### PR DESCRIPTION
```
struct sqlStoreTEst
{
    std::string sInOut; //VARCHAR2(200);
    int nInOut; // NUMBER;
    std::string sIn; // VARCHAR2(200);
    int nIn; // NUMBER;
    std::string sOut; // VARCHAR2(200);
    int nOut; // NUMBER;

    sqlStoreTEst()
    {
        sInOut = "Change me";
        nInOut = 25;
        sIn = "const line";
        nIn = 55;
        sOut="?";
        nOut=2;
    }
};


        sqlStoreTEst storTest;
        Statement stmt_stor_proc(session);
                stmt_stor_proc << "CALL M_TEST_P(?, ?, ?, ?, ?, ?);",
             io(storTest.sInOut),// Here we lose input value
             io(storTest.nInOut),
             in(storTest.sIn),
             in(storTest.nIn),
             out(storTest.sOut),
             out(storTest.nOut);
```
