### PR TITLE
Enable parsing absolute Windows paths even if it starts with a slash

### DIFF
--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -766,7 +766,7 @@ void Path::parseWindows(const std::string& path)
 			char d = *it++;
 			if (it != end && *it == ':') // drive letter
 			{
-				if (_absolute || !((d >= 'a' && d <= 'z') || (d >= 'A' && d <= 'Z'))) throw PathSyntaxException(path);
+				if (!((d >= 'a' && d <= 'z') || (d >= 'A' && d <= 'Z'))) throw PathSyntaxException(path);
 				_absolute = true;
 				_device += d;
 				++it;

--- a/Foundation/testsuite/src/PathTest.cpp
+++ b/Foundation/testsuite/src/PathTest.cpp
@@ -860,6 +860,20 @@ void PathTest::testParseWindows4()
 	assert (p.toString(Path::PATH_WINDOWS) == "a\\b\\c\\d");
 }
 
+void PathTest::testParseWindows5()
+{
+	Path p;
+	p.parse("/c:/windows/system32/", Path::PATH_WINDOWS);
+	assert(!p.isRelative());
+	assert(p.isAbsolute());
+	assert(p.getDevice() == "c");
+	assert(p.depth() == 2);
+	assert(p[0] == "windows");
+	assert(p[1] == "system32");
+	assert(p.isDirectory());
+	assert(!p.isFile());
+	assert(p.toString(Path::PATH_WINDOWS) == "c:\\windows\\system32\\");
+}
 
 void PathTest::testParseVMS1()
 {
@@ -1668,6 +1682,7 @@ CppUnit::Test* PathTest::suite()
 	CppUnit_addTest(pSuite, PathTest, testParseWindows2);
 	CppUnit_addTest(pSuite, PathTest, testParseWindows3);
 	CppUnit_addTest(pSuite, PathTest, testParseWindows4);
+	CppUnit_addTest(pSuite, PathTest, testParseWindows5);
 	CppUnit_addTest(pSuite, PathTest, testParseVMS1);
 	CppUnit_addTest(pSuite, PathTest, testParseVMS2);
 	CppUnit_addTest(pSuite, PathTest, testParseVMS3);

--- a/Foundation/testsuite/src/PathTest.h
+++ b/Foundation/testsuite/src/PathTest.h
@@ -36,6 +36,7 @@ public:
 	void testParseWindows2();
 	void testParseWindows3();
 	void testParseWindows4();
+	void testParseWindows5();
 	void testParseVMS1();
 	void testParseVMS2();
 	void testParseVMS3();


### PR DESCRIPTION
In file URI when using absolute path on windows one has to write additional
'/' before the drive letter (empty host part). Eg: `file:///c:/windows/system32/`
`Path::parseWindows` throws an exception when using `URI::getPath()` to feed
it directly. The whole point of the commit to enable `/<DRIVE_LETTER>:` style
path as absolute path.
Test case added.