### PR TITLE
Prevent possible error when adding files from current directory to a zip file.

### DIFF
--- a/Zip/src/Compress.cpp
+++ b/Zip/src/Compress.cpp
@@ -210,7 +210,7 @@ void Compress::addFile(const Poco::Path& file, const Poco::Path& fileName, ZipCo
 	Poco::FileInputStream in(file.toString());
 	if (fileName.depth() > 1)
 	{
-		Poco::File aParent(file.parent());
+		Poco::File aParent(file.depth() > 1 ? file.parent() : ".");
 		addDirectory(fileName.parent(), aParent.getLastModified());
 	}
 	addFile(in, aFile.getLastModified(), fileName, cm, cl);


### PR DESCRIPTION
This fixes issue #1612 