### PR TITLE
Fixes for AppVeyor & Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,24 +61,21 @@ matrix:
         - export CC="clang"
         - export CXX="clang++"
         - clang++ -x c++ /dev/null -dM -E
-        - ./configure --everything --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL && make -s -j2 && sudo make install
-        - ./travis/OSX/runtests.sh
+        - ./configure --everything --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL && make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
     - env:    TEST_NAME="Linux gcc 4.6 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc"
         - export CXX="g++"
-        - ./configure --everything && make -s -j2 
-        - ./travis/Linux/runtests.sh
+        - ./configure --everything && make -s -j2 && ./travis/Linux/runtests.sh
     
     - env:    TEST_NAME="Linux gcc 4.8 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
-        - ./configure --everything && make -s -j2
-        - ./travis/Linux/runtests.sh
+        - ./configure --everything && make -s -j2 && ./travis/Linux/runtests.sh
     
     - env:    TEST_NAME="Linux gcc 4.6 (make) unbundled"
       compiler: gcc
@@ -86,8 +83,7 @@ matrix:
         - export CC="gcc"
         - export CXX="g++"
         - sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev
-        - ./configure --everything --unbundled && make -s -j2
-        - ./travis/Linux/runtests.sh
+        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    TEST_NAME="Linux gcc 4.8 (make) unbundled"
       compiler: gcc
@@ -95,14 +91,12 @@ matrix:
         - sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev
         - export CC="gcc-4.8"
         - export CXX="g++-4.8"
-        - ./configure --everything --unbundled && make -s -j2
-        - ./travis/Linux/runtests.sh
+        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
     
     - env:    TEST_NAME="Linux clang 3.4 (make)"
       compiler: clang
       script:
-        - ./configure --everything --config=Linux-clang && make -s -j2
-        - ./travis/Linux/runtests.sh
+        - ./configure --everything --config=Linux-clang && make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    TEST_NAME="Linux arm-linux-gnueabi- (make)"
       compiler: gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,12 +128,12 @@ install:
         } else {
             choco install jom
         }
-        if (Test-Path "$env:ChocolateyInstall\bin\cmake.exe") {
-          echo "using cmake from cache"
-        } else {
-          choco install cmake
-        }
       }
+#        if (Test-Path "$env:ChocolateyInstall\bin\cmake.exe") {
+#          echo "using cmake from cache"
+#        } else {
+#          choco install cmake
+#        }
   - set
 
 # -------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi

This PR fixes the abort of the CMake installation on AppVeyor that blocks all builds and make the running of the testsuites dependent on a successful compile/link/install on Travis.