### PR TITLE
Fixes #1337 : Poco::HTMLForm throws invalid exception when _encoding == ENCODING_URL.

### DIFF
--- a/Net/src/HTMLForm.cpp
+++ b/Net/src/HTMLForm.cpp
@@ -245,7 +245,11 @@ void HTMLForm::prepareSubmit(HTTPRequest& request)
 
 std::streamsize HTMLForm::calculateContentLength()
 {
-	if (_boundary.empty())
+	if (_encoding == ENCODING_URL)
+	{
+		return 0;
+	}
+	else if (_boundary.empty())
 		throw HTMLFormException("Form must be prepared");
 
 	HTMLFormCountingOutputStream c;


### PR DESCRIPTION
Fixes bug #1337 : Poco::HTMLForm throws invalid exception when _encoding == ENCODING_URL.