### PR TITLE
Fix OpenSSLInitialized thread safety (#1739)

### DIFF
--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -84,6 +84,7 @@ protected:
 	static void dynlockDestroy(struct CRYPTO_dynlock_value* lock, const char* file, int line);
 
 private:
+	static Poco::FastMutex _synchronizationMutex;
 	static Poco::FastMutex* _mutexes;
 	static Poco::AtomicCounter _rc;
     static bool _disableSSLInitialization;

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -86,7 +86,7 @@ protected:
 private:
 	static Poco::FastMutex _mutex;
 	static Poco::FastMutex* _mutexes;
-	static Poco::AtomicCounter _rc;
+	static int _rc;
     static bool _disableSSLInitialization;
 };
 

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -84,7 +84,7 @@ protected:
 	static void dynlockDestroy(struct CRYPTO_dynlock_value* lock, const char* file, int line);
 
 private:
-	static Poco::FastMutex _synchronizationMutex;
+	static Poco::FastMutex _mutex;
 	static Poco::FastMutex* _mutexes;
 	static Poco::AtomicCounter _rc;
     static bool _disableSSLInitialization;

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -35,7 +35,7 @@ namespace Crypto {
 
 Poco::FastMutex OpenSSLInitializer::_mutex;
 Poco::FastMutex* OpenSSLInitializer::_mutexes(0);
-Poco::AtomicCounter OpenSSLInitializer::_rc;
+int OpenSSLInitializer::_rc(0);
 bool OpenSSLInitializer::_disableSSLInitialization = false;
 
 OpenSSLInitializer::OpenSSLInitializer()

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -33,7 +33,7 @@ using Poco::Thread;
 namespace Poco {
 namespace Crypto {
 
-
+Poco::FastMutex OpenSSLInitializer::_synchronizationMutex;
 Poco::FastMutex* OpenSSLInitializer::_mutexes(0);
 Poco::AtomicCounter OpenSSLInitializer::_rc;
 bool OpenSSLInitializer::_disableSSLInitialization = false;
@@ -59,6 +59,7 @@ OpenSSLInitializer::~OpenSSLInitializer()
 
 void OpenSSLInitializer::initialize()
 {
+	_synchronizationMutex.lock();
 	if (++_rc == 1)
 	{
 #if OPENSSL_VERSION_NUMBER >= 0x0907000L
@@ -99,11 +100,13 @@ void OpenSSLInitializer::initialize()
 		    CRYPTO_set_dynlock_destroy_callback(&OpenSSLInitializer::dynlockDestroy);
         }
 	}
+	_synchronizationMutex.unlock();
 }
 
 
 void OpenSSLInitializer::uninitialize()
 {
+	_synchronizationMutex.lock();
 	if (--_rc == 0)
 	{
         if(_mutexes != NULL) {
@@ -127,6 +130,7 @@ void OpenSSLInitializer::uninitialize()
     		CONF_modules_free();
         }
 	}
+	_synchronizationMutex.unlock();
 }
 
 


### PR DESCRIPTION
The init/uninit methods can be called from multiple threads, and thus need synchronization with a mutex.