### PR TITLE
Fix always true condition, possible out-of-bounds

### DIFF
--- a/Net/src/ICMPv4PacketImpl.cpp
+++ b/Net/src/ICMPv4PacketImpl.cpp
@@ -234,7 +234,7 @@ std::string ICMPv4PacketImpl::errorDescription(unsigned char* buffer, int length
 		break;
 
 	case TIME_EXCEEDED_TYPE:
-		if (code >= TIME_TO_LIVE || code < TIME_EXCEEDED_UNKNOWN)
+		if (code >= TIME_TO_LIVE && code < TIME_EXCEEDED_UNKNOWN)
 			err << TIME_EXCEEDED_CODE[code];
 		else
 			err << TIME_EXCEEDED_CODE[TIME_EXCEEDED_UNKNOWN];


### PR DESCRIPTION
Conditional is supposed to be checking if code is in the range of TIME_EXCEEDED_CODE array. Instead, since an 'or' conditional is used, the statement will always be true as code (taken from a uint8_t) will always be greater than or equal to TIME_TO_LIVE (0).