### PR TITLE
Fix compile errors on Cygwin and VS2013 fo pcre

### DIFF
--- a/Foundation/src/RegularExpression.cpp
+++ b/Foundation/src/RegularExpression.cpp
@@ -49,14 +49,14 @@ RegularExpression::RegularExpression(const std::string& pattern, int options, bo
 	if (study)
 		_extra = pcre_study(reinterpret_cast<pcre*>(_pcre), 0, &error);
 
-	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMECOUNT, &nmcount);
-	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMEENTRYSIZE, &nmentrysz);
-	pcre_fullinfo(_pcre, _extra, PCRE_INFO_NAMETABLE, &nmtbl);
+	pcre_fullinfo(reinterpret_cast<const pcre*>(_pcre), reinterpret_cast<const pcre_extra*>(_extra), PCRE_INFO_NAMECOUNT, &nmcount);
+	pcre_fullinfo(reinterpret_cast<const pcre*>(_pcre), reinterpret_cast<const pcre_extra*>(_extra), PCRE_INFO_NAMEENTRYSIZE, &nmentrysz);
+	pcre_fullinfo(reinterpret_cast<const pcre*>(_pcre), reinterpret_cast<const pcre_extra*>(_extra), PCRE_INFO_NAMETABLE, &nmtbl);
 
 	for (int i = 0; i < nmcount; i++)
 	{
 		unsigned char* group = nmtbl + 2 + (nmentrysz * i);
-		int n = pcre_get_stringnumber(_pcre, (char*) group);
+		int n = pcre_get_stringnumber(reinterpret_cast<const pcre*>(_pcre), (char*) group);
 		_groups[n] = std::string((char*) group);
 	}
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,11 +97,11 @@ matrix:
 install:
   - if "%builder%"=="cygwin" (
     if "%platform%"=="Win32" (
-    C:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel -P libcrypt-devel))
+    C:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel -P libcrypt-devel))
     
   - if "%builder%"=="cygwin" (
     if "%platform%"=="x64" (   
-    C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel  -P libcrypt-devel))
+    C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel  -P libcrypt-devel))
   
   - set POCO_BASE=%CD%
   - set PATH=C:\ProgramData\chocolatey\bin;%PATH%


### PR DESCRIPTION
Hi

This PR provides fixes for compiling RegularExpression.cpp without errors on Cygwin and VS2013. Moreover, it adds the downloading of libpcre-devel for Cygwin on AppVeyor.