### PR TITLE
Internet connection is not available on build servers, making tests fail

### DIFF
--- a/Net/testsuite/src/ICMPClientTest.cpp
+++ b/Net/testsuite/src/ICMPClientTest.cpp
@@ -51,14 +51,7 @@ void ICMPClientTest::testPing()
 	assert(ICMPClient::pingIPv4("localhost") > 0);
 
 	assert(_icmpClient.ping("localhost") > 0);
-	assert(_icmpClient.ping("www.appinf.com", 4) > 0);
-
-	// warning: may fail depending on the existence of the addresses at test site
-	// if so, adjust accordingly (i.e. specify non-existent or unreachable IP addresses)
-	assert(0 == _icmpClient.ping("192.168.243.1"));
-	assert(0 == _icmpClient.ping("10.11.12.13"));
 }
-
 
 void ICMPClientTest::setUp()
 {

--- a/Net/testsuite/src/NTPClientTest.cpp
+++ b/Net/testsuite/src/NTPClientTest.cpp
@@ -17,6 +17,7 @@
 #include "Poco/Net/NTPEventArgs.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/NetException.h"
+#include "Poco/Net/ICMPClient.h"
 #include "Poco/AutoPtr.h"
 #include "Poco/Delegate.h"
 #include "Poco/DateTimeFormatter.h"
@@ -29,6 +30,7 @@ using Poco::Net::NTPClient;
 using Poco::Net::NTPEventArgs;
 using Poco::Net::SocketAddress;
 using Poco::Net::IPAddress;
+using Poco::Net::ICMPClient;
 using Poco::Net::HostNotFoundException;
 using Poco::Delegate;
 using Poco::AutoPtr;
@@ -48,6 +50,9 @@ NTPClientTest::~NTPClientTest()
 
 void NTPClientTest::testTimeSync()
 {
+        if (ICMPClient::pingIPv4("pool.ntp.org") <= 0)
+                return;
+
 	assert(_ntpClient.request("pool.ntp.org") > 0);
 }
 


### PR DESCRIPTION
It's more the exception that outside Internet is available from build servers, definitely not the case in our outfit. Since hosts are not available ping tests fail and also ntp tests that expect to find the ntp pool.
