### PR TITLE
Exception in destructor

### DIFF
--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -67,7 +67,13 @@ public:
 
 	~BasicBufferedStreamBuf()
 	{
-		Allocator::deallocate(_pBuffer, _bufsize);
+		try 
+		{
+			Allocator::deallocate(_pBuffer, _bufsize);
+		} catch (...)
+		{
+			// Do nothing
+		}
 	}
 
 	virtual int_type overflow(int_type c)

--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -72,7 +72,7 @@ public:
 			Allocator::deallocate(_pBuffer, _bufsize);
 		} catch (...)
 		{
-			// Do nothing
+			poco_unexpected();
 		}
 	}
 


### PR DESCRIPTION
The destructor of BasicBufferedStreamBuf() calls Allocator::deallocate which can throw exceptions. In particular it throws Poco::SystemException when can't lock mutex.
#1776 