### PR TITLE
Improve XDG Base Directory Specification implementation

### DIFF
--- a/Foundation/include/Poco/Path.h
+++ b/Foundation/include/Poco/Path.h
@@ -304,11 +304,6 @@ public:
 		/// On Unix systems, this is the '~/.local/share/'. On Windows systems,
 		/// this is '%APPDATA%'.
 		
-	static std::string tempHome();
-		/// Returns the user's temp directory.
-		///
-		/// On Unix systems, this is the '~/.local/temp/'.
-		
 	static std::string cacheHome();
 		/// Returns the user's cache directory.
 		///

--- a/Foundation/include/Poco/Path_UNIX.h
+++ b/Foundation/include/Poco/Path_UNIX.h
@@ -34,7 +34,6 @@ public:
 	static std::string homeImpl();
 	static std::string configHomeImpl();
 	static std::string dataHomeImpl();
-	static std::string tempHomeImpl();
 	static std::string cacheHomeImpl();
 	static std::string tempImpl();
 	static std::string configImpl();

--- a/Foundation/include/Poco/Path_WIN32.h
+++ b/Foundation/include/Poco/Path_WIN32.h
@@ -35,7 +35,6 @@ public:
 	static std::string configHomeImpl();
 	static std::string dataHomeImpl();
 	static std::string cacheHomeImpl();
-	static std::string tempHomeImpl();
 	static std::string tempImpl();
 	static std::string configImpl();
 	static std::string nullImpl();

--- a/Foundation/include/Poco/Path_WIN32U.h
+++ b/Foundation/include/Poco/Path_WIN32U.h
@@ -35,7 +35,6 @@ public:
 	static std::string configHomeImpl();
 	static std::string dataHomeImpl();
 	static std::string cacheHomeImpl();
-	static std::string tempHomeImpl();
 	static std::string tempImpl();
 	static std::string configImpl();
 	static std::string nullImpl();

--- a/Foundation/include/Poco/Path_WINCE.h
+++ b/Foundation/include/Poco/Path_WINCE.h
@@ -35,7 +35,6 @@ public:
   static std::string configHomeImpl();
   static std::string dataHomeImpl();
   static std::string cacheHomeImpl();
-  static std::string tempHomeImpl();
   static std::string tempImpl();
   static std::string configImpl();
   static std::string nullImpl();

--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -615,16 +615,6 @@ std::string Path::dataHome()
 }
 
 	
-std::string Path::tempHome()
-{
-#if defined(POCO_OS_FAMILY_UNIX) || defined(POCO_OS_FAMILY_WINDOWS)
-	return PathImpl::tempHomeImpl();
-#else
-	return PathImpl::tempImpl();
-#endif
-}
-
-	
 std::string Path::cacheHome()
 {
 #if defined(POCO_OS_FAMILY_UNIX) || defined(POCO_OS_FAMILY_WINDOWS)

--- a/Foundation/src/Path_UNIX.cpp
+++ b/Foundation/src/Path_UNIX.cpp
@@ -81,15 +81,23 @@ std::string PathImpl::configHomeImpl()
 {
 #if defined(POCO_VXWORKS)
 	return PathImpl::homeImpl();
-#else
+#elif POCO_OS == POCO_OS_MAC_OS_X
 	std::string path = PathImpl::homeImpl();
 	std::string::size_type n = path.size();
 	if (n > 0 && path[n - 1] == '/') 
-#if POCO_OS == POCO_OS_MAC_OS_X
-	  path.append("Library/Preferences/");
+		path.append("Library/Preferences/");
+	return path;
 #else
-	  path.append(".config/");
-#endif
+	std::string path;
+	if (EnvironmentImpl::hasImpl("XDG_CONFIG_HOME"))
+		path = EnvironmentImpl::getImpl("XDG_CONFIG_HOME");
+	if (!path.empty())
+		return path;
+
+	path = PathImpl::homeImpl();
+	std::string::size_type n = path.size();
+	if (n > 0 && path[n - 1] == '/')
+		path.append(".config/");
 
 	return path;
 #endif
@@ -100,15 +108,23 @@ std::string PathImpl::dataHomeImpl()
 {
 #if defined(POCO_VXWORKS)
 	return PathImpl::homeImpl();
-#else
+#elif POCO_OS == POCO_OS_MAC_OS_X
 	std::string path = PathImpl::homeImpl();
 	std::string::size_type n = path.size();
 	if (n > 0 && path[n - 1] == '/') 
-#if POCO_OS == POCO_OS_MAC_OS_X
-	  path.append("Library/Application Support/");
+		path.append("Library/Application Support/");
+	return path;
 #else
-	  path.append(".local/share/");
-#endif
+	std::string path;
+	if (EnvironmentImpl::hasImpl("XDG_DATA_HOME"))
+		path = EnvironmentImpl::getImpl("XDG_DATA_HOME");
+	if (!path.empty())
+		return path;
+
+	path = PathImpl::homeImpl();
+	std::string::size_type n = path.size();
+	if (n > 0 && path[n - 1] == '/')
+		path.append(".local/share/");
 
 	return path;
 #endif
@@ -119,34 +135,23 @@ std::string PathImpl::cacheHomeImpl()
 {
 #if defined(POCO_VXWORKS)
 	return PathImpl::tempImpl();
-#else
+#elif POCO_OS == POCO_OS_MAC_OS_X
 	std::string path = PathImpl::homeImpl();
 	std::string::size_type n = path.size();
 	if (n > 0 && path[n - 1] == '/') 
-#if POCO_OS == POCO_OS_MAC_OS_X
-	  path.append("Library/Caches/");
-#else
-	  path.append(".cache/");
-#endif
-
+		path.append("Library/Caches/");
 	return path;
-#endif
-}
-
-
-std::string PathImpl::tempHomeImpl()
-{
-#if defined(POCO_VXWORKS)
-	return PathImpl::tempImpl();
 #else
-	std::string path = PathImpl::homeImpl();
+	std::string path;
+	if (EnvironmentImpl::hasImpl("XDG_CACHE_HOME"))
+		path = EnvironmentImpl::getImpl("XDG_CACHE_HOME");
+	if (!path.empty())
+		return path;
+
+	path = PathImpl::homeImpl();
 	std::string::size_type n = path.size();
-	if (n > 0 && path[n - 1] == '/') 
-#if POCO_OS == POCO_OS_MAC_OS_X
-	  path.append("Library/Caches/");
-#else
-	  path.append(".local/tmp/");
-#endif
+	if (n > 0 && path[n - 1] == '/')
+		path.append(".cache/");
 
 	return path;
 #endif

--- a/Foundation/src/Path_WIN32.cpp
+++ b/Foundation/src/Path_WIN32.cpp
@@ -124,12 +124,6 @@ std::string PathImpl::cacheHomeImpl()
 }
 
 
-std::string PathImpl::tempHomeImpl()
-{
-	return tempImpl();
-}
-
-
 std::string PathImpl::tempImpl()
 {
 	char buffer[MAX_PATH];

--- a/Foundation/src/Path_WIN32U.cpp
+++ b/Foundation/src/Path_WIN32U.cpp
@@ -134,12 +134,6 @@ std::string PathImpl::cacheHomeImpl()
 }
 
 
-std::string PathImpl::tempHomeImpl()
-{
-	return tempImpl();
-}
-
-
 std::string PathImpl::tempImpl()
 {
 	Buffer<wchar_t> buffer(MAX_PATH_LEN);

--- a/Foundation/src/Path_WINCE.cpp
+++ b/Foundation/src/Path_WINCE.cpp
@@ -56,12 +56,6 @@ std::string PathImpl::cacheHomeImpl()
 }
 
 
-std::string PathImpl::tempHomeImpl()
-{
-  return tempImpl();
-}
-
-
 std::string PathImpl::configImpl()
 {
   return("\\");

--- a/Util/include/Poco/Util/SystemConfiguration.h
+++ b/Util/include/Poco/Util/SystemConfiguration.h
@@ -44,7 +44,6 @@ class Util_API SystemConfiguration: public AbstractConfiguration
 	///   - system.configHomeDir: the base directory relative to which user specific configuration files should be stored
 	///   - system.cacheHomeDir: the base directory relative to which user specific non-essential data files should be stored
 	///   - system.dataHomeDir: the base directory relative to which user specific data files should be stored
-	///   - system.tempHomeDir: the base directory relative to which user-specific temporary files and other file objects should be placed
 	///   - system.tempDir: the system's temporary directory
 	///   - system.configDir: the system's configuration directory
 	///   - system.dateTime: the current UTC date and time, formatted in ISO 8601 format.
@@ -84,7 +83,6 @@ private:
 	static const std::string CONFIGHOMEDIR;
 	static const std::string CACHEHOMEDIR;
 	static const std::string DATAHOMEDIR;
-	static const std::string TEMPHOMEDIR;
 	static const std::string TEMPDIR;
 	static const std::string CONFIGDIR;
 	static const std::string DATETIME;

--- a/Util/src/Application.cpp
+++ b/Util/src/Application.cpp
@@ -170,7 +170,6 @@ void Application::init()
 	_pConfig->setString("application.dir", appPath.parent().toString());
 	_pConfig->setString("application.configDir", Path::configHome() + appPath.getBaseName() + Path::separator());
 	_pConfig->setString("application.cacheDir", Path::cacheHome() + appPath.getBaseName() + Path::separator());
-	_pConfig->setString("application.tempDir", Path::tempHome() + appPath.getBaseName() + Path::separator());
 	_pConfig->setString("application.dataDir", Path::dataHome() + appPath.getBaseName() + Path::separator());
 	processOptions();
 }

--- a/Util/src/SystemConfiguration.cpp
+++ b/Util/src/SystemConfiguration.cpp
@@ -46,7 +46,6 @@ const std::string SystemConfiguration::HOMEDIR        = "system.homeDir";
 const std::string SystemConfiguration::CONFIGHOMEDIR  = "system.configHomeDir";
 const std::string SystemConfiguration::CACHEHOMEDIR   = "system.cacheHomeDir";
 const std::string SystemConfiguration::DATAHOMEDIR    = "system.dataHomeDir";
-const std::string SystemConfiguration::TEMPHOMEDIR    = "system.tempHomeDir";
 const std::string SystemConfiguration::TEMPDIR        = "system.tempDir";
 const std::string SystemConfiguration::CONFIGDIR      = "system.configDir";
 const std::string SystemConfiguration::DATETIME       = "system.dateTime";
@@ -125,10 +124,6 @@ bool SystemConfiguration::getRaw(const std::string& key, std::string& value) con
 	{
 		value = Path::dataHome();
 	}
-	else if (key == TEMPHOMEDIR)
-	{
-		value = Path::tempHome();
-	}
 	else if (key == TEMPDIR)
 	{
 		value = Path::temp();
@@ -181,7 +176,6 @@ void SystemConfiguration::enumerate(const std::string& key, Keys& range) const
 		range.push_back("configHomeDir");
 		range.push_back("cacheHomeDir");
 		range.push_back("dataHomeDir");
-		range.push_back("tempHomeDir");
 		range.push_back("tempDir");
 		range.push_back("configDir");
 		range.push_back("dateTime");

--- a/Util/testsuite/src/SystemConfigurationTest.cpp
+++ b/Util/testsuite/src/SystemConfigurationTest.cpp
@@ -99,7 +99,6 @@ void SystemConfigurationTest::testKeys()
 	assert (std::find(keys.begin(), keys.end(), "configHomeDir") != keys.end());
 	assert (std::find(keys.begin(), keys.end(), "cacheHomeDir") != keys.end());
 	assert (std::find(keys.begin(), keys.end(), "dataHomeDir") != keys.end());
-	assert (std::find(keys.begin(), keys.end(), "tempHomeDir") != keys.end());
 	assert (std::find(keys.begin(), keys.end(), "tempDir") != keys.end());
 	assert (std::find(keys.begin(), keys.end(), "configDir") != keys.end());
 	assert (std::find(keys.begin(), keys.end(), "dateTime") != keys.end());


### PR DESCRIPTION
This builds upon #561 .

---

The XDG Base Directory Specification requires that the end user can specify a custom location for their config, data, and cache directories, simply by changing the values of three environment variables (XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME). In case any of those is unset or empty, its default should be used.

#561 implements the spec only partially: it always returns the default values (~/.config, ~/.local/share, ~/.cache), regardless of the values of the aforementioned environment variables.

**This PR implements the missing functionality.**

---

Furthermore, #561 added the concept of a userwide temporary directory. This concept does not exist in the XDG Base Dir Spec. I have personally never seen such a thing on any of the unix systems I have used either. If the application wants a real temp dir, it should use /tmp, which is automatically cleared on reboot. Otherwise it should use the cache dir (or, if it really wants system-wide persistent temp, it may use /var/tmp).

#561 defined this userwide temp to be ~/.local/tmp on unixes (and equal to the normal temp on other systems), but I find this to be a bad idea, because on the one hand it is not standard, and on the other hand, it is not automatically cleared, and thus would become a place that slowly fills up the disk with garbage (for those semantics, use the cache dir instead).

Based on this reasoning, **this PR removes the Poco::Path::tempHome() function and its implementation**.