### PR TITLE
Manifest: explicitly set visibility for export

### DIFF
--- a/Foundation/include/Poco/ClassLibrary.h
+++ b/Foundation/include/Poco/ClassLibrary.h
@@ -27,6 +27,8 @@
 
 #if defined(_WIN32)
 	#define POCO_LIBRARY_API __declspec(dllexport)
+#elif defined(__GNUC__) && (__GNUC__ >= 4)
+	#define POCO_LIBRARY_API __attribute__ ((visibility ("default")))
 #else
 	#define POCO_LIBRARY_API
 #endif


### PR DESCRIPTION
Useful when using -fvisibility=hidden with GCC > 4!