### PR TITLE
Add missing if not defined POCO_NO_SYSLOGCHANNEL.

### DIFF
--- a/Foundation/src/SyslogChannel.cpp
+++ b/Foundation/src/SyslogChannel.cpp
@@ -17,6 +17,7 @@
 #include "Poco/SyslogChannel.h"
 #include "Poco/Message.h"
 #include "Poco/StringTokenizer.h"
+#if defined(POCO_OS_FAMILY_UNIX) && !defined(POCO_NO_SYSLOGCHANNEL)
 #include <syslog.h>
 
 
@@ -256,3 +257,5 @@ int SyslogChannel::getPrio(const Message& msg)
 
 
 } // namespace Poco
+
+#endif // defined(POCO_OS_FAMILY_UNIX) && !defined(POCO_NO_SYSLOGCHANNEL)


### PR DESCRIPTION
For example, on QNX/BB10 there is no syslog support.
To prevent to compile with syslog support I see in the issue [trivial build fixes #321](https://github.com/pocoproject/poco/issues/321) or in the fix  [GH #321: trivial build fixes (BB QNX build) ](https://github.com/pocoproject/poco/commit/f9057157e861d7bf6e5bd561a0964e76ec1fe5a4) there is POCO_NO_SYSLOGCHANNEL defined. I'm not sure how this fix "GH #321: trivial build fixes" is compiling on BB10, because SyslogChannel.cpp is still included for the compiler.
In this fix, I added a preprocessor if statement like in Foundation/src/LoggingFactory.cpp. 
I don't now if this approach will accepted but it was for me the fastest solution
