### PR TITLE
Net::HTTPSession: split timeout to connection, receive, send

### DIFF
--- a/Net/include/Poco/Net/HTTPSession.h
+++ b/Net/include/Poco/Net/HTTPSession.h
@@ -55,7 +55,10 @@ public:
 
 	void setTimeout(const Poco::Timespan& timeout);
 		/// Sets the timeout for the HTTP session.
-		
+
+	void setTimeout(const Poco::Timespan& connectionTimeout, const Poco::Timespan& sendTimeout, const Poco::Timespan& receiveTimeout);
+		/// Sets different timeouts for the HTTP session.
+
 	Poco::Timespan getTimeout() const;
 		/// Returns the timeout for the HTTP session.
 
@@ -171,7 +174,8 @@ protected:
 private:
 	enum
 	{
-		HTTP_DEFAULT_TIMEOUT = 60000000
+		HTTP_DEFAULT_TIMEOUT = 60000000,
+		HTTP_DEFAULT_CONNECTION_TIMEOUT = 30000000
 	};
 	
 	HTTPSession(const HTTPSession&);
@@ -182,7 +186,9 @@ private:
 	char*            _pCurrent;
 	char*            _pEnd;
 	bool             _keepAlive;
-	Poco::Timespan   _timeout;
+	Poco::Timespan   _connectionTimeout;
+	Poco::Timespan   _receiveTimeout;
+	Poco::Timespan   _sendTimeout;
 	Poco::Exception* _pException;
 	Poco::Any        _data;
 	
@@ -204,7 +210,7 @@ inline bool HTTPSession::getKeepAlive() const
 
 inline Poco::Timespan HTTPSession::getTimeout() const
 {
-	return _timeout;
+	return _receiveTimeout;
 }
 
 

--- a/Net/src/HTTPSession.cpp
+++ b/Net/src/HTTPSession.cpp
@@ -32,7 +32,9 @@ HTTPSession::HTTPSession():
 	_pCurrent(0),
 	_pEnd(0),
 	_keepAlive(false),
-	_timeout(HTTP_DEFAULT_TIMEOUT),
+	_connectionTimeout(HTTP_DEFAULT_CONNECTION_TIMEOUT),
+	_receiveTimeout(HTTP_DEFAULT_TIMEOUT),
+	_sendTimeout(HTTP_DEFAULT_TIMEOUT),
 	_pException(0)
 {
 }
@@ -44,7 +46,9 @@ HTTPSession::HTTPSession(const StreamSocket& socket):
 	_pCurrent(0),
 	_pEnd(0),
 	_keepAlive(false),
-	_timeout(HTTP_DEFAULT_TIMEOUT),
+	_connectionTimeout(HTTP_DEFAULT_CONNECTION_TIMEOUT),
+	_receiveTimeout(HTTP_DEFAULT_TIMEOUT),
+	_sendTimeout(HTTP_DEFAULT_TIMEOUT),
 	_pException(0)
 {
 }
@@ -56,7 +60,9 @@ HTTPSession::HTTPSession(const StreamSocket& socket, bool keepAlive):
 	_pCurrent(0),
 	_pEnd(0),
 	_keepAlive(keepAlive),
-	_timeout(HTTP_DEFAULT_TIMEOUT),
+	_connectionTimeout(HTTP_DEFAULT_CONNECTION_TIMEOUT),
+	_receiveTimeout(HTTP_DEFAULT_TIMEOUT),
+	_sendTimeout(HTTP_DEFAULT_TIMEOUT),
 	_pException(0)
 {
 }
@@ -91,7 +97,14 @@ void HTTPSession::setKeepAlive(bool keepAlive)
 
 void HTTPSession::setTimeout(const Poco::Timespan& timeout)
 {
-	_timeout = timeout;
+	setTimeout(timeout, timeout, timeout);
+}
+
+void HTTPSession::setTimeout(const Poco::Timespan& connectionTimeout, const Poco::Timespan& sendTimeout, const Poco::Timespan& receiveTimeout)
+{
+	 _connectionTimeout = connectionTimeout;
+	 _sendTimeout = sendTimeout;
+	 _receiveTimeout = receiveTimeout;
 }
 
 
@@ -181,8 +194,9 @@ bool HTTPSession::connected() const
 
 void HTTPSession::connect(const SocketAddress& address)
 {
-	_socket.connect(address, _timeout);
-	_socket.setReceiveTimeout(_timeout);
+	_socket.connect(address, _connectionTimeout);
+	_socket.setReceiveTimeout(_receiveTimeout);
+	_socket.setSendTimeout(_sendTimeout);
 	_socket.setNoDelay(true);
 	// There may be leftover data from a previous (failed) request in the buffer,
 	// so we clear it.


### PR DESCRIPTION
Useful for setting 1s connect timeout.

tested and used in https://github.com/yandex/ClickHouse