### PR TITLE
Update for using g++ 5 & clang 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,15 @@ branches:
     - /.*pp.eyor.*/
 
 before_install:
-  # we need a recent version of CMake
-  # - sudo add-apt-repository -y ppa:andykimpe/cmake3
-  # linux prereqisite packages
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget --no-check-certificate https://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tar -xzvf cmake-3.2.3-Linux-x86_64.tar.gz; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export PATH=$PWD/cmake-3.2.3-Linux-x86_64/bin:$PATH; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev libsqlite3-dev; fi 
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update  -qq; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y libpq-dev unixodbc-dev libmysqlclient-dev libsqlite3-dev; fi 
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y sloccount cppcheck; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y g++-4.8; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update  -qq; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -qq -y gcc-5 g++-5; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5; fi
 
 services:
   - mongodb
@@ -28,6 +24,9 @@ services:
   - postgresql
   - mysql
 
+dist: trusty
+sudo: enabled
+  
 addons:
   postgresql: "9.3"
 
@@ -42,6 +41,8 @@ env:
     TEST_NAME=""
     
 before_script:
+ # sleep 15
+ # mongo mydb_test --eval 'db.createUser("travis", "test");'
  - echo ${TEST_NAME}
  - chmod 755 ./travis/Linux/runtests.sh
  - chmod 755 ./travis/OSX/runtests.sh
@@ -54,95 +55,83 @@ matrix:
   fast_finish: true
 
   include:
-    - env:    TEST_NAME="OSX   clang (make) bundled"
+    - env:    TEST_NAME="clang (make) bundled"
       os: osx
       compiler: clang
       script:
         - export CC="clang"
         - export CXX="clang++"
+        - $CXX --version
         - clang++ -x c++ /dev/null -dM -E
         - ./configure --everything --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL && make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
-    - env:    TEST_NAME="Linux gcc 4.6 (make) bundled"
-      compiler: gcc
-      script:
-        - export CC="gcc"
-        - export CXX="g++"
-        - ./configure --everything && make -s -j2 && ./travis/Linux/runtests.sh
-    
-    - env:    TEST_NAME="Linux gcc 4.8 (make) bundled"
-      compiler: gcc
-      script:
-        - export CC="gcc-4.8"
-        - export CXX="g++-4.8"
-        - ./configure --everything && make -s -j2 && ./travis/Linux/runtests.sh
-    
-    - env:    TEST_NAME="Linux gcc 4.6 (make) unbundled"
-      compiler: gcc
-      script:
-        - export CC="gcc"
-        - export CXX="g++"
-        - sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev
-        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
-
-    - env:    TEST_NAME="Linux gcc 4.8 (make) unbundled"
-      compiler: gcc
-      script:
-        - sudo apt-get install -qq -y libpcre3-dev libssl-dev libexpat1-dev
-        - export CC="gcc-4.8"
-        - export CXX="g++-4.8"
-        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
-    
-    - env:    TEST_NAME="Linux clang 3.4 (make)"
+    - env:    TEST_NAME="clang (make) bundled"
       compiler: clang
       script:
-        - ./configure --everything --config=Linux-clang && make -s -j2 && ./travis/Linux/runtests.sh
-
-    - env:    TEST_NAME="Linux arm-linux-gnueabi- (make)"
+        - sudo apt-get install -qq -y clang
+        - export CC="clang"
+        - export CXX="clang++"
+        - $CXX --version
+        - ./configure --everything  && make -s -j2 && ./travis/Linux/runtests.sh
+    
+    - env:    TEST_NAME="clang (make) unbundled"
+      compiler: clang
+      script:
+        - export CC="clang"
+        - export CXX="clang++"
+        - $CXX --version
+        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
+    
+    - env:    TEST_NAME="gcc 5 (make) bundled"
+      compiler: gcc
+      script:
+        - $CXX --version
+        - ./configure --everything && make -s -j2 && ./travis/Linux/runtests.sh
+    
+    - env:    TEST_NAME="gcc 5 (make) unbundled"
+      compiler: gcc
+      script:
+        - $CXX --version
+        - ./configure --everything --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
+    
+    - env:    TEST_NAME="arm-linux-gnueabi- (make)"
       compiler: gcc
       script:
         - ./configure --omit=Data/ODBC,Data/MySQL,Data/PostgreSQL,Crypto,NetSSL,PageCompiler && make -s -j2  CROSS_COMPILE=arm-linux-gnueabi- POCO_TARGET_OSARCH=armv7l
 
-    - env:    TEST_NAME="Linux gcc 4.6 (CMake)"
+    - env:    TEST_NAME="gcc 5 (CMake)"
       compiler: gcc
       script:
-        - export CC="gcc"
-        - export CXX="g++"
+        - $CXX --version
         - source ./travis/ignored.sh
         - export POCO_BASE=`pwd`
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
  
-    - env:    TEST_NAME="Linux gcc 4.8 (CMake)"
-      compiler: gcc
-      script:
-        - export CC="gcc-4.8"
-        - export CXX="g++-4.8"
-        - source ./travis/ignored.sh
-        - export POCO_BASE=`pwd`
-        - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
 
-    - env:    TEST_NAME="Linux clang 3.4 (CMake)"
-      compiler: clang
-      script:
-        - source ./travis/ignored.sh
-        - export POCO_BASE=`pwd`
-        - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
+    # env:    TEST_NAME="clang (CMake)"
+    #  compiler: clang
+    #  script:
+    #    - source ./travis/ignored.sh
+    #    - export POCO_BASE=`pwd`
+    #    - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
 
-    - env:    TEST_NAME="Linux arm-linux-gnueabi-g++ (CMake)"
-      compiler: gcc
-      script:
-        - export CC="arm-linux-gnueabi-gcc"
-        - export CXX="arm-linux-gnueabi-g++"
-        - source ./travis/ignored.sh
-        - export POCO_BASE=`pwd`
-        - mkdir cmake-build 
-        - cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -s -j2 && cd ..
+    #- env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
+    #  compiler: gcc
+    #  script:
+    #    - export CC="arm-linux-gnueabi-gcc"
+    #    - export CXX="arm-linux-gnueabi-g++"
+    #    - $CXX --version
+    #    - source ./travis/ignored.sh
+    #    - export POCO_BASE=`pwd`
+    #    - mkdir cmake-build 
+    #    - cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -s -j2 && cd ..
 
-    - env:    TEST_NAME="Linux arm-linux-gnueabihf-g++ (CMake)"
+    - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
       compiler: gcc
       script:
         - export CC="arm-linux-gnueabihf-gcc"
         - export CXX="arm-linux-gnueabihf-g++"
+        - $CXX --version
         - source ./travis/ignored.sh
         - export POCO_BASE=`pwd`
         - mkdir cmake-build
@@ -151,11 +140,10 @@ matrix:
 
     # QA jobs for code analytics and metrics
     # build documentation and release
-    - env:    TEST_NAME="Linux documentation & release"
+    - env:    TEST_NAME="documentation & release"
       compiler: gcc
       script:
-        - export CC="gcc"
-        - export CXX="g++"
+        - $CXX --version
         - . env.sh && mkdoc all && mkrel all
 
     # static code analysis with cppcheck (we can add --enable=all later)


### PR DESCRIPTION
This PR make Travis CI building poco & running unit tests using g++ 5 and clang 3.5.0. Only Cmake jobs have been commented out due to a configuration issue.