### PR TITLE
Detection of closed websocket connection

### DIFF
--- a/Net/samples/WebSocketServer/src/WebSocketServer.cpp
+++ b/Net/samples/WebSocketServer/src/WebSocketServer.cpp
@@ -119,7 +119,7 @@ public:
 				app.logger().information(Poco::format("Frame received (length=%d, flags=0x%x).", n, unsigned(flags)));
 				ws.sendFrame(buffer, n, flags);
 			}
-			while (n > 0 || (flags & WebSocket::FRAME_OP_BITMASK) != WebSocket::FRAME_OP_CLOSE);
+			while (n > 0 && (flags & WebSocket::FRAME_OP_BITMASK) != WebSocket::FRAME_OP_CLOSE);
 			app.logger().information("WebSocket connection closed.");
 		}
 		catch (WebSocketException& exc)


### PR DESCRIPTION
When the websocket connection is closed, a non-empty frame (n>0) may be received with FRAME_OP_CLOSE flag bit set.
Tested with chrome 54.0.2840.99 ; after establishing the websocket connection, if the connection is not closed by javascript and the tab is closed, a frame of length n=2 is received with FRAME_OP_CLOSE flag set.

This was previously not detected and a Net Exception was thrown.