### PR TITLE
enable CppUnit with ENABLE_CPPUNIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ set(Poco_COMPONENTS "")
 # Pthreads/threads support
 find_package(Threads REQUIRED)
 
-if (ENABLE_TESTS)
+if (ENABLE_TESTS OR ENABLE_CPPUNIT)
    add_subdirectory(CppUnit)
    list(APPEND Poco_COMPONENTS "CppUnit")
 endif ()


### PR DESCRIPTION
I wasted some time because ENABLE_CPPUNIT seems not to enable anything,

Also we could enable CppUnit component without enabling the poco unit tests.