### PR TITLE
Support ODBC GUID data type as string

### DIFF
--- a/Data/ODBC/src/ODBCMetaColumn.cpp
+++ b/Data/ODBC/src/ODBCMetaColumn.cpp
@@ -88,6 +88,9 @@ void ODBCMetaColumn::init()
 	case SQL_CHAR:
 	case SQL_VARCHAR:
 	case SQL_LONGVARCHAR:
+#ifdef SQL_GUID
+	case SQL_GUID:
+#endif
 		setType(MetaColumn::FDT_STRING); break;
 
 	case SQL_WCHAR:


### PR DESCRIPTION
The ODBC defines SQL_GUID datatype in sqlext.h. It is used
e.g. for transfer of UUID datatype from PostgreSQL.

Signed-off-by: Jan Viktorin <viktorin@rehivetech.com>