### PR TITLE
Fix for issue #1043

### DIFF
--- a/Data/ODBC/src/Binder.cpp
+++ b/Data/ODBC/src/Binder.cpp
@@ -113,6 +113,13 @@ void Binder::freeMemory()
 		for (; itStr != itStrEnd; ++itStr) std::free(itStr->first);
 	}
 
+	if (_utf16Strings.size() > 0)
+	{
+		UTF16StringMap::iterator itStr = _utf16Strings.begin();
+		UTF16StringMap::iterator itStrEnd = _utf16Strings.end();
+		for (; itStr != itStrEnd; ++itStr) std::free(itStr->first);
+	}
+
 	if (_charPtrs.size() > 0)
 	{
 		CharPtrVec::iterator itChr = _charPtrs.begin();
@@ -174,7 +181,6 @@ void Binder::bind(std::size_t pos, const std::string& val, Direction dir, const 
 	SQLPOINTER pVal = 0;
 	SQLINTEGER size = (SQLINTEGER) val.size();
 
-	SQLSMALLINT sqType = SQL_LONGVARCHAR;
 	if (isOutBound(dir))
 	{
 		getColumnOrParameterSize(pos, size);
@@ -182,13 +188,11 @@ void Binder::bind(std::size_t pos, const std::string& val, Direction dir, const 
 		pVal = (SQLPOINTER) pChar;
 		_outParams.insert(ParamMap::value_type(pVal, size));
 		_strings.insert(StringMap::value_type(pChar, const_cast<std::string*>(&val)));
-		if (size < _maxCharColLength) sqType = SQL_VARCHAR;
 	}
 	else if (isInBound(dir))
 	{
 		pVal = (SQLPOINTER) val.c_str();
 		_inParams.insert(ParamMap::value_type(pVal, size));
-		if (size < _maxCharColLength) sqType = SQL_VARCHAR;
 	}
 	else
 		throw InvalidArgumentException("Parameter must be [in] OR [out] bound.");
@@ -205,6 +209,8 @@ void Binder::bind(std::size_t pos, const std::string& val, Direction dir, const 
 		*pLenIn = SQL_LEN_DATA_AT_EXEC(size);
 
 	_lengthIndicator.push_back(pLenIn);
+
+	SQLSMALLINT sqType = (size <= _maxCharColLength) ? SQL_VARCHAR : SQL_LONGVARCHAR;
 
 	if (Utility::isError(SQLBindParameter(_rStmt, 
 		(SQLUSMALLINT) pos + 1, 
@@ -228,11 +234,11 @@ void Binder::bind(std::size_t pos, const UTF16String& val, Direction dir, const 
 
 	SQLPOINTER pVal = 0;
 	SQLINTEGER size = (SQLINTEGER)(val.size() * sizeof(CharT));
-	SQLSMALLINT sqType = (val.size() < _maxWCharColLength) ? SQL_WVARCHAR : SQL_WLONGVARCHAR;
+	
 	if (isOutBound(dir))
 	{
 		getColumnOrParameterSize(pos, size);
-		CharT* pChar = (CharT*)std::calloc(size, 1);
+		CharT* pChar = (CharT*)std::calloc(size, sizeof(CharT));
 		pVal = (SQLPOINTER)pChar;
 		_outParams.insert(ParamMap::value_type(pVal, size));
 		_utf16Strings.insert(UTF16StringMap::value_type(pChar, const_cast<UTF16String*>(&val)));
@@ -260,6 +266,8 @@ void Binder::bind(std::size_t pos, const UTF16String& val, Direction dir, const 
 	}
 
 	_lengthIndicator.push_back(pLenIn);
+
+	SQLSMALLINT sqType = (size <= _maxWCharColLength) ? SQL_WVARCHAR : SQL_WLONGVARCHAR;
 
 	if (Utility::isError(SQLBindParameter(_rStmt,
 		(SQLUSMALLINT)pos + 1,
@@ -480,6 +488,14 @@ void Binder::synchronize()
 			it->second->assign(it->first, std::strlen(it->first));
 	}
 
+	if (_utf16Strings.size())
+	{
+		UTF16StringMap::iterator it = _utf16Strings.begin();
+		UTF16StringMap::iterator end = _utf16Strings.end();
+		for (; it != end; ++it)
+			it->second->assign(it->first, std::wcslen(it->first));
+	}
+
 	if (_nullCbMap.size())
 	{
 		NullCbMap::iterator it = _nullCbMap.begin();
@@ -508,6 +524,8 @@ void Binder::reset()
 		_timestamps.clear();
 	if (_strings.size() > 0)
 		_strings.clear();
+	if (_utf16Strings.size() > 0)
+		_utf16Strings.clear();
 	if (_dateVecVec.size() > 0)
 		_dateVecVec.clear();
 	if (_timeVecVec.size() > 0)

--- a/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
+++ b/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
@@ -297,27 +297,46 @@ void ODBCSQLServerTest::testStoredProcedure()
 
 		k += 2;
 	}
-/*TODO - currently fails with following error:
 
-[Microsoft][ODBC SQL Server Driver][SQL Server]Invalid parameter 
-2 (''):  Data type 0x23 is a deprecated large object, or LOB, but is marked as output parameter.  
-Deprecated types are not supported as output parameters.  Use current large object types instead.
+	{
+		session().setFeature("autoBind", true);
+		session() << "CREATE PROCEDURE storedProcedure(@inParam VARCHAR(MAX), @outParam VARCHAR(MAX) OUTPUT) AS "
+			"BEGIN "
+			"SET @outParam = @inParam; "
+			"END;"
+			, now;
 
-	session().setFeature("autoBind", true);
-	session() << "CREATE PROCEDURE storedProcedure(@inParam VARCHAR(MAX), @outParam VARCHAR(MAX) OUTPUT) AS "
-		"BEGIN "
-		"SET @outParam = @inParam; "
-		"END;"
-	, now;
+		std::string inParam = "123";
+		std::string outParam;
+		try {
+			session() << "{call storedProcedure(?, ?)}", in(inParam), out(outParam), now;
+		}
+		catch(StatementException& ex) {
+			std::cout << ex.toString();
+		}
+		assert(outParam == inParam);
+		dropObject("PROCEDURE", "storedProcedure");
+	}
 
-	std::string inParam = "123";
-	std::string outParam;
-	try{
-	session() << "{call storedProcedure(?, ?)}", in(inParam), out(outParam), now;
-	}catch(StatementException& ex){std::cout << ex.toString();}
-	assert(outParam == inParam);
-	dropObject("PROCEDURE", "storedProcedure");
-	*/
+	{
+		session().setFeature("autoBind", true);
+		session() << "CREATE PROCEDURE storedProcedure(@inParam NVARCHAR(MAX), @outParam NVARCHAR(MAX) OUTPUT) AS "
+			"BEGIN "
+			"SET @outParam = @inParam; "
+			"END;"
+			, now;
+
+		std::wstring inParam = L"123";
+		std::wstring outParam;
+		try {
+			session() << "{call storedProcedure(?, ?)}", in(inParam), out(outParam), now;
+		}
+		catch (StatementException& ex) {
+			std::cout << ex.toString();
+		}
+		assert(outParam == inParam);
+		dropObject("PROCEDURE", "storedProcedure");
+	}
 }
 
 


### PR DESCRIPTION
The fix for this issue was partially implemented in development branch.
However, there are still some issues, that were not covered:
1. The std::string overload will sets SQL_LONGVARCHAR as fSqlType if the
output parameter is of type VARCHAR(MAX)
2. The UTF16String overload of bind method:
  a) always resolves fSqlType using the size of formal parameter const
std::string& val.
  b) allocates half of the size of the SP's output parameter.
3. The _utf16Strings member is not synchronized in Binder::synchronize()
method.
4. The _utf16Strings member is not cleared in Binder::reset() method.