### PR TITLE
Improve convert to big-endian from little-endian (#1804)

### DIFF
--- a/Foundation/src/SHA1Engine.cpp
+++ b/Foundation/src/SHA1Engine.cpp
@@ -18,6 +18,7 @@
 
 
 #include "Poco/SHA1Engine.h"
+#include "Poco/ByteOrder.h"
 #include <cstring>
 
 
@@ -50,13 +51,12 @@ inline void SHA1Engine::byteReverse(UInt32* buffer, int byteCount)
 	byteCount /= sizeof(UInt32);
 	for(int count = 0; count < byteCount; count++)
 	{
-		UInt32 value = (buffer[ count ] << 16) | (buffer[ count ] >> 16);
-		buffer[count] = ((value & 0xFF00FF00L) >> 8) | ((value & 0x00FF00FFL) << 8);
+		buffer[count] = Poco::ByteOrder::toBigEndian(buffer[ count ]);
 	}
 #endif // POCO_ARCH_LITTLE_ENDIAN
 }
 
-	
+
 void SHA1Engine::updateImpl(const void* buffer_, std::size_t count)
 {
 	const BYTE* buffer = (const BYTE*) buffer_;


### PR DESCRIPTION
Dear, developers.

I dealt with issues #1804 with use `Poco::ByteOrder` method by using issues #1804's comments as reference.
And I had removed needless space too.