### PR TITLE
Fix String.h startsWith/endsWith

### DIFF
--- a/Foundation/include/Poco/String.h
+++ b/Foundation/include/Poco/String.h
@@ -627,7 +627,7 @@ template <class S>
 bool startsWith(const S& str, const S& prefix)
 	/// Tests whether the string starts with the given prefix.
 {
-	return equal(prefix.begin(), prefix.end(), str.begin());
+	return str.size() >= prefix.size() && equal(prefix.begin(), prefix.end(), str.begin());
 }
 
 
@@ -635,7 +635,7 @@ template <class S>
 bool endsWith(const S& str, const S& suffix)
 	/// Tests whether the string ends with the given suffix.
 {
-	return equal(suffix.rbegin(), suffix.rend(), str.rbegin());
+	return str.size() >= suffix.size() && equal(suffix.rbegin(), suffix.rend(), str.rbegin());
 }
 
 


### PR DESCRIPTION
Test testStartsWith will fail in Windows when compiled with VS2013 and linked with the debug runtime.

Test fails because of invalid string dereference when the prefix/suffix is longer than the actual length of the string. It happens to run when linked with the runtime release, but it's still a big problem because it can very well read invalid memory.