### PR TITLE
Remove redundant memmove call in BasicFIFOBuffer::advance()

### DIFF
--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -338,17 +338,11 @@ public:
 	{
 		Mutex::ScopedLock lock(_mutex);
 
-		if (length > available())
+		if (length > _buffer.size() - _used - _begin)
 			throw Poco::InvalidAccessException("Cannot extend buffer.");
 		
 		if (!isWritable())
 			throw Poco::InvalidAccessException("Buffer not writable.");
-
-		if (_buffer.size() - (_begin + _used) < length)
-		{
-			std::memmove(_buffer.begin(), begin(), _used * sizeof(T));
-			_begin = 0;
-		}
 
 		std::size_t usedBefore = _used;
 		_used += length;


### PR DESCRIPTION
The memmove call is redundant since begin() is always the same as
_buffer.begin().

And since the call to begin() is removed, this function will not move
the data to the start of the buffer.