### PR TITLE
-change shared pointer access private members to be protected

### DIFF
--- a/Foundation/include/Poco/SharedPtr.h
+++ b/Foundation/include/Poco/SharedPtr.h
@@ -378,7 +378,7 @@ public:
 		return _pCounter->referenceCount();
 	}
 
-private:
+protected:
 	C* deref() const
 	{
 		if (!_ptr)
@@ -408,7 +408,7 @@ private:
 		_pCounter->duplicate();
 	}
 
-private:
+protected:
 	RC* _pCounter;
 	C*  _ptr;
 


### PR DESCRIPTION
… to create an extensibility point. we need to have access to the release policy instance of the shared pointer. we will use it to provide a weak pointer implementation.
