### PR TITLE
No environmental variable: VS150COMNTOOLS defined

### DIFF
--- a/buildwin.cmd
+++ b/buildwin.cmd
@@ -40,6 +40,9 @@ rem VS_VERSION {90 | 100 | 110 | 120 | 140 | 150}
 if "%1"=="" goto usage
 set VS_VERSION=vs%1
 if %VS_VERSION%==vs150 (
+  if "%VS150COMNTOOLS%"=="" (
+    set VS150COMNTOOLS=C:\Program Files ^(x86^)\Microsoft Visual Studio\2017\Community\Common7\Tools\
+  )
   set VS_VARSALL=..\..\VC\Auxiliary\Build\vcvarsall.bat
 ) else (
   set VS_VARSALL=..\..\VC\vcvarsall.bat


### PR DESCRIPTION
When undefined, default environment variable VS150COMNTOOLS  to C:\Program Files (x86)(x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\
See  [VisualStudio report](https://developercommunity.visualstudio.com/content/problem/13223/no-environmental-variable-vscomntools150.html)
