### PR TITLE
Use stable_sort to preserve order of IP addresses from DNS

### DIFF
--- a/Net/src/SocketAddress.cpp
+++ b/Net/src/SocketAddress.cpp
@@ -170,7 +170,7 @@ SocketAddress& SocketAddress::operator = (const SocketAddress& socketAddress)
 		destruct();
 		if (socketAddress.family() == IPv4)
 			newIPv4(reinterpret_cast<const sockaddr_in*>(socketAddress.addr()));
-#if defined(POCO_HAVE_IPv6)			
+#if defined(POCO_HAVE_IPv6)
 		else if (socketAddress.family() == IPv6)
 			newIPv6(reinterpret_cast<const sockaddr_in6*>(socketAddress.addr()));
 #endif
@@ -252,7 +252,7 @@ void SocketAddress::init(const std::string& hostAddress, Poco::UInt16 portNumber
 		{
 #if defined(POCO_HAVE_IPv6)
 			// if we get both IPv4 and IPv6 addresses, prefer IPv4
-			std::sort(addresses.begin(), addresses.end(), AFLT());
+			std::stable_sort(addresses.begin(), addresses.end(), AFLT());
 #endif
 			init(addresses[0], portNumber);
 		}
@@ -285,7 +285,7 @@ void SocketAddress::init(const std::string& hostAndPort)
 	std::string port;
 	std::string::const_iterator it  = hostAndPort.begin();
 	std::string::const_iterator end = hostAndPort.end();
-	
+
 #if defined(POCO_OS_FAMILY_UNIX)
 	if (*it == '/')
 	{


### PR DESCRIPTION
SocketAddress uses a sort operation on IP addresses returned from DNS to ensure that IPv4 addresses are preferred over IPv6 addresses. Unfortunately, std::sort does not guarantee that the order of "equal" elements will be preserved, in which case SocketAddress can wind up with an IP other than the first one when multiple addresses are returned. Since DNS round robin-ing (https://en.wikipedia.org/wiki/Round-robin_DNS) assumes that a client will typically use the first address, it would be beneficial to have the order preserved by the sort. Switching to std::stable_sort achieves this.