### PR TITLE
Allow link application with double_conversion

### DIFF
--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -18,6 +18,7 @@
 
 
 // +++ double conversion +++
+#define double_conversion poco_double_conversion	// don't collide with standalone double_conversion library
 #define UNREACHABLE poco_bugcheck
 #define UNIMPLEMENTED poco_bugcheck
 #include "diy-fp.cc"


### PR DESCRIPTION
Without this linking fails with duplicate function names errors