### PR TITLE
Shell expansion rules say that tilde must be replaced with $HOME before calling getpwuid

### DIFF
--- a/Foundation/src/Path_UNIX.cpp
+++ b/Foundation/src/Path_UNIX.cpp
@@ -204,7 +204,19 @@ std::string PathImpl::expandImpl(const std::string& path)
 		++it;
 		if (it != end && *it == '/')
 		{
-			result += homeImpl(); ++it;
+                       const char* homeEnv = getenv("HOME");
+                       if (homeEnv)
+                       {
+                               result += homeEnv;
+                               std::string::size_type resultSize = result.size();
+                               if (resultSize > 0 && result[resultSize - 1] != '/')
+                                       result.append("/");
+                       }
+                       else
+                       {
+                               result += homeImpl();
+                       }
+                       ++it;
 		}
 		else result += '~';
 	}


### PR DESCRIPTION
Foundation test N7CppUnit10TestCallerI8PathTestEE.testExpand fails on our systems because, for some reason, getpwuid(getuid())->pw_dir returns a different string than $HOME.
However, shell expansion rules say that if $HOME is set in the environment then it should be used first. Only if not set it can be replaced with pw_dir.