### PR TITLE
Fix issues #1373 for ODBC

### DIFF
--- a/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
@@ -80,6 +80,7 @@ public:
 
 	void close();
 		/// Closes the connection
+		/// Throws ODBCException if close was not successful.
 
 	bool isConnected();
 		/// Returns true if session is connected

--- a/Data/ODBC/src/SessionImpl.cpp
+++ b/Data/ODBC/src/SessionImpl.cpp
@@ -406,7 +406,8 @@ void SessionImpl::close()
 	SQLINTEGER nativeErrorCode;
 	SQLSMALLINT sqlErrorMessageLength;
 	unsigned int retryCount = 10;
-	do {
+	do
+	{
 		SQLRETURN rc = SQLDisconnect(_db);
 		if (SQL_SUCCESS != rc && SQL_SUCCESS_WITH_INFO != rc)
 		{
@@ -430,10 +431,11 @@ void SessionImpl::close()
 		{
 			return;
 		}
-	} while(retryCount > 0);
+	}
+	while(retryCount > 0);
 		
-	throw ODBCException(nativeErrorCode);
-			(std::string(reinterpret_cast<const char *>(sqlErrorMessage)), nativeErrorCode);
+	throw ODBCException
+		(std::string(reinterpret_cast<const char *>(sqlErrorMessage)), nativeErrorCode);
 }
 
 

--- a/Data/ODBC/src/SessionImpl.cpp
+++ b/Data/ODBC/src/SessionImpl.cpp
@@ -401,7 +401,39 @@ void SessionImpl::close()
 	{
 	}
 
-	SQLDisconnect(_db);
+	SQLCHAR sqlState[5+1];
+	SQLCHAR sqlErrorMessage[SQL_MAX_MESSAGE_LENGTH];
+	SQLINTEGER nativeErrorCode;
+	SQLSMALLINT sqlErrorMessageLength;
+	unsigned int retryCount = 10;
+	do {
+		SQLRETURN rc = SQLDisconnect(_db);
+		if (SQL_SUCCESS != rc && SQL_SUCCESS_WITH_INFO != rc)
+		{
+			SQLGetDiagRec(SQL_HANDLE_DBC, _db,
+							1,
+							sqlState,
+							&nativeErrorCode,
+							sqlErrorMessage, SQL_MAX_MESSAGE_LENGTH, &sqlErrorMessageLength);
+			if (std::string(reinterpret_cast<const char *>(sqlState)) == "25000"
+				|| std::string(reinterpret_cast<const char *>(sqlState)) == "25501")
+			{
+				--retryCount;
+				Poco::Thread::sleep(100);
+			}
+			else
+			{
+				break;
+			}
+		}
+		else
+		{
+			return;
+		}
+	} while(retryCount > 0);
+		
+	throw ODBCException(nativeErrorCode);
+			(std::string(reinterpret_cast<const char *>(sqlErrorMessage)), nativeErrorCode);
 }
 
 


### PR DESCRIPTION
Dear, developers.

I tried fix issues #1373 for ODBC.
The function `SQLDisconnect(_db);` can fail with SQL_ERROR or SQL_INVALID_HANDLE.
So, I modified check return value of `SQLDisconnect(_db);`.

When SQLState is "25000" or "25501", retried `SQLDisconnect(_db);`.
The reason why retrying is done is that if SQLState is "25000" or "25501", there is a possibility that `SQLDisconnect(_db);` will succeed by retrying.


For Poco::Data::MySQL::SessionHandle::close() and  Poco::Data::PostgreSQL::SessionHandle::disconnect(), the same problem does not occur.
Because mysql_close and PQfinish don't have return value.