### PR TITLE
avoid multipart boundary conflict

### DIFF
--- a/Net/src/MultipartWriter.cpp
+++ b/Net/src/MultipartWriter.cpp
@@ -78,7 +78,7 @@ const std::string& MultipartWriter::boundary() const
 std::string MultipartWriter::createBoundary()
 {
 	std::string boundary("MIME_boundary_");
-	Random rnd;
+	static Random rnd;
 	NumberFormatter::appendHex(boundary, rnd.next(), 8);
 	NumberFormatter::appendHex(boundary, rnd.next(), 8);
 	return boundary;


### PR DESCRIPTION
when nesting multipart, descendant parts currently may have the same boundary as the top-level multipart.