### PR TITLE
Export Poco::Zip::ZipUtil class

### DIFF
--- a/Zip/include/Poco/Zip/ZipUtil.h
+++ b/Zip/include/Poco/Zip/ZipUtil.h
@@ -31,7 +31,7 @@ namespace Poco {
 namespace Zip {
 
 
-class ZipUtil
+class Zip_API ZipUtil
 	/// A utility class used for parsing header information inside of zip files
 {
 public:
@@ -51,7 +51,7 @@ public:
 
 	static void setDateTime(const Poco::DateTime& dt, char* pVal, const Poco::UInt32 timePos, const Poco::UInt32 datePos);
 
-	static std::string fakeZLibInitString(ZipCommon::CompressionLevel cl);
+	static std::string fakeZlibInitString(ZipCommon::CompressionLevel cl);
 
 	static void sync(std::istream& in);
 		/// Searches the next valid header in the input stream, stops right before it


### PR DESCRIPTION
HI

Add Zip_API to oco::Zip::ZipUtil class in order to export the static method Poco::ZLib::ZlibUtil::fakeZlibINputString

Otherwise one gets 
```
PartialStreamTest.obj : error LNK2019: symbole
externe non rÚsolu "public: static class std::string __cdecl
Poco::Zip::ZipUtil::fakeZLibInitString(enum
Poco::Zip::ZipCommon::CompressionLevel)

```