### PR TITLE
MongoDB BSON type 0x11 support, fixes #1429

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Element.h
+++ b/MongoDB/include/Poco/MongoDB/Element.h
@@ -291,7 +291,7 @@ inline void BSONWriter::write<NullValue>(NullValue& from)
 {
 }
 
-struct SpecialTimestamp {
+struct Timestamp {
 	Poco::Timestamp ts;
 	Poco::Int32 inc;
 };
@@ -299,11 +299,11 @@ struct SpecialTimestamp {
 // BSON Timestamp
 // spec: int64
 template<>
-struct ElementTraits<SpecialTimestamp>
+struct ElementTraits<Timestamp>
 {
 	enum { TypeId = 0x11 };
 
-	static std::string toString(const SpecialTimestamp& value, int indent = 0)
+	static std::string toString(const Timestamp& value, int indent = 0)
 	{
 		std::string result;
 		result.append(1, '"');
@@ -317,18 +317,18 @@ struct ElementTraits<SpecialTimestamp>
 
 
 template<>
-inline void BSONReader::read<SpecialTimestamp>(SpecialTimestamp& to)
+inline void BSONReader::read<Timestamp>(Timestamp& to)
 {
 	Poco::Int64 value;
 	_reader >> value;
 	to.inc = value & 0xffffffff;
 	value >>= 32;
-	to.ts = Timestamp::fromEpochTime(static_cast<std::time_t>(value));
+	to.ts = Poco::Timestamp::fromEpochTime(static_cast<std::time_t>(value));
 }
 
 
 template<>
-inline void BSONWriter::write<SpecialTimestamp>(SpecialTimestamp& from)
+inline void BSONWriter::write<Timestamp>(Timestamp& from)
 {
 	Poco::Int64 value = from.ts.epochMicroseconds() / 1000;
 	value <<= 32;

--- a/MongoDB/include/Poco/MongoDB/Element.h
+++ b/MongoDB/include/Poco/MongoDB/Element.h
@@ -291,6 +291,51 @@ inline void BSONWriter::write<NullValue>(NullValue& from)
 {
 }
 
+struct SpecialTimestamp {
+	Poco::Timestamp ts;
+	Poco::Int32 inc;
+};
+
+// BSON Timestamp
+// spec: int64
+template<>
+struct ElementTraits<SpecialTimestamp>
+{
+	enum { TypeId = 0x11 };
+
+	static std::string toString(const SpecialTimestamp& value, int indent = 0)
+	{
+		std::string result;
+		result.append(1, '"');
+		result.append(DateTimeFormatter::format(value.ts, "%Y-%m-%dT%H:%M:%s%z"));
+		result.append(1, ' ');
+		result.append(NumberFormatter::format(value.inc));
+		result.append(1, '"');
+		return result;
+	}
+};
+
+
+template<>
+inline void BSONReader::read<SpecialTimestamp>(SpecialTimestamp& to)
+{
+	Poco::Int64 value;
+	_reader >> value;
+	to.inc = value & 0xffffffff;
+	value >>= 32;
+	to.ts = Timestamp::fromEpochTime(static_cast<std::time_t>(value));
+}
+
+
+template<>
+inline void BSONWriter::write<SpecialTimestamp>(SpecialTimestamp& from)
+{
+	Poco::Int64 value = from.ts.epochMicroseconds() / 1000;
+	value <<= 32;
+	value += from.inc;
+	_writer << value;
+}
+
 
 // BSON 64-bit integer
 // spec: int64

--- a/MongoDB/include/Poco/MongoDB/Element.h
+++ b/MongoDB/include/Poco/MongoDB/Element.h
@@ -291,7 +291,7 @@ inline void BSONWriter::write<NullValue>(NullValue& from)
 {
 }
 
-struct Timestamp {
+struct SpecialTimestamp {
 	Poco::Timestamp ts;
 	Poco::Int32 inc;
 };
@@ -299,11 +299,11 @@ struct Timestamp {
 // BSON Timestamp
 // spec: int64
 template<>
-struct ElementTraits<Timestamp>
+struct ElementTraits<SpecialTimestamp>
 {
 	enum { TypeId = 0x11 };
 
-	static std::string toString(const Timestamp& value, int indent = 0)
+	static std::string toString(const SpecialTimestamp& value, int indent = 0)
 	{
 		std::string result;
 		result.append(1, '"');
@@ -317,18 +317,18 @@ struct ElementTraits<Timestamp>
 
 
 template<>
-inline void BSONReader::read<Timestamp>(Timestamp& to)
+inline void BSONReader::read<SpecialTimestamp>(SpecialTimestamp& to)
 {
 	Poco::Int64 value;
 	_reader >> value;
 	to.inc = value & 0xffffffff;
 	value >>= 32;
-	to.ts = Poco::Timestamp::fromEpochTime(static_cast<std::time_t>(value));
+	to.ts = Timestamp::fromEpochTime(static_cast<std::time_t>(value));
 }
 
 
 template<>
-inline void BSONWriter::write<Timestamp>(Timestamp& from)
+inline void BSONWriter::write<SpecialTimestamp>(SpecialTimestamp& from)
 {
 	Poco::Int64 value = from.ts.epochMicroseconds() / 1000;
 	value <<= 32;

--- a/MongoDB/include/Poco/MongoDB/Element.h
+++ b/MongoDB/include/Poco/MongoDB/Element.h
@@ -291,7 +291,7 @@ inline void BSONWriter::write<NullValue>(NullValue& from)
 {
 }
 
-struct SpecialTimestamp {
+struct BSONTimestamp {
 	Poco::Timestamp ts;
 	Poco::Int32 inc;
 };
@@ -299,11 +299,11 @@ struct SpecialTimestamp {
 // BSON Timestamp
 // spec: int64
 template<>
-struct ElementTraits<SpecialTimestamp>
+struct ElementTraits<BSONTimestamp>
 {
 	enum { TypeId = 0x11 };
 
-	static std::string toString(const SpecialTimestamp& value, int indent = 0)
+	static std::string toString(const BSONTimestamp& value, int indent = 0)
 	{
 		std::string result;
 		result.append(1, '"');
@@ -317,7 +317,7 @@ struct ElementTraits<SpecialTimestamp>
 
 
 template<>
-inline void BSONReader::read<SpecialTimestamp>(SpecialTimestamp& to)
+inline void BSONReader::read<BSONTimestamp>(BSONTimestamp& to)
 {
 	Poco::Int64 value;
 	_reader >> value;
@@ -328,7 +328,7 @@ inline void BSONReader::read<SpecialTimestamp>(SpecialTimestamp& to)
 
 
 template<>
-inline void BSONWriter::write<SpecialTimestamp>(SpecialTimestamp& from)
+inline void BSONWriter::write<BSONTimestamp>(BSONTimestamp& from)
 {
 	Poco::Int64 value = from.ts.epochMicroseconds() / 1000;
 	value <<= 32;

--- a/MongoDB/include/Poco/MongoDB/ObjectId.h
+++ b/MongoDB/include/Poco/MongoDB/ObjectId.h
@@ -56,7 +56,7 @@ public:
 	virtual ~ObjectId();
 		/// Destructor
 
-	Timestamp timestamp() const;
+	Poco::Timestamp timestamp() const;
 		/// Returns the timestamp which is stored in the first four bytes of the id
 
 	std::string toString(const std::string& fmt = "%02x") const;
@@ -81,7 +81,7 @@ private:
 };
 
 
-inline Timestamp ObjectId::timestamp() const
+inline Poco::Timestamp ObjectId::timestamp() const
 {
 	int time;
 	char* T = (char *) &time;
@@ -89,7 +89,7 @@ inline Timestamp ObjectId::timestamp() const
 	T[1] = _id[2];
 	T[2] = _id[1];
 	T[3] = _id[0];
-	return Timestamp::fromEpochTime((time_t) time);
+	return Poco::Timestamp::fromEpochTime((time_t) time);
 }
 
 inline int ObjectId::fromHex(char c)

--- a/MongoDB/include/Poco/MongoDB/ObjectId.h
+++ b/MongoDB/include/Poco/MongoDB/ObjectId.h
@@ -56,7 +56,7 @@ public:
 	virtual ~ObjectId();
 		/// Destructor
 
-	Poco::Timestamp timestamp() const;
+	Timestamp timestamp() const;
 		/// Returns the timestamp which is stored in the first four bytes of the id
 
 	std::string toString(const std::string& fmt = "%02x") const;
@@ -81,7 +81,7 @@ private:
 };
 
 
-inline Poco::Timestamp ObjectId::timestamp() const
+inline Timestamp ObjectId::timestamp() const
 {
 	int time;
 	char* T = (char *) &time;
@@ -89,7 +89,7 @@ inline Poco::Timestamp ObjectId::timestamp() const
 	T[1] = _id[2];
 	T[2] = _id[1];
 	T[3] = _id[0];
-	return Poco::Timestamp::fromEpochTime((time_t) time);
+	return Timestamp::fromEpochTime((time_t) time);
 }
 
 inline int ObjectId::fromHex(char c)

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -96,8 +96,8 @@ void Document::read(BinaryReader& reader)
 		case ElementTraits<Poco::Timestamp>::TypeId:
 			element = new ConcreteElement<Poco::Timestamp>(name, Poco::Timestamp());
 			break;
-		case ElementTraits<Timestamp>::TypeId:
-			element = new ConcreteElement<Timestamp>(name, Timestamp());
+		case ElementTraits<SpecialTimestamp>::TypeId:
+			element = new ConcreteElement<SpecialTimestamp>(name, SpecialTimestamp());
 			break;
 		case ElementTraits<NullValue>::TypeId:
 			element = new ConcreteElement<NullValue>(name, NullValue(0));

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -96,8 +96,8 @@ void Document::read(BinaryReader& reader)
 		case ElementTraits<Poco::Timestamp>::TypeId:
 			element = new ConcreteElement<Poco::Timestamp>(name, Poco::Timestamp());
 			break;
-		case ElementTraits<SpecialTimestamp>::TypeId:
-			element = new ConcreteElement<SpecialTimestamp>(name, SpecialTimestamp());
+		case ElementTraits<BSONTimestamp>::TypeId:
+			element = new ConcreteElement<BSONTimestamp>(name, BSONTimestamp());
 			break;
 		case ElementTraits<NullValue>::TypeId:
 			element = new ConcreteElement<NullValue>(name, NullValue(0));

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -96,6 +96,9 @@ void Document::read(BinaryReader& reader)
 		case ElementTraits<Poco::Timestamp>::TypeId:
 			element = new ConcreteElement<Poco::Timestamp>(name, Poco::Timestamp());
 			break;
+		case ElementTraits<SpecialTimestamp>::TypeId:
+			element = new ConcreteElement<SpecialTimestamp>(name, SpecialTimestamp());
+			break;
 		case ElementTraits<NullValue>::TypeId:
 			element = new ConcreteElement<NullValue>(name, NullValue(0));
 			break;
@@ -111,7 +114,7 @@ void Document::read(BinaryReader& reader)
 		default:
 			{
 				std::stringstream ss;
-				ss << "Element " << name << " contains an unsupported type " << std::hex << (int) type;
+				ss << "Element " << name << " contains an unsupported type 0x" << std::hex << (int) type;
 				throw Poco::NotImplementedException(ss.str());
 			}
 		//TODO: x0F -> JavaScript code with scope

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -96,8 +96,8 @@ void Document::read(BinaryReader& reader)
 		case ElementTraits<Poco::Timestamp>::TypeId:
 			element = new ConcreteElement<Poco::Timestamp>(name, Poco::Timestamp());
 			break;
-		case ElementTraits<SpecialTimestamp>::TypeId:
-			element = new ConcreteElement<SpecialTimestamp>(name, SpecialTimestamp());
+		case ElementTraits<Timestamp>::TypeId:
+			element = new ConcreteElement<Timestamp>(name, Timestamp());
 			break;
 		case ElementTraits<NullValue>::TypeId:
 			element = new ConcreteElement<NullValue>(name, NullValue(0));


### PR DESCRIPTION
New SpecialTimestamp support used only internally by mongodb handling replica set and sharded collections.