### PR TITLE
Poco Path and simbol $

### DIFF
--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -205,9 +205,14 @@ void SessionImpl::open(const std::string& connect)
 
 void SessionImpl::close()
 {
-	if (_pDB)
-	{
-		sqlite3_close(_pDB);
+	if (_pDB) {
+		int result = 0;
+		do {
+			result = sqlite3_close(_pDB);
+			if (result == SQLITE_BUSY) {
+				Poco::Thread::sleep(100);
+			}
+		} while (SQLITE_BUSY == result);
 		_pDB = 0;
 	}
 

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -214,21 +214,24 @@ void SessionImpl::close()
 			result = sqlite3_close(_pDB);
 			if (result == SQLITE_BUSY) 
 			{
-				sqlite3_stmt *pStmt = NULL;
-				do 
-				{
-					pStmt = sqlite3_next_stmt(_pDB, NULL);
-					if (pStmt && sqlite3_stmt_busy(pStmt)) 
-					{
-						sqlite3_finalize(pStmt);
-					}
-				}
-				while (pStmt != NULL);
-				Poco::Thread::sleep(100);
 				--times;
 			}			
 		} 
 		while (SQLITE_BUSY == result && times > 0);
+		if (SQLITE_BUSY == result && times == 0) 
+		{
+			sqlite3_stmt *pStmt = NULL;
+			do 
+			{
+				pStmt = sqlite3_next_stmt(_pDB, NULL);
+				if (pStmt && sqlite3_stmt_busy(pStmt)) 
+				{
+					sqlite3_finalize(pStmt);
+				}
+			}
+			while (pStmt != NULL);
+			sqlite3_close(_pDB);		
+		}
 		_pDB = 0;
 	}
 

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -214,9 +214,19 @@ void SessionImpl::close()
 			result = sqlite3_close(_pDB);
 			if (result == SQLITE_BUSY) 
 			{
+				sqlite3_stmt *pStmt = NULL;
+				do 
+				{
+					pStmt = sqlite3_next_stmt(_pDB, NULL);
+					if (pStmt && sqlite3_stmt_busy(pStmt)) 
+					{
+						sqlite3_finalize(pStmt);
+					}
+				}
+				while (pStmt != NULL);
 				Poco::Thread::sleep(100);
-			}
-			--times;
+				--times;
+			}			
 		} 
 		while (SQLITE_BUSY == result && times > 0);
 		_pDB = 0;

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -205,16 +205,20 @@ void SessionImpl::open(const std::string& connect)
 
 void SessionImpl::close()
 {
-	if (_pDB) {
+	if (_pDB) 
+	{
 		int result = 0;
 		int times = 50;
-		do {
+		do 
+		{
 			result = sqlite3_close(_pDB);
-			if (result == SQLITE_BUSY) {
+			if (result == SQLITE_BUSY) 
+			{
 				Poco::Thread::sleep(100);
 			}
 			--times;
-		} while (SQLITE_BUSY == result && times > 0);
+		} 
+		while (SQLITE_BUSY == result && times > 0);
 		_pDB = 0;
 	}
 

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -207,12 +207,14 @@ void SessionImpl::close()
 {
 	if (_pDB) {
 		int result = 0;
+		int times = 50;
 		do {
 			result = sqlite3_close(_pDB);
 			if (result == SQLITE_BUSY) {
 				Poco::Thread::sleep(100);
 			}
-		} while (SQLITE_BUSY == result);
+			--times;
+		} while (SQLITE_BUSY == result && times > 0);
 		_pDB = 0;
 	}
 

--- a/Foundation/src/Path_UNIX.cpp
+++ b/Foundation/src/Path_UNIX.cpp
@@ -120,7 +120,15 @@ std::string PathImpl::expandImpl(const std::string& path)
 	}
 	while (it != end)
 	{
-		if (*it == '$')
+		if (*it == '\\')
+		{
+			++it;
+			if (*it == '$')
+			{
+				result += *it++;
+			}
+		}
+		else if (*it == '$')
 		{
 			std::string var;
 			++it;

--- a/Foundation/testsuite/src/PathTest.cpp
+++ b/Foundation/testsuite/src/PathTest.cpp
@@ -373,6 +373,18 @@ void PathTest::testParseUnix5()
 	assert (p.toString(Path::PATH_UNIX) == "/c:/windows/system32/");	
 }
 
+void PathTest::testExpandUnix()
+{
+	std::string pathWithOutVar = "/usr/share/O1\\$\\$/folder";
+	std::string pathWithVar = "${PWD}/folder";
+	Path p;
+	std::string s = p.expand(pathWithOutVar);
+	assert (s == "/usr/share/O1$$/folder");
+	s = p.expand(pathWithVar);
+	Path tmpPath = Path::current();
+	tmpPath.append("folder");
+	assert (s == tmpPath.toString());
+}
 
 void PathTest::testParseWindows1()
 {
@@ -1641,6 +1653,7 @@ CppUnit::Test* PathTest::suite()
 	CppUnit_addTest(pSuite, PathTest, testParseUnix3);
 	CppUnit_addTest(pSuite, PathTest, testParseUnix4);
 	CppUnit_addTest(pSuite, PathTest, testParseUnix5);
+	CppUnit_addTest(pSuite, PathTest, testExpandUnix);
 	CppUnit_addTest(pSuite, PathTest, testParseWindows1);
 	CppUnit_addTest(pSuite, PathTest, testParseWindows2);
 	CppUnit_addTest(pSuite, PathTest, testParseWindows3);

--- a/Foundation/testsuite/src/PathTest.h
+++ b/Foundation/testsuite/src/PathTest.h
@@ -31,6 +31,7 @@ public:
 	void testParseUnix3();
 	void testParseUnix4();
 	void testParseUnix5();
+	void testExpandUnix();
 	void testParseWindows1();
 	void testParseWindows2();
 	void testParseWindows3();


### PR DESCRIPTION
bug : into current implementation od path_unix.cpp I can't use simbol $ like a simbol, not a variable prefix, for example,
I need to use path /home/user/O1$$/folder. I propose to use escape sequence for this, for ex., if I want to use Poco::Glob, I can do 
```
std::set<std::string> files;
std::string path = "/home/user/O1$$/folder"
Poco::replaceInPlace(path, "$", "\\$");
Poco::Glob::glob(path, files);
```