### PR TITLE
moved #endif to the correct place

### DIFF
--- a/MongoDB/include/Poco/MongoDB/ReplicaSet.h
+++ b/MongoDB/include/Poco/MongoDB/ReplicaSet.h
@@ -53,8 +53,6 @@ private:
 	std::vector<Net::SocketAddress> _addresses;
 };
 
+} } // namespace Poco::MongoDB
 
 #endif // MongoDB_ReplicaSet_INCLUDED
-
-
-} } // namespace Poco::MongoDB


### PR DESCRIPTION
Before
```
#if...
namespace ...{
    ...
#endif
}
```

After
```
#if...
namespace ...{
    ...
}
#endif
```