### PR TITLE
Log file fix

### DIFF
--- a/Foundation/include/Poco/LogFile_STD.h
+++ b/Foundation/include/Poco/LogFile_STD.h
@@ -45,6 +45,7 @@ private:
 	std::string _path;
 	mutable Poco::FileOutputStream _str;
 	Timestamp _creationDate;
+	UInt64 _size;
 };
 
 

--- a/Foundation/src/LogFile_STD.cpp
+++ b/Foundation/src/LogFile_STD.cpp
@@ -27,7 +27,6 @@ LogFileImpl::LogFileImpl(const std::string& path):
 	_str(_path, std::ios::app),
 	_size((UInt64) _str.tellp())
 {
-	if(!_str.good()) throw OpenFileException(_path);
 	if (_size == 0)
 		_creationDate = File(path).getLastModified();
 	else

--- a/Foundation/src/LogFile_STD.cpp
+++ b/Foundation/src/LogFile_STD.cpp
@@ -24,9 +24,11 @@ namespace Poco {
 
 LogFileImpl::LogFileImpl(const std::string& path): 
 	_path(path),
-	_str(_path, std::ios::app)
+	_str(_path, std::ios::app),
+	_size((UInt64) _str.tellp())
 {
-	if (sizeImpl() == 0)
+	if(!_str.good()) throw OpenFileException(_path);
+	if (_size == 0)
 		_creationDate = File(path).getLastModified();
 	else
 		_creationDate = File(path).created();
@@ -46,12 +48,13 @@ void LogFileImpl::writeImpl(const std::string& text, bool flush)
 	else
 		_str << "\n";
 	if (!_str.good()) throw WriteFileException(_path);
+	_size = (UInt64) _str.tellp();
 }
 
 
 UInt64 LogFileImpl::sizeImpl() const
 {
-	return (UInt64) _str.tellp();
+	return _size;
 }
 
 

--- a/Foundation/src/LogFile_STD.cpp
+++ b/Foundation/src/LogFile_STD.cpp
@@ -42,6 +42,12 @@ LogFileImpl::~LogFileImpl()
 
 void LogFileImpl::writeImpl(const std::string& text, bool flush)
 {
+	if (!_str.good())
+	{
+		_str.close();
+		_str.open(_path, std::ios::app);
+	}
+	if (!_str.good()) throw WriteFileException(_path);
 	_str << text;
 	if (flush)
 		_str << std::endl;


### PR DESCRIPTION
Log file misbehaves in two ways on disk full condition (possibly some others too):
- logs are continuously rotated because `tellp()` returns -1, which as unsigned is larger than rotation size
- LogFile never recovers from bad stream and continues to err after the abnormal condition is removed (ie. disk space freed)