### PR TITLE
C++11: Fix AppVeyor CI yaml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,8 @@ services:
   - postgresql94
 
   
-#image:
-#  - Visual Studio 2017
+image:
+  - Visual Studio 2017
 
   
 platform:
@@ -54,12 +54,15 @@ configuration:
 # -------------------------------------------------------------------------------------------
 
 environment:
-  bundling: bundled
-  MYSQL32:    C:\mysql-5.7.17-win32
-  MYSQL64:    C:\Program Files\MySql\MySQL Server 5.7
-  POSTGRES32: C:\Program Files (x86)\PostgreSQL\9.4
-  POSTGRES64: C:\Program Files\PostgreSQL\9.4
-
+  bundling:     bundled
+  MYSQL32:      C:\mysql-5.7.17-win32
+  MYSQL64:      C:\Program Files\MySql\MySQL Server 5.7
+  POSTGRES32:   C:\Program Files (x86)\PostgreSQL\9.4
+  POSTGRES64:   C:\Program Files\PostgreSQL\9.4
+  OPENSSLURL:   https://slproweb.com/download
+  OPENSSL32EXE: Win32OpenSSL-1_1_0f.exe
+  OPENSSL64EXE: Win64OpenSSL-1_1_0f.exe
+  
   matrix:
       
     - builder: msbuild
@@ -169,9 +172,9 @@ install:
              echo "using C:\OpenSSL-Win32 from cache"
            } else {
              echo "downloading OpenSSL-Win32"
-             Start-FileDownload 'http://slproweb.com/download/Win32OpenSSL-1_0_2e.exe'
+             Start-FileDownload $env:OPENSSLURL + "/" + $env:OPENSSL32EXE
              echo "installing C:\OpenSSL-Win32"
-             Start-Process "Win32OpenSSL-1_0_2e.exe" -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
+             Start-Process $env:OPENSSL32EXE -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
            }
          }
          if ($env:platform -eq "x64")
@@ -180,9 +183,9 @@ install:
              echo "using C:\OpenSSL-Win64 from cache"
            } else {
              echo "downloading OpenSSL-Win64"
-             Start-FileDownload 'http://slproweb.com/download/Win64OpenSSL-1_0_2e.exe'
+             Start-FileDownload $env:OPENSSLURL + "/" + $env:OPENSSL64EXE
              echo "installing C:\OpenSSL-Win64"
-             Start-Process "Win64OpenSSL-1_0_2e.exe" -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
+             Start-Process $env:OPENSSL64EXE -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
            }
          }
        }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,8 @@ services:
   - postgresql94
 
   
-image:
-  - Visual Studio 2017
+#image:
+#  - Visual Studio 2017
 
   
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,9 +62,16 @@ environment:
   OPENSSLURL:   https://slproweb.com/download
   OPENSSL32EXE: Win32OpenSSL-1_1_0f.exe
   OPENSSL64EXE: Win64OpenSSL-1_1_0f.exe
+  OPENSSL32:    C:\OpenSSL-Win32
+  OPENSSL64:    C:\OpenSSL-Win64
   
   matrix:
-      
+    - builder: cmake
+      vsver: 140
+
+    - builder: cygwin
+
+     
     - builder: msbuild
       vsver: 140
       linkmode: shared
@@ -92,22 +99,17 @@ environment:
 #    - builder: cmake
 #      vsver: 120
 
-    - builder: cmake
-      vsver: 140
-
-    - builder: cygwin
-
 matrix:
   fast_finish: true
 
 install:
   - if "%builder%"=="cygwin" (
     if "%platform%"=="Win32" (
-    C:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel -P libcrypt-devel))
+    C:\cygwin\setup-x86.exe      -qnNdO -R C:/cygwin   -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup   -P libpq-devel -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel -P libcrypt-devel))
     
   - if "%builder%"=="cygwin" (
     if "%platform%"=="x64" (   
-    C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel  -P libcrypt-devel))
+    C:\cygwin64\setup-x86_64.exe -qnNdO -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P libpq-devel -P libpcre-devel -P openssl-devel -P libiodbc-devel -P libiodbc2 -P odbc-mysql -P odbc-pgsql -P odbc-sqlite3 -P libmysqlclient-devel -P libsqlite3-devel  -P libcrypt-devel))
   
   - set POCO_BASE=%CD%
   - set PATH=C:\ProgramData\chocolatey\bin;%PATH%
@@ -168,25 +170,23 @@ install:
        {
          if ($env:platform -eq "Win32")
          {
-           if (Test-Path "C:\OpenSSL-Win32") {
-             echo "using C:\OpenSSL-Win32 from cache"
-           } else {
-             echo "downloading OpenSSL-Win32"
-             Start-FileDownload $env:OPENSSLURL + "/" + $env:OPENSSL32EXE
-             echo "installing C:\OpenSSL-Win32"
-             Start-Process $env:OPENSSL32EXE -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
-           }
+             $openssl     = $env:OPENSSL32
+             $opensslexe  = $env:OPENSSL32EXE
          }
          if ($env:platform -eq "x64")
          {
-           if (Test-Path "C:\OpenSSL-Win64") {
-             echo "using C:\OpenSSL-Win64 from cache"
-           } else {
-             echo "downloading OpenSSL-Win64"
-             Start-FileDownload $env:OPENSSLURL + "/" + $env:OPENSSL64EXE
-             echo "installing C:\OpenSSL-Win64"
-             Start-Process $env:OPENSSL64EXE -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
-           }
+             $openssl     = $env:OPENSSL64
+             $opensslexe  = $env:OPENSSL64EXE
+         }
+         $opensslurl  = $env:OPENSSLURL + "/" + $opensslexe
+         
+         if (Test-Path $openssl) {
+           echo "using " + $openssl + " from cache"
+         } else {
+           echo "downloading " + $openssl
+           Start-FileDownload $opensslurl
+           echo "installing " + $openssl
+           Start-Process $opensslexe -Args "/silent /verysilent /sp- /suppressmsgboxes" -Wait
          }
        }
 # -------------------------------------------------------------------------------------------  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,10 @@ services:
   - postgresql94
 
   
+image:
+  - Visual Studio 2017
+
+  
 platform:
   - Win32
   - x64
@@ -59,18 +63,6 @@ environment:
   matrix:
       
     - builder: msbuild
-      vsver: 120
-      linkmode: shared
-
-#    - builder: msbuild
-#      vsver: 120
-#      linkmode: static_md
-
-#    - builder: msbuild
-#      vsver: 120
-#      linkmode: static_mt
-
-    - builder: msbuild
       vsver: 140
       linkmode: shared
 
@@ -82,8 +74,20 @@ environment:
 #      vsver: 140
 #      linkmode: static_mt
 
-    - builder: cmake
-      vsver: 120
+#    - builder: msbuild
+#      vsver: 150
+#      linkmode: shared
+
+#    - builder: msbuild
+#      vsver: 150
+#      linkmode: static_md
+
+#    - builder: msbuild
+#      vsver: 150
+#      linkmode: static_mt
+
+#    - builder: cmake
+#      vsver: 120
 
     - builder: cmake
       vsver: 140
@@ -249,6 +253,14 @@ before_build:
         if ($env:vsver -eq "140")
         {
           $vspath= convert-path $env:VS140COMNTOOLS\..\..\VC\bin; $yyyy='2015'
+          if($env:platform -eq 'Win32') { $vctool='';}
+          if($env:platform -eq 'x64')   { $vctool='x86_amd64';$vspath+='\'+$vctool }
+        }
+        if ($env:vsver -eq "150")
+        {
+          Install-Module VSSetup -Scope CurrentUser
+          Get-VSSetupInstance | Select-VSSetupInstance -Latest -Require Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+          $vspath= convert-path $env:VS150COMNTOOLS\..\..\VC\bin; $yyyy='2017'
           if($env:platform -eq 'Win32') { $vctool='';}
           if($env:platform -eq 'x64')   { $vctool='x86_amd64';$vspath+='\'+$vctool }
         }


### PR DESCRIPTION
Hi
As per issue #1793 C++11 Support, this PR cleanups the AppVeyor CI configuration file by running only VS2015 distribution and gcc 5.4.1 for Cygwin.