### PR TITLE
ODBC: fix uninitialized variable

### DIFF
--- a/Data/ODBC/src/ODBCStatementImpl.cpp
+++ b/Data/ODBC/src/ODBCStatementImpl.cpp
@@ -499,7 +499,7 @@ int ODBCStatementImpl::affectedRowCount() const
 {
 	if (0 == _affectedRowCount)
 	{
-		SQLLEN rows;
+		SQLLEN rows = 0;
 		if (!Utility::isError(SQLRowCount(_stmt, &rows)))
 			_affectedRowCount = static_cast<std::size_t>(rows);
 	}


### PR DESCRIPTION
This prevents valgrind reports like:

==18426== Conditional jump or move depends on uninitialised value(s)
==18426==    at 0x6423EB5: Poco::Data::StatementImpl::execute(bool const&) (in /usr/lib/libPocoDatad.so.46)
==18426==    by 0x641DB5F: Poco::Data::Statement::execute(bool) (in /usr/lib/libPocoDatad.so.46)
==18426==    by 0x632A0C: Poco::Data::Keywords::now(Poco::Data::Statement&) (Statement.h:443)
==18426==    by 0x641C8E5: Poco::Data::Statement::operator,(void (*)(Poco::Data::Statement&)) (in /usr/lib/libPocoDatad.so.46)
...
==18426==  Uninitialised value was created by a stack allocation
==18426==    at 0x6A1A170: Poco::Data::ODBC::ODBCStatementImpl::affectedRowCount() const (in /usr/lib/libPocoDataODBCd.so.46)

Signed-off-by: Jan Viktorin <viktorin@rehivetech.com>