### PR TITLE
Modify validation check in Poco::DateTime

### DIFF
--- a/Foundation/include/Poco/DateTime.h
+++ b/Foundation/include/Poco/DateTime.h
@@ -106,6 +106,7 @@ public:
 		///   * second is from 0 to 59.
 		///   * millisecond is from 0 to 999.
 		///   * microsecond is from 0 to 999.
+		/// Throws an InvalidArgumentException if an argument date is out of range.
 
 	DateTime(double julianDay);
 		/// Creates a DateTime for the given Julian day.
@@ -140,6 +141,7 @@ public:
 		///   * second is from 0 to 59.
 		///   * millisecond is from 0 to 999.
 		///   * microsecond is from 0 to 999.
+		/// Throws an InvalidArgumentException if an argument date is out of range.
 
 	void swap(DateTime& dateTime);
 		/// Swaps the DateTime with another one.

--- a/Foundation/src/DateTime.cpp
+++ b/Foundation/src/DateTime.cpp
@@ -17,6 +17,7 @@
 #include "Poco/DateTime.h"
 #include "Poco/Timespan.h"
 #include "Poco/Exception.h"
+#include "Poco/Format.h"
 #include <algorithm>
 #include <cmath>
 
@@ -70,7 +71,19 @@ DateTime::DateTime(int otherYear, int otherMonth, int otherDay, int otherHour, i
 	}
 	else
 	{
-		throw Poco::InvalidArgumentException("DataTime is invalid");
+		throw Poco::InvalidArgumentException(Poco::format("Your Date time is %d-%d-%dT%d:%d:%d:%d:%d\n"
+                                                                  "Date time must be values of below.\n"
+                                                                  "Year must be betweent 0 and 9999\n"
+                                                                  "Month must be betweent 1 and 12\n"
+                                                                  "Day must be betweent  1 and %d\n"
+                                                                  "Hour must be betweent 0 and 23\n"
+                                                                  "Minute must be betweent 0 and 59\n"
+                                                                  "Second must be betweent 0 and 59\n"
+                                                                  "Millisecond must be betweent 0 and 999\n"
+                                                                  "Microseconds must be betweent 0 and 999",
+                                                                  _year, _month, _day, _hour, _minute,
+                                                                  _second, _millisecond, _microsecond,
+                                                                  daysOfMonth(_year, _month)));
 	}
 }
 
@@ -159,9 +172,21 @@ DateTime& DateTime::assign(int otherYear, int otherMonth, int otherDay, int othe
 	}
 	else
 	{
-		throw Poco::InvalidArgumentException("DataTime is invalid");
+		throw Poco::InvalidArgumentException(Poco::format("Your Date time is %d-%d-%dT%d:%d:%d:%d:%d\n"
+                                                                  "Date time must be values of below.\n"
+                                                                  "Year must be betweent 0 and 9999\n"
+                                                                  "Month must be betweent 1 and 12\n"
+                                                                  "Day must be betweent  1 and %d\n"
+                                                                  "Hour must be betweent 0 and 23\n"
+                                                                  "Minute must be betweent 0 and 59\n"
+                                                                  "Second must be betweent 0 and 59\n"
+                                                                  "Millisecond must be betweent 0 and 999\n"
+                                                                  "Microseconds must be betweent 0 and 999",
+                                                                  otherYear, otherMonth, otherDay, otherHour, otherMinute,
+                                                                  otherSecond, otherMillisecond, otherMicrosecond,
+                                                                  daysOfMonth(otherYear, otherMonth)));
 	}
-	
+
 	return *this;
 }
 

--- a/Foundation/src/DateTime.cpp
+++ b/Foundation/src/DateTime.cpp
@@ -16,6 +16,7 @@
 
 #include "Poco/DateTime.h"
 #include "Poco/Timespan.h"
+#include "Poco/Exception.h"
 #include <algorithm>
 #include <cmath>
 
@@ -63,18 +64,15 @@ DateTime::DateTime(int otherYear, int otherMonth, int otherDay, int otherHour, i
 	_millisecond(otherMillisecond),
 	_microsecond(otherMicrosecond)
 {
-	poco_assert (_year >= 0 && _year <= 9999);
-	poco_assert (_month >= 1 && _month <= 12);
-	poco_assert (_day >= 1 && _day <= daysOfMonth(_year, _month));
-	poco_assert (_hour >= 0 && _hour <= 23);
-	poco_assert (_minute >= 0 && _minute <= 59);
-	poco_assert (_second >= 0 && _second <= 59);
-	poco_assert (_millisecond >= 0 && _millisecond <= 999);
-	poco_assert (_microsecond >= 0 && _microsecond <= 999);
-	
-	_utcTime = toUtcTime(toJulianDay(_year, _month, _day)) + 10*(_hour*Timespan::HOURS + _minute*Timespan::MINUTES + _second*Timespan::SECONDS + _millisecond*Timespan::MILLISECONDS + _microsecond);
+	if(isValid(_year, _month, _day, _hour, _minute, _second, _millisecond, _microsecond))
+	{
+		_utcTime = toUtcTime(toJulianDay(_year, _month, _day)) + 10*(_hour*Timespan::HOURS + _minute*Timespan::MINUTES + _second*Timespan::SECONDS + _millisecond*Timespan::MILLISECONDS + _microsecond);
+	}
+	else
+	{
+		throw Poco::InvalidArgumentException("DataTime is invalid");
+	}
 }
-
 
 DateTime::DateTime(double otherJulianDay):
 	_utcTime(toUtcTime(otherJulianDay))
@@ -147,24 +145,22 @@ DateTime& DateTime::operator = (double otherJulianDay)
 
 DateTime& DateTime::assign(int otherYear, int otherMonth, int otherDay, int otherHour, int otherMinute, int otherSecond, int otherMillisecond, int otherMicrosecond)
 {
-	poco_assert (otherYear >= 0 && otherYear <= 9999);
-	poco_assert (otherMonth >= 1 && otherMonth <= 12);
-	poco_assert (otherDay >= 1 && otherDay <= daysOfMonth(otherYear, otherMonth));
-	poco_assert (otherHour >= 0 && otherHour <= 23);
-	poco_assert (otherMinute >= 0 && otherMinute <= 59);
-	poco_assert (otherSecond >= 0 && otherSecond <= 59);
-	poco_assert (otherMillisecond >= 0 && otherMillisecond <= 999);
-	poco_assert (otherMicrosecond >= 0 && otherMicrosecond <= 999);
-
-	_utcTime     = toUtcTime(toJulianDay(otherYear, otherMonth, otherDay)) + 10*(otherHour*Timespan::HOURS + otherMinute*Timespan::MINUTES + otherSecond*Timespan::SECONDS + otherMillisecond*Timespan::MILLISECONDS + otherMicrosecond);
-	_year        = otherYear;
-	_month       = otherMonth;
-	_day         = otherDay;
-	_hour        = otherHour;
-	_minute      = otherMinute;
-	_second      = otherSecond;
-	_millisecond = otherMillisecond;
-	_microsecond = otherMicrosecond;
+	if(isValid(otherYear, otherMonth, otherDay, otherHour, otherMinute, otherSecond, otherMillisecond, otherMicrosecond))
+	{
+		_utcTime     = toUtcTime(toJulianDay(otherYear, otherMonth, otherDay)) + 10*(otherHour*Timespan::HOURS + otherMinute*Timespan::MINUTES + otherSecond*Timespan::SECONDS + otherMillisecond*Timespan::MILLISECONDS + otherMicrosecond);
+		_year        = otherYear;
+		_month       = otherMonth;
+		_day         = otherDay;
+		_hour        = otherHour;
+		_minute      = otherMinute;
+		_second      = otherSecond;
+		_millisecond = otherMillisecond;
+		_microsecond = otherMicrosecond;
+	}
+	else
+	{
+		throw Poco::InvalidArgumentException("DataTime is invalid");
+	}
 	
 	return *this;
 }


### PR DESCRIPTION
Dear, developers.

I tried improved validation check in `Poco::DateTime` and `Poco::DateTime.assign` according to issues #1540's ideas.

I modified that used exception(InvalidArgumentException) in place of `poco_assert`.