### PR TITLE
Fixes #1331 - Poco::HTMLForm fails to set content length for HTTPMessage::HTTP_1_0 for ENCODING_MULTIPART

### DIFF
--- a/Net/src/HTMLForm.cpp
+++ b/Net/src/HTMLForm.cpp
@@ -230,6 +230,10 @@ void HTMLForm::prepareSubmit(HTTPRequest& request)
 		{
 			request.setChunkedTransferEncoding(true);
 		}
+		if (!request.getChunkedTransferEncoding())
+		{
+			request.setContentLength(calculateContentLength());
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This is a proposed fix for #1331.