### PR TITLE
Fix mkdoc excluded files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tar -xzvf cmake-3.2.3-Linux-x86_64.tar.gz; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export PATH=$PWD/cmake-3.2.3-Linux-x86_64/bin:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev libsqlite3-dev; fi 
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y libpq-dev unixodbc-dev libmysqlclient-dev libsqlite3-dev; fi 
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y sloccount cppcheck; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi

--- a/Foundation/include/Poco/UnWindows.h
+++ b/Foundation/include/Poco/UnWindows.h
@@ -80,15 +80,14 @@
 #endif
 #endif
 
+#if !defined(POCO_NO_WINDOWS_H)
+#include <windows.h>
+#endif
 
 // To prevent Platform_WIN32.h to modify version defines,
 // uncomment this, otherwise versions will be automatically
 // discovered in Platform_WIN32.h.
 // #define POCO_FORCE_MIN_WINDOWS_OS_SUPPORT
-
-
-#include <windows.h>
-
 
 #if !defined(POCO_NO_UNWINDOWS)
 // A list of annoying macros to #undef.

--- a/PocoDoc/cfg/mkdoc-poco.xml
+++ b/PocoDoc/cfg/mkdoc-poco.xml
@@ -49,10 +49,12 @@
 				${Includes},
 				-I/usr/local/mysql/include,
 				-I/usr/include/mysql,
+				-I/usr/include/postgresql,
 				-D_DEBUG,
 				-E,
 				-C,
 				-DPOCO_NO_GCC_API_ATTRIBUTE
+				-DPOCO_NO_WINDOWS_H
 			</options>
 			<path></path>
 			<usePipe>true</usePipe>

--- a/PocoDoc/cfg/mkdocumentation.xml
+++ b/PocoDoc/cfg/mkdocumentation.xml
@@ -46,10 +46,12 @@
 				${Includes},
 				-I/usr/local/mysql/include,
 				-I/usr/include/mysql,
+				-I/usr/include/postgresql,
 				-D_DEBUG,
 				-E,
 				-C,
 				-DPOCO_NO_GCC_API_ATTRIBUTE
+				-DPOCO_NO_WINDOWS_H
 			</options>
 			<path></path>
 			<usePipe>true</usePipe>


### PR DESCRIPTION
Hi

This PR adds the new constant POCO_NO_WINDOWS_H to avoid including the include <windows.h> when running mkdoc all on a Linux pltaform.