### PR TITLE
Rollback fix #1605 since it breaks the unit test

### DIFF
--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -229,10 +229,15 @@ void SecureSocketImpl::shutdown()
 			// OpenSSL and/or browser versions, and things
 			// seem to work better now.
 			int rc = SSL_shutdown(_pSSL);
+#if FIXME
+			#1605: try to do a proper SSL_shutdown()
+			This fix for the issue above breaks the 
+			HTTPSClientSessionTest::testCachedSession() Unit test
 			if (rc == 0 && _pSocket->getBlocking())
 			{
 				rc = SSL_shutdown(_pSSL);
 			}
+#endif
 			if (rc < 0) handleError(rc);
 			if (_pSocket->getBlocking())
 			{


### PR DESCRIPTION
Hi
The fix done for solving the issue #1605 is breaking the unit test `HTTPSClientSessionTest ::testCachedSession()` that makes all CI AppVeyor and Travis jobs failing. Removing this fix makes all jobs from AppVeyor and Travis be successful..