### PR TITLE
use double check for SingletonHolder

### DIFF
--- a/Foundation/include/Poco/SingletonHolder.h
+++ b/Foundation/include/Poco/SingletonHolder.h
@@ -54,8 +54,11 @@ public:
 		/// hold by the SingletonHolder. The first call
 		/// to get will create the singleton.
 	{
-		FastMutex::ScopedLock lock(_m);
-		if (!_pS) _pS = new S;
+		if (!_ps)
+		{
+			FastMutex::ScopedLock lock(_m);
+			if (!_pS) _pS = new S;
+		}
 		return _pS;
 	}
 	


### PR DESCRIPTION
use double check for SingletonHolder, avoid the lock competition whe calling the 'get' function every time