### PR TITLE
Fix corner square comparison (utf16Path.size() >= MAX_PATH - 12) 

### DIFF
--- a/Foundation/src/File_WIN32U.cpp
+++ b/Foundation/src/File_WIN32U.cpp
@@ -442,7 +442,7 @@ void FileImpl::handleLastErrorImpl(const std::string& path)
 void FileImpl::convertPath(const std::string& utf8Path, std::wstring& utf16Path)
 {
 	UnicodeConverter::toUTF16(utf8Path, utf16Path);
-	if (utf16Path.size() > MAX_PATH - 12) // Note: CreateDirectory has a limit of MAX_PATH - 12 (room for 8.3 file name)
+	if (utf16Path.size() >= MAX_PATH - 12) // Note: CreateDirectory has a limit of MAX_PATH - 12 (room for 8.3 file name)
 	{
 		if (utf16Path[0] == '\\' || utf16Path[1] == ':')
 		{


### PR DESCRIPTION
Fix corner square comparison (utf16Path.size() >= MAX_PATH - 12) instead of (utf16Path.size() > MAX_PATH - 12) to avoid
```
Z:\git\poco-develop>build\script\runtests2.cmd Foundation FileTest


****************************************
*** Foundation
****************************************


testCreateFile:
testFileAttributes1:
testFileAttributes2:
testFileAttributes3:
testCompare:
testSwap:
testSize:
testSpace:
testDirectory:
testCopy:
testMove:
testCopyDirectory:
testRename:
testRootDir:
testLongPath: ERROR

!!!FAILURES!!!
Runs: 15   Failures: 0   Errors: 1

There was 1 error:
 1: class CppUnit::TestCaller<class FileTest>.testLongPath
    "class Poco::PathSyntaxException: Bad path syntax"
    in "<unknown>", line -1



1 runs, 1 failed.

Failed: Foundation
```