### PR TITLE
fp: support environments without hardware floating point

### DIFF
--- a/Foundation/include/Poco/FPEnvironment_C99.h
+++ b/Foundation/include/Poco/FPEnvironment_C99.h
@@ -33,18 +33,54 @@ class FPEnvironmentImpl
 protected:
 	enum RoundingModeImpl
 	{
+#if defined(FE_DOWNWARD)
 		FP_ROUND_DOWNWARD_IMPL   = FE_DOWNWARD,
+#else
+		FP_ROUND_DOWNWARD_IMPL   = 0,
+#endif
+#if defined(FE_UPWARD)
 		FP_ROUND_UPWARD_IMPL     = FE_UPWARD,
+#else
+		FP_ROUND_UPWARD_IMPL     = 0,
+#endif
+#if defined(FE_TONEAREST)
 		FP_ROUND_TONEAREST_IMPL  = FE_TONEAREST,
+#else
+		FP_ROUND_TONEAREST_IMPL  = 0,
+#endif
+#if defined(FE_TOWARDZERO)
 		FP_ROUND_TOWARDZERO_IMPL = FE_TOWARDZERO
+#else
+		FP_ROUND_TOWARDZERO_IMPL = 0
+#endif
 	};
 	enum FlagImpl
 	{
+#if defined(FE_DIVBYZERO)
 		FP_DIVIDE_BY_ZERO_IMPL = FE_DIVBYZERO,
+#else
+		FP_DIVIDE_BY_ZERO_IMPL = 0,
+#endif
+#if defined(FE_INEXACT)
 		FP_INEXACT_IMPL        = FE_INEXACT,
+#else
+		FP_INEXACT_IMPL        = 0,
+#endif
+#if defined(FE_OVERFLOW)
 		FP_OVERFLOW_IMPL       = FE_OVERFLOW,
+#else
+		FP_OVERFLOW_IMPL       = 0,
+#endif
+#if defined(FE_UNDERFLOW)
 		FP_UNDERFLOW_IMPL      = FE_UNDERFLOW,
+#else
+		FP_UNDERFLOW_IMPL      = 0,
+#endif
+#if defined(FE_INVALID)
 		FP_INVALID_IMPL        = FE_INVALID
+#else
+		FP_INVALID_IMPL        = 0
+#endif
 	};
 	FPEnvironmentImpl();
 	FPEnvironmentImpl(const FPEnvironmentImpl& env);


### PR DESCRIPTION
| cd <build>/Foundation && \
|    mipsel-poky-linux-musl-g++   -DFoundation_EXPORTS -DHAVE_PTHREAD_SETAFFINITY_NP -DHAVE_THREE_PARAM_SCHED_SETAFFINITY \
|         -DPCRE_STATIC -DPOCO_HAVE_FD_EPOLL -DPOCO_NO_AUTOMATIC_LIBS -DPOCO_OS_FAMILY_UNIX -DPOCO_UNBUNDLED \
|         -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_REENTRANT -D_THREAD_SAFE -D_XOPEN_SOURCE=500 \
|         -I<sysroot>/usr/include -I<poco>/Foundation/include -I<poco>/Foundation/src  \
|         -mel -mabi=32 -msoft-float -march=mips32r2 -mno-mips16  -minterlink-compressed -mtune=24kec -mdsp  \
|         --sysroot=<sysroot> -O2 -pipe -g -feliminate-unused-debug-types \
|         -fstack-protector-strong -pie -fpie -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security \
|         -fvisibility-inlines-hidden  -mel -mabi=32 -msoft-float -march=mips32r2 -mno-mips16  -minterlink-compressed \
|         -mtune=24kec -mdsp  --sysroot=<sysroot> -O2 -g -DNDEBUG -fPIC   \
|         -o CMakeFiles/Foundation.dir/src/ArchiveStrategy.cpp.o \
|         -c <poco>/Foundation/src/ArchiveStrategy.cpp
| In file included from <poco>/Foundation/include/Poco/FPEnvironment.h:33:0,
|                  from <poco>/Foundation/include/Poco/NumericString.h:25,
|                  from <poco>/Foundation/include/Poco/NumberFormatter.h:24,
|                  from <poco>/Foundation/include/Poco/ArchiveStrategy.h:27,
|                  from <poco>/Foundation/src/ArchiveStrategy.cpp:17:
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:36:30: error: 'FE_DOWNWARD' was not declared in this scope
|    FP_ROUND_DOWNWARD_IMPL   = FE_DOWNWARD,
|                               ^~~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:37:30: error: 'FE_UPWARD' was not declared in this scope
|    FP_ROUND_UPWARD_IMPL     = FE_UPWARD,
|                               ^~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:39:30: error: 'FE_TOWARDZERO' was not declared in this scope
|    FP_ROUND_TOWARDZERO_IMPL = FE_TOWARDZERO
|                               ^~~~~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:43:28: error: 'FE_DIVBYZERO' was not declared in this scope
|    FP_DIVIDE_BY_ZERO_IMPL = FE_DIVBYZERO,
|                             ^~~~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:44:28: error: 'FE_INEXACT' was not declared in this scope
|    FP_INEXACT_IMPL        = FE_INEXACT,
|                             ^~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:45:28: error: 'FE_OVERFLOW' was not declared in this scope
|    FP_OVERFLOW_IMPL       = FE_OVERFLOW,
|                             ^~~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:46:28: error: 'FE_UNDERFLOW' was not declared in this scope
|    FP_UNDERFLOW_IMPL      = FE_UNDERFLOW,
|                             ^~~~~~~~~~~~
| <poco>/Foundation/include/Poco/FPEnvironment_C99.h:47:28: error: 'FE_INVALID' was not declared in this scope
|    FP_INVALID_IMPL        = FE_INVALID
|                             ^~~~~~~~~~

The reason is that some (notably FPU-less) architectures,
including mips*-nf, don't define/implement some of the
floating point constants, even though fenv.h is
available.

The key point is:
  A fully standards conforming fenv.h does not have to
  define any FE_* macros, and if it does define them,
  then it defines macros only for the FP exceptions it
  actually supports.

See similar issue in boost:
  https://svn.boost.org/trac/boost/ticket/11756