### PR TITLE
Fixed "integer constant is too large for 'long' type" issue

### DIFF
--- a/XML/src/xmlparse.cpp
+++ b/XML/src/xmlparse.cpp
@@ -742,7 +742,7 @@ generate_hash_secret_salt(XML_Parser parser)
   if (sizeof(unsigned long) == 4) {
     return entropy * 2147483647;
   } else {
-    return entropy * (unsigned long)2305843009213693951;
+    return entropy * 2305843009213693951ULL;
   }
 }
 


### PR DESCRIPTION
Cross-compiling Poco for PowerPC (using a rather old toolchain based on gcc-4.3.2) didn't like the numeric literal for M61. Need to suffix it with `LL` and it compiles OK. While I am at it: adding an `U` suffix makes the literal unsigned, thus no more need to type cast it.

Summary: added suffix `ULL`, removed `(unsigned long)` type cast.

Best regards,
Adrian

P.S.: Great work! The only thing which is IMHO "unusual": the `///` comments are always placed after the member they describe. To work properly as Doxygen comments, such comments should be placed _before_ the member described. Or add an additional `<`. See https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html
This is particularly annoying because it makes my IDE (VS2015 w/ ReSharper) display the wrong descriptions.