### PR TITLE
Fix VisualStudio warning C4245 in `NetworkInterface.h`(#916)

### DIFF
--- a/Net/include/Poco/Net/NetworkInterface.h
+++ b/Net/include/Poco/Net/NetworkInterface.h
@@ -99,7 +99,7 @@ public:
 		IPv4_OR_IPv6  /// Return interfaces with IPv4 or IPv6 address
 	};
 
-	static const unsigned NO_INDEX = ~0;
+	static const unsigned NO_INDEX = ~(static_cast<unsigned>(0));
 #if defined(POCO_OS_FAMILY_WINDOWS)
 	static const char MAC_SEPARATOR = '-';
 #else


### PR DESCRIPTION
Dear, developers.

I tried to fix Issues #916.