### PR TITLE
Update Platform_WIN32.h

### DIFF
--- a/Foundation/include/Poco/Platform_WIN32.h
+++ b/Foundation/include/Poco/Platform_WIN32.h
@@ -89,8 +89,8 @@
 #endif
 
 
-// Enable C++11 support for VS 2010 and newer
-#if defined(_MSC_VER) && (_MSC_VER >= 1700) && !defined(POCO_ENABLE_CPP11)
+// Enable C++11 support for VS 2014 and newer
+#if defined(_MSC_VER) && (_MSC_VER >= 1900) && !defined(POCO_ENABLE_CPP11)
 	#define POCO_ENABLE_CPP11
 #endif
 


### PR DESCRIPTION
Default move semantics are not supported with 2012 (1700).