### PR TITLE
[Format] support format characters pointer as %s

### DIFF
--- a/Foundation/src/Format.cpp
+++ b/Foundation/src/Format.cpp
@@ -222,8 +222,10 @@ namespace
 				case 's':
 					if (itVal->type() == typeid(std::string))
 						str << RefAnyCast<std::string>(*itVal++);
-					else
+					else if (itVal->type() == typeid(const char *))
 						str << AnyCast<const char *>(*itVal++);
+					else
+						str << AnyCast<char *>(*itVal++);
 					break;
 				case 'z':
 					str << AnyCast<std::size_t>(*itVal++);

--- a/Foundation/src/Format.cpp
+++ b/Foundation/src/Format.cpp
@@ -220,7 +220,10 @@ namespace
 					}
 					break;
 				case 's':
-					str << RefAnyCast<std::string>(*itVal++);
+					if (itVal->type() == typeid(std::string))
+						str << RefAnyCast<std::string>(*itVal++);
+					else
+						str << AnyCast<const char *>(*itVal++);
 					break;
 				case 'z':
 					str << AnyCast<std::size_t>(*itVal++);

--- a/Foundation/testsuite/src/FormatTest.cpp
+++ b/Foundation/testsuite/src/FormatTest.cpp
@@ -414,12 +414,12 @@ void FormatTest::testString()
 	assertTrue (s == "'foo%''foo%'");
 
 	s = format("%s", foo.c_str());
-	assert (s == "foo");
+	assertTrue (s == "foo");
 
 	char bar[] = "bar";
 	// s = format("%s", bar);	// compile error: array used as initializer
 	s = format("%s", +bar);
-	assert (s == "bar");
+	assertTrue (s == "bar");
 }
 
 

--- a/Foundation/testsuite/src/FormatTest.cpp
+++ b/Foundation/testsuite/src/FormatTest.cpp
@@ -415,6 +415,11 @@ void FormatTest::testString()
 
 	s = format("%s", foo.c_str());
 	assert (s == "foo");
+
+	char bar[] = "bar";
+	// s = format("%s", bar);	// compile error: array used as initializer
+	s = format("%s", +bar);
+	assert (s == "bar");
 }
 
 

--- a/Foundation/testsuite/src/FormatTest.cpp
+++ b/Foundation/testsuite/src/FormatTest.cpp
@@ -412,6 +412,9 @@ void FormatTest::testString()
 
 	s = format("'%s%%''%s%%'", foo, foo);
 	assertTrue (s == "'foo%''foo%'");
+
+	s = format("%s", foo.c_str());
+	assert (s == "foo");
 }
 
 


### PR DESCRIPTION
There is a case that I need to use both ``poco`` and another c++ library which has it's own string class. And its annoying to write code like:
```
Poco::format("%s", std::string(otheStr.c_str()));
```