### PR TITLE
Fixes an issue in DirectoryWatcher where it stops listening for events

### DIFF
--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -108,7 +108,20 @@ protected:
 		DirectoryIterator end;
 		while (it != end)
 		{
-			entries[it.path().getFileName()] = ItemInfo(*it);
+			// DirectoryWatcher should not stop watching if it fails to get the info
+			// of a file, it should just ignore it.
+			try
+			{
+				entries[it.path().getFileName()] = ItemInfo(*it);
+			}
+			catch(const Poco::FileNotFoundException& fnfe)
+			{
+				// The file is missing, remove it from the entries so it is treated as
+				// deleted.
+				entries.erase(it.path().getFileName());
+
+				poco_unexpected();
+			}
 			++it;
 		}
 	}


### PR DESCRIPTION
Hello there,

When doing batch deletions on a directory that is currently being observed by DirectoryWatcher it throws FileNotFoundException and it stops observing.

Here is what I run in terminal to reproduce the issue:
`$ for i in ``seq 1 10`` ; do touch $i.mp3 ; done`
`$ rm *.mp3`

As you can see it doesn't have to be a large amount of files to reproduce this issue.

The fix I propose is encapsulated to this issue, any other exceptions are going to throw and stop DirectoryWatcher.

This is the first time creating a pull request in poco, please let me know if I should make any other changes.

Thanks a lot for open sourcing Poco, I have very little time using it and this is the first show stopper I have found, and if I find any other I will do the same, test, test, add comments and then create a pull request.

I will be open sourcing the project where I'm using DirectoryWatcher, but It has to work right first =)

Thanks a lot for your time!
- Sal