### PR TITLE
Update excluded includes to run successfully "mkdoc all"

### DIFF
--- a/PocoDoc/cfg/mkdoc-poco.xml
+++ b/PocoDoc/cfg/mkdoc-poco.xml
@@ -13,7 +13,22 @@
 				expat*.h,
 				zconf.h,
 				zlib.h,
-				XMLStreamParser.h
+				XMLStreamParser.h,
+				Units.h,
+				AbstractBinder.h,
+				Alignment.h,
+				QName.h,
+				CppUnitException.h,
+				RepeatedTest.h,
+				Test.h,
+				TestCase.h,
+				TestDecorator.h,
+				TestFailure.h,
+				TestResult.h,
+				TestRunner.h,
+				TestSetup.h,
+				TestSuite.h,
+				TextTestResult.h
 			</exclude>
 		</files>
 		<pages>

--- a/PocoDoc/cfg/mkdocumentation.xml
+++ b/PocoDoc/cfg/mkdocumentation.xml
@@ -13,8 +13,19 @@
 				expat*.h,
 				zconf.h,
 				zlib.h,
-				XMLStreamParser.h
-				${PocoBuild}/Util/include/Poco/Util/Units.h
+				XMLStreamParser.h,
+				Units.h,
+				CppUnitException.h,
+				RepeatedTest.h,
+				Test.h,
+				TestCase.h,
+				TestDecorator.h,
+				TestFailure.h,
+				TestResult.h,
+				TestRunner.h,
+				TestSetup.h,
+				TestSuite.h,
+				TextTestResult.h
 			</exclude>
 		</files>
 		<pages>


### PR DESCRIPTION
Hi

This PR contains an update of the list of include to exclude from the mkdoc process as the PocoParser does not parse them properly. See the log below. This update should be rollabcked when the parser be fixed.
```
PATH=/cygdrive/z/git/poco-develop/stage/tools/PocoDoc/bin/Cygwin/i686:/cygdrive/z/git/poco-develop/stage/tools/lib/Cygwin/i686:/cygdrive/z/git/poco-develop/release/script:/usr/local/bin:/usr/bin:/cygdrive/c/Python33:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/Microsoft SQL Server/110/Tools/Binn:/cygdrive/c/Program Files (x86)/Subversion/bin:/cygdrive/c/Program Files (x86)/Dr. Memory/bin:/cygdrive/c/Program Files (x86)/Windows Kits/10/Windows Performance Toolkit:/cygdrive/c/Program Files (x86)/Skype/Phone:/cygdrive/c/Program Files (x86)/GNU/GnuPG/pub:/cygdrive/c/Program Files (x86)/Microsoft SDKs/TypeScript/1.0:/cygdrive/c/Program Files (x86)/nodejs:/cygdrive/c/Program Files/Microsoft SQL Server/130/Tools/Binn:/cygdrive/c/Program Files/OpenVPN/bin:/cygdrive/c/Program Files/Git/cmd:/cygdrive/c/ProgramFiles/Ruby22/bin:/cygdrive/c/Users/FrancisANDRE/.dnx/bin:/cygdrive/z/git/win-flex-bison/bin/Release:/cygdrive/c/ASF/apache-maven-3.3.9/bin:/cygdrive/c/ASF/apache-ant-1.9.3/bin:/cygdrive/c/ProgramData/chocolatey/bin:/cygdrive/c/Users/FrancisANDRE/AppData/Roaming/npm:/usr/lib/lapack
Building documentation 2.0.0-all (using /cygdrive/z/git/poco-develop/PocoDoc/cfg/mkdoc-poco.xml)
Cleaning build directory: /cygdrive/z/git/poco-develop/stage/docbuild
Copying sources
Generating documentation
PocoDoc --config=/cygdrive/z/git/poco-develop/PocoDoc/cfg/mkdoc-poco.xml --config=/cygdrive/z/git/poco-develop/stage/docbuild/PocoDoc.ini
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/CppUnitException.h(21)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/RepeatedTest.h(30)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/Test.h(28)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestCase.h(87)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestDecorator.h(30)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestFailure.h(37)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestResult.h(45)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestRunner.h(42)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestSetup.h(25)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TestSuite.h(39)
Application: [Error] Syntax error: Expected: ;, found ): /cygdrive/z/git/poco-develop/stage/docbuild/CppUnit/include/Poco/CppUnit/TextTestResult.h(22)
Application: [Error] Syntax error: Expected: ;, found (: /cygdrive/z/git/poco-develop/stage/docbuild/Data/include/Poco/Data/AbstractBinder.h(120)
Application: [Error] Syntax error: Expected: ;, found ]: /cygdrive/z/git/poco-develop/stage/docbuild/Foundation/include/Poco/Alignment.h(223)
Application: [Error] Syntax error: Expected: ;, found friend: /cygdrive/z/git/poco-develop/stage/docbuild/XML/include/Poco/XML/QName.h(76)
Done.
```