### PR TITLE
Update SystemConfigurationTest assert to match SystemCOnfiguration.size()

### DIFF
--- a/Util/testsuite/src/SystemConfigurationTest.cpp
+++ b/Util/testsuite/src/SystemConfigurationTest.cpp
@@ -84,9 +84,9 @@ void SystemConfigurationTest::testKeys()
 
 	pConf->keys("system", keys);
 #if defined(POCO_VXWORKS)
-	assert (keys.size() == 15);
+	assert (keys.size() == 14);
 #else
-	assert (keys.size() == 16);
+	assert (keys.size() == 15);
 #endif
 
 	assert (std::find(keys.begin(), keys.end(), "osName") != keys.end());


### PR DESCRIPTION
Update SystemConfigurationTest to avoid failure on assert(keys.size() == 16);