### PR TITLE
http/https can request with specific ip(split host and ip)

### DIFF
--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -125,6 +125,15 @@ public:
 	Poco::UInt16 getPort() const;
 		/// Returns the port number of the target HTTP server.
 
+	void setRemoteIp(const std::string& remoteIp);
+		/// Sets the remote ip of the target HTTP server.
+		///
+		/// The ip must not be changed once there is an
+		/// open connection to the server.
+
+	const std::string& getRemoteIp() const;
+		/// Returns the remote ip of the target HTTP server.
+
 	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT);
 		/// Sets the proxy host name and port number.
 		
@@ -283,6 +292,7 @@ protected:
 		/// to the HTTPClientSession.
 
 private:
+	std::string     _remoteIp;
 	std::string     _host;
 	Poco::UInt16    _port;
 	ProxyConfig     _proxyConfig;
@@ -311,6 +321,10 @@ inline const std::string& HTTPClientSession::getHost() const
 	return _host;
 }
 
+inline const std::string& HTTPClientSession::getRemoteIp() const 
+{
+    return _remoteIp;
+}
 
 inline Poco::UInt16 HTTPClientSession::getPort() const
 {


### PR DESCRIPTION
http/https can request with specific ip, such as follow curl command:

```
curl -X "GET" "https://183.134.20.77/otn/lcxxcx/query?purpose_codes=ADULT&queryDate=2016-02-22&from_station=SHH&to_station=SZH" \
	-H "Accept: */*" \
	-H "X-FirePHP-Version: 0.0.6" \
	-H "Connection: keep-alive" \
	-H "Cache-Control: no-cache" \
	-H "Referer: https://kyfw.12306.cn/otn/lcxxcx/init" \
	-H "Host: kyfw.12306.cn" \
	-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.99 Safari/537.36" \
	-H "Accept-Encoding: gzip, deflate, sdch" \
	-H "Accept-Language: en,zh-CN;q=0.8,zh;q=0.6,zh-TW;q=0.4" \
	-H "X-Requested-With: XMLHttpRequest" \
	-H "If-Modified-Since: 0"
``` 