### PR TITLE
When on MS Windows, install cmake config scripts to "cmake" rather th…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,13 +367,22 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 
+# Set config script install location in a location that find_package() will
+# look for, which is different on MS Windows than for UNIX
+# Note: also set in POCO_GENERATE_PACKAGE macro in cmake/PocoMacros.cmake
+if (WIN32)
+  set(PocoConfigPackageLocation "cmake")
+else()
+  set(PocoConfigPackageLocation "lib/cmake/${PROJECT_NAME}")
+endif()
+
 configure_file(cmake/${PROJECT_NAME}Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake" @ONLY)
 install(
     FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake
     DESTINATION
-        "lib/cmake/${PROJECT_NAME}"
+        "${PocoConfigPackageLocation}"
     COMPONENT
         Devel
 )

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -223,20 +223,27 @@ configure_file("cmake/Poco${target_name}Config.cmake"
   @ONLY
 )
 
-set(ConfigPackageLocation "lib/cmake/${PROJECT_NAME}")
+# Set config script install location in a location that find_package() will
+# look for, which is different on MS Windows than for UNIX
+# Note: also set in root CMakeLists.txt
+if (WIN32)
+  set(PocoConfigPackageLocation "cmake")
+else()
+  set(PocoConfigPackageLocation "lib/cmake/${PROJECT_NAME}")
+endif()
 
 install(
     EXPORT "${target_name}Targets"
     FILE "${PROJECT_NAME}${target_name}Targets.cmake"
     NAMESPACE "${PROJECT_NAME}::"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "${PocoConfigPackageLocation}"
     )
 
 install(
     FILES
         "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Config.cmake"
         "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}ConfigVersion.cmake"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "${PocoConfigPackageLocation}"
     COMPONENT Devel
     )
 


### PR DESCRIPTION
…an "lib/cmake/Poco", as that will allow find_package() on an MS Windows build to find the installation if it is in a common location with other packages.

The motivation for this is discussed in issue #1450 
