### PR TITLE
Fix typos in comments, documentation and strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -128,7 +128,7 @@ Release 1.5.3 (2014-06-30)
 - Add extern "C" around <net/if.h> on HPUX platform.
 - added runtests.sh
 - fixed CPPUNIT_IGNORE parsing
-- fixed Glob from start path, for platforms not alowing transverse from root (Android)
+- fixed Glob from start path, for platforms not allowing transverse from root (Android)
 - added NTPClient (Rangel Reale)
 - added PowerShell build script
 - added SmartOS build support
@@ -991,7 +991,7 @@ Release 1.4.0 (2010-12-14)
 - Added Poco::Nullable class template.
 - Added Poco::NullMutex, a no-op mutex to be used as template argument for template classes
   taking a mutex policy argument.
-- Poco::XML::XMLWriter: fixed a namespace handling issue that occured with startPrefixMapping() and endPrefixMapping()
+- Poco::XML::XMLWriter: fixed a namespace handling issue that occurred with startPrefixMapping() and endPrefixMapping()
 - Poco::Net::Context now allows for loading certificates and private keys from Poco::Crypto::X509Certificate objects 
   and Poco::Crypto::RSAKey objects.
 - Poco::Crypto::RSAKey no longer uses temporary files for stream operations. Memory buffers are used instead.
@@ -1208,7 +1208,7 @@ Release 1.3.6 (2009-11-24)
 - fixed SF# 2828401: Deadlock in SocketReactor/NotificationCenter (also fixes patch# 1956490)
   NotificationCenter now uses a std::vector internally instead of a std::list, and the mutex is
   no longer held while notifications are sent to observers.
-- fixed SF# 2835206: File_WIN32 not checking aganist INVALID_HANDLE_VALUE
+- fixed SF# 2835206: File_WIN32 not checking against INVALID_HANDLE_VALUE
 - fixed SF# 2841812: Posix ThreadImpl::sleepImpl throws exceptions on EINTR
 - fixed SF# 2839579: simple DoS for SSL TCPServer, HTTPS server
   No SSL handshake is performed during accept() - the handshake is delayed until
@@ -1805,7 +1805,7 @@ Release 1.2.5 (2006-10-23)
 - XML now compiles with -DXML_UNICODE_WCHAR_T (SF# 1575174)
 - fixed SF# 1572757: HTML forms can have more than one key/value pair with the same name
 - got rid of the dynamic casts in Events, Events/Cache: simpler/faster Delegate < operator, 
-  prevents some rare dynamic casts error from occuring when using StrategyCollection with Caches
+  prevents some rare dynamic casts error from occurring when using StrategyCollection with Caches
 - improvements to Logger and LoggingConfigurator:
   * added Logger::unsafeGet()
   * added Logger::setProperty(loggerName, propertyName, value)
@@ -2066,7 +2066,7 @@ Release 1.0b1 (2006-01-09)
 Release 1.0a1 (2006-01-03) [internal]
 =====================================
 
-- mediaType is used consistently to refer to a MIME media type (some occurences of contentType and mimeType have been replaced)
+- mediaType is used consistently to refer to a MIME media type (some occurrences of contentType and mimeType have been replaced)
 - moved MediaType::quote() to MessageHeader and made it public
 - added MultipartWriter::stream()
 - Renamed AttachmentSource to PartSource and AttachmentHandler to PartHandler
@@ -2180,7 +2180,7 @@ Relesae 0.95.1 (2005-10-15) [internal]
 - Socket classes use Timespan::useconds() to fill struct timeval
 - added DatagramSocket, MulticastSocket and NetworkInterface classes
 - added socket classes and related basic stuff
-- added additonal constructor/assign to Timespan- added BasicBufferedBidirectionalStreamBuf
+- added additional constructor/assign to Timespan- added BasicBufferedBidirectionalStreamBuf
 - fixed a potential MT issue in Base64Decoder
 - code beautifying in [Un]BufferedStreamBuf
 - more improvements to ClassLoader

--- a/CppParser/include/Poco/CppParser/CppParser.h
+++ b/CppParser/include/Poco/CppParser/CppParser.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the CppParser_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// CppParser_API functions as being imported from a DLL, wheras this DLL sees symbols
+// CppParser_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if (defined(_WIN32) || defined(__CYGWIN__)) && defined(POCO_DLL)

--- a/CppUnit/include/Poco/CppUnit/CppUnit.h
+++ b/CppUnit/include/Poco/CppUnit/CppUnit.h
@@ -24,7 +24,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Poco_CppUnitEXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// CppUnit_API functions as being imported from a DLL, wheras this DLL sees symbols
+// CppUnit_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Crypto/include/Poco/Crypto/Crypto.h
+++ b/Crypto/include/Poco/Crypto/Crypto.h
@@ -57,7 +57,7 @@ enum RSAPaddingMode
 // from a DLL simpler. All files within this DLL are compiled with the Crypto_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Crypto_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Crypto_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32)

--- a/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
@@ -28,7 +28,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the ODBC_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// ODBC_API functions as being imported from a DLL, wheras this DLL sees symbols
+// ODBC_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Data/ODBC/include/Poco/Data/ODBC/ODBC.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBC.h
@@ -33,7 +33,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the ODBC_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// ODBC_API functions as being imported from a DLL, wheras this DLL sees symbols
+// ODBC_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQL.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQL.h
@@ -28,7 +28,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the ODBC_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// ODBC_API functions as being imported from a DLL, wheras this DLL sees symbols
+// ODBC_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/StatementExecutor.h
@@ -58,7 +58,7 @@ public:
 		/// Prepares the statement for execution.
 
 	void bindParams(const InputParameterVector& anInputParameterVector);
-		/// Binds the params - REQUIRED if the statment has input parameters/placeholders
+		/// Binds the params - REQUIRED if the statement has input parameters/placeholders
 		/// Pointer and list elements must stay valid for the lifetime of the StatementExecutor!
 
 	void execute();

--- a/Data/PostgreSQL/src/SessionImpl.cpp
+++ b/Data/PostgreSQL/src/SessionImpl.cpp
@@ -199,7 +199,7 @@ SessionImpl::begin()
 void
 SessionImpl::commit()
 {
-	// Not an error to issue a COMMIT without a preceeding BEGIN
+	// Not an error to issue a COMMIT without a preceding BEGIN
 	_sessionHandle.commit();
 }
 
@@ -207,7 +207,7 @@ SessionImpl::commit()
 void
 SessionImpl::rollback()
 {
-	// Not an error to issue a ROLLBACK without a preceeding BEGIN
+	// Not an error to issue a ROLLBACK without a preceding BEGIN
 	_sessionHandle.rollback();
 }
 

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -121,7 +121,7 @@ public:
 	static int sqliteCommitCallbackFn(void* pVal);
 		/// Commit callback event dispatcher. If an exception occurs, it is caught inside this function,
 		/// non-zero value is returned, which causes SQLite engine to turn commit into a rollback.
-		/// Therefore, callers should check for return value - if it is zero, callback completed successfuly
+		/// Therefore, callers should check for return value - if it is zero, callback completed successfully
 		/// and transaction was committed.
 
 	static void sqliteRollbackCallbackFn(void* pVal);

--- a/Data/SQLite/include/Poco/Data/SQLite/SQLite.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/SQLite.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the SQLite_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// SQLite_API functions as being imported from a DLL, wheras this DLL sees symbols
+// SQLite_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Data/SQLite/include/Poco/Data/SQLite/Utility.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Utility.h
@@ -60,7 +60,7 @@ public:
 		/// Adds or replaces the mapping for SQLite column type sqliteType 
 		/// to a Poco type pocoType.
 		/// 
-		/// sqliteType is a case-insensitive desription of the column type with
+		/// sqliteType is a case-insensitive description of the column type with
 		/// any value pocoType value but MetaColumn::FDT_UNKNOWN. 
 		/// A Poco::Data::NotSupportedException is thrown if pocoType is invalid.
 

--- a/Data/doc/00200-DataUserManual.page
+++ b/Data/doc/00200-DataUserManual.page
@@ -213,7 +213,7 @@ first into clause.
 
 !! Handling NULL entries
 A common case with databases are optional data fields that can contain NULL.
-To accomodate for NULL, use the Poco::Nullable template:
+To accommodate for NULL, use the Poco::Nullable template:
 
     std::string firstName("Peter";
     Poco::Nullable<std::string> lastName("Junior");
@@ -231,7 +231,7 @@ If the returned value was null, age.isNull() will return true. Whether empty
 string is null or not is more of a philosophical question (a topic for discussion
 in some other time and place); for the purpose of this document, suffice it to say 
 that different databases handle it differently and Poco::Data provides a way to 
-tweak it to user's needs through folowing <[Session]> features:
+tweak it to user's needs through following <[Session]> features:
 
   *emptyStringIsNull
   *forceEmptyString

--- a/Data/include/Poco/Data/Data.h
+++ b/Data/include/Poco/Data/Data.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Data_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Data_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Data_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Foundation/include/Poco/Foundation.h
+++ b/Foundation/include/Poco/Foundation.h
@@ -43,7 +43,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Foundation_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see 
-// Foundation_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Foundation_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if (defined(_WIN32) || defined(_WIN32_WCE)) && defined(POCO_DLL)

--- a/Foundation/include/Poco/ObjectPool.h
+++ b/Foundation/include/Poco/ObjectPool.h
@@ -41,7 +41,7 @@ class PoolableObjectFactory
 	/// a policy class to change the behavior of the ObjectPool when
 	/// creating new objects, returning used objects back to the pool
 	/// and destroying objects, when the pool itself is destroyed or
-	/// shrinked.
+	/// shrunk.
 {
 public:
 	P createObject()

--- a/Foundation/include/Poco/StringTokenizer.h
+++ b/Foundation/include/Poco/StringTokenizer.h
@@ -69,7 +69,7 @@ public:
 		/// Returns true if token exists, false otherwise.
 
 	std::string::size_type find(const std::string& token, std::string::size_type pos = 0) const;
-		/// Returns the index of the first occurence of the token
+		/// Returns the index of the first occurrence of the token
 		/// starting at position pos.
 		/// Throws a NotFoundException if the token is not found.
 

--- a/Foundation/src/double-conversion.h
+++ b/Foundation/src/double-conversion.h
@@ -96,7 +96,7 @@ class DoubleToStringConverter {
   // Example with max_leading_padding_zeroes_in_precision_mode = 6.
   //   ToPrecision(0.0000012345, 2) -> "0.0000012"
   //   ToPrecision(0.00000012345, 2) -> "1.2e-7"
-  // Similarily the converter may add up to
+  // Similarly the converter may add up to
   // max_trailing_padding_zeroes_in_precision_mode in precision mode to avoid
   // returning an exponential representation. A zero added by the
   // EMIT_TRAILING_ZERO_AFTER_POINT flag is counted for this limit.
@@ -242,7 +242,7 @@ class DoubleToStringConverter {
   // Example with max_leading_padding_zeroes_in_precision_mode = 6.
   //   ToPrecision(0.0000012345, 2) -> "0.0000012"
   //   ToPrecision(0.00000012345, 2) -> "1.2e-7"
-  // Similarily the converter may add up to
+  // Similarly the converter may add up to
   // max_trailing_padding_zeroes_in_precision_mode in precision mode to avoid
   // returning an exponential representation. A zero added by the
   // EMIT_TRAILING_ZERO_AFTER_POINT flag is counted for this limit.

--- a/Foundation/src/pcre_exec.c
+++ b/Foundation/src/pcre_exec.c
@@ -1041,7 +1041,7 @@ for (;;)
     the result of a recursive call to match() whatever happened so it was
     possible to reduce stack usage by turning this into a tail recursion,
     except in the case of a possibly empty group. However, now that there is
-    the possiblity of (*THEN) occurring in the final alternative, this
+    the possibility of (*THEN) occurring in the final alternative, this
     optimization is no longer always possible.
 
     We can optimize if we know there are no (*THEN)s in the pattern; at present

--- a/Foundation/src/pcre_jit_compile.c
+++ b/Foundation/src/pcre_jit_compile.c
@@ -6425,7 +6425,7 @@ switch(type)
   if (common->mode == JIT_PARTIAL_HARD_COMPILE)
     {
     jump[0] = CMP(SLJIT_LESS, STR_PTR, 0, STR_END, 0);
-    /* Since we successfully read a char above, partial matching must occure. */
+    /* Since we successfully read a char above, partial matching must occur. */
     check_partial(common, TRUE);
     JUMPHERE(jump[0]);
     }

--- a/Foundation/wcelibcex-1.0/BUILD.txt
+++ b/Foundation/wcelibcex-1.0/BUILD.txt
@@ -35,7 +35,7 @@ Building the library
 
 1. Go to 'msvc80' directory
 2. Open 'wcelibcex_lib.sln' project in Visual C++ 2005 IDE
-3. From the main toolbar, select prefered 'Solution Configuration'
+3. From the main toolbar, select preferred 'Solution Configuration'
    and 'Solution Platform'
 4. Run Build -> Build Solution
-5. If no errors occured, the library is ready to use
+5. If no errors occurred, the library is ready to use

--- a/Foundation/wcelibcex-1.0/src/wce_mktime.c
+++ b/Foundation/wcelibcex-1.0/src/wce_mktime.c
@@ -111,7 +111,7 @@ static time_t __wceex_mktime_internal(struct tm *tmbuff, time_t _loctime_offset)
         return (time_t) -1;
     }
 
-    /* Convert calender time to a time_t value. */
+    /* Convert calendar time to a time_t value. */
     tres = 0;
 
     /* Sum total amount of days from the Epoch with respect to leap years. */

--- a/JSON/include/Poco/JSON/JSON.h
+++ b/JSON/include/Poco/JSON/JSON.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the JSON_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// JSON_API functions as being imported from a DLL, wheras this DLL sees symbols
+// JSON_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/MongoDB/include/Poco/MongoDB/MongoDB.h
+++ b/MongoDB/include/Poco/MongoDB/MongoDB.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the MongoDB_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// MongoDB_API functions as being imported from a DLL, wheras this DLL sees symbols
+// MongoDB_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 

--- a/MongoDB/include/Poco/MongoDB/ObjectId.h
+++ b/MongoDB/include/Poco/MongoDB/ObjectId.h
@@ -49,7 +49,7 @@ public:
 	explicit ObjectId(const std::string& id);
 		/// Creates an ObjectId from a string. 
 		///
-		/// The string must contain a hexidecimal representation
+		/// The string must contain a hexadecimal representation
 		/// of an object ID. This means a string of 24 characters.
 
 	ObjectId(const ObjectId& copy);

--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Net_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Net_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Net_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Net/samples/HTTPLoadTest/src/HTTPLoadTest.cpp
+++ b/Net/samples/HTTPLoadTest/src/HTTPLoadTest.cpp
@@ -188,7 +188,7 @@ void HTTPClient::printStats(std::string uri, int repetitions, int success, Poco:
 	std::cout << std::endl << "--------------" << std::endl 
 		<< "Statistics for " << uri << std::endl << "--------------" 
 		<< std::endl
-		<< repetitions << " attempts, " << success << " succesful (" 
+		<< repetitions << " attempts, " << success << " successful (" 
 		<<  ((float) success / (float) repetitions) * 100.0 << "%)" << std::endl
 		<< "Avg response time: " << ((float) usec / (float) repetitions) / 1000.0 << "ms, " << std::endl
 		<< "Avg requests/second handled: " << ((float) success  /((float) usec / 1000000.0)) << std::endl

--- a/Net/src/MessageHeader.cpp
+++ b/Net/src/MessageHeader.cpp
@@ -330,7 +330,7 @@ void MessageHeader::decodeRFC2047(const std::string& ins, std::string& outs, con
 	}
 	else 
 	{
-		// Not conversion necesary.
+		// Not conversion necessary.
 		outs = tempout;
 	}
 }
@@ -341,7 +341,7 @@ std::string MessageHeader::decodeWord(const std::string& text, const std::string
 	std::string outs, tmp = text;
 	do {
 		std::string tmp2;
-		// find the begining of the next rfc2047 chunk 
+		// find the beginning of the next rfc2047 chunk
 		size_t pos = tmp.find("=?");
 		if (pos == std::string::npos) {
 			// No more found, return

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -1200,7 +1200,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 					bool hasBroadcast = (pAddress->IfType == IF_TYPE_ETHERNET_CSMACD) || (pAddress->IfType == IF_TYPE_SOFTWARE_LOOPBACK) || (pAddress->IfType == IF_TYPE_IEEE80211);
 					if (hasBroadcast)
 					{
-						// On Windows, a valid broadcast address will be all 1's (== address | ~subnetMask); additionaly, on pre-Vista versions of
+						// On Windows, a valid broadcast address will be all 1's (== address | ~subnetMask); additionally, on pre-Vista versions of
 						// OS, master address structure does not contain member for prefix length; we go an extra mile here in order to make sure
 						// we reflect the actual values held by system and protect against misconfiguration (e.g. bad DHCP config entry)
 						ULONG prefixLength = 0;

--- a/NetSSL_OpenSSL/include/Poco/Net/NetSSL.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/NetSSL.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the NetSSL_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// NetSSL_API functions as being imported from a DLL, wheras this DLL sees symbols
+// NetSSL_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if (defined(_WIN32) || defined(__CYGWIN__)) && defined(POCO_DLL)

--- a/NetSSL_Win/include/Poco/Net/NetSSL.h
+++ b/NetSSL_Win/include/Poco/Net/NetSSL.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the NetSSL_Win_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// NetSSL_Win_API functions as being imported from a DLL, wheras this DLL sees symbols
+// NetSSL_Win_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if (defined(_WIN32) || defined(__CYGWIN__)) && defined(POCO_DLL)

--- a/PDF/include/Poco/PDF/PDF.h
+++ b/PDF/include/Poco/PDF/PDF.h
@@ -39,7 +39,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the PDF_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// PDF_API functions as being imported from a DLL, wheras this DLL sees symbols
+// PDF_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/PDF/include/Poco/PDF/deflate.h
+++ b/PDF/include/Poco/PDF/deflate.h
@@ -188,7 +188,7 @@ typedef struct internal_state {
     int nice_match; /* Stop searching when current match exceeds this */
 
                 /* used by trees.c: */
-    /* Didn't use ct_data typedef below to supress compiler warning */
+    /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */
     struct ct_data_s dyn_dtree[2*D_CODES+1]; /* distance tree */
     struct ct_data_s bl_tree[2*BL_CODES+1];  /* Huffman tree for bit lengths */

--- a/PDF/include/Poco/PDF/hpdf_font.h
+++ b/PDF/include/Poco/PDF/hpdf_font.h
@@ -69,7 +69,7 @@ typedef struct _HPDF_FontAttr_Rec {
     HPDF_Encoder                encoder;
 
     /* if the encoding-type is HPDF_ENCODER_TYPE_SINGLE_BYTE, the width of
-     * each charactors are cashed in 'widths'.
+     * each characters are cashed in 'widths'.
      * when HPDF_ENCODER_TYPE_DOUBLE_BYTE the width is calculate each time.
      */
     HPDF_INT16*                 widths;

--- a/PDF/include/Poco/PDF/png.h
+++ b/PDF/include/Poco/PDF/png.h
@@ -911,7 +911,7 @@ defined(PNG_READ_BACKGROUND_SUPPORTED)
    /* The sCAL chunk describes the actual physical dimensions of the
     * subject matter of the graphic.  The chunk contains a unit specification
     * a byte value, and two ASCII strings representing floating-point
-    * values.  The values are width and height corresponsing to one pixel
+    * values.  The values are width and height corresponding to one pixel
     * in the image.  This external representation is converted to double
     * here.  Data values are valid if (valid & PNG_INFO_sCAL) is non-zero.
     */

--- a/PDF/include/Poco/PDF/pngconf.h
+++ b/PDF/include/Poco/PDF/pngconf.h
@@ -829,7 +829,7 @@
 */
 
 /* Any chunks you are not interested in, you can undef here.  The
- * ones that allocate memory may be expecially important (hIST,
+ * ones that allocate memory may be especially important (hIST,
  * tEXt, zTXt, tRNS, pCAL).  Others will just save time and make png_info
  * a bit smaller.
  */

--- a/PDF/src/gzio.c
+++ b/PDF/src/gzio.c
@@ -256,7 +256,7 @@ int ZEXPORT gzsetparams (file, level, strategy)
 /* ===========================================================================
      Read a byte from a gz_stream; update next_in and avail_in. Return EOF
    for end of file.
-   IN assertion: the stream s has been sucessfully opened for reading.
+   IN assertion: the stream s has been successfully opened for reading.
 */
 local int get_byte(s)
     gz_stream *s;
@@ -281,7 +281,7 @@ local int get_byte(s)
     mode to transparent if the gzip magic header is not present; set s->err
     to Z_DATA_ERROR if the magic header is present but the rest of the header
     is incorrect.
-    IN assertion: the stream s has already been created sucessfully;
+    IN assertion: the stream s has already been created successfully;
        s->stream.avail_in is zero for the first time, but may be non-zero
        for concatenated .gz files.
 */

--- a/PDF/src/hpdf_encoder.c
+++ b/PDF/src/hpdf_encoder.c
@@ -2573,7 +2573,7 @@ HPDF_CMapEncoder_InitAttr  (HPDF_Encoder  encoder)
 
     for (i = 0; i <= 255; i++) {
         for (j = 0; j <= 255; j++) {
-            /* undefined charactors are replaced to square */
+            /* undefined characters are replaced to square */
             encoder_attr->unicode_map[i][j] = 0x25A1;
         }
     }

--- a/PDF/src/hpdf_fontdef_type1.c
+++ b/PDF/src/hpdf_fontdef_type1.c
@@ -401,7 +401,7 @@ HPDF_Type1FontDef_Load  (HPDF_MMgr         mmgr,
         return NULL;
     }
 
-    /* if font-data is specified, the font data is embeded */
+    /* if font-data is specified, the font data is embedded */
     if (font_data) {
         ret = LoadFontData (fontdef, font_data);
         if (ret != HPDF_OK) {

--- a/PDF/src/hpdf_streams.c
+++ b/PDF/src/hpdf_streams.c
@@ -132,7 +132,7 @@ HPDF_Stream_Read  (HPDF_Stream  stream,
  *  s : Pointer to a buffer to copy read data.
  *  size : buffer-size of s.
  *
- *  Read from stream until the buffer is exhausted or line-feed charactor is
+ *  Read from stream until the buffer is exhausted or line-feed character is
  *  read.
  *
  */

--- a/PDF/src/hpdf_utils.c
+++ b/PDF/src/hpdf_utils.c
@@ -24,7 +24,7 @@ HPDF_AToI  (const char  *s)
     HPDF_BOOL flg = HPDF_FALSE;
     HPDF_INT  v = 0;
 
-    /* increment pointer until the charactor of 's' is not
+    /* increment pointer until the character of 's' is not
      * white-space-charactor.
      */
     while (*s) {
@@ -60,7 +60,7 @@ HPDF_AToF  (const char  *s)
     HPDF_DOUBLE v;
     HPDF_INT tmp = 1;
 
-    /* increment pointer until the charactor of 's' is not
+    /* increment pointer until the character of 's' is not
      * white-space-charactor.
      */
     while (*s) {

--- a/PDF/src/hpdf_xref.c
+++ b/PDF/src/hpdf_xref.c
@@ -142,7 +142,7 @@ HPDF_Xref_Add  (HPDF_Xref  xref,
     }
 
     /* in the following, we have to dispose the object when an error is
-     * occured.
+     * occurred.
      */
 
     entry = (HPDF_XrefEntry)HPDF_GetMem (xref->mmgr,

--- a/PDF/src/pngmem.c
+++ b/PDF/src/pngmem.c
@@ -327,7 +327,7 @@ png_free_default(png_structp png_ptr, png_voidp ptr)
 
 /* Allocate memory for a png_struct or a png_info.  The malloc and
    memset can be replaced by a single call to calloc() if this is thought
-   to improve performance noticably. */
+   to improve performance noticeably. */
 png_voidp /* PRIVATE */
 png_create_struct(int type)
 {
@@ -337,7 +337,7 @@ png_create_struct(int type)
 
 /* Allocate memory for a png_struct or a png_info.  The malloc and
    memset can be replaced by a single call to calloc() if this is thought
-   to improve performance noticably. */
+   to improve performance noticeably. */
 png_voidp /* PRIVATE */
 png_create_struct_2(int type, png_malloc_ptr malloc_fn, png_voidp mem_ptr)
 {

--- a/PDF/src/pngwutil.c
+++ b/PDF/src/pngwutil.c
@@ -466,7 +466,7 @@ png_write_IHDR(png_structp png_ptr, png_uint_32 width, png_uint_32 height,
    interlace_type=PNG_INTERLACE_NONE;
 #endif
 
-   /* save off the relevent information */
+   /* save off the relevant information */
    png_ptr->bit_depth = (png_byte)bit_depth;
    png_ptr->color_type = (png_byte)color_type;
    png_ptr->interlaced = (png_byte)interlace_type;

--- a/PageCompiler/samples/HTTPTimeServer/Makefile
+++ b/PageCompiler/samples/HTTPTimeServer/Makefile
@@ -28,7 +28,7 @@ ifdef POCO_UNBUNDLED
     SYSLIBS += -lz -lpcre -lexpat
 endif
 
-# Rule for runnning PageCompiler
+# Rule for running PageCompiler
 src/%.cpp: src/%.cpsp
 	@echo "** Compiling Page" $<
 	$(SET_LD_LIBRARY_PATH) $(PAGECOMPILER) $<

--- a/PocoDoc/resources/js/iframeResizer.contentWindow.js
+++ b/PocoDoc/resources/js/iframeResizer.contentWindow.js
@@ -187,7 +187,7 @@
 					resetIFrame('parentIFrame.size');
 				},
 				scrollTo: function scrollToF(x,y){
-					sendMsg(y,x,'scrollTo'); // X&Y reversed at sendMsg uses hieght/width
+					sendMsg(y,x,'scrollTo'); // X&Y reversed at sendMsg uses height/width
 				},
 				sendMessage: function sendMessageF(msg,targetOrigin){
 					sendMsg(0,0,'message',msg,targetOrigin);
@@ -379,11 +379,11 @@
 	}
 
 	var getHeight = {
-		offset                : getBodyOffsetHeight, //Backward compatability
+		offset                : getBodyOffsetHeight, //Backward compatibility
 		bodyOffset            : getBodyOffsetHeight,
 		bodyScroll            : getBodyScrollHeight,
 		documentElementOffset : getDEOffsetHeight,
-		scroll                : getDEScrollHeight, //Backward compatability
+		scroll                : getDEScrollHeight, //Backward compatibility
 		documentElementScroll : getDEScrollHeight,
 		max                   : getMaxHeight,
 		min                   : getMinHeight,

--- a/Redis/include/Poco/Redis/Redis.h
+++ b/Redis/include/Poco/Redis/Redis.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Redis_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Redis_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Redis_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/SevenZip/include/Poco/SevenZip/SevenZip.h
+++ b/SevenZip/include/Poco/SevenZip/SevenZip.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the SevenZip_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// SevenZip_API functions as being imported from a DLL, wheras this DLL sees symbols
+// SevenZip_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Util/include/Poco/Util/Util.h
+++ b/Util/include/Poco/Util/Util.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Util_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Util_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Util_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/XML/include/Poco/XML/XML.h
+++ b/XML/include/Poco/XML/XML.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the XML_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see 
-// XML_API functions as being imported from a DLL, wheras this DLL sees symbols
+// XML_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Zip/include/Poco/Zip/Zip.h
+++ b/Zip/include/Poco/Zip/Zip.h
@@ -30,7 +30,7 @@
 // from a DLL simpler. All files within this DLL are compiled with the Zip_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// Zip_API functions as being imported from a DLL, wheras this DLL sees symbols
+// Zip_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && defined(POCO_DLL)

--- a/Zip/src/PartialStream.cpp
+++ b/Zip/src/PartialStream.cpp
@@ -194,7 +194,7 @@ int PartialStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 
 void PartialStreamBuf::close()
 {
-	// DONT write data from _buffer!
+	// DON'T write data from _buffer!
 }
 
 

--- a/doc/00100-GuidedTour.page
+++ b/doc/00100-GuidedTour.page
@@ -201,7 +201,7 @@ complete access to an XML
 document, using a tree-style object hierarchy. For this to work, the DOM
 parser provided by POCO has to load the entire document into memory. To
 reduce the memory footprint of the DOM document, the POCO DOM
-implementation uses string pooling, storing frequently occuring strings
+implementation uses string pooling, storing frequently occurring strings
 such as element and attribute names only once. The XML library is based
 on the Expat open source XML parser library (http://www.libexpat.org). 
 Built on top of Expat

--- a/doc/99100-ReleaseNotes.page
+++ b/doc/99100-ReleaseNotes.page
@@ -166,7 +166,7 @@ AAAIntroduction
   - Add extern "C" around <net/if.h> on HPUX platform.
   - added runtests.sh
   - fixed CPPUNIT_IGNORE parsing
-  - fixed Glob from start path, for platforms not alowing transverse from root (Android)
+  - fixed Glob from start path, for platforms not allowing transverse from root (Android)
   - added NTPClient (Rangel Reale)
   - added PowerShell build script
   - added SmartOS build support
@@ -1094,7 +1094,7 @@ AAAIntroduction
   - Added Poco::Nullable class template.
   - Added Poco::NullMutex, a no-op mutex to be used as template argument for template classes
     taking a mutex policy argument.
-  - Poco::XML::XMLWriter: fixed a namespace handling issue that occured with startPrefixMapping() and endPrefixMapping()
+  - Poco::XML::XMLWriter: fixed a namespace handling issue that occurred with startPrefixMapping() and endPrefixMapping()
   - Poco::Net::Context now allows for loading certificates and private keys from Poco::Crypto::X509Certificate objects 
     and Poco::Crypto::RSAKey objects.
   - Poco::Crypto::RSAKey no longer uses temporary files for stream operations. Memory buffers are used instead.
@@ -1346,7 +1346,7 @@ AAAIntroduction
   - fixed SF# 2828401: Deadlock in SocketReactor/NotificationCenter (also fixes patch# 1956490)
     NotificationCenter now uses a std::vector internally instead of a std::list, and the mutex is
     no longer held while notifications are sent to observers.
-  - fixed SF# 2835206: File_WIN32 not checking aganist INVALID_HANDLE_VALUE
+  - fixed SF# 2835206: File_WIN32 not checking against INVALID_HANDLE_VALUE
   - fixed SF# 2841812: Posix ThreadImpl::sleepImpl throws exceptions on EINTR
   - fixed SF# 2839579: simple DoS for SSL TCPServer, HTTPS server
     No SSL handshake is performed during accept() - the handshake is delayed until

--- a/doc/99150-GMakeBuildNotes.page
+++ b/doc/99150-GMakeBuildNotes.page
@@ -11,7 +11,7 @@ every other Unix platform, as well as Cygwin and MinGW on Windows.
 Why GNU Make? Well, GNU Make is available virtually everywhere
 and it's usually readily available, such as on Linux and Mac OS X. 
 Sure, there are more advanced build systems out there, but the 
-philisophy for POCO is download -- compile -- go. Requiring the user 
+philosophy for POCO is download -- compile -- go. Requiring the user
 to download and install another build tool just for getting 
 POCO to work is unacceptable.
 
@@ -780,37 +780,37 @@ an executable if compiling in 64 bit mode.
 
 !STATICOPT_CC
 
-<*STATICOPT_CC*> specifies additonal flags passed to the C compiler 
+<*STATICOPT_CC*> specifies additional flags passed to the C compiler
 if compiling for static linking.
 
 
 !STATICOPT_CXX
 
-<*STATICOPT_CXX*> specifies additonal flags passed to the C++ compiler if 
+<*STATICOPT_CXX*> specifies additional flags passed to the C++ compiler if
 compiling for static linking.
 
 
 !STATICOPT_LINK
 
-<*STATICOPT_LINK*> specifies additonal flags passed to the linker for 
+<*STATICOPT_LINK*> specifies additional flags passed to the linker for
 static linking.
 
 
 !SHAREDOPT_CC
 
-<*SHAREDOPT_CC*> specifies additonal flags passed to the C compiler 
+<*SHAREDOPT_CC*> specifies additional flags passed to the C compiler
 for dynamic linking.
 
 
 !SHAREDOPT_CXX
 
-<*SHAREDOPT_CXX*> specifies additonal flags passed to the C++ compiler if 
+<*SHAREDOPT_CXX*> specifies additional flags passed to the C++ compiler if
 compiling for dynamic linking.
 
 
 !SHAREDOPT_LINK
 
-<*SHAREDOPT_LINK*> specifies additonal flags passed to the linker for dynamic linking.
+<*SHAREDOPT_LINK*> specifies additional flags passed to the linker for dynamic linking.
 
 
 !DEBUGOPT_CC


### PR DESCRIPTION
All of them were found using codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>