### PR TITLE
Add SQLite Notifier table name getter

### DIFF
--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -137,6 +137,9 @@ public:
 	void setRow(Poco::Int64 row);
 		/// Sets the row number.
 
+    std::string getTable() const;
+        /// Returns the table name.
+
 	const Poco::Dynamic::Var& getValue() const;
 		/// Returns the value.
 
@@ -155,6 +158,7 @@ private:
 	const Session&     _session;
 	Poco::Dynamic::Var _value;
 	Poco::Int64        _row;
+    std::string        _table;
 	EnabledEventType   _enabledEvents;
 	Poco::Mutex        _mutex;
 };
@@ -175,6 +179,12 @@ inline bool Notifier::operator == (const Notifier& other) const
 inline Poco::Int64 Notifier::getRow() const
 {
 	return _row;
+}
+
+
+inline std::string Notifier::getTable() const
+{
+    return _table;
 }
 
 

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -137,7 +137,7 @@ public:
 	void setRow(Poco::Int64 row);
 		/// Sets the row number.
 
-	std::string getTable() const;
+	const std::string& getTable() const;
 		/// Returns the table name.
 
 	const Poco::Dynamic::Var& getValue() const;
@@ -183,7 +183,7 @@ inline Poco::Int64 Notifier::getRow() const
 }
 
 
-inline std::string Notifier::getTable() const
+inline const std::string& Notifier::getTable() const
 {
 	return _table;
 }

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -158,7 +158,7 @@ private:
 	const Session&     _session;
 	Poco::Dynamic::Var _value;
 	Poco::Int64        _row;
-    std::string        _table;
+	std::string        _table;
 	EnabledEventType   _enabledEvents;
 	Poco::Mutex        _mutex;
 };
@@ -184,7 +184,7 @@ inline Poco::Int64 Notifier::getRow() const
 
 inline std::string Notifier::getTable() const
 {
-    return _table;
+	return _table;
 }
 
 

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -172,6 +172,7 @@ inline bool Notifier::operator == (const Notifier& other) const
 {
 	return _value == other._value &&
 		_row == other._row &&
+		_table == other._table &&
 		Utility::dbHandle(_session) == Utility::dbHandle(other._session);
 }
 

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -137,8 +137,8 @@ public:
 	void setRow(Poco::Int64 row);
 		/// Sets the row number.
 
-    std::string getTable() const;
-        /// Returns the table name.
+	std::string getTable() const;
+		/// Returns the table name.
 
 	const Poco::Dynamic::Var& getValue() const;
 		/// Returns the value.

--- a/Data/SQLite/src/Notifier.cpp
+++ b/Data/SQLite/src/Notifier.cpp
@@ -27,7 +27,7 @@ namespace SQLite {
 Notifier::Notifier(const Session& session, EnabledEventType enabled):
 	_session(session),
 	_row(),
-    _table(),
+	_table(),
 	_enabledEvents()
 {
 	if (enabled & SQLITE_NOTIFY_UPDATE)   enableUpdate();
@@ -164,19 +164,19 @@ void Notifier::sqliteUpdateCallbackFn(void* pVal, int opCode, const char* pDB, c
 	if (opCode == Utility::OPERATION_INSERT)
 	{
 		pV->_row = row;
-        pV->_table = pTable;
+		pV->_table = pTable;
 		pV->insert.notify(pV);
 	}
 	else if (opCode == Utility::OPERATION_UPDATE)
 	{
 		pV->_row = row;
-        pV->_table = pTable;
+		pV->_table = pTable;
 		pV->update.notify(pV);
 	}
 	else if (opCode == Utility::OPERATION_DELETE)
 	{
 		pV->_row = row;
-        pV->_table = pTable;
+		pV->_table = pTable;
 		pV->erase.notify(pV);
 	}
 }

--- a/Data/SQLite/src/Notifier.cpp
+++ b/Data/SQLite/src/Notifier.cpp
@@ -27,7 +27,6 @@ namespace SQLite {
 Notifier::Notifier(const Session& session, EnabledEventType enabled):
 	_session(session),
 	_row(),
-	_table(),
 	_enabledEvents()
 {
 	if (enabled & SQLITE_NOTIFY_UPDATE)   enableUpdate();

--- a/Data/SQLite/src/Notifier.cpp
+++ b/Data/SQLite/src/Notifier.cpp
@@ -27,6 +27,7 @@ namespace SQLite {
 Notifier::Notifier(const Session& session, EnabledEventType enabled):
 	_session(session),
 	_row(),
+    _table(),
 	_enabledEvents()
 {
 	if (enabled & SQLITE_NOTIFY_UPDATE)   enableUpdate();
@@ -163,16 +164,19 @@ void Notifier::sqliteUpdateCallbackFn(void* pVal, int opCode, const char* pDB, c
 	if (opCode == Utility::OPERATION_INSERT)
 	{
 		pV->_row = row;
+        pV->_table = pTable;
 		pV->insert.notify(pV);
 	}
 	else if (opCode == Utility::OPERATION_UPDATE)
 	{
 		pV->_row = row;
+        pV->_table = pTable;
 		pV->update.notify(pV);
 	}
 	else if (opCode == Utility::OPERATION_DELETE)
 	{
 		pV->_row = row;
+        pV->_table = pTable;
 		pV->erase.notify(pV);
 	}
 }

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -2886,7 +2886,7 @@ void SQLiteTest::testNotifier()
 	assert (_updateCounter == 3);
 	assert (notifier.getRow() == 3);
 
-    assert (notifier.getTable() == "Person");
+	assert (notifier.getTable() == "Person");
 
 	notifier.setRow(0);
 	// SQLite optimizes DELETE so here we must have

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -2886,6 +2886,8 @@ void SQLiteTest::testNotifier()
 	assert (_updateCounter == 3);
 	assert (notifier.getRow() == 3);
 
+    assert (notifier.getTable() == "Person");
+
 	notifier.setRow(0);
 	// SQLite optimizes DELETE so here we must have
 	// the WHERE clause to trigger per-row notifications


### PR DESCRIPTION
The SQLite callback table name is available anyway, so we just expose it in the Notifier..