### PR TITLE
make RecordSet::reset(stmt) return a reference to itself

### DIFF
--- a/Data/include/Poco/Data/RecordSet.h
+++ b/Data/include/Poco/Data/RecordSet.h
@@ -323,7 +323,7 @@ public:
 	using Statement::reset;
 		/// Don't hide base class method.
 
-	void reset(const Statement& stmt);
+	RecordSet& reset(const Statement& stmt);
 		/// Resets the RecordSet and assigns a new statement.
 		/// Should be called after the given statement has been reset,
 		/// assigned a new SQL statement, and executed.

--- a/Data/src/RecordSet.cpp
+++ b/Data/src/RecordSet.cpp
@@ -89,7 +89,7 @@ RecordSet::~RecordSet()
 }
 
 
-void RecordSet::reset(const Statement& stmt)
+RecordSet& RecordSet::reset(const Statement& stmt)
 {
 	delete _pBegin;
 	_pBegin = 0;
@@ -107,6 +107,8 @@ void RecordSet::reset(const Statement& stmt)
 
 	_pBegin = new RowIterator(this, 0 == rowsExtracted());
 	_pEnd = new RowIterator(this, true);
+
+	return *this;
 }
 
 


### PR DESCRIPTION
Statement::reset returning a self-reference is very convenient.
Lets make RecordSet::reset do the same  :-)