### PR TITLE
Make the Object(bool) an explicit constructor

### DIFF
--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -67,7 +67,7 @@ public:
 	typedef ValueMap::iterator                  Iterator;
 	typedef ValueMap::const_iterator            ConstIterator;
 
-	Object(bool preserveInsertionOrder = false);
+	explicit Object(bool preserveInsertionOrder = false);
 		/// Default constructor. If preserveInsertionOrder, object
 		/// will preserve the items insertion order. Otherwise, items
 		/// will be sorted by keys.


### PR DESCRIPTION
It prevents from memory leaks made by clients of `Poco::JSON::Object`.
The problem has been described better in the GH issue #1335.

Issue:
https://github.com/pocoproject/poco/issues/1335