### PR TITLE
fix-unresolved-fakeZlibInitString

### DIFF
--- a/Zip/include/Poco/Zip/ZipUtil.h
+++ b/Zip/include/Poco/Zip/ZipUtil.h
@@ -31,7 +31,7 @@ namespace Poco {
 namespace Zip {
 
 
-class ZipUtil
+class Zip_API ZipUtil
 	/// A utility class used for parsing header information inside of zip files
 {
 public:


### PR DESCRIPTION
HI

Add Zip_API to Poco::Zip::ZipUtil class in order to export the static method Poco::ZLib::ZlibUtil::fakeZlibInputString

Otherwise one gets 
```
PartialStreamTest.obj : error LNK2019: symbole
externe non rÚsolu "public: static class std::string __cdecl
Poco::Zip::ZipUtil::fakeZLibInitString(enum
Poco::Zip::ZipCommon::CompressionLevel)

```