### PR TITLE
1439 make config h a cmake configure file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,75 @@ option(POCO_STATIC
 option(POCO_UNBUNDLED
   "Set to OFF|ON (default is OFF) to control linking dependencies as external" OFF)
 
+# Config.h switches
+option(POCO_ENABLE_CPP11
+  "Set to OFF|ON (default is OFF) to control C++11 support" OFF)
+
+option(POCO_NO_AUTOMATIC_LIBS
+  "Set to OFF|ON (default is OFF) to control implicit linking" OFF)
+
+option(POCO_NO_SHAREDMEMORY
+  "Set to OFF|ON (default is OFF) to control shared memory" OFF)
+
+set(POCO_THREAD_PRIORITY_MIN 0 CACHE STRING
+  "")
+
+set(POCO_THREAD_PRIORITY_MAX 31 CACHE STRING
+  "")
+
+option(POCO_NO_WSTRING
+  "" OFF)
+
+option(POCO_NO_LOCALE
+  "" OFF)
+
+option(POCO_NO_INOTIFY
+  "" OFF)
+
+# Following are options to remove certain features
+# to reduce library/executable size for smaller
+# embedded platforms. By enabling these options,
+# the size of a statically executable can be
+# reduced by a few 100 Kbytes.
+option(POCO_NO_FILECHANNEL
+  "Set OFF|ON (default is OFF) to control automatic registration of FIleChannel in LoggingFactory" OFF)
+option(POCO_NO_SPLITTERCHANNEL
+  "Set OFF|ON (default is OFF) to control automatic registration of SplitterChannel in LoggingFactory" OFF)
+option(POCO_NO_SYSLOGCHANNEL
+  "Set OFF|ON (default is OFF) to control automatic registration of SyslogChannel in LoggingFactory" OFF)
+
+if(MSVC)
+    option(POCO_MSVC_SECURE_WARNINGS
+      "Set OFF|ON (default is OFF) to control MSVC secure warnings" OFF)
+endif()
+
+option(POCO_UTIL_NO_INIFILECONFIGURATION
+  "Set OFF|ON (default is OFF) to control support for INI file configurations in Poco::Util::Application" OFF)
+
+option(POCO_UTIL_NO_JSONCONFIGURATION
+  "Set OFF|ON (default is OFF) to control support for JSON configuration in Poco::Util::Application" OFF)
+
+option(POCO_UTIL_NO_XMLCONFIGURATION
+  "Set OFF|ON (default is OFF) to control support for XML configuration in Poco::Util::Application" OFF)
+
+option(POCO_NET_NO_IPv6
+  "Set OFF|ON (default is OFF) to control support for IPv6" OFF)
+
+option(POCO_LOG_DEBUG
+  "Set OFF|ON (default is OFF) to control poco_debug_* and poco_trace_* macros even if the _DEBUG var is not set" OFF)
+
+if(WIN32)
+    option(POCO_EXTERNAL_OPENSSL
+      "Set OFF|ON (default is OFF) to control use of bundled OpenSSL binaries" OFF)
+endif()
+
+# populate configure_file Config.h
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/Foundation/Config.h.in ${CMAKE_BINARY_DIR}/Poco/Config.h )
+include_directories( ${CMAKE_BINARY_DIR} )
+install(FILES ${CMAKE_BINARY_DIR}/Poco/Config.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include/Poco/)
+
+mark_as_advanced(POCO_ENABLE_CPP11 POCO_NO_AUTOMATIC_LIBS POCO_NO_WSTRING POCO_NO_SHAREDMEMORY POCO_NO_LOCALE POCO_THREAD_PRIORITY_MIN POCO_THREAD_PRIORITY_MAX POCO_NO_INOTIFY POCO_NO_FILECHANNEL POCO_NO_SPLITTERCHANNEL POCO_NO_SYSLOGCHANNEL POCO_MSVC_SECURE_WARNINGS POCO_UTIL_NO_INIFILECONFIGURATION POCO_UTIL_NO_JSONCONFIGURATION POCO_UTIL_NO_XMLCONFIGURATION POCO_NET_NO_IPv6 POCO_LOG_DEBUG POCO_EXTERNAL_OPENSSL)
+
 if(MSVC)
     option(POCO_MT
       "Set to OFF|ON (default is OFF) to control build of POCO as /MT instead of /MD" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,20 +105,21 @@ option(POCO_NO_AUTOMATIC_LIBS
 option(POCO_NO_SHAREDMEMORY
   "Set to OFF|ON (default is OFF) to control shared memory" OFF)
 
+option(POCO_OVERRIDE_THREAD_PRIORITIES
+  "Set to OFF|ON (default is OFF) to control overriding thread priorities on POSIX platforms" OFF)
 set(POCO_THREAD_PRIORITY_MIN 0 CACHE STRING
   "")
-
 set(POCO_THREAD_PRIORITY_MAX 31 CACHE STRING
   "")
 
 option(POCO_NO_WSTRING
-  "" OFF)
+  "Set OFF|ON (default is OFF) to control use of wstring" OFF)
 
 option(POCO_NO_LOCALE
-  "" OFF)
+  "Set OFF|ON (default is OFF) to control use of <locale> header" OFF)
 
 option(POCO_NO_INOTIFY
-  "" OFF)
+  "Set OFF|ON (default is OFF) to control" OFF)
 
 # Following are options to remove certain features
 # to reduce library/executable size for smaller

--- a/Foundation/Config.h.in
+++ b/Foundation/Config.h.in
@@ -67,6 +67,8 @@
 #endif
 
 
+#cmakedefine POCO_OVERRIDE_THREAD_PRIORITIES
+#ifdef POCO_OVERRIDE_THREAD_PRIORITIES
 // Define to override system-provided
 // minimum thread priority value on POSIX
 // platforms (returned by Poco::Thread::getMinOSPriority()).
@@ -77,6 +79,7 @@
 // maximum thread priority value on POSIX
 // platforms (returned by Poco::Thread::getMaxOSPriority()).
 #define POCO_THREAD_PRIORITY_MAX @POCO_THREAD_PRIORITY_MAX@
+#endif
 
 
 // Define to disable small object optimization. If not

--- a/Foundation/Config.h.in
+++ b/Foundation/Config.h.in
@@ -29,11 +29,11 @@
 
 
 // Define to enable C++11 support
-// #define POCO_ENABLE_CPP11
+#cmakedefine POCO_ENABLE_CPP11
 
 
 // Define to disable implicit linking
-// #define POCO_NO_AUTOMATIC_LIBS
+#cmakedefine POCO_NO_AUTOMATIC_LIBS
 
 
 // Define to disable automatic initialization
@@ -41,23 +41,23 @@
 // initialization framework-wide (e.g. Net
 // on Windows, all Data back-ends, etc).
 //
-// #define POCO_NO_AUTOMATIC_LIB_INIT
+#cmakedefine POCO_NO_AUTOMATIC_LIB_INIT
 
 
 // Define to disable FPEnvironment support
-// #define POCO_NO_FPENVIRONMENT
+#cmakedefine POCO_NO_FPENVIRONMENT
 
 
 // Define if std::wstring is not available
-// #define POCO_NO_WSTRING
+#cmakedefine POCO_NO_WSTRING
 
 
 // Define to disable shared memory
-// #define POCO_NO_SHAREDMEMORY
+#cmakedefine POCO_NO_SHAREDMEMORY
 
 
 // Define if no <locale> header is available (such as on WinCE)
-// #define POCO_NO_LOCALE
+#cmakedefine POCO_NO_LOCALE
 
 
 // Define to desired default thread stack size
@@ -70,13 +70,13 @@
 // Define to override system-provided
 // minimum thread priority value on POSIX
 // platforms (returned by Poco::Thread::getMinOSPriority()).
-// #define POCO_THREAD_PRIORITY_MIN 0
+#define POCO_THREAD_PRIORITY_MIN @POCO_THREAD_PRIORITY_MIN@
 
 
 // Define to override system-provided
 // maximum thread priority value on POSIX
 // platforms (returned by Poco::Thread::getMaxOSPriority()).
-// #define POCO_THREAD_PRIORITY_MAX 31
+#define POCO_THREAD_PRIORITY_MAX @POCO_THREAD_PRIORITY_MAX@
 
 
 // Define to disable small object optimization. If not
@@ -109,7 +109,7 @@
 
 // Define to disable compilation of DirectoryWatcher
 // on platforms with no inotify.
-// #define POCO_NO_INOTIFY
+#cmakedefine POCO_NO_INOTIFY
 
 
 // Following are options to remove certain features
@@ -122,45 +122,45 @@
 // No automatic registration of FileChannel in
 // LoggingFactory - avoids FileChannel and friends
 // being linked to executable.
-// #define POCO_NO_FILECHANNEL
+#cmakedefine POCO_NO_FILECHANNEL
 
 
 // No automatic registration of SplitterChannel in
 // LoggingFactory - avoids SplitterChannel being
 // linked to executable.
-// #define POCO_NO_SPLITTERCHANNEL
+#cmakedefine POCO_NO_SPLITTERCHANNEL
 
 
 // No automatic registration of SyslogChannel in
 // LoggingFactory - avoids SyslogChannel being
 // linked to executable on Unix/Linux systems.
-// #define POCO_NO_SYSLOGCHANNEL
+#cmakedefine POCO_NO_SYSLOGCHANNEL
 
 
 // Define to enable MSVC secure warnings
-// #define POCO_MSVC_SECURE_WARNINGS
+#cmakedefine POCO_MSVC_SECURE_WARNINGS
 
 
 // No support for INI file configurations in
 // Poco::Util::Application.
-// #define POCO_UTIL_NO_INIFILECONFIGURATION
+#cmakedefine POCO_UTIL_NO_INIFILECONFIGURATION
 
 
 // No support for JSON configuration in
 // Poco::Util::Application. Avoids linking of JSON
 // library and saves a few 100 Kbytes.
-// #define POCO_UTIL_NO_JSONCONFIGURATION
+#cmakedefine POCO_UTIL_NO_JSONCONFIGURATION
 
 
 // No support for XML configuration in
 // Poco::Util::Application. Avoids linking of XML
 // library and saves a few 100 Kbytes.
-// #define POCO_UTIL_NO_XMLCONFIGURATION
+#cmakedefine POCO_UTIL_NO_XMLCONFIGURATION
 
 
 // No IPv6 support
 // Define to disable IPv6
-// #define POCO_NET_NO_IPv6
+#cmakedefine POCO_NET_NO_IPv6
 
 
 // Windows CE has no locale support
@@ -171,10 +171,10 @@
 // Enable the poco_debug_* and poco_trace_* macros
 // even if the _DEBUG variable is not set.
 // This allows the use of these macros in a release version.
-// #define POCO_LOG_DEBUG
+#cmakedefine POCO_LOG_DEBUG
 
 // Uncomment to disable the use of bundled OpenSSL binaries
 // (Windows only)
-// #define POCO_EXTERNAL_OPENSSL
+#cmakedefine POCO_EXTERNAL_OPENSSL
 
 #endif // Foundation_Config_INCLUDED


### PR DESCRIPTION
Does not apply C++ standards using CMAKE_CXX_STANDARDS as in #1439 as that requires incrementally increasing the minimum required CMake version for the project.