### PR TITLE
ReuseAddress and reusePort options should be separeted.

### DIFF
--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -76,7 +76,7 @@ public:
 		/// the TCP server at the given address. Prior to opening the
 		/// connection the socket is set to nonblocking mode.
 	
-	virtual void bind(const SocketAddress& address, bool reuseAddress = false);
+	virtual void bind(const SocketAddress& address, bool reuseAddress = false, bool reusePort = false);
 		/// Bind a local address to the socket.
 		///
 		/// This is usually only done when establishing a server
@@ -85,8 +85,10 @@ public:
 		///
 		/// If reuseAddress is true, sets the SO_REUSEADDR
 		/// socket option.
+        /// If reusePort is true, set the SO_REUSEPORT
+        /// socket option.
 
-	virtual void bind6(const SocketAddress& address, bool reuseAddress = false, bool ipV6Only = false);
+	virtual void bind6(const SocketAddress& address, bool reuseAddress = false, bool reusePort = false, bool ipV6Only = false);
 		/// Bind a local IPv6 address to the socket.
 		///
 		/// This is usually only done when establishing a server
@@ -95,6 +97,8 @@ public:
 		///
 		/// If reuseAddress is true, sets the SO_REUSEADDR
 		/// socket option.
+        /// if reusePort is true, sets the SO_REUSEPORT
+        /// socket option.
 		///
 		/// The given address must be an IPv6 address. The
 		/// IPPROTO_IPV6/IPV6_V6ONLY option is set on the socket

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -189,17 +189,16 @@ void SocketImpl::connectNB(const SocketAddress& address)
 }
 
 
-void SocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SocketImpl::bind(const SocketAddress& address, bool reuseAddress, bool reusePort)
 {
 	if (_sockfd == POCO_INVALID_SOCKET)
 	{
 		init(address.af());
 	}
 	if (reuseAddress)
-	{
 		setReuseAddress(true);
+    if (reusePort)
 		setReusePort(true);
-	}
 #if defined(POCO_VXWORKS)
 	int rc = ::bind(_sockfd, (sockaddr*) address.addr(), address.length());
 #else
@@ -209,7 +208,7 @@ void SocketImpl::bind(const SocketAddress& address, bool reuseAddress)
 }
 
 
-void SocketImpl::bind6(const SocketAddress& address, bool reuseAddress, bool ipV6Only)
+void SocketImpl::bind6(const SocketAddress& address, bool reuseAddress, bool reusePort, bool ipV6Only)
 {
 #if defined(POCO_HAVE_IPv6)
 	if (address.family() != SocketAddress::IPv6)
@@ -225,10 +224,9 @@ void SocketImpl::bind6(const SocketAddress& address, bool reuseAddress, bool ipV
 	if (ipV6Only) throw Poco::NotImplementedException("IPV6_V6ONLY not defined.");
 #endif
 	if (reuseAddress)
-	{
 		setReuseAddress(true);
+    if (reusePort)
 		setReusePort(true);
-	}
 	int rc = ::bind(_sockfd, address.addr(), address.length());
 	if (rc != 0) error(address.toString());
 #else


### PR DESCRIPTION
The reuseAddress option is to reuse a socket in TIME-WAIT state, bind still fails
if the socket is in-use, server applications often use the option.

But reusePort can reuse a port which is already in-use, I don't think you want
to share a port with another irrelevant application, unless you know what you
are doing, this is a more error prone option only is used in rare cases.