### PR TITLE
Add support for std::tuple to Data/TypeHandler.h.

### DIFF
--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -533,6 +533,26 @@ void MySQLTest::testTupleVector()
 	_pExecutor->tupleVector();
 }
 
+#if __cplusplus >= 201103L
+
+void MySQLTest::testStdTuple()
+{
+	if (!_pSession) fail ("Test not available.");
+
+	recreateTuplesTable();
+	_pExecutor->stdTuples();
+}
+
+
+void MySQLTest::testStdTupleVector()
+{
+	if (!_pSession) fail ("Test not available.");
+
+	recreateTuplesTable();
+	_pExecutor->stdTupleVector();
+}
+
+#endif // __cplusplus >= 201103L
 
 void MySQLTest::testInternalExtraction()
 {
@@ -934,6 +954,10 @@ CppUnit::Test* MySQLTest::suite()
 	CppUnit_addTest(pSuite, MySQLTest, testDouble);
 	CppUnit_addTest(pSuite, MySQLTest, testTuple);
 	CppUnit_addTest(pSuite, MySQLTest, testTupleVector);
+#if __cplusplus >= 201103L
+	CppUnit_addTest(pSuite, MySQLTest, testStdTuple);
+	CppUnit_addTest(pSuite, MySQLTest, testStdTupleVector);
+#endif
 	CppUnit_addTest(pSuite, MySQLTest, testInternalExtraction);
 	CppUnit_addTest(pSuite, MySQLTest, testNull);
 	CppUnit_addTest(pSuite, MySQLTest, testNullableInt);

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -89,6 +89,13 @@ public:
 	void testTuple();
 	void testTupleVector();
 
+#if __cplusplus >= 201103L
+
+	void testStdTuple();
+	void testStdTupleVector();
+
+#endif
+
 	void testInternalExtraction();
 
 	void testNull();

--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -31,6 +31,10 @@
 #include "Poco/Data/MySQL/Connector.h"
 #include "Poco/Data/MySQL/MySQLException.h"
 
+#if __cplusplus >= 201103L
+#include <tuple>
+#endif
+
 #if POCO_MSVS_VERSION == 2015
 #define HAVE_STRUCT_TIMESPEC
 #endif
@@ -1475,6 +1479,58 @@ void SQLExecutor::tupleVector()
 	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
 	assert (ret == v);
 }
+
+#if __cplusplus >= 201103L
+
+void SQLExecutor::stdTuples()
+{
+	typedef std::tuple<int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int> TupleType;
+	std::string funct = "stdTuples()";
+	TupleType t = std::make_tuple(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19);
+
+	try { *_pSession << "INSERT INTO Tuples VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", use(t), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+
+	TupleType ret = std::make_tuple(-10,-11,-12,-13,-14,-15,-16,-17,-18,-19,-20,-21,-22,-23,-24,-25,-26,-27,-28,-29);
+	assert (ret != t);
+	try { *_pSession << "SELECT * FROM Tuples", into(ret), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	assert (ret == t);
+}
+
+
+void SQLExecutor::stdTupleVector()
+{
+	typedef std::tuple<int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int> TupleType;
+	std::string funct = "stdTupleVector()";
+	TupleType t = std::make_tuple(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19);
+	auto t10 = std::make_tuple(10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29);
+	TupleType t100 = std::make_tuple(100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119);
+	std::vector<TupleType> v;
+	v.push_back(t);
+	v.push_back(t10);
+	v.push_back(t100);
+
+	try { *_pSession << "INSERT INTO Tuples VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", use(v), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+
+	int count = 0;
+	try { *_pSession << "SELECT COUNT(*) FROM Tuples", into(count), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	assert (v.size() == (std::size_t) count);
+
+	std::vector<TupleType> ret;
+	try { *_pSession << "SELECT * FROM Tuples", into(ret), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	assert (ret == v);
+}
+
+#endif //__cplusplus >= 201103L
 
 
 void SQLExecutor::internalExtraction()

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -91,6 +91,11 @@ public:
 	void tuples();
 	void tupleVector();
 
+#if __cplusplus >= 201103L
+	void stdTuples();
+	void stdTupleVector();
+#endif
+
 	void internalExtraction();
 	void doNull();
 

--- a/Data/include/Poco/Data/TypeHandler.h
+++ b/Data/include/Poco/Data/TypeHandler.h
@@ -2109,7 +2109,7 @@ private:
 
 #if __cplusplus >= 201103L
 
-template<size_t N>
+template<std::size_t N>
 struct TupleBind
 /// Helper for specialization of type handler for std::tuple
 {
@@ -2130,7 +2130,7 @@ struct TupleBind
 };
 
 
-template<size_t N>
+template<std::size_t N>
 struct TupleSize
 /// Helper for specialization of type handler for std::tuple
 {
@@ -2150,7 +2150,7 @@ struct TupleSize
 };
 
 
-template<size_t N>
+template<std::size_t N>
 struct TupleExtract
 /// Helper for specialization of type handler for std::tuple
 {
@@ -2171,7 +2171,7 @@ struct TupleExtract
 };
 
 
-template<size_t N>
+template<std::size_t N>
 struct TuplePrepare
 /// Helper for specialization of type handler for std::tuple
 {

--- a/Data/include/Poco/Data/TypeHandler.h
+++ b/Data/include/Poco/Data/TypeHandler.h
@@ -30,6 +30,9 @@
 #include "Poco/SharedPtr.h"
 #include <cstddef>
 
+#if __cplusplus >= 201103L
+#include <tuple>
+#endif
 
 namespace Poco {
 namespace Data {
@@ -2103,6 +2106,131 @@ private:
 	TypeHandler& operator = (const TypeHandler&);
 };
 
+
+#if __cplusplus >= 201103L
+
+template<size_t N>
+struct TupleBind
+/// Helper for specialization of type handler for std::tuple
+{
+	template<typename... T>
+	static typename std::enable_if<N < sizeof...(T)>::type
+	bind(std::size_t& pos, const std::tuple<T...>& t, AbstractBinder::Ptr pBinder, AbstractBinder::Direction dir)
+	{
+		using Type = typename std::tuple_element<N, std::tuple<T...>>::type;
+		TypeHandler<Type>::bind(pos, std::get<N>(t), pBinder, dir);
+		pos += TypeHandler<Type>::size();
+		TupleBind<N+1>::bind(pos, t, pBinder, dir);
+	}
+
+	template<typename... T>
+	static typename std::enable_if<!(N < sizeof...(T))>::type
+	bind(std::size_t& pos, const std::tuple<T...>& t, AbstractBinder::Ptr pBinder, AbstractBinder::Direction dir)
+	{}
+};
+
+
+template<size_t N>
+struct TupleSize
+/// Helper for specialization of type handler for std::tuple
+{
+	template<typename... T>
+	static typename std::enable_if<N < sizeof...(T)>::type
+	size(std::size_t& sz)
+	{
+		using Type = typename std::tuple_element<N, std::tuple<T...>>::type;
+		sz += TypeHandler<Type>::size();
+		TupleSize<N+1>::size(sz);
+	}
+
+	template<typename... T>
+	static typename std::enable_if<!(N < sizeof...(T))>::type
+	size(std::size_t& sz)
+	{}
+};
+
+
+template<size_t N>
+struct TupleExtract
+/// Helper for specialization of type handler for std::tuple
+{
+	template<typename... T>
+	static typename std::enable_if<N < sizeof...(T)>::type
+	extract(std::size_t& pos, std::tuple<T...>& t, const std::tuple<T...>& defVal, AbstractExtractor::Ptr pExt)
+	{
+		using Type = typename std::tuple_element<N, std::tuple<T...>>::type;
+		TypeHandler<Type>::extract(pos, std::get<N>(t), std::get<N>(defVal), pExt);
+		pos += TypeHandler<Type>::size();
+		TupleExtract<N+1>::extract(pos, t, defVal, pExt);
+	}
+
+	template<typename... T>
+	static typename std::enable_if<!(N < sizeof...(T))>::type
+	extract(std::size_t& pos, std::tuple<T...>& t, const std::tuple<T...>& defVal, AbstractExtractor::Ptr pExt)
+	{}
+};
+
+
+template<size_t N>
+struct TuplePrepare
+/// Helper for specialization of type handler for std::tuple
+{
+	template<typename... T>
+	static typename std::enable_if<N < sizeof...(T)>::type
+	prepare(std::size_t& pos, const std::tuple<T...>& t, AbstractPreparator::Ptr pPreparator)
+	{
+		using Type = typename std::tuple_element<N, std::tuple<T...>>::type;
+		TypeHandler<Type>::prepare(pos, std::get<N>(t), pPreparator);
+		pos += TypeHandler<Type>::size();
+		TuplePrepare<N+1>::prepare(pos, t, pPreparator);
+	}
+
+	template<typename... T>
+	static typename std::enable_if<!(N < sizeof...(T))>::type
+	prepare(std::size_t& pos, const std::tuple<T...>& t, AbstractPreparator::Ptr pPreparator)
+	{}
+};
+
+
+
+template <typename...T>
+class TypeHandler<std::tuple<T...>>
+/// Specialization of type handler for std::tuple
+{
+public:
+	static void bind(std::size_t pos, const std::tuple<T...> & t, AbstractBinder::Ptr pBinder, AbstractBinder::Direction dir)
+	{
+		poco_assert_dbg (!pBinder.isNull());
+		TupleBind<0>::bind(pos, t, pBinder, dir);
+	}
+
+	static std::size_t size()
+	{
+		std::size_t sz = 0;
+		TupleSize<0>::size(sz);
+		return sz;
+	}
+
+	static void extract(std::size_t pos, std::tuple<T...>& t, const std::tuple<T...>& defVal, AbstractExtractor::Ptr pExt)
+	{
+		poco_assert_dbg (!pExt.isNull());
+		TupleExtract<0>::extract(pos, t, defVal, pExt);
+	}
+
+	static void prepare(std::size_t pos, const std::tuple<T...> & t, AbstractPreparator::Ptr pPrepare)
+	{
+		poco_assert_dbg (!pPrepare.isNull());
+		TuplePrepare<0>::prepare(pos, t, pPrepare);
+	}
+
+private:
+	TypeHandler();
+	~TypeHandler();
+	TypeHandler(const TypeHandler&);
+	TypeHandler& operator=(const TypeHandler&);
+};
+
+#endif // __cplusplus >= 201103L
 
 } } // namespace Poco::Data
 

--- a/Data/testsuite/src/DataTest.cpp
+++ b/Data/testsuite/src/DataTest.cpp
@@ -38,6 +38,10 @@
 #include <iomanip>
 #include <set>
 
+#if __cplusplus >= 201103L
+#include <tuple>
+#endif
+
 
 using namespace Poco::Data::Keywords;
 
@@ -1400,6 +1404,22 @@ void DataTest::testExternalBindingAndExtraction()
 }
 
 
+#if __cplusplus >= 201103L
+
+void DataTest::testStdTuple()
+{
+    using Row = std::tuple<std::string, std::string, int>;
+
+    Session sess(SessionFactory::instance().create("test", "cs"));
+    Row person = std::make_tuple(std::string("Scott"), std::string("Washington, DC"), 42);
+    sess << "INSERT INTO Person(name, address, age) VALUES (?, ?, ?)", use(person), now;
+    std::vector<Row> rows;
+    sess << "SELECT name, address, age FROM Person", into(rows) , now;
+}
+
+#endif // __cplusplus >= 201103L
+
+
 void DataTest::setUp()
 {
 }
@@ -1430,7 +1450,11 @@ CppUnit::Test* DataTest::suite()
 	CppUnit_addTest(pSuite, DataTest, testSimpleRowFormatter);
 	CppUnit_addTest(pSuite, DataTest, testJSONRowFormatter);
 	CppUnit_addTest(pSuite, DataTest, testDateAndTime);
-	CppUnit_addTest(pSuite, DataTest, testExternalBindingAndExtraction);
+    CppUnit_addTest(pSuite, DataTest, testExternalBindingAndExtraction);
+#if __cplusplus >= 201103L
+    CppUnit_addTest(pSuite, DataTest, testStdTuple);
+#endif
+
 
 	return pSuite;
 }

--- a/Data/testsuite/src/DataTest.cpp
+++ b/Data/testsuite/src/DataTest.cpp
@@ -1408,13 +1408,13 @@ void DataTest::testExternalBindingAndExtraction()
 
 void DataTest::testStdTuple()
 {
-    using Row = std::tuple<std::string, std::string, int>;
+	using Row = std::tuple<std::string, std::string, int>;
 
-    Session sess(SessionFactory::instance().create("test", "cs"));
-    Row person = std::make_tuple(std::string("Scott"), std::string("Washington, DC"), 42);
-    sess << "INSERT INTO Person(name, address, age) VALUES (?, ?, ?)", use(person), now;
-    std::vector<Row> rows;
-    sess << "SELECT name, address, age FROM Person", into(rows) , now;
+	Session sess(SessionFactory::instance().create("test", "cs"));
+	Row person = std::make_tuple(std::string("Scott"), std::string("Washington, DC"), 42);
+	sess << "INSERT INTO Person(name, address, age) VALUES (?, ?, ?)", use(person), now;
+	std::vector<Row> rows;
+	sess << "SELECT name, address, age FROM Person", into(rows) , now;
 }
 
 #endif // __cplusplus >= 201103L
@@ -1450,9 +1450,9 @@ CppUnit::Test* DataTest::suite()
 	CppUnit_addTest(pSuite, DataTest, testSimpleRowFormatter);
 	CppUnit_addTest(pSuite, DataTest, testJSONRowFormatter);
 	CppUnit_addTest(pSuite, DataTest, testDateAndTime);
-    CppUnit_addTest(pSuite, DataTest, testExternalBindingAndExtraction);
+	CppUnit_addTest(pSuite, DataTest, testExternalBindingAndExtraction);
 #if __cplusplus >= 201103L
-    CppUnit_addTest(pSuite, DataTest, testStdTuple);
+	CppUnit_addTest(pSuite, DataTest, testStdTuple);
 #endif
 
 

--- a/Data/testsuite/src/DataTest.h
+++ b/Data/testsuite/src/DataTest.h
@@ -47,6 +47,10 @@ public:
 	void testDateAndTime();
 	void testExternalBindingAndExtraction();
 
+#if __cplusplus >= 201103L
+    void testStdTuple();
+#endif
+
 	void setUp();
 	void tearDown();
 

--- a/Data/testsuite/src/DataTest.h
+++ b/Data/testsuite/src/DataTest.h
@@ -48,7 +48,7 @@ public:
 	void testExternalBindingAndExtraction();
 
 #if __cplusplus >= 201103L
-    void testStdTuple();
+	void testStdTuple();
 #endif
 
 	void setUp();


### PR DESCRIPTION
This allows to use std::tuple instead of Poco::Tuple for SQL statements. 

I use this code in an in-house project. It was written mainly to support tables that have more than 20 columns (and to make use of C++ 11 features wherever it makes sense). It is tested on MacOS and Linux.

The code is visible only if compiled in C++ 11 mode.