### PR TITLE
Use proper x86_amd64 parameter value to vsvarsall.bat for building poco on x64 architecture

### DIFF
--- a/buildwin.cmd
+++ b/buildwin.cmd
@@ -93,42 +93,42 @@ if "%TESTS%"=="" (set TESTS=notests)
 if not defined VCINSTALLDIR (
   if %VS_VERSION%==vs90 (
     if %PLATFORM%==x64 (
-      call "%VS90COMNTOOLS%%VS_VARSALL%" amd64
+      call "%VS90COMNTOOLS%%VS_VARSALL%" x86_amd64
     ) else (
       call "%VS90COMNTOOLS%%VS_VARSALL%" x86
     )
   ) else (
     if %VS_VERSION%==vs100 (
       if %PLATFORM%==x64 (
-        call "%VS100COMNTOOLS%%VS_VARSALL%" amd64
+        call "%VS100COMNTOOLS%%VS_VARSALL%" x86_amd64
       ) else (
         call "%VS100COMNTOOLS%%VS_VARSALL%" x86
       )
     ) else (
       if %VS_VERSION%==vs110 (
         if %PLATFORM%==x64 (
-          call "%VS110COMNTOOLS%%VS_VARSALL%" amd64
+          call "%VS110COMNTOOLS%%VS_VARSALL%" x86_amd64
         ) else (
           call "%VS110COMNTOOLS%%VS_VARSALL%" x86
         ) 
       ) else (
         if %VS_VERSION%==vs120 (
           if %PLATFORM%==x64 (
-            call "%VS120COMNTOOLS%%VS_VARSALL%" amd64
+            call "%VS120COMNTOOLS%%VS_VARSALL%" x86_amd64
           ) else (
             call "%VS120COMNTOOLS%%VS_VARSALL%" x86
           )     
         ) else (
           if %VS_VERSION%==vs140 (
             if %PLATFORM%==x64 (
-              call "%VS140COMNTOOLS%%VS_VARSALL%" amd64
+              call "%VS140COMNTOOLS%%VS_VARSALL%" x86_amd64
             ) else (
               call "%VS140COMNTOOLS%%VS_VARSALL%" x86
             )
           ) else (
             if %VS_VERSION%==vs150 (
               if %PLATFORM%==x64 (
-                call "%VS150COMNTOOLS%%VS_VARSALL%" amd64
+                call "%VS150COMNTOOLS%%VS_VARSALL%" x86_amd64
               ) else (
                 call "%VS150COMNTOOLS%%VS_VARSALL%" x86
               )


### PR DESCRIPTION
Use proper x86_amd64 parameter value to vsvarsall.bat for building poco on x64 architecture