### PR TITLE
Improve launchImpl in Process_WIN32.cpp

### DIFF
--- a/Foundation/src/Process_WIN32.cpp
+++ b/Foundation/src/Process_WIN32.cpp
@@ -163,7 +163,7 @@ static std::string escapeArg(const std::string& arg)
 
 ProcessHandleImpl* ProcessImpl::launchImpl(const std::string& command, const ArgsImpl& args, const std::string& initialDirectory, Pipe* inPipe, Pipe* outPipe, Pipe* errPipe, const EnvImpl& env)
 {
-	std::string commandLine = command;
+	std::string commandLine = escapeArg(command);
 	for (ArgsImpl::const_iterator it = args.begin(); it != args.end(); ++it)
 	{
 		commandLine.append(" ");


### PR DESCRIPTION
Dear, developers.

How about add `escapeArg` function as with `Process_WIN32U.cpp`?
Because I think `escapeArg(command)` is more safe than only `command`.