### PR TITLE
TCPServerDispatcher: fix thread accounting leak

### DIFF
--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -18,6 +18,7 @@
 #include "Poco/Net/TCPServerConnectionFactory.h"
 #include "Poco/Notification.h"
 #include "Poco/AutoPtr.h"
+#include "Poco/ErrorHandler.h"
 #include <memory>
 
 
@@ -104,24 +105,38 @@ void TCPServerDispatcher::run()
 
 	for (;;)
 	{
-		AutoPtr<Notification> pNf = _queue.waitDequeueNotification(idleTime);
-		if (pNf)
-		{
-			TCPConnectionNotification* pCNf = dynamic_cast<TCPConnectionNotification*>(pNf.get());
-			if (pCNf)
+		try {
+			AutoPtr<Notification> pNf = _queue.waitDequeueNotification(idleTime);
+			if (pNf)
 			{
-#if __cplusplus < 201103L
-				std::auto_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
-#else
-				std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
-#endif
-				poco_check_ptr(pConnection.get());
-				beginConnection();
-				pConnection->start();
-				endConnection();
+				TCPConnectionNotification* pCNf = dynamic_cast<TCPConnectionNotification*>(pNf.get());
+				if (pCNf)
+				{
+	#if __cplusplus < 201103L
+					std::auto_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
+	#else
+					std::unique_ptr<TCPServerConnection> pConnection(_pConnectionFactory->createConnection(pCNf->socket()));
+	#endif
+					poco_check_ptr(pConnection.get());
+					beginConnection();
+					pConnection->start();
+					endConnection();
+				}
 			}
 		}
-	
+		catch (Poco::Exception &exc)
+		{
+			ErrorHandler::handle(exc);
+		}
+		catch (std::exception &exc)
+		{
+			ErrorHandler::handle(exc);
+		}
+		catch (...)
+		{
+			ErrorHandler::handle();
+		}
+
 		FastMutex::ScopedLock lock(_mutex);
 		if (_stopped || (_currentThreads > 1 && _queue.empty()))
 		{


### PR DESCRIPTION
In TCPServerDispatcher's run method, any exceptions thrown are unhandled and cause the thread to exit without updating the accounting of currentThreads. Since calls to _pConnectionFactory->createConnection are not protected without ConnectionFactory, this can cause the TCPServerDispatcher to eventually stop handling connections, since it thinks no threads are available to serve requests.

This PR wraps the majority of the run logic in a try/catch so that the currentThreads accounting logic is managed correctly.