### PR TITLE
fix build when using poll

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -473,7 +473,7 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 		}
 	}
 	while (rc < 0 && lastError() == POCO_EINTR);
-	if (rc < 0) error(errorCode);
+	if (rc < 0) error();
 	return rc > 0; 
 
 #else


### PR DESCRIPTION
This commit fixes build when POCO_HAVE_FD_POLL is defined and POCO_HAVE_FD_EPOLL is not defined. One such platform is FreeBSD. The problem is not present on the develop branch, only on the master branch.