### PR TITLE
Workaround bug in SolarisStudio 12.4 on RVO-ed objects.

### DIFF
--- a/Foundation/include/Poco/String.h
+++ b/Foundation/include/Poco/String.h
@@ -404,7 +404,13 @@ S translateInPlace(S& str, const typename S::value_type* from, const typename S:
 	poco_check_ptr (from);
 	poco_check_ptr (to);
 	str = translate(str, S(from), S(to));
+#if defined(__SUNPRO_CC)
+   // Fix around the RVO bug in SunStudio 12.4
+   S ret(str);
+   return ret;
+#else
 	return str;
+#endif
 }
 
 


### PR DESCRIPTION
Test StringTest.testTranslateInPlace fails because of this bug in the Sun Studio 12.4 targeting Solaris 5.11.
