### PR TITLE
VS2013/VS2015: Buildwin without environment variables

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -388,7 +388,7 @@ build_script:
         $verbosity='minimal';
     
         $process = Start-Process -PassThru -nnw -Wait -FilePath "$env:poco_base\buildwin.cmd" -RSO cout -RSE cerr `
-        -EA Stop -Args "$env:vsver build $env:linkmode $env:configuration $env:platform samples tests msbuild $verbosity $logger";
+        -EA Stop -Args "$env:vsver build $env:linkmode $env:configuration $env:platform samples tests msbuild env $verbosity $logger";
         gc cout; gc cerr;
         Write-Host -ForegroundColor Yellow '>>> current directory is '  $(get-location).Path;
       }


### PR DESCRIPTION
Hi

This PR brings a new paramtere to the buildwin.bat procedure: useenv with a domain value of ('env', 'noenv') with 'env' as the default value. This new parameter is used only when running the msbuild tool and specifies if msbuild should take into account the environnement variables ('env') or not ('noenv'). This new parameter is useful for building VS projects with all external dependencies set in   
```
%APPDATALOCAL%\Microsoft\MSBuild\v4.0\Microsoft.Cpp.Win32.user.props 
%APPDATALOCAL%\Microsoft\MSBuild\v4.0\Microsoft.Cpp.x64.user.props
```

As for exemple, one could setup
```
<?xml version="1.0" encoding="utf-8"?>
<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <ImportGroup Label="PropertySheets">
  </ImportGroup>
  <PropertyGroup Label="UserMacros">
     <MySQL>C:\mysql-5.7.14-win32</MySQL>
    <PostgreSQL>C:\Program Files (x86)\PostgreSQL\9.5</PostgreSQL>
  </PropertyGroup>

  <PropertyGroup >
	<IncludePath>$(MySQL)\include;$(IncludePath)</IncludePath>
	<LibraryPath>$(MySQL)\lib;$(LibraryPath)</LibraryPath>
	<ExecutablePath>$(MySQL)\bin;$(ExecutablePath)</ExecutablePath>
	
	<IncludePath>$(PostgreSQL)\include;$(PostgreSQL)\include\server;$(IncludePath)</IncludePath>
	<LibraryPath>$(PostgreSQL)\lib;$(LibraryPath)</LibraryPath>
	<ExecutablePath>$(PostgreSQL)\bin;$(ExecutablePath)</ExecutablePath>
  </PropertyGroup>
  <ItemDefinitionGroup >
  </ItemDefinitionGroup >
  <ItemGroup >
  </ItemGroup >
</Project>
```

The noenv value is necessary for msbuild to take into account those user's defined properties instead of the LIB, INCLUDE environement variables. As result, LIB and INCLUDE variables are not polluted by the building of Poco, and I would suggest this way to become the proper way of building Poco with VS2010 & VS2015.