### PR TITLE
Add FTPS (FTP over explicit SSL) implementation

### DIFF
--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -134,7 +134,7 @@ public:
 	void setFileType(FileType type);
 		/// Sets the file type for transferring files.
 		///
-		/// Sends a TYPE command with a corresponsing argument to the
+		/// Sends a TYPE command with a corresponding argument to the
 		/// server.
 		///
 		/// Throws a FTPException in case of a FTP-specific error, or a
@@ -160,7 +160,7 @@ public:
 		
 	void cdup();
 		/// Moves one directory up from the current working directory
-		/// on teh server.
+		/// on the server.
 		///
 		/// Sends a CDUP command to the server.
 		///
@@ -227,7 +227,7 @@ public:
 	std::ostream& beginUpload(const std::string& path);
 		/// Starts uploading the file with the given name.
 		/// After all data has been written to the returned stream,
-		/// endUpload() must be called to finish the download.
+		/// endUpload() must be called to finish the upload.
 		///
 		/// A stream for reading the file's content is returned.
 		/// The stream is valid until endUpload() is called.
@@ -258,7 +258,7 @@ public:
 		/// The stream is valid until endList() is called.
 		///
 		/// Optionally, a path to a directory or file can be specified.
-		/// According to the FTP prototol, if a path to a filename is
+		/// According to the FTP protocol, if a path to a filename is
 		/// given, only information for the specific file is returned.
 		/// If a path to a directory is given, a listing of that directory
 		/// is returned. If no path is given, a listing of the current

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -101,14 +101,14 @@ public:
 	bool getPassive() const;
 		/// Returns true iff passive mode is enabled for this connection.
 		
-	void open(const std::string& host,
+	virtual void open(const std::string& host,
 		Poco::UInt16 port,
 		const std::string& username = "",
 		const std::string& password = "");
 		/// Opens the FTP connection to the given host and port.
 		/// If username is supplied, login is attempted.
 
-	void login(const std::string& username, const std::string& password);
+	virtual void login(const std::string& username, const std::string& password);
 		/// Authenticates the user against the FTP server. Must be
 		/// called before any other commands (except QUIT) can be sent.
 		///
@@ -134,7 +134,7 @@ public:
 	void setFileType(FileType type);
 		/// Sets the file type for transferring files.
 		///
-		/// Sends a TYPE command with a corresponding argument to the
+		/// Sends a TYPE command with a corresponsing argument to the
 		/// server.
 		///
 		/// Throws a FTPException in case of a FTP-specific error, or a
@@ -160,7 +160,7 @@ public:
 		
 	void cdup();
 		/// Moves one directory up from the current working directory
-		/// on the server.
+		/// on teh server.
 		///
 		/// Sends a CDUP command to the server.
 		///
@@ -227,7 +227,7 @@ public:
 	std::ostream& beginUpload(const std::string& path);
 		/// Starts uploading the file with the given name.
 		/// After all data has been written to the returned stream,
-		/// endUpload() must be called to finish the upload.
+		/// endUpload() must be called to finish the download.
 		///
 		/// A stream for reading the file's content is returned.
 		/// The stream is valid until endUpload() is called.
@@ -258,7 +258,7 @@ public:
 		/// The stream is valid until endList() is called.
 		///
 		/// Optionally, a path to a directory or file can be specified.
-		/// According to the FTP protocol, if a path to a filename is
+		/// According to the FTP prototol, if a path to a filename is
 		/// given, only information for the specific file is returned.
 		/// If a path to a directory is given, a listing of that directory
 		/// is returned. If no path is given, a listing of the current
@@ -304,7 +304,13 @@ public:
 	bool isLoggedIn() const;
 		/// Returns true if the session is logged in.
 
+	bool isSecure() const;
+		/// Returns true if the session is FTPS.
+
 protected:
+	virtual void receiveServerReadyReply();
+		/// Function that read server welcome message after connetion
+
 	enum StatusClass
 	{
 		FTP_POSITIVE_PRELIMINARY  = 1,
@@ -324,7 +330,7 @@ protected:
 	static bool isTransientNegative(int status);
 	static bool isPermanentNegative(int status);
 	std::string extractPath(const std::string& response);
-	StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
+	virtual StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
 	StreamSocket activeDataConnection(const std::string& command, const std::string& arg);
 	StreamSocket passiveDataConnection(const std::string& command, const std::string& arg);
 	void sendPortCommand(const SocketAddress& addr);
@@ -336,21 +342,21 @@ protected:
 	void parseAddress(const std::string& str, SocketAddress& addr);
 	void parseExtAddress(const std::string& str, SocketAddress& addr);
 	void endTransfer();
-	
+
+	DialogSocket*  _pControlSocket = nullptr;
+	SocketStream*  _pDataStream = nullptr;
+
 private:
 	FTPClientSession(const FTPClientSession&);
-	FTPClientSession& operator = (const FTPClientSession&);
-		
+
+	bool	   _passiveMode = true;
+	bool	   _supports1738 = true;
+	bool	   _serverReady = false;
+	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
 	std::string    _host;
-	Poco::UInt16   _port;
-	DialogSocket*  _pControlSocket;
-	SocketStream*  _pDataStream;
-	bool	   _passiveMode;
-	FileType       _fileType;
-	bool	   _supports1738;
-	bool	   _serverReady;
-	bool	   _isLoggedIn;
-	Poco::Timespan _timeout;
+	Poco::UInt16   _port = 0;
+	bool	   _isLoggedIn = false;
+	FileType       _fileType = TYPE_BINARY;
 };
 
 
@@ -398,6 +404,10 @@ inline bool FTPClientSession::isLoggedIn() const
 	return _isLoggedIn;
 }
 
+inline bool FTPClientSession::isSecure() const
+{
+	return false;
+}
 
 } } // namespace Poco::Net
 

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -348,15 +348,15 @@ protected:
 
 private:
 	FTPClientSession(const FTPClientSession&);
-
-	bool	   _passiveMode = true;
-	bool	   _supports1738 = true;
-	bool	   _serverReady = false;
-	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
+	
 	std::string    _host;
 	Poco::UInt16   _port = 0;
-	bool	   _isLoggedIn = false;
+	bool	   _passiveMode = true;
 	FileType       _fileType = TYPE_BINARY;
+	bool	   _supports1738 = true;
+	bool	   _serverReady = false;
+	bool	   _isLoggedIn = false;
+	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
 };
 
 

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -75,10 +75,9 @@ FTPClientSession::FTPClientSession(const std::string& host,
 	_isLoggedIn(false),
 	_timeout(DEFAULT_TIMEOUT)
 {
+	_pControlSocket->setReceiveTimeout(_timeout);
 	if (!username.empty())
 		login(username, password);
-	else
-		_pControlSocket->setReceiveTimeout(_timeout);
 }
 
 
@@ -92,7 +91,6 @@ FTPClientSession::~FTPClientSession()
 	{
 	}
 }
-
 
 void FTPClientSession::setTimeout(const Poco::Timespan& timeout)
 {
@@ -141,6 +139,17 @@ void FTPClientSession::open(const std::string& host,
 	}
 }
 
+void  FTPClientSession::receiveServerReadyReply()
+{
+	if (_serverReady)
+		return;
+	std::string response;
+	int status = _pControlSocket->receiveStatusMessage(response);
+	if (!isPositiveCompletion(status))
+		throw FTPException("Cannot receive status message", response, status);
+
+	_serverReady = true;
+}
 
 void FTPClientSession::login(const std::string& username, const std::string& password)
 {
@@ -153,15 +162,7 @@ void FTPClientSession::login(const std::string& username, const std::string& pas
 		_pControlSocket = new DialogSocket(SocketAddress(_host, _port));
 		_pControlSocket->setReceiveTimeout(_timeout);
 	}
-
-	if (!_serverReady)
-	{
-		status = _pControlSocket->receiveStatusMessage(response);
-		if (!isPositiveCompletion(status))
-			throw FTPException("Cannot login to server", response, status);
-
-		_serverReady = true;
-	}
+	receiveServerReadyReply();
 
 	status = sendCommand("USER", username, response);
 	if (isPositiveIntermediate(status))
@@ -592,6 +593,5 @@ void FTPClientSession::endTransfer()
 			throw FTPException("Data transfer failed", response, status);
 	}
 }
-
 
 } } // namespace Poco::Net

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -31,9 +31,9 @@ namespace Net {
 
 
 FTPClientSession::FTPClientSession():
-	_port(0),
 	_pControlSocket(0),
 	_pDataStream(0),
+	_port(0),		
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),
@@ -45,10 +45,10 @@ FTPClientSession::FTPClientSession():
 
 	
 FTPClientSession::FTPClientSession(const StreamSocket& socket):
-	_host(socket.address().host().toString()),
-	_port(socket.address().port()),
 	_pControlSocket(new DialogSocket(socket)),
 	_pDataStream(0),
+	_host(socket.address().host().toString()),
+	_port(socket.address().port()),
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),
@@ -64,10 +64,10 @@ FTPClientSession::FTPClientSession(const std::string& host,
 	Poco::UInt16 port,
 	const std::string& username,
 	const std::string& password):
-	_host(host),
-	_port(port),
 	_pControlSocket(new DialogSocket(SocketAddress(host, port))),
 	_pDataStream(0),
+	_host(host),
+	_port(port),		
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),

--- a/NetSSL_OpenSSL/Makefile
+++ b/NetSSL_OpenSSL/Makefile
@@ -5,6 +5,7 @@
 #
 # Makefile for Poco NetSSL_OpenSSL
 #
+
 include $(POCO_BASE)/build/rules/global
 
 SYSLIBS += -lssl -lcrypto
@@ -17,7 +18,7 @@ objects = AcceptCertificateHandler RejectCertificateHandler ConsoleCertificateHa
 	PrivateKeyPassphraseHandler SecureServerSocket SecureServerSocketImpl \
 	SecureSocketImpl SecureStreamSocket SecureStreamSocketImpl \
 	SSLException SSLManager Utility VerificationErrorArgs \
-	X509Certificate Session SecureSMTPClientSession
+	X509Certificate Session SecureSMTPClientSession FTPSClientSession
 
 target         = PocoNetSSL
 target_version = $(LIBVERSION)

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|Win32">
@@ -32,7 +32,7 @@
     <RootNamespace>NetSSL_OpenSSL</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'">PocoNetSSLd</TargetName>
@@ -122,7 +122,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NetSSL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -132,13 +132,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin\PocoNetSSLd.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -156,7 +156,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NetSSL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -164,13 +164,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin\PocoNetSSL.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -185,21 +185,22 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmtd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoNetSSLmtd.lib</OutputFile>
@@ -212,7 +213,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -220,10 +221,11 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib\PocoNetSSLmt.lib</OutputFile>
@@ -232,7 +234,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -242,7 +244,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmdd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -259,7 +261,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -267,86 +269,86 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libeay32md.lib;ssleay32md.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\lib\PocoNetSSLmd.lib</OutputFile>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\Context.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h"/>
-    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyFileHandler.h"/>
-    <ClInclude Include="include\Poco\Net\NetSSL.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h"/>
-    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\Session.h"/>
-    <ClInclude Include="include\Poco\Net\SSLException.h"/>
-    <ClInclude Include="include\Poco\Net\SSLManager.h"/>
-    <ClInclude Include="include\Poco\Net\Utility.h"/>
-    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h"/>
-    <ClInclude Include="include\Poco\Net\X509Certificate.h"/>
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\Context.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyFileHandler.h" />
+    <ClInclude Include="include\Poco\Net\NetSSL.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h" />
+    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h" />
+    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\Session.h" />
+    <ClInclude Include="include\Poco\Net\SSLException.h" />
+    <ClInclude Include="include\Poco\Net\SSLManager.h" />
+    <ClInclude Include="include\Poco\Net\Utility.h" />
+    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h" />
+    <ClInclude Include="include\Poco\Net\X509Certificate.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\AcceptCertificateHandler.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactory.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp"/>
-    <ClCompile Include="src\ConsoleCertificateHandler.cpp"/>
-    <ClCompile Include="src\Context.cpp"/>
-    <ClCompile Include="src\HTTPSClientSession.cpp"/>
-    <ClCompile Include="src\HTTPSSessionInstantiator.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactory.cpp"/>
-    <ClCompile Include="src\InvalidCertificateHandler.cpp"/>
-    <ClCompile Include="src\KeyConsoleHandler.cpp"/>
-    <ClCompile Include="src\KeyFileHandler.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactory.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp"/>
-    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp"/>
-    <ClCompile Include="src\RejectCertificateHandler.cpp"/>
-    <ClCompile Include="src\SecureServerSocket.cpp"/>
-    <ClCompile Include="src\SecureServerSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureSMTPClientSession.cpp"/>
-    <ClCompile Include="src\SecureSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureStreamSocket.cpp"/>
-    <ClCompile Include="src\SecureStreamSocketImpl.cpp"/>
-    <ClCompile Include="src\Session.cpp"/>
-    <ClCompile Include="src\SSLException.cpp"/>
-    <ClCompile Include="src\SSLManager.cpp"/>
-    <ClCompile Include="src\Utility.cpp"/>
-    <ClCompile Include="src\VerificationErrorArgs.cpp"/>
-    <ClCompile Include="src\X509Certificate.cpp"/>
+    <ClCompile Include="src\FTPSClientSession.cpp" />
+    <ClCompile Include="src\AcceptCertificateHandler.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactory.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp" />
+    <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
+    <ClCompile Include="src\Context.cpp" />
+    <ClCompile Include="src\HTTPSClientSession.cpp" />
+    <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactory.cpp" />
+    <ClCompile Include="src\InvalidCertificateHandler.cpp" />
+    <ClCompile Include="src\KeyConsoleHandler.cpp" />
+    <ClCompile Include="src\KeyFileHandler.cpp" />
+    <ClCompile Include="src\PrivateKeyFactory.cpp" />
+    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp" />
+    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp" />
+    <ClCompile Include="src\RejectCertificateHandler.cpp" />
+    <ClCompile Include="src\SecureServerSocket.cpp" />
+    <ClCompile Include="src\SecureServerSocketImpl.cpp" />
+    <ClCompile Include="src\SecureSMTPClientSession.cpp" />
+    <ClCompile Include="src\SecureSocketImpl.cpp" />
+    <ClCompile Include="src\SecureStreamSocket.cpp" />
+    <ClCompile Include="src\SecureStreamSocketImpl.cpp" />
+    <ClCompile Include="src\Session.cpp" />
+    <ClCompile Include="src\SSLException.cpp" />
+    <ClCompile Include="src\SSLManager.cpp" />
+    <ClCompile Include="src\Utility.cpp" />
+    <ClCompile Include="src\VerificationErrorArgs.cpp" />
+    <ClCompile Include="src\X509Certificate.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_static_md|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_shared|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_mt|Win32'">true</ExcludedFromBuild>
     </ResourceCompile>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj
@@ -185,7 +185,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>false</MinimalRebuild>
@@ -213,7 +213,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -287,6 +287,7 @@
     <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h" />
     <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
     <ClInclude Include="include\Poco\Net\Context.h" />
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h" />
     <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
     <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
     <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
@@ -318,6 +319,7 @@
     <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp" />
     <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
     <ClCompile Include="src\Context.cpp" />
+    <ClCompile Include="src\FTPSStreamFactory.cpp" />
     <ClCompile Include="src\HTTPSClientSession.cpp" />
     <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
     <ClCompile Include="src\HTTPSStreamFactory.cpp" />

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
       <Filter>FTPSClient</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h">
+      <Filter>FTPSClient</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -213,6 +216,9 @@
       <Filter>Mail\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClient</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSStreamFactory.cpp">
       <Filter>FTPSClient</Filter>
     </ClCompile>
   </ItemGroup>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs140.vcxproj.filters
@@ -2,40 +2,43 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="SSLCore">
-      <UniqueIdentifier>{789ddb0d-3464-4175-a1ec-887b7f45bc4b}</UniqueIdentifier>
+      <UniqueIdentifier>{450d9657-d364-4e40-873b-e26130399dce}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLCore\Header Files">
-      <UniqueIdentifier>{69073133-2b1b-4129-9b7f-c98798689020}</UniqueIdentifier>
+      <UniqueIdentifier>{bf592bcb-f0d9-4af2-aa87-3c588ef594d0}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLCore\Source Files">
-      <UniqueIdentifier>{2b1c83a8-72f8-49ec-bdcc-c63c05479758}</UniqueIdentifier>
+      <UniqueIdentifier>{4382965b-a069-4c84-ad5e-37ba8b1bf476}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient">
-      <UniqueIdentifier>{241aa54a-0f0f-4642-a7ff-1260befba572}</UniqueIdentifier>
+      <UniqueIdentifier>{94f05287-6383-4756-9ae6-4b407ee2fb2b}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Header Files">
-      <UniqueIdentifier>{a2c4b088-a8ea-4436-b739-dda340fed322}</UniqueIdentifier>
+      <UniqueIdentifier>{cfad4897-e6e8-426e-9d84-9fed0a6aafef}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Source Files">
-      <UniqueIdentifier>{1401db41-9ecb-4ee1-a030-067aaef1d2cb}</UniqueIdentifier>
+      <UniqueIdentifier>{4ee5a13f-57be-49b6-b97e-e9b718af3347}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets">
-      <UniqueIdentifier>{48c94e28-fd44-4f4e-98d1-ca35d36037cc}</UniqueIdentifier>
+      <UniqueIdentifier>{7f1f559c-4bcf-4912-87fd-0102484414d9}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets\Header Files">
-      <UniqueIdentifier>{dac39e16-4b41-400a-be69-cf32bf8cea82}</UniqueIdentifier>
+      <UniqueIdentifier>{95e63809-0ca9-4872-a237-39bed9e08efd}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets\Source Files">
-      <UniqueIdentifier>{7269f7da-1ad9-4bea-bead-b527c8803c28}</UniqueIdentifier>
+      <UniqueIdentifier>{2bf067b3-457c-4e5b-81cc-a41fea3bfc8c}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail">
-      <UniqueIdentifier>{8cfd2f8c-f11c-4b80-a15e-fac5e86d966a}</UniqueIdentifier>
+      <UniqueIdentifier>{06d51655-0134-4907-aede-aa9d169e3a73}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail\Header Files">
-      <UniqueIdentifier>{08b0b775-7ac7-40ff-aae5-c99e4ab71a0c}</UniqueIdentifier>
+      <UniqueIdentifier>{722ba30d-ada8-4d4d-90e2-0d2fcc613298}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail\Source Files">
-      <UniqueIdentifier>{411ae688-a196-41e1-ad15-df5f35c0af97}</UniqueIdentifier>
+      <UniqueIdentifier>{40f537d2-fb64-4707-99f8-b50fcce91eed}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClient">
+      <UniqueIdentifier>{6d799797-8cba-4a1d-9afa-7505c8e9761a}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -123,6 +126,9 @@
     <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h">
       <Filter>Mail\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
+      <Filter>FTPSClient</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -205,6 +211,9 @@
     </ClCompile>
     <ClCompile Include="src\SecureSMTPClientSession.cpp">
       <Filter>Mail\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClient</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.sln
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.sln
@@ -1,5 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2017
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NetSSL_OpenSSL", "NetSSL_OpenSSL_vs150.vcxproj", "{5AECC55E-A469-11DA-8DA6-005056C00008}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestSuite", "testsuite\TestSuite_vs150.vcxproj", "{B2B88092-5BCE-4AC0-941E-88167138B4A7}"
@@ -10,49 +12,49 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		debug_shared|Win32 = debug_shared|Win32
-		release_shared|Win32 = release_shared|Win32
-		debug_static_mt|Win32 = debug_static_mt|Win32
-		release_static_mt|Win32 = release_static_mt|Win32
 		debug_static_md|Win32 = debug_static_md|Win32
+		debug_static_mt|Win32 = debug_static_mt|Win32
+		release_shared|Win32 = release_shared|Win32
 		release_static_md|Win32 = release_static_md|Win32
+		release_static_mt|Win32 = release_static_mt|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|Win32.ActiveCfg = debug_shared|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|Win32.Build.0 = debug_shared|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|Win32.Deploy.0 = debug_shared|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.ActiveCfg = release_shared|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.Build.0 = release_shared|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.Deploy.0 = release_shared|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.ActiveCfg = debug_static_mt|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.Build.0 = debug_static_mt|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.Deploy.0 = debug_static_mt|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.ActiveCfg = release_static_mt|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.Build.0 = release_static_mt|Win32
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.Deploy.0 = release_static_mt|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|Win32.ActiveCfg = debug_static_md|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|Win32.Build.0 = debug_static_md|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|Win32.Deploy.0 = debug_static_md|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.ActiveCfg = debug_static_mt|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.Build.0 = debug_static_mt|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|Win32.Deploy.0 = debug_static_mt|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.ActiveCfg = release_shared|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.Build.0 = release_shared|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|Win32.Deploy.0 = release_shared|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|Win32.ActiveCfg = release_static_md|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|Win32.Build.0 = release_static_md|Win32
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|Win32.Deploy.0 = release_static_md|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.ActiveCfg = release_static_mt|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.Build.0 = release_static_mt|Win32
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|Win32.Deploy.0 = release_static_mt|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|Win32.ActiveCfg = debug_shared|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|Win32.Build.0 = debug_shared|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|Win32.Deploy.0 = debug_shared|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.ActiveCfg = release_shared|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.Build.0 = release_shared|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.Deploy.0 = release_shared|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.ActiveCfg = debug_static_mt|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.Build.0 = debug_static_mt|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.Deploy.0 = debug_static_mt|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.ActiveCfg = release_static_mt|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.Build.0 = release_static_mt|Win32
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.Deploy.0 = release_static_mt|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|Win32.ActiveCfg = debug_static_md|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|Win32.Build.0 = debug_static_md|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|Win32.Deploy.0 = debug_static_md|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.ActiveCfg = debug_static_mt|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.Build.0 = debug_static_mt|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|Win32.Deploy.0 = debug_static_mt|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.ActiveCfg = release_shared|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.Build.0 = release_shared|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|Win32.Deploy.0 = release_shared|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|Win32.ActiveCfg = release_static_md|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|Win32.Build.0 = release_static_md|Win32
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|Win32.Deploy.0 = release_static_md|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.ActiveCfg = release_static_mt|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.Build.0 = release_static_mt|Win32
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|Win32.Deploy.0 = release_static_mt|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|Win32">
@@ -32,7 +32,7 @@
     <RootNamespace>NetSSL_OpenSSL</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'">PocoNetSSLd</TargetName>
@@ -132,7 +132,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -164,9 +164,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -195,7 +195,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmtd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -220,9 +220,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
@@ -242,7 +242,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmdd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -267,10 +267,10 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib\PocoNetSSLmd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
@@ -279,63 +279,67 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\Context.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h"/>
-    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyFileHandler.h"/>
-    <ClInclude Include="include\Poco\Net\NetSSL.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h"/>
-    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\Session.h"/>
-    <ClInclude Include="include\Poco\Net\SSLException.h"/>
-    <ClInclude Include="include\Poco\Net\SSLManager.h"/>
-    <ClInclude Include="include\Poco\Net\Utility.h"/>
-    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h"/>
-    <ClInclude Include="include\Poco\Net\X509Certificate.h"/>
+    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\Context.h" />
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyFileHandler.h" />
+    <ClInclude Include="include\Poco\Net\NetSSL.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h" />
+    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h" />
+    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\Session.h" />
+    <ClInclude Include="include\Poco\Net\SSLException.h" />
+    <ClInclude Include="include\Poco\Net\SSLManager.h" />
+    <ClInclude Include="include\Poco\Net\Utility.h" />
+    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h" />
+    <ClInclude Include="include\Poco\Net\X509Certificate.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\AcceptCertificateHandler.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactory.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp"/>
-    <ClCompile Include="src\ConsoleCertificateHandler.cpp"/>
-    <ClCompile Include="src\Context.cpp"/>
-    <ClCompile Include="src\HTTPSClientSession.cpp"/>
-    <ClCompile Include="src\HTTPSSessionInstantiator.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactory.cpp"/>
-    <ClCompile Include="src\InvalidCertificateHandler.cpp"/>
-    <ClCompile Include="src\KeyConsoleHandler.cpp"/>
-    <ClCompile Include="src\KeyFileHandler.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactory.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp"/>
-    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp"/>
-    <ClCompile Include="src\RejectCertificateHandler.cpp"/>
-    <ClCompile Include="src\SecureServerSocket.cpp"/>
-    <ClCompile Include="src\SecureServerSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureSMTPClientSession.cpp"/>
-    <ClCompile Include="src\SecureSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureStreamSocket.cpp"/>
-    <ClCompile Include="src\SecureStreamSocketImpl.cpp"/>
-    <ClCompile Include="src\Session.cpp"/>
-    <ClCompile Include="src\SSLException.cpp"/>
-    <ClCompile Include="src\SSLManager.cpp"/>
-    <ClCompile Include="src\Utility.cpp"/>
-    <ClCompile Include="src\VerificationErrorArgs.cpp"/>
-    <ClCompile Include="src\X509Certificate.cpp"/>
+    <ClCompile Include="src\AcceptCertificateHandler.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactory.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp" />
+    <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
+    <ClCompile Include="src\Context.cpp" />
+    <ClCompile Include="src\FTPSClientSession.cpp" />
+    <ClCompile Include="src\FTPSStreamFactory.cpp" />
+    <ClCompile Include="src\HTTPSClientSession.cpp" />
+    <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactory.cpp" />
+    <ClCompile Include="src\InvalidCertificateHandler.cpp" />
+    <ClCompile Include="src\KeyConsoleHandler.cpp" />
+    <ClCompile Include="src\KeyFileHandler.cpp" />
+    <ClCompile Include="src\PrivateKeyFactory.cpp" />
+    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp" />
+    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp" />
+    <ClCompile Include="src\RejectCertificateHandler.cpp" />
+    <ClCompile Include="src\SecureServerSocket.cpp" />
+    <ClCompile Include="src\SecureServerSocketImpl.cpp" />
+    <ClCompile Include="src\SecureSMTPClientSession.cpp" />
+    <ClCompile Include="src\SecureSocketImpl.cpp" />
+    <ClCompile Include="src\SecureStreamSocket.cpp" />
+    <ClCompile Include="src\SecureStreamSocketImpl.cpp" />
+    <ClCompile Include="src\Session.cpp" />
+    <ClCompile Include="src\SSLException.cpp" />
+    <ClCompile Include="src\SSLManager.cpp" />
+    <ClCompile Include="src\Utility.cpp" />
+    <ClCompile Include="src\VerificationErrorArgs.cpp" />
+    <ClCompile Include="src\X509Certificate.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">
@@ -347,6 +351,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_mt|Win32'">true</ExcludedFromBuild>
     </ResourceCompile>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_vs150.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="Mail\Source Files">
       <UniqueIdentifier>{411ae688-a196-41e1-ad15-df5f35c0af97}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FTPSClientSession">
+      <UniqueIdentifier>{b7576a8c-16d7-441a-a69c-39734bf72731}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h">
@@ -123,6 +126,12 @@
     <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h">
       <Filter>Mail\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -205,6 +214,12 @@
     </ClCompile>
     <ClCompile Include="src\SecureSMTPClientSession.cpp">
       <Filter>Mail\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClientSession</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSStreamFactory.cpp">
+      <Filter>FTPSClientSession</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|x64">
@@ -32,7 +32,7 @@
     <RootNamespace>NetSSL_OpenSSL</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">PocoNetSSL64d</TargetName>
@@ -122,7 +122,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NetSSL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -132,13 +132,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoNetSSL64d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -156,7 +156,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NetSSL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -164,13 +164,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoNetSSL64.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -185,21 +185,22 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <BufferSecurityCheck>true</BufferSecurityCheck>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib64\PocoNetSSLmtd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoNetSSLmtd.lib</OutputFile>
@@ -212,7 +213,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -220,10 +221,11 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>..\lib64\PocoNetSSLmt.lib</OutputFile>
@@ -232,7 +234,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -242,7 +244,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib64\PocoNetSSLmdd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -259,7 +261,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -267,9 +269,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
@@ -277,74 +279,74 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\Context.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h"/>
-    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyFileHandler.h"/>
-    <ClInclude Include="include\Poco\Net\NetSSL.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h"/>
-    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\Session.h"/>
-    <ClInclude Include="include\Poco\Net\SSLException.h"/>
-    <ClInclude Include="include\Poco\Net\SSLManager.h"/>
-    <ClInclude Include="include\Poco\Net\Utility.h"/>
-    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h"/>
-    <ClInclude Include="include\Poco\Net\X509Certificate.h"/>
+    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\Context.h" />
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyFileHandler.h" />
+    <ClInclude Include="include\Poco\Net\NetSSL.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h" />
+    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h" />
+    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\Session.h" />
+    <ClInclude Include="include\Poco\Net\SSLException.h" />
+    <ClInclude Include="include\Poco\Net\SSLManager.h" />
+    <ClInclude Include="include\Poco\Net\Utility.h" />
+    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h" />
+    <ClInclude Include="include\Poco\Net\X509Certificate.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\AcceptCertificateHandler.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactory.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp"/>
-    <ClCompile Include="src\ConsoleCertificateHandler.cpp"/>
-    <ClCompile Include="src\Context.cpp"/>
-    <ClCompile Include="src\HTTPSClientSession.cpp"/>
-    <ClCompile Include="src\HTTPSSessionInstantiator.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactory.cpp"/>
-    <ClCompile Include="src\InvalidCertificateHandler.cpp"/>
-    <ClCompile Include="src\KeyConsoleHandler.cpp"/>
-    <ClCompile Include="src\KeyFileHandler.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactory.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp"/>
-    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp"/>
-    <ClCompile Include="src\RejectCertificateHandler.cpp"/>
-    <ClCompile Include="src\SecureServerSocket.cpp"/>
-    <ClCompile Include="src\SecureServerSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureSMTPClientSession.cpp"/>
-    <ClCompile Include="src\SecureSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureStreamSocket.cpp"/>
-    <ClCompile Include="src\SecureStreamSocketImpl.cpp"/>
-    <ClCompile Include="src\Session.cpp"/>
-    <ClCompile Include="src\SSLException.cpp"/>
-    <ClCompile Include="src\SSLManager.cpp"/>
-    <ClCompile Include="src\Utility.cpp"/>
-    <ClCompile Include="src\VerificationErrorArgs.cpp"/>
-    <ClCompile Include="src\X509Certificate.cpp"/>
+    <ClCompile Include="src\AcceptCertificateHandler.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactory.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp" />
+    <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
+    <ClCompile Include="src\Context.cpp" />
+    <ClCompile Include="src\FTPSClientSession.cpp" />
+    <ClCompile Include="src\HTTPSClientSession.cpp" />
+    <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactory.cpp" />
+    <ClCompile Include="src\InvalidCertificateHandler.cpp" />
+    <ClCompile Include="src\KeyConsoleHandler.cpp" />
+    <ClCompile Include="src\KeyFileHandler.cpp" />
+    <ClCompile Include="src\PrivateKeyFactory.cpp" />
+    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp" />
+    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp" />
+    <ClCompile Include="src\RejectCertificateHandler.cpp" />
+    <ClCompile Include="src\SecureServerSocket.cpp" />
+    <ClCompile Include="src\SecureServerSocketImpl.cpp" />
+    <ClCompile Include="src\SecureSMTPClientSession.cpp" />
+    <ClCompile Include="src\SecureSocketImpl.cpp" />
+    <ClCompile Include="src\SecureStreamSocket.cpp" />
+    <ClCompile Include="src\SecureStreamSocketImpl.cpp" />
+    <ClCompile Include="src\Session.cpp" />
+    <ClCompile Include="src\SSLException.cpp" />
+    <ClCompile Include="src\SSLManager.cpp" />
+    <ClCompile Include="src\Utility.cpp" />
+    <ClCompile Include="src\VerificationErrorArgs.cpp" />
+    <ClCompile Include="src\X509Certificate.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_shared|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'">true</ExcludedFromBuild>
     </ResourceCompile>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
@@ -185,7 +185,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>false</MinimalRebuild>
@@ -213,7 +213,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;..\Foundation\include;..\Net\include;..\Util\include;..\Crypto\include;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj
@@ -285,6 +285,7 @@
     <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
     <ClInclude Include="include\Poco\Net\Context.h" />
     <ClInclude Include="include\Poco\Net\FTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h" />
     <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
     <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
     <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
@@ -316,6 +317,7 @@
     <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
     <ClCompile Include="src\Context.cpp" />
     <ClCompile Include="src\FTPSClientSession.cpp" />
+    <ClCompile Include="src\FTPSStreamFactory.cpp" />
     <ClCompile Include="src\HTTPSClientSession.cpp" />
     <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
     <ClCompile Include="src\HTTPSStreamFactory.cpp" />

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj.filters
@@ -2,40 +2,43 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="SSLCore">
-      <UniqueIdentifier>{b91c5df5-613c-4874-bdf2-e66a0dae1cd5}</UniqueIdentifier>
+      <UniqueIdentifier>{2825feac-d0b8-43a1-a02c-4be335a08ffc}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLCore\Header Files">
-      <UniqueIdentifier>{3be4dfec-1bc3-4644-9d2d-de4fcdf2e8b2}</UniqueIdentifier>
+      <UniqueIdentifier>{7a57b699-d03e-42ed-b9d8-f1bb4dd2b5ac}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLCore\Source Files">
-      <UniqueIdentifier>{7138002d-d8aa-4f19-a1a7-39569e2c6977}</UniqueIdentifier>
+      <UniqueIdentifier>{fadd3de5-29bf-4aee-bdc4-c3f891fc8fba}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient">
-      <UniqueIdentifier>{41d87832-cf2a-4cd2-b974-05c4b9ca797d}</UniqueIdentifier>
+      <UniqueIdentifier>{3ea1e146-320d-4fb4-912a-2e9256cf23ca}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Header Files">
-      <UniqueIdentifier>{b437968d-451f-450c-9879-d448d7abfdd4}</UniqueIdentifier>
+      <UniqueIdentifier>{c4bc68cb-62cb-4d93-bd52-f685fe483d6d}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Source Files">
-      <UniqueIdentifier>{1f033138-4c2e-45af-b2a1-f2596d53f8ab}</UniqueIdentifier>
+      <UniqueIdentifier>{0190d97a-4f6a-4389-a77d-f7d53246f984}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets">
-      <UniqueIdentifier>{ce05bd5b-cb0a-436d-a5a8-fe68be7a88a1}</UniqueIdentifier>
+      <UniqueIdentifier>{2ccd473c-fa6d-4c3d-9129-1a84e086f850}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets\Header Files">
-      <UniqueIdentifier>{1971017d-cfc9-4601-a88e-8f0e3d21d1a5}</UniqueIdentifier>
+      <UniqueIdentifier>{dde0d53a-c83a-4af2-8fca-e2512a31e73d}</UniqueIdentifier>
     </Filter>
     <Filter Include="SSLSockets\Source Files">
-      <UniqueIdentifier>{4f4ab228-37eb-42c0-9b77-b68d31663755}</UniqueIdentifier>
+      <UniqueIdentifier>{0e6237de-7ba2-4a42-a014-2c0bea727832}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail">
-      <UniqueIdentifier>{5f58196e-61e9-4455-b96e-60c98c0ce638}</UniqueIdentifier>
+      <UniqueIdentifier>{8940d6cb-2dff-4672-86b6-cf16739eb4e5}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail\Header Files">
-      <UniqueIdentifier>{1c73c85c-dbf5-4c3f-91e3-7a3481402b81}</UniqueIdentifier>
+      <UniqueIdentifier>{36416186-8918-4553-941f-71e7cd8136cc}</UniqueIdentifier>
     </Filter>
     <Filter Include="Mail\Source Files">
-      <UniqueIdentifier>{6b568f03-d4e6-4b50-90ac-9f31de7cad4c}</UniqueIdentifier>
+      <UniqueIdentifier>{5b30a32f-ed8c-45e7-a052-6abbe7165635}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClientSession">
+      <UniqueIdentifier>{e7ac1ab3-ce1c-487e-8fb1-195df14a5527}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -123,6 +126,9 @@
     <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h">
       <Filter>Mail\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -205,6 +211,9 @@
     </ClCompile>
     <ClCompile Include="src\SecureSMTPClientSession.cpp">
       <Filter>Mail\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClientSession</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs140.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
       <Filter>FTPSClientSession</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -213,6 +216,9 @@
       <Filter>Mail\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClientSession</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSStreamFactory.cpp">
       <Filter>FTPSClientSession</Filter>
     </ClCompile>
   </ItemGroup>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.sln
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.sln
@@ -1,5 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2017
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NetSSL_OpenSSL", "NetSSL_OpenSSL_x64_vs150.vcxproj", "{5AECC55E-A469-11DA-8DA6-005056C00008}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestSuite", "testsuite\TestSuite_x64_vs150.vcxproj", "{B2B88092-5BCE-4AC0-941E-88167138B4A7}"
@@ -10,49 +12,49 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		debug_shared|x64 = debug_shared|x64
-		release_shared|x64 = release_shared|x64
-		debug_static_mt|x64 = debug_static_mt|x64
-		release_static_mt|x64 = release_static_mt|x64
 		debug_static_md|x64 = debug_static_md|x64
+		debug_static_mt|x64 = debug_static_mt|x64
+		release_shared|x64 = release_shared|x64
 		release_static_md|x64 = release_static_md|x64
+		release_static_mt|x64 = release_static_mt|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|x64.ActiveCfg = debug_shared|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|x64.Build.0 = debug_shared|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_shared|x64.Deploy.0 = debug_shared|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.ActiveCfg = release_shared|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.Build.0 = release_shared|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.Deploy.0 = release_shared|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.ActiveCfg = debug_static_mt|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.Build.0 = debug_static_mt|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.Deploy.0 = debug_static_mt|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.ActiveCfg = release_static_mt|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.Build.0 = release_static_mt|x64
-		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.Deploy.0 = release_static_mt|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|x64.ActiveCfg = debug_static_md|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|x64.Build.0 = debug_static_md|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_md|x64.Deploy.0 = debug_static_md|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.ActiveCfg = debug_static_mt|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.Build.0 = debug_static_mt|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.debug_static_mt|x64.Deploy.0 = debug_static_mt|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.ActiveCfg = release_shared|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.Build.0 = release_shared|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_shared|x64.Deploy.0 = release_shared|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|x64.ActiveCfg = release_static_md|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|x64.Build.0 = release_static_md|x64
 		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_md|x64.Deploy.0 = release_static_md|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.ActiveCfg = release_static_mt|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.Build.0 = release_static_mt|x64
+		{5AECC55E-A469-11DA-8DA6-005056C00008}.release_static_mt|x64.Deploy.0 = release_static_mt|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|x64.ActiveCfg = debug_shared|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|x64.Build.0 = debug_shared|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_shared|x64.Deploy.0 = debug_shared|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.ActiveCfg = release_shared|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.Build.0 = release_shared|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.Deploy.0 = release_shared|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.ActiveCfg = debug_static_mt|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.Build.0 = debug_static_mt|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.Deploy.0 = debug_static_mt|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.ActiveCfg = release_static_mt|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.Build.0 = release_static_mt|x64
-		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.Deploy.0 = release_static_mt|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|x64.ActiveCfg = debug_static_md|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|x64.Build.0 = debug_static_md|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_md|x64.Deploy.0 = debug_static_md|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.ActiveCfg = debug_static_mt|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.Build.0 = debug_static_mt|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.debug_static_mt|x64.Deploy.0 = debug_static_mt|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.ActiveCfg = release_shared|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.Build.0 = release_shared|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_shared|x64.Deploy.0 = release_shared|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|x64.ActiveCfg = release_static_md|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|x64.Build.0 = release_static_md|x64
 		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_md|x64.Deploy.0 = release_static_md|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.ActiveCfg = release_static_mt|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.Build.0 = release_static_mt|x64
+		{B2B88092-5BCE-4AC0-941E-88167138B4A7}.release_static_mt|x64.Deploy.0 = release_static_mt|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|x64">
@@ -32,7 +32,7 @@
     <RootNamespace>NetSSL_OpenSSL</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">PocoNetSSL64d</TargetName>
@@ -132,7 +132,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -164,9 +164,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -195,7 +195,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib64\PocoNetSSLmtd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -220,9 +220,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
@@ -242,7 +242,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <ProgramDataBaseFileName>..\lib64\PocoNetSSLmdd.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -267,9 +267,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Lib>
@@ -277,63 +277,67 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h"/>
-    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\Context.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h"/>
-    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h"/>
-    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h"/>
-    <ClInclude Include="include\Poco\Net\KeyFileHandler.h"/>
-    <ClInclude Include="include\Poco\Net\NetSSL.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h"/>
-    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h"/>
-    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h"/>
-    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h"/>
-    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h"/>
-    <ClInclude Include="include\Poco\Net\Session.h"/>
-    <ClInclude Include="include\Poco\Net\SSLException.h"/>
-    <ClInclude Include="include\Poco\Net\SSLManager.h"/>
-    <ClInclude Include="include\Poco\Net\Utility.h"/>
-    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h"/>
-    <ClInclude Include="include\Poco\Net\X509Certificate.h"/>
+    <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactory.h" />
+    <ClInclude Include="include\Poco\Net\CertificateHandlerFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\ConsoleCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\Context.h" />
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSClientSession.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSSessionInstantiator.h" />
+    <ClInclude Include="include\Poco\Net\HTTPSStreamFactory.h" />
+    <ClInclude Include="include\Poco\Net\InvalidCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyConsoleHandler.h" />
+    <ClInclude Include="include\Poco\Net\KeyFileHandler.h" />
+    <ClInclude Include="include\Poco\Net\NetSSL.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactory.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyFactoryMgr.h" />
+    <ClInclude Include="include\Poco\Net\PrivateKeyPassphraseHandler.h" />
+    <ClInclude Include="include\Poco\Net\RejectCertificateHandler.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureServerSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h" />
+    <ClInclude Include="include\Poco\Net\SecureSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocket.h" />
+    <ClInclude Include="include\Poco\Net\SecureStreamSocketImpl.h" />
+    <ClInclude Include="include\Poco\Net\Session.h" />
+    <ClInclude Include="include\Poco\Net\SSLException.h" />
+    <ClInclude Include="include\Poco\Net\SSLManager.h" />
+    <ClInclude Include="include\Poco\Net\Utility.h" />
+    <ClInclude Include="include\Poco\Net\VerificationErrorArgs.h" />
+    <ClInclude Include="include\Poco\Net\X509Certificate.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\AcceptCertificateHandler.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactory.cpp"/>
-    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp"/>
-    <ClCompile Include="src\ConsoleCertificateHandler.cpp"/>
-    <ClCompile Include="src\Context.cpp"/>
-    <ClCompile Include="src\HTTPSClientSession.cpp"/>
-    <ClCompile Include="src\HTTPSSessionInstantiator.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactory.cpp"/>
-    <ClCompile Include="src\InvalidCertificateHandler.cpp"/>
-    <ClCompile Include="src\KeyConsoleHandler.cpp"/>
-    <ClCompile Include="src\KeyFileHandler.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactory.cpp"/>
-    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp"/>
-    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp"/>
-    <ClCompile Include="src\RejectCertificateHandler.cpp"/>
-    <ClCompile Include="src\SecureServerSocket.cpp"/>
-    <ClCompile Include="src\SecureServerSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureSMTPClientSession.cpp"/>
-    <ClCompile Include="src\SecureSocketImpl.cpp"/>
-    <ClCompile Include="src\SecureStreamSocket.cpp"/>
-    <ClCompile Include="src\SecureStreamSocketImpl.cpp"/>
-    <ClCompile Include="src\Session.cpp"/>
-    <ClCompile Include="src\SSLException.cpp"/>
-    <ClCompile Include="src\SSLManager.cpp"/>
-    <ClCompile Include="src\Utility.cpp"/>
-    <ClCompile Include="src\VerificationErrorArgs.cpp"/>
-    <ClCompile Include="src\X509Certificate.cpp"/>
+    <ClCompile Include="src\AcceptCertificateHandler.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactory.cpp" />
+    <ClCompile Include="src\CertificateHandlerFactoryMgr.cpp" />
+    <ClCompile Include="src\ConsoleCertificateHandler.cpp" />
+    <ClCompile Include="src\Context.cpp" />
+    <ClCompile Include="src\FTPSClientSession.cpp" />
+    <ClCompile Include="src\FTPSStreamFactory.cpp" />
+    <ClCompile Include="src\HTTPSClientSession.cpp" />
+    <ClCompile Include="src\HTTPSSessionInstantiator.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactory.cpp" />
+    <ClCompile Include="src\InvalidCertificateHandler.cpp" />
+    <ClCompile Include="src\KeyConsoleHandler.cpp" />
+    <ClCompile Include="src\KeyFileHandler.cpp" />
+    <ClCompile Include="src\PrivateKeyFactory.cpp" />
+    <ClCompile Include="src\PrivateKeyFactoryMgr.cpp" />
+    <ClCompile Include="src\PrivateKeyPassphraseHandler.cpp" />
+    <ClCompile Include="src\RejectCertificateHandler.cpp" />
+    <ClCompile Include="src\SecureServerSocket.cpp" />
+    <ClCompile Include="src\SecureServerSocketImpl.cpp" />
+    <ClCompile Include="src\SecureSMTPClientSession.cpp" />
+    <ClCompile Include="src\SecureSocketImpl.cpp" />
+    <ClCompile Include="src\SecureStreamSocket.cpp" />
+    <ClCompile Include="src\SecureStreamSocketImpl.cpp" />
+    <ClCompile Include="src\Session.cpp" />
+    <ClCompile Include="src\SSLException.cpp" />
+    <ClCompile Include="src\SSLManager.cpp" />
+    <ClCompile Include="src\Utility.cpp" />
+    <ClCompile Include="src\VerificationErrorArgs.cpp" />
+    <ClCompile Include="src\X509Certificate.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">
@@ -345,6 +349,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'">true</ExcludedFromBuild>
     </ResourceCompile>
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="Mail\Source Files">
       <UniqueIdentifier>{6b568f03-d4e6-4b50-90ac-9f31de7cad4c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FTPSClientSession">
+      <UniqueIdentifier>{494ecb3f-a378-4c72-a377-e4b8c00f729e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\Net\AcceptCertificateHandler.h">
@@ -123,6 +126,12 @@
     <ClInclude Include="include\Poco\Net\SecureSMTPClientSession.h">
       <Filter>Mail\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSStreamFactory.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Poco\Net\FTPSClientSession.h">
+      <Filter>FTPSClientSession</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AcceptCertificateHandler.cpp">
@@ -205,6 +214,12 @@
     </ClCompile>
     <ClCompile Include="src\SecureSMTPClientSession.cpp">
       <Filter>Mail\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSStreamFactory.cpp">
+      <Filter>FTPSClientSession</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSession.cpp">
+      <Filter>FTPSClientSession</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -1,0 +1,66 @@
+#pragma once
+#include "Poco/Net/FTPClientSession.h"
+
+namespace Poco {
+namespace Net {
+
+class FTPSClientSession :
+	public Poco::Net::FTPClientSession
+{
+public:
+	FTPSClientSession();
+	/// Creates an FTPSClientSession.
+	///
+	/// Passive mode will be used for data transfers.
+
+	explicit FTPSClientSession(const StreamSocket& socket);
+	/// Creates an FTPSClientSession using the given
+	/// connected socket for the control connection.
+	///
+	/// Passive mode will be used for data transfers.
+
+	FTPSClientSession(const std::string& host,
+		Poco::UInt16 port = FTP_PORT,
+		const std::string& username = "",
+		const std::string& password = "");
+	/// Creates an FTPSClientSession using a socket connected
+	/// to the given host and port. If username is supplied,
+	/// login is attempted.
+	///
+	/// Passive mode will be used for data transfers.
+
+	virtual ~FTPSClientSession();	
+
+	void tryFTPSmode(bool bTryFTPS);
+		/// avoid or require TLS mode
+
+	bool isSecure() const;
+		/// Returns true if the session is FTPS.
+
+protected:
+	virtual StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
+		/// Create secure data connection
+
+	virtual void receiveServerReadyReply();
+		/// Function that read server welcome message after connetion and set and make secure socket
+
+private:
+	bool _bTryFTPS = true;
+
+	void beforeCreateDataSocket();
+		///Send commands to check if we can encrypt data socket
+
+	void afterCreateControlSocket();
+		///Send commands to make SSL negotiating of control channel
+
+	bool _bSecureDataConnection = false;
+};
+
+inline bool FTPSClientSession::isSecure() const
+{
+	if (_pControlSocket != nullptr)
+		return _pControlSocket->secure();
+	return false;
+}
+
+}} // namespace Poco::Net

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
@@ -1,0 +1,122 @@
+//
+// FTPSStreamFactory.h
+//
+// $Id: //poco/1.4/Net/include/Poco/Net/FTPSStreamFactory.h#1 $
+//
+// Library: Net
+// Package: FTP
+// Module:  FTPSStreamFactory
+//
+// Definition of the FTPSStreamFactory class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Net_FTPSStreamFactory_INCLUDED
+#define Net_FTPSStreamFactory_INCLUDED
+
+
+#include "Poco/Net/Net.h"
+#include "Poco/Net/HTTPSession.h"
+#include "Poco/URIStreamFactory.h"
+
+
+namespace Poco {
+namespace Net {
+
+
+class Net_API FTPPasswordProvider
+	/// The base class for all password providers.
+	/// An instance of a subclass of this class can be
+	/// registered with the FTPSStreamFactory to 
+	/// provide a password
+{
+public:
+	virtual std::string password(const std::string& username, const std::string& host) = 0;
+		/// Provide the password for the given user on the given host.
+
+protected:
+	FTPPasswordProvider();
+	virtual ~FTPPasswordProvider();
+};
+
+
+class Net_API FTPSStreamFactory: public Poco::URIStreamFactory
+	/// An implementation of the URIStreamFactory interface
+	/// that handles File Transfer Protocol (ftp) URIs.
+	///
+	/// The URI's path may end with an optional type specification
+	/// in the form (;type=<typecode>), where <typecode> is
+	/// one of a, i or d. If type=a, the file identified by the path
+	/// is transferred in ASCII (text) mode. If type=i, the file
+	/// is transferred in Image (binary) mode. If type=d, a directory
+	/// listing (in NLST format) is returned. This corresponds with
+	/// the FTP URL format specified in RFC 1738.
+	///
+	/// If the URI does not contain a username and password, the
+	/// username "anonymous" and the password "
+{
+public:
+	FTPSStreamFactory();
+		/// Creates the FTPSStreamFactory.
+
+	~FTPSStreamFactory();
+		/// Destroys the FTPSStreamFactory.
+		
+	std::istream* open(const Poco::URI& uri);
+		/// Creates and opens a HTTP stream for the given URI.
+		/// The URI must be a ftp://... URI.
+		///
+		/// Throws a NetException if anything goes wrong.
+		
+	static void setAnonymousPassword(const std::string& password);
+		/// Sets the password used for anonymous FTP.
+		///
+		/// WARNING: Setting the anonymous password is not
+		/// thread-safe, so it's best to call this method
+		/// during application initialization, before the
+		/// FTPSStreamFactory is used for the first time.
+		
+	static const std::string& getAnonymousPassword();
+		/// Returns the password used for anonymous FTP.
+		
+	static void setPasswordProvider(FTPPasswordProvider* pProvider);
+		/// Sets the FTPPasswordProvider. If NULL is given,
+		/// no password provider is used.
+		///
+		/// WARNING: Setting the password provider is not
+		/// thread-safe, so it's best to call this method
+		/// during application initialization, before the
+		/// FTPSStreamFactory is used for the first time.
+		
+	static FTPPasswordProvider* getPasswordProvider();
+		/// Returns the FTPPasswordProvider currently in use,
+		/// or NULL if no one has been set.
+
+	static void registerFactory();
+		/// Registers the FTPSStreamFactory with the
+		/// default URIStreamOpener instance.
+
+	static void unregisterFactory();
+		/// Unregisters the FTPSStreamFactory with the
+		/// default URIStreamOpener instance.
+
+protected:
+	static void splitUserInfo(const std::string& userInfo, std::string& username, std::string& password);
+	static void getUserInfo(const Poco::URI& uri, std::string& username, std::string& password);
+	static void getPathAndType(const Poco::URI& uri, std::string& path, char& type);
+	
+private:
+	static std::string          _anonymousPassword;
+	static FTPPasswordProvider* _pPasswordProvider;
+};
+
+
+} } // namespace Poco::Net
+
+
+#endif // Net_FTPSStreamFactory_INCLUDED

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -1,0 +1,117 @@
+#include "Poco/Net/FTPSClientSession.h"
+#include "Poco/Net/SecureStreamSocket.h"
+#include "Poco/Net/SecureStreamSocketImpl.h"
+#include "Poco/Net/SSLManager.h"
+#include "Poco/Net/NetException.h"
+
+namespace Poco {
+namespace Net {
+
+FTPSClientSession::FTPSClientSession() :
+	FTPClientSession()
+{
+}
+
+
+FTPSClientSession::~FTPSClientSession()
+{
+}
+
+FTPSClientSession::FTPSClientSession(const StreamSocket& socket) :
+	FTPClientSession(socket)
+{
+}
+
+
+FTPSClientSession::FTPSClientSession(const std::string& host,
+										Poco::UInt16 port,
+										const std::string& username,
+										const std::string& password) :
+	FTPClientSession(host, port)
+{
+	if(!username.empty())
+		login(username, password);	
+}
+
+void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
+{
+	_bTryFTPS = bTryFTPS;
+}
+
+void FTPSClientSession::beforeCreateDataSocket()
+{
+	if (_bSecureDataConnection)
+		return;
+	_bSecureDataConnection = false;
+	if (!_pControlSocket->secure())
+		return;
+	std::string sResponse;
+	int status = sendCommand("PBSZ 0", sResponse);
+	if (isPositiveCompletion(status)) 
+	{
+		status = sendCommand("PROT P", sResponse);
+		if (isPositiveCompletion(status)) 
+			_bSecureDataConnection = true;
+	}
+}
+
+void FTPSClientSession::afterCreateControlSocket()
+{
+	if (!_bTryFTPS)
+		return;
+	_pControlSocket->setNoDelay(true);
+	if (_pControlSocket->secure())
+		return;
+
+	std::string sResponse;
+	int status = sendCommand("AUTH TLS", sResponse);
+	if (!isPositiveCompletion(status))
+		status = sendCommand("AUTH SSL", sResponse);
+
+	if (isPositiveCompletion(status))
+	{
+		//Server support FTPS
+		try
+		{
+			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(*_pControlSocket, Poco::Net::SSLManager::instance().defaultClientContext()));
+			*_pControlSocket = sss;
+		}
+		catch (Poco::Exception&)
+		{
+			throw;
+		}
+	}
+	else
+	{
+		_bTryFTPS = false;
+	}
+}
+
+StreamSocket FTPSClientSession::establishDataConnection(const std::string& command, const std::string& arg)
+{
+	beforeCreateDataSocket();
+
+	StreamSocket ss = FTPClientSession::establishDataConnection(command, arg);
+	ss.setNoDelay(true);
+
+	//SSL nogotiating of data socket
+	if ((_bSecureDataConnection) && (_pControlSocket->secure()))
+	{
+		//We need to reuse the control socket SSL session so the server can ensure that client that opened control socket is the same using data socket
+		Poco::Net::SecureStreamSocketImpl* pSecure = dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(_pControlSocket->impl());
+		if (pSecure != nullptr)
+		{
+			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
+			ss = sss;
+		}
+	}
+	return ss;
+}
+
+void FTPSClientSession::receiveServerReadyReply()
+{
+	FTPClientSession::receiveServerReadyReply();
+	afterCreateControlSocket();
+}
+
+}} // namespace Poco::Net

--- a/NetSSL_OpenSSL/src/FTPSStreamFactory.cpp
+++ b/NetSSL_OpenSSL/src/FTPSStreamFactory.cpp
@@ -1,0 +1,245 @@
+//
+// FTPSStreamFactory.cpp
+//
+// $Id: //poco/1.4/Net/src/FTPSStreamFactory.cpp#1 $
+//
+// Library: Net
+// Package: FTP
+// Module:  FTPSStreamFactory
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Net/FTPSStreamFactory.h"
+#include "Poco/Net/FTPSClientSession.h"
+#include "Poco/Net/NetException.h"
+#include "Poco/URI.h"
+#include "Poco/URIStreamOpener.h"
+#include "Poco/UnbufferedStreamBuf.h"
+#include "Poco/Path.h"
+
+
+using Poco::URIStreamFactory;
+using Poco::URI;
+using Poco::URIStreamOpener;
+using Poco::UnbufferedStreamBuf;
+using Poco::Path;
+
+
+namespace Poco {
+namespace Net {
+
+
+class FTPStreamBuf: public UnbufferedStreamBuf
+{
+public:
+	FTPStreamBuf(std::istream& istr):
+		_istr(istr)
+	{
+		// make sure exceptions from underlying string propagate
+		_istr.exceptions(std::ios::badbit);
+	}
+	
+	~FTPStreamBuf()
+	{
+	}
+		
+private:
+	int readFromDevice()
+	{
+		return _istr.get();
+	}
+	
+	std::istream& _istr;
+};
+
+
+class FTPSIOS: public virtual std::ios
+{
+public:
+	FTPSIOS(std::istream& istr):
+		_buf(istr)
+	{
+		poco_ios_init(&_buf);
+	}
+	
+	~FTPSIOS()
+	{
+	}
+	
+	FTPStreamBuf* rdbuf()
+	{
+		return &_buf;
+	}
+
+protected:
+	FTPStreamBuf _buf;
+};
+
+
+class FTPSStream: public FTPSIOS, public std::istream
+{
+public:
+	FTPSStream(std::istream& istr, FTPSClientSession* pSession):
+		FTPSIOS(istr),
+		std::istream(&_buf),
+		_pSession(pSession)
+	{
+	}
+		
+	~FTPSStream()
+	{
+		delete _pSession;
+	}
+	
+private:
+	FTPSClientSession* _pSession;
+};
+
+
+FTPPasswordProvider::FTPPasswordProvider()
+{
+}
+
+
+FTPPasswordProvider::~FTPPasswordProvider()
+{
+}
+
+
+std::string          FTPSStreamFactory::_anonymousPassword("poco@localhost");
+FTPPasswordProvider* FTPSStreamFactory::_pPasswordProvider(0);
+
+
+FTPSStreamFactory::FTPSStreamFactory()
+{
+}
+
+
+FTPSStreamFactory::~FTPSStreamFactory()
+{
+}
+
+
+std::istream* FTPSStreamFactory::open(const URI& uri)
+{
+	poco_assert (uri.getScheme() == "ftps");
+
+	FTPSClientSession* pSession = new FTPSClientSession(uri.getHost(), uri.getPort());
+	try
+	{
+		std::string username;
+		std::string password;
+		getUserInfo(uri, username, password);
+		
+		std::string path;
+		char        type;
+		getPathAndType(uri, path, type);
+			
+		pSession->login(username, password);
+		if (type == 'a')
+			pSession->setFileType(FTPClientSession::TYPE_TEXT);
+			
+		Path p(path, Path::PATH_UNIX);
+		p.makeFile();
+		for (int i = 0; i < p.depth(); ++i)
+			pSession->setWorkingDirectory(p[i]);
+		std::string file(p.getFileName());
+		std::istream& istr = (type == 'd' ? pSession->beginList(file) : pSession->beginDownload(file));
+		return new FTPSStream(istr, pSession);
+	}
+	catch (...)
+	{
+		delete pSession;
+		throw;
+	}
+}
+
+
+void FTPSStreamFactory::setAnonymousPassword(const std::string& password)
+{
+	_anonymousPassword = password;
+}
+
+	
+const std::string& FTPSStreamFactory::getAnonymousPassword()
+{
+	return _anonymousPassword;
+}
+
+	
+void FTPSStreamFactory::setPasswordProvider(FTPPasswordProvider* pProvider)
+{
+	_pPasswordProvider = pProvider;
+}
+
+	
+FTPPasswordProvider* FTPSStreamFactory::getPasswordProvider()
+{
+	return _pPasswordProvider;
+}
+
+
+void FTPSStreamFactory::splitUserInfo(const std::string& userInfo, std::string& username, std::string& password)
+{
+	std::string::size_type pos = userInfo.find(':');
+	if (pos != std::string::npos)
+	{
+		username.assign(userInfo, 0, pos++);
+		password.assign(userInfo, pos, userInfo.size() - pos);
+	}
+	else username = userInfo;
+}
+
+
+void FTPSStreamFactory::getUserInfo(const URI& uri, std::string& username, std::string& password)
+{
+	splitUserInfo(uri.getUserInfo(), username, password);
+	if (username.empty())
+	{
+		username = "anonymous";
+		password = _anonymousPassword;
+	}
+	else if (password.empty())
+	{
+		if (_pPasswordProvider)
+			password = _pPasswordProvider->password(username, uri.getHost());
+		else
+			throw FTPException(std::string("Password required for ") + username + "@" + uri.getHost());
+	}
+}
+
+
+void FTPSStreamFactory::getPathAndType(const Poco::URI& uri, std::string& path, char& type)
+{
+	path = uri.getPath();
+	type = 'i';
+	std::string::size_type pos = path.rfind(';');
+	if (pos != std::string::npos)
+	{
+		if (path.length() == pos + 7 && path.compare(pos + 1, 5, "type=") == 0)
+		{
+			type = path[pos + 6];
+			path.resize(pos);
+		}
+	}
+}
+
+
+void FTPSStreamFactory::registerFactory()
+{
+	URIStreamOpener::defaultOpener().registerStreamFactory("ftps", new FTPSStreamFactory);
+}
+
+
+void FTPSStreamFactory::unregisterFactory()
+{
+	URIStreamOpener::defaultOpener().unregisterStreamFactory("ftps");
+}
+
+
+} } // namespace Poco::Net

--- a/NetSSL_OpenSSL/testsuite/Makefile
+++ b/NetSSL_OpenSSL/testsuite/Makefile
@@ -18,7 +18,7 @@ endif
 objects = NetSSLTestSuite Driver \
 	HTTPSClientSessionTest HTTPSClientTestSuite HTTPSServerTest HTTPSServerTestSuite \
 	HTTPSStreamFactoryTest HTTPSTestServer TCPServerTest TCPServerTestSuite \
-	WebSocketTest WebSocketTestSuite FTPSClientSessionTest FTPSClientTestSuite
+	WebSocketTest WebSocketTestSuite FTPSClientSessionTest FTPSClientTestSuite DialogServer
 
 target         = testrunner
 target_version = 1

--- a/NetSSL_OpenSSL/testsuite/Makefile
+++ b/NetSSL_OpenSSL/testsuite/Makefile
@@ -18,7 +18,7 @@ endif
 objects = NetSSLTestSuite Driver \
 	HTTPSClientSessionTest HTTPSClientTestSuite HTTPSServerTest HTTPSServerTestSuite \
 	HTTPSStreamFactoryTest HTTPSTestServer TCPServerTest TCPServerTestSuite \
-	WebSocketTest WebSocketTestSuite
+	WebSocketTest WebSocketTestSuite FTPSClientSessionTest FTPSClientTestSuite
 
 target         = testrunner
 target_version = 1

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|Win32">
@@ -32,7 +32,7 @@
     <RootNamespace>TestSuite</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|Win32'">TestSuited</TargetName>
@@ -136,7 +136,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -167,9 +167,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -196,7 +196,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -227,9 +227,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -256,7 +256,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -287,9 +287,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -304,32 +304,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="src\HTTPSClientSessionTest.h"/>
-    <ClInclude Include="src\HTTPSClientTestSuite.h"/>
-    <ClInclude Include="src\HTTPSServerTest.h"/>
-    <ClInclude Include="src\HTTPSServerTestSuite.h"/>
-    <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
-    <ClInclude Include="src\HTTPSTestServer.h"/>
-    <ClInclude Include="src\NetSSLTestSuite.h"/>
-    <ClInclude Include="src\TCPServerTest.h"/>
-    <ClInclude Include="src\TCPServerTestSuite.h"/>
-    <ClInclude Include="src\WebSocketTest.h"/>
-    <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\DialogServer.h" />
+    <ClInclude Include="src\FTPSClientSessionTest.h" />
+    <ClInclude Include="src\FTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSClientSessionTest.h" />
+    <ClInclude Include="src\HTTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSServerTest.h" />
+    <ClInclude Include="src\HTTPSServerTestSuite.h" />
+    <ClInclude Include="src\HTTPSStreamFactoryTest.h" />
+    <ClInclude Include="src\HTTPSTestServer.h" />
+    <ClInclude Include="src\NetSSLTestSuite.h" />
+    <ClInclude Include="src\TCPServerTest.h" />
+    <ClInclude Include="src\TCPServerTestSuite.h" />
+    <ClInclude Include="src\WebSocketTest.h" />
+    <ClInclude Include="src\WebSocketTestSuite.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\Driver.cpp"/>
-    <ClCompile Include="src\HTTPSClientSessionTest.cpp"/>
-    <ClCompile Include="src\HTTPSClientTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSServerTest.cpp"/>
-    <ClCompile Include="src\HTTPSServerTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
-    <ClCompile Include="src\HTTPSTestServer.cpp"/>
-    <ClCompile Include="src\NetSSLTestSuite.cpp"/>
-    <ClCompile Include="src\TCPServerTest.cpp"/>
-    <ClCompile Include="src\TCPServerTestSuite.cpp"/>
-    <ClCompile Include="src\WebSocketTest.cpp"/>
-    <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\DialogServer.cpp" />
+    <ClCompile Include="src\Driver.cpp" />
+    <ClCompile Include="src\FTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\FTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\HTTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSServerTest.cpp" />
+    <ClCompile Include="src\HTTPSServerTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp" />
+    <ClCompile Include="src\HTTPSTestServer.cpp" />
+    <ClCompile Include="src\NetSSLTestSuite.cpp" />
+    <ClCompile Include="src\TCPServerTest.cpp" />
+    <ClCompile Include="src\TCPServerTestSuite.cpp" />
+    <ClCompile Include="src\WebSocketTest.cpp" />
+    <ClCompile Include="src\WebSocketTestSuite.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{0b09c7ce-5036-4bb6-a3cd-fa80199fc035}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FTPSClient">
+      <UniqueIdentifier>{f711d632-ad1b-42e1-8989-2a1d2ab62a5c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClient\Header Files">
+      <UniqueIdentifier>{6e76011c-a3d9-4b46-8635-ce5f9028cb14}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClient\Source files">
+      <UniqueIdentifier>{ac5da877-65bb-4219-8a5c-640bdeeb2ba0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,15 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\DialogServer.h">
+      <Filter>FTPSClient</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FTPSClientSessionTest.h">
+      <Filter>FTPSClient\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FTPSClientTestSuite.h">
+      <Filter>FTPSClient\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +151,15 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\DialogServer.cpp">
+      <Filter>FTPSClient</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSessionTest.cpp">
+      <Filter>FTPSClient\Source files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientTestSuite.cpp">
+      <Filter>FTPSClient\Source files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
@@ -316,6 +316,8 @@
     <ClInclude Include="src\NetSSLTestSuite.h" />
     <ClInclude Include="src\TCPServerTest.h" />
     <ClInclude Include="src\TCPServerTestSuite.h" />
+    <ClInclude Include="src\WebSocketTest.h" />
+    <ClInclude Include="src\WebSocketTestSuite.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogServer.cpp" />
@@ -331,6 +333,8 @@
     <ClCompile Include="src\NetSSLTestSuite.cpp" />
     <ClCompile Include="src\TCPServerTest.cpp" />
     <ClCompile Include="src\TCPServerTestSuite.cpp" />
+    <ClCompile Include="src\WebSocketTest.cpp" />
+    <ClCompile Include="src\WebSocketTestSuite.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|x64">
@@ -32,7 +32,7 @@
     <RootNamespace>TestSuite</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">TestSuited</TargetName>
@@ -126,7 +126,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;WINVER=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -136,13 +136,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnitd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnitd.lib;libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\TestSuited.exe</OutputFile>
       <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -159,7 +159,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;WINVER=0x0600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -167,13 +167,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnit.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnit.lib;libeay32.lib;ssleay32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\TestSuite.exe</OutputFile>
       <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -186,7 +186,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -196,15 +196,15 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnitmtd.lib;iphlpapi.lib;winmm.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnitmtd.lib;iphlpapi.lib;winmm.lib;libeay32mtd.lib;ssleay32mtd.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_mt\TestSuited.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\lib64;c:\SALVA\VS2005\libs\OpenSSL64\lib_2015;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>bin64\static_mt\TestSuited.pdb</ProgramDatabaseFile>
@@ -219,7 +219,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -227,15 +227,15 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnitmt.lib;iphlpapi.lib;winmm.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnitmt.lib;iphlpapi.lib;winmm.lib;libeay32mt.lib;ssleay32mt.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_mt\TestSuite.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\lib64;c:\SALVA\VS2005\libs\OpenSSL64\lib_2015;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -246,7 +246,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -256,13 +256,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnitmdd.lib;iphlpapi.lib;winmm.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnitmdd.lib;iphlpapi.lib;winmm.lib;libeay32mdd.lib;ssleay32mdd.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_md\TestSuited.exe</OutputFile>
       <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -279,7 +279,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -287,13 +287,13 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>PocoCppUnitmd.lib;iphlpapi.lib;winmm.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>CppUnitmd.lib;iphlpapi.lib;winmm.lib;libeay32md.lib;ssleay32md.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_md\TestSuite.exe</OutputFile>
       <AdditionalLibraryDirectories>..\..\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
@@ -304,32 +304,34 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="src\HTTPSClientSessionTest.h"/>
-    <ClInclude Include="src\HTTPSClientTestSuite.h"/>
-    <ClInclude Include="src\HTTPSServerTest.h"/>
-    <ClInclude Include="src\HTTPSServerTestSuite.h"/>
-    <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
-    <ClInclude Include="src\HTTPSTestServer.h"/>
-    <ClInclude Include="src\NetSSLTestSuite.h"/>
-    <ClInclude Include="src\TCPServerTest.h"/>
-    <ClInclude Include="src\TCPServerTestSuite.h"/>
-    <ClInclude Include="src\WebSocketTest.h"/>
-    <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\DialogServer.h" />
+    <ClInclude Include="src\FTPSClientSessionTest.h" />
+    <ClInclude Include="src\FTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSClientSessionTest.h" />
+    <ClInclude Include="src\HTTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSServerTest.h" />
+    <ClInclude Include="src\HTTPSServerTestSuite.h" />
+    <ClInclude Include="src\HTTPSStreamFactoryTest.h" />
+    <ClInclude Include="src\HTTPSTestServer.h" />
+    <ClInclude Include="src\NetSSLTestSuite.h" />
+    <ClInclude Include="src\TCPServerTest.h" />
+    <ClInclude Include="src\TCPServerTestSuite.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\Driver.cpp"/>
-    <ClCompile Include="src\HTTPSClientSessionTest.cpp"/>
-    <ClCompile Include="src\HTTPSClientTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSServerTest.cpp"/>
-    <ClCompile Include="src\HTTPSServerTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
-    <ClCompile Include="src\HTTPSTestServer.cpp"/>
-    <ClCompile Include="src\NetSSLTestSuite.cpp"/>
-    <ClCompile Include="src\TCPServerTest.cpp"/>
-    <ClCompile Include="src\TCPServerTestSuite.cpp"/>
-    <ClCompile Include="src\WebSocketTest.cpp"/>
-    <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\DialogServer.cpp" />
+    <ClCompile Include="src\Driver.cpp" />
+    <ClCompile Include="src\FTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\FTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\HTTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSServerTest.cpp" />
+    <ClCompile Include="src\HTTPSServerTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp" />
+    <ClCompile Include="src\HTTPSTestServer.cpp" />
+    <ClCompile Include="src\NetSSLTestSuite.cpp" />
+    <ClCompile Include="src\TCPServerTest.cpp" />
+    <ClCompile Include="src\TCPServerTestSuite.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
@@ -186,7 +186,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
@@ -202,9 +202,9 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>CppUnitmtd.lib;iphlpapi.lib;winmm.lib;libeay32mtd.lib;ssleay32mtd.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>PocoCppUnitmtd.lib;iphlpapi.lib;winmm.lib;libeay32mtd.lib;ssleay32mtd.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_mt\TestSuited.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\lib64;c:\SALVA\VS2005\libs\OpenSSL64\lib_2015;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\lib64;..\..\openssl\win32\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>bin64\static_mt\TestSuited.pdb</ProgramDatabaseFile>
@@ -219,7 +219,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
-      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;c:\SALVA\VS2005\libs\OpenSSL64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\include;..\..\CppUnit\include;..\..\CppUnit\WinTestRunner\include;..\..\Foundation\include;..\..\XML\include;..\..\Util\include;..\..\Net\include;..\..\Crypto\include;..\..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;WINVER=0x0600;POCO_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -235,7 +235,7 @@
     <Link>
       <AdditionalDependencies>CppUnitmt.lib;iphlpapi.lib;winmm.lib;libeay32mt.lib;ssleay32mt.lib;Crypt32.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>bin64\static_mt\TestSuite.exe</OutputFile>
-      <AdditionalLibraryDirectories>..\..\lib64;c:\SALVA\VS2005\libs\OpenSSL64\lib_2015;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\lib64;..\..\openssl\win64\lib\release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="FTPSClient\Header Files">
       <UniqueIdentifier>{c12db3ef-a857-4f57-8e49-3292aca89151}</UniqueIdentifier>
     </Filter>
+    <Filter Include="WebSocket">
+      <UniqueIdentifier>{aaafad05-402a-4cd2-aa7d-da3a2e09c9f2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WebSocket\Header Files">
+      <UniqueIdentifier>{676caae1-cfac-49dc-a53d-5b710a37b39e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WebSocket\Source Files">
+      <UniqueIdentifier>{3b14eae2-2b25-4f69-b6e5-64bf3f8770bb}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -98,6 +107,12 @@
     </ClInclude>
     <ClInclude Include="src\DialogServer.h">
       <Filter>FTPSClient</Filter>
+    </ClInclude>
+    <ClInclude Include="src\WebSocketTest.h">
+      <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\WebSocketTestSuite.h">
+      <Filter>WebSocket\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -139,6 +154,12 @@
     </ClCompile>
     <ClCompile Include="src\DialogServer.cpp">
       <Filter>FTPSClient</Filter>
+    </ClCompile>
+    <ClCompile Include="src\WebSocketTest.cpp">
+      <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\WebSocketTestSuite.cpp">
+      <Filter>WebSocket\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
@@ -2,64 +2,64 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="HTTPS">
-      <UniqueIdentifier>{dfafea20-4fd5-4b5c-8611-d19435908da9}</UniqueIdentifier>
+      <UniqueIdentifier>{69868896-69ce-4cc2-91f2-b77ee718f31f}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPS\Header Files">
-      <UniqueIdentifier>{1dba01ca-6985-416b-9dca-e9918d998357}</UniqueIdentifier>
+      <UniqueIdentifier>{98ba682c-9e7b-4197-a70f-fb98368df50a}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPS\Source Files">
-      <UniqueIdentifier>{9b4f2d71-8306-4277-90f0-f7d48dbe4e25}</UniqueIdentifier>
+      <UniqueIdentifier>{78a82d8e-09de-4817-908e-eb637a98e212}</UniqueIdentifier>
     </Filter>
     <Filter Include="_Suite">
-      <UniqueIdentifier>{7e5405b0-cbcd-4ab1-9327-0f7ad5e3cd1e}</UniqueIdentifier>
+      <UniqueIdentifier>{11436519-16bb-4806-be26-fe18a6c9adf1}</UniqueIdentifier>
     </Filter>
     <Filter Include="_Suite\Header Files">
-      <UniqueIdentifier>{277ff02e-5164-4bf3-8895-f3c4c9b51af1}</UniqueIdentifier>
+      <UniqueIdentifier>{1c831c77-718d-4162-a6e8-ca98483afae0}</UniqueIdentifier>
     </Filter>
     <Filter Include="_Suite\Source Files">
-      <UniqueIdentifier>{a299061a-c424-4eca-a2c1-156de3730fde}</UniqueIdentifier>
+      <UniqueIdentifier>{14e01d46-b059-47b1-80a4-ef6e5c453722}</UniqueIdentifier>
     </Filter>
     <Filter Include="_Driver">
-      <UniqueIdentifier>{aac8771e-f0d3-4137-80eb-667110843ef6}</UniqueIdentifier>
+      <UniqueIdentifier>{b5a6c410-d564-49e0-82b6-de8e78a5561d}</UniqueIdentifier>
     </Filter>
     <Filter Include="_Driver\Source Files">
-      <UniqueIdentifier>{3802303d-c998-43b2-8965-85d6758fb5c4}</UniqueIdentifier>
+      <UniqueIdentifier>{5879c722-d670-42b8-9b10-e2fa4f4f52c2}</UniqueIdentifier>
     </Filter>
     <Filter Include="TCPServer">
-      <UniqueIdentifier>{f63a1f34-145f-48ac-afce-a9731b2c8397}</UniqueIdentifier>
+      <UniqueIdentifier>{a0394a30-a5c5-432c-85a9-dd7a72632551}</UniqueIdentifier>
     </Filter>
     <Filter Include="TCPServer\Header Files">
-      <UniqueIdentifier>{80a88167-7a4f-4035-868c-b410625854b3}</UniqueIdentifier>
+      <UniqueIdentifier>{f0f132af-8eda-4f0f-ba43-5782bc7b0b66}</UniqueIdentifier>
     </Filter>
     <Filter Include="TCPServer\Source Files">
-      <UniqueIdentifier>{16d8251e-9bd0-426d-ba40-b75a9af2d634}</UniqueIdentifier>
+      <UniqueIdentifier>{a382a977-708c-4ee4-9f36-15df2ce7253d}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSServer">
-      <UniqueIdentifier>{40fd3832-88a1-4065-a6f0-5b22f8469d2e}</UniqueIdentifier>
+      <UniqueIdentifier>{77155a28-d472-4425-bb94-90059828142b}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSServer\Header Files">
-      <UniqueIdentifier>{0844b02c-6171-475f-99a7-c3c7b7c02627}</UniqueIdentifier>
+      <UniqueIdentifier>{68610420-e641-485b-b8a4-d46c223aec61}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSServer\Source Files">
-      <UniqueIdentifier>{5fc387c4-5ce1-4104-b6b5-239cc4e2b5fa}</UniqueIdentifier>
+      <UniqueIdentifier>{cd303de2-ef06-4041-989c-14ba2cfadad4}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient">
-      <UniqueIdentifier>{d521f476-f53e-41a4-9869-c3bb4857e9c6}</UniqueIdentifier>
+      <UniqueIdentifier>{1bc00141-3c81-42bc-bf80-6a4175312bd4}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Header Files">
-      <UniqueIdentifier>{760629b4-dd17-4cac-a9c5-abf4519716f4}</UniqueIdentifier>
+      <UniqueIdentifier>{540408fd-c882-4880-954a-e34848a0278a}</UniqueIdentifier>
     </Filter>
     <Filter Include="HTTPSClient\Source Files">
-      <UniqueIdentifier>{aa304803-3a13-45fe-b9b8-c810e2739a7a}</UniqueIdentifier>
+      <UniqueIdentifier>{ffb7e3b7-b35a-43b9-b4a0-a1ffec53d835}</UniqueIdentifier>
     </Filter>
-    <Filter Include="WebSocket">
-      <UniqueIdentifier>{3cc49046-9d9a-4577-9161-0a945d89fd29}</UniqueIdentifier>
+    <Filter Include="FTPSClient">
+      <UniqueIdentifier>{ad25418f-08ed-4202-b909-b57dfe084dae}</UniqueIdentifier>
     </Filter>
-    <Filter Include="WebSocket\Source Files">
-      <UniqueIdentifier>{62a54e98-b44e-4987-96db-d28556ea124e}</UniqueIdentifier>
+    <Filter Include="FTPSClient\Source Files">
+      <UniqueIdentifier>{14d4d12a-2212-46c6-a8fd-e262d1909536}</UniqueIdentifier>
     </Filter>
-    <Filter Include="WebSocket\Header Files">
-      <UniqueIdentifier>{9f52ca3f-265f-488e-8a7b-735eb0d5d425}</UniqueIdentifier>
+    <Filter Include="FTPSClient\Header Files">
+      <UniqueIdentifier>{c12db3ef-a857-4f57-8e49-3292aca89151}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -90,11 +90,14 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h">
       <Filter>HTTPSClient\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\WebSocketTest.h">
-      <Filter>WebSocket\Header Files</Filter>
+    <ClInclude Include="src\FTPSClientSessionTest.h">
+      <Filter>FTPSClient\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\WebSocketTestSuite.h">
-      <Filter>WebSocket\Header Files</Filter>
+    <ClInclude Include="src\FTPSClientTestSuite.h">
+      <Filter>FTPSClient\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\DialogServer.h">
+      <Filter>FTPSClient</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -128,11 +131,14 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp">
       <Filter>HTTPSClient\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\WebSocketTest.cpp">
-      <Filter>WebSocket\Source Files</Filter>
+    <ClCompile Include="src\FTPSClientSessionTest.cpp">
+      <Filter>FTPSClient\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\WebSocketTestSuite.cpp">
-      <Filter>WebSocket\Source Files</Filter>
+    <ClCompile Include="src\FTPSClientTestSuite.cpp">
+      <Filter>FTPSClient\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\DialogServer.cpp">
+      <Filter>FTPSClient</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="debug_shared|x64">
@@ -32,7 +32,7 @@
     <RootNamespace>TestSuite</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
@@ -63,27 +63,27 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-  <ImportGroup Label="ExtensionSettings"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_md|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_static_mt|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='release_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='debug_shared|x64'">TestSuited</TargetName>
@@ -136,7 +136,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -167,9 +167,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -196,7 +196,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -227,9 +227,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -256,7 +256,7 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
@@ -287,9 +287,9 @@
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
       <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PrecompiledHeader/>
+      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat/>
+      <DebugInformationFormat />
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
@@ -304,32 +304,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="src\HTTPSClientSessionTest.h"/>
-    <ClInclude Include="src\HTTPSClientTestSuite.h"/>
-    <ClInclude Include="src\HTTPSServerTest.h"/>
-    <ClInclude Include="src\HTTPSServerTestSuite.h"/>
-    <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
-    <ClInclude Include="src\HTTPSTestServer.h"/>
-    <ClInclude Include="src\NetSSLTestSuite.h"/>
-    <ClInclude Include="src\TCPServerTest.h"/>
-    <ClInclude Include="src\TCPServerTestSuite.h"/>
-    <ClInclude Include="src\WebSocketTest.h"/>
-    <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\DialogServer.h" />
+    <ClInclude Include="src\FTPSClientSessionTest.h" />
+    <ClInclude Include="src\FTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSClientSessionTest.h" />
+    <ClInclude Include="src\HTTPSClientTestSuite.h" />
+    <ClInclude Include="src\HTTPSServerTest.h" />
+    <ClInclude Include="src\HTTPSServerTestSuite.h" />
+    <ClInclude Include="src\HTTPSStreamFactoryTest.h" />
+    <ClInclude Include="src\HTTPSTestServer.h" />
+    <ClInclude Include="src\NetSSLTestSuite.h" />
+    <ClInclude Include="src\TCPServerTest.h" />
+    <ClInclude Include="src\TCPServerTestSuite.h" />
+    <ClInclude Include="src\WebSocketTest.h" />
+    <ClInclude Include="src\WebSocketTestSuite.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\Driver.cpp"/>
-    <ClCompile Include="src\HTTPSClientSessionTest.cpp"/>
-    <ClCompile Include="src\HTTPSClientTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSServerTest.cpp"/>
-    <ClCompile Include="src\HTTPSServerTestSuite.cpp"/>
-    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
-    <ClCompile Include="src\HTTPSTestServer.cpp"/>
-    <ClCompile Include="src\NetSSLTestSuite.cpp"/>
-    <ClCompile Include="src\TCPServerTest.cpp"/>
-    <ClCompile Include="src\TCPServerTestSuite.cpp"/>
-    <ClCompile Include="src\WebSocketTest.cpp"/>
-    <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\DialogServer.cpp" />
+    <ClCompile Include="src\Driver.cpp" />
+    <ClCompile Include="src\FTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\FTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSClientSessionTest.cpp" />
+    <ClCompile Include="src\HTTPSClientTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSServerTest.cpp" />
+    <ClCompile Include="src\HTTPSServerTestSuite.cpp" />
+    <ClCompile Include="src\HTTPSStreamFactoryTest.cpp" />
+    <ClCompile Include="src\HTTPSTestServer.cpp" />
+    <ClCompile Include="src\NetSSLTestSuite.cpp" />
+    <ClCompile Include="src\TCPServerTest.cpp" />
+    <ClCompile Include="src\TCPServerTestSuite.cpp" />
+    <ClCompile Include="src\WebSocketTest.cpp" />
+    <ClCompile Include="src\WebSocketTestSuite.cpp" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{9f52ca3f-265f-488e-8a7b-735eb0d5d425}</UniqueIdentifier>
     </Filter>
+    <Filter Include="FTPSClient">
+      <UniqueIdentifier>{d26e866e-d515-411c-9c27-1fdc7f7bd32a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClient\Header Files">
+      <UniqueIdentifier>{2403f2e6-2da1-4435-aec3-9a32c294cf66}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FTPSClient\Source Files">
+      <UniqueIdentifier>{ce729123-5eef-4fc5-a105-a89de5b91454}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,15 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\DialogServer.h">
+      <Filter>FTPSClient</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FTPSClientTestSuite.h">
+      <Filter>FTPSClient\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FTPSClientSessionTest.h">
+      <Filter>FTPSClient\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +151,15 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\DialogServer.cpp">
+      <Filter>FTPSClient</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientTestSuite.cpp">
+      <Filter>FTPSClient\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FTPSClientSessionTest.cpp">
+      <Filter>FTPSClient\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/src/DialogServer.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/DialogServer.cpp
@@ -1,0 +1,256 @@
+//
+// DialogServer.cpp
+//
+// $Id: //poco/1.4/Net/testsuite/src/DialogServer.cpp#1 $
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "DialogServer.h"
+#include "Poco/Net/DialogSocket.h"
+#include "Poco/Net/SocketAddress.h"
+#include "Poco/Timespan.h"
+#include <iostream>
+#include "Poco/Net/SecureStreamSocket.h"
+#include "Poco/Net/SSLManager.h"
+#include "Poco/Net/Context.h"
+#include "Poco/Net/SecureStreamSocketImpl.h"
+
+using Poco::Net::Socket;
+using Poco::Net::DialogSocket;
+using Poco::Net::SocketAddress;
+using Poco::FastMutex;
+using Poco::Thread;
+using Poco::Net::SecureStreamSocket;
+using Poco::Net::SSLManager;
+using Poco::Exception;
+using Poco::Net::Context;
+using Poco::Net::Session;
+using Poco::Net::SecureStreamSocketImpl;
+
+DialogServer::DialogServer(bool acceptCommands, bool ssl):
+	_socket(SocketAddress()),
+	_thread("DialogServer"),
+	_stop(false),
+	_acceptCommands(acceptCommands),
+	_log(false),
+	_ssl(ssl)
+{
+	_thread.start(*this);
+	_ready.wait();
+}
+
+
+DialogServer::~DialogServer()
+{
+	_stop = true;
+	_thread.join();
+}
+
+
+Poco::UInt16 DialogServer::port() const
+{
+	return _socket.address().port();
+}
+
+
+void handleDataSSLrequest(DialogSocket& ds, bool ssl, Session::Ptr& sslSession)
+{	
+	if (ssl)
+	{		
+		try
+		{
+			Context::Ptr cDefaultServerContext = SSLManager::instance().defaultServerContext();
+			SecureStreamSocket sss(SecureStreamSocket::attach(ds, cDefaultServerContext, sslSession));
+			sss.setLazyHandshake(true);
+			if (sss.completeHandshake() == 1)
+			{
+				ds = sss;
+			}
+		}
+		catch (Exception&) {
+		}
+	}
+}
+
+void handleSSLrequest(DialogSocket& ds, bool ssl, Session::Ptr& sslSession)
+{
+	if (ssl)
+	{
+		try
+		{
+			Context::Ptr cDefaultServerContext = SSLManager::instance().defaultServerContext();
+			ds.sendMessage("200 OK");
+			SecureStreamSocket sss(SecureStreamSocket::attach(ds, cDefaultServerContext));
+			sss.setLazyHandshake(true);
+			if (sss.completeHandshake() == 1)
+			{
+				ds = sss;
+
+				SecureStreamSocketImpl* pSecure = dynamic_cast<SecureStreamSocketImpl*>(sss.impl());
+				if (pSecure != nullptr)
+					sslSession = pSecure->currentSession();
+			}
+			else
+			{
+				ds.sendMessage("501 Explicit TLS authentication not available");
+			}
+		}
+		catch (Exception&) {
+			ds.sendMessage("501 Explicit TLS authentication not available");
+		}
+	}
+	else
+	{
+		ds.sendMessage("501 Explicit TLS authentication not available");
+	}
+}
+
+void DialogServer::run()
+{
+	_ready.set();
+	Poco::Timespan span(250000);
+	while (!_stop)
+	{
+		if (_socket.poll(span, Socket::SELECT_READ))
+		{
+			DialogSocket ds = _socket.acceptConnection();
+			if (!_SSLsession.isNull()) {
+				handleDataSSLrequest(ds, _ssl, _SSLsession);
+			}
+			{
+				FastMutex::ScopedLock lock(_mutex);
+				if (!_nextResponses.empty())
+				{
+					ds.sendMessage(_nextResponses.front());
+					_nextResponses.erase(_nextResponses.begin());
+				}
+			}
+			if (_acceptCommands)
+			{
+				try
+				{					
+
+					std::string command;
+					while (ds.receiveMessage(command))
+					{
+						if ((command == "AUTH TLS") || (command == "AUTH SSL"))
+						{
+							handleSSLrequest(ds, _ssl, _SSLsession);
+							continue;
+						}
+						else if ((command == "PBSZ 0") || (command == "PROT P"))
+						{
+							ds.sendMessage("200 OK");							
+							continue;
+						}
+
+						if (_log) std::cout << ">> " << command << std::endl;
+						{
+							FastMutex::ScopedLock lock(_mutex);
+							_lastCommands.push_back(command);
+							if (!_nextResponses.empty())
+							{
+								if (_log) std::cout << "<< " << _nextResponses.front() << std::endl;
+								ds.sendMessage(_nextResponses.front());
+								_nextResponses.erase(_nextResponses.begin());
+							}
+						}
+					}
+				}
+				catch (Poco::Exception& exc)
+				{
+					std::cerr << "DialogServer: " << exc.displayText() << std::endl;
+				}
+			}
+		}
+	}
+}
+
+
+const std::string& DialogServer::lastCommand() const
+{
+	FastMutex::ScopedLock lock(_mutex);
+	
+	static const std::string EMPTY;
+	if (_lastCommands.empty())
+		return EMPTY;
+	else
+		return _lastCommands.back();
+}
+
+
+const std::vector<std::string>& DialogServer::lastCommands() const
+{
+	return _lastCommands;
+}
+
+
+std::string DialogServer::popCommand()
+{
+	FastMutex::ScopedLock lock(_mutex);
+
+	std::string command;
+	if (!_lastCommands.empty())
+	{
+		command = _lastCommands.front();
+		_lastCommands.erase(_lastCommands.begin());
+	}
+	return command;
+}
+
+
+std::string DialogServer::popCommandWait()
+{
+	std::string result(popCommand());
+	while (result.empty())
+	{
+		Thread::sleep(100);
+		result = popCommand();
+	}
+	return result;
+}
+
+
+void DialogServer::addResponse(const std::string& response)
+{
+	FastMutex::ScopedLock lock(_mutex);
+
+	_nextResponses.push_back(response);
+}
+
+	
+void DialogServer::clearCommands()
+{
+	FastMutex::ScopedLock lock(_mutex);
+
+	_lastCommands.clear();
+}
+
+		
+void DialogServer::clearResponses()
+{
+	FastMutex::ScopedLock lock(_mutex);
+	
+	_nextResponses.clear();
+}
+
+
+void DialogServer::log(bool flag)
+{
+	_log = flag;
+}
+
+void DialogServer::setSslSession(Session::Ptr cSession)
+{
+	_SSLsession = cSession;
+}
+
+Session::Ptr DialogServer::getSslSession()
+{
+	return _SSLsession;
+}

--- a/NetSSL_OpenSSL/testsuite/src/DialogServer.h
+++ b/NetSSL_OpenSSL/testsuite/src/DialogServer.h
@@ -1,0 +1,89 @@
+//
+// DialogServer.h
+//
+// $Id: //poco/1.4/Net/testsuite/src/DialogServer.h#1 $
+//
+// Definition of the DialogServer class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef DialogServer_INCLUDED
+#define DialogServer_INCLUDED
+
+
+#include "Poco/Net/Net.h"
+#include "Poco/Net/ServerSocket.h"
+#include "Poco/Net/StreamSocket.h"
+#include "Poco/Thread.h"
+#include "Poco/Event.h"
+#include "Poco/Mutex.h"
+#include <vector>
+#include "Poco/Net/Session.h"
+
+
+class DialogServer: public Poco::Runnable
+	/// A server for testing FTPClientSession and friends.
+{
+public:
+	DialogServer(bool acceptCommands = true, bool ssl = false);
+		/// Creates the DialogServer.
+
+	~DialogServer();
+		/// Destroys the DialogServer.
+
+	Poco::UInt16 port() const;
+		/// Returns the port the echo server is
+		/// listening on.
+		
+	void run();
+		/// Does the work.
+		
+	const std::string& lastCommand() const;
+		/// Returns the last command received by the server.
+
+	std::string popCommand();
+		/// Pops the next command from the list of received commands.
+
+	std::string popCommandWait();
+		/// Pops the next command from the list of received commands.
+		/// Waits until a command is available.
+
+	const std::vector<std::string>& lastCommands() const;
+		/// Returns the last command received by the server.
+		
+	void addResponse(const std::string& response);
+		/// Sets the next response returned by the server.
+	
+	void clearCommands();
+		/// Clears all commands.
+		
+	void clearResponses();
+		/// Clears all responses.
+		
+	void log(bool flag);
+		/// Enables or disables logging to stdout.
+
+	Poco::Net::Session::Ptr getSslSession();
+	void setSslSession(Poco::Net::Session::Ptr cSession);
+	
+private:
+	Poco::Net::ServerSocket _socket;
+	Poco::Thread             _thread;
+	Poco::Event              _ready;
+	mutable Poco::FastMutex  _mutex;
+	bool                     _stop;
+	std::vector<std::string> _nextResponses;
+	std::vector<std::string> _lastCommands;
+	bool                     _acceptCommands;
+	bool                     _log;
+	bool					 _ssl;
+	Poco::Net::Session::Ptr	 _SSLsession = nullptr;
+};
+
+
+#endif // DialogServer_INCLUDED

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
@@ -1,0 +1,645 @@
+//
+// FTPSClientSessionTest.cpp
+//
+// $Id: //poco/svn/Net/testsuite/src/FTPSClientSessionTest.cpp#2 $
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "FTPSClientSessionTest.h"
+#include "CppUnit/TestCaller.h"
+#include "CppUnit/TestSuite.h"
+#include "DialogServer.h"
+#include "Poco/Net/FTPSClientSession.h"
+#include "Poco/Net/DialogSocket.h"
+#include "Poco/Net/SocketAddress.h"
+#include "Poco/Net/NetException.h"
+#include "Poco/Thread.h"
+#include "Poco/ActiveMethod.h"
+#include "Poco/StreamCopier.h"
+#include <sstream>
+#include "Poco/Net/Session.h"
+
+using Poco::Net::FTPSClientSession;
+using Poco::Net::DialogSocket;
+using Poco::Net::SocketAddress;
+using Poco::Net::FTPException;
+using Poco::ActiveMethod;
+using Poco::ActiveResult;
+using Poco::StreamCopier;
+using Poco::Thread;
+using Poco::Net::Session;
+
+namespace
+{
+	class ActiveDownloader
+	{
+	public:
+		ActiveDownloader(FTPSClientSession& session):
+			download(this, &ActiveDownloader::downloadImp),
+			_session(session)
+		{
+		}
+		
+		ActiveMethod<std::string, std::string, ActiveDownloader> download;
+		
+	protected:
+		std::string downloadImp(const std::string& path)
+		{
+			std::istream& istr = _session.beginDownload(path);
+			std::ostringstream ostr;
+			StreamCopier::copyStream(istr, ostr);
+			_session.endDownload();
+			return ostr.str();
+		}
+		
+	private:
+		FTPSClientSession& _session;
+	};
+};
+
+
+FTPSClientSessionTest::FTPSClientSessionTest(const std::string& name): CppUnit::TestCase(name)
+{
+}
+
+
+FTPSClientSessionTest::~FTPSClientSessionTest()
+{
+}
+
+
+void FTPSClientSessionTest::login(DialogServer& server, FTPSClientSession& session)
+{
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	session.login("user", "password");
+	std::string cmd = server.popCommand();	
+	assert (cmd == "USER user");
+	cmd = server.popCommand();
+	assert (cmd == "PASS password");
+	cmd = server.popCommand();
+	assert (cmd == "TYPE I");
+	
+	assert (session.getFileType() == FTPSClientSession::TYPE_BINARY);
+}
+
+
+void FTPSClientSessionTest::testLogin1()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	FTPSClientSession session("localhost", server.port());
+	assert (session.isOpen());
+	assert (!session.isLoggedIn());
+	login(server, session);
+	assert (session.isOpen());
+	assert (session.isLoggedIn());
+	server.addResponse("221 Good Bye");
+	session.logout();
+	assert (session.isOpen());
+	assert (!session.isLoggedIn());
+
+	server.clearCommands();
+	server.clearResponses();
+
+	session.tryFTPSmode(true);
+	login(server, session);
+	assert (session.isOpen());
+	assert (session.isLoggedIn());
+	server.addResponse("221 Good Bye");
+	session.close();
+	assert (!session.isOpen());
+	assert (!session.isLoggedIn());
+}
+
+
+void FTPSClientSessionTest::testLogin2()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	Poco::UInt16 serverPort = server.port();
+	FTPSClientSession session("localhost", serverPort, "user", "password");
+	assert (session.isOpen());
+	assert (session.isLoggedIn());
+	server.addResponse("221 Good Bye");
+	session.close();
+	assert (!session.isOpen());
+	assert (!session.isLoggedIn());
+
+	server.clearCommands();
+	server.clearResponses();
+	server.addResponse("220 localhost FTP ready");
+
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	session.tryFTPSmode(true);
+	session.open("localhost", serverPort, "user", "password");
+	assert (session.isOpen());
+	assert (session.isLoggedIn());
+	server.addResponse("221 Good Bye");
+	session.close();
+	assert (!session.isOpen());
+	assert (!session.isLoggedIn());
+}
+
+
+void FTPSClientSessionTest::testLogin3()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session;
+	assert (!session.isOpen());
+	assert (!session.isLoggedIn());
+	session.open("localhost", server.port(), "user", "password");
+	server.addResponse("221 Good Bye");
+	session.close();
+	assert (!session.isOpen());
+	assert (!session.isLoggedIn());
+}
+
+
+
+void FTPSClientSessionTest::testLoginFailed1()
+{
+	DialogServer server;
+	server.addResponse("421 localhost FTP not ready");	
+	FTPSClientSession session("localhost", server.port());
+	try
+	{		
+		session.login("user", "password");
+		fail("server not ready - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.addResponse("221 Good Bye");	
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testLoginFailed2()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("530 Login incorrect");
+	FTPSClientSession session("localhost", server.port());
+	try
+	{
+		session.login("user", "password");
+		fail("login incorrect - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testCommands()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	std::string cmd = server.popCommand();
+	assert (cmd == "USER user");
+	cmd = server.popCommand();
+	assert (cmd == "PASS password");
+	cmd = server.popCommand();
+	assert (cmd == "TYPE I");
+	
+	// systemType
+	server.clearCommands();
+	server.addResponse("215 UNIX Type: L8 Version: dummyFTP 1.0");
+	std::string type = session.systemType();
+	cmd = server.popCommand();
+	assert (cmd == "SYST");
+	assert (type == "UNIX Type: L8 Version: dummyFTP 1.0");
+	
+	// getWorkingDirectory
+	server.addResponse("257 \"/usr/test\" is current directory");
+	std::string cwd = session.getWorkingDirectory();
+	cmd = server.popCommand();
+	assert (cmd == "PWD");
+	assert (cwd == "/usr/test");
+
+	// getWorkingDirectory (quotes in filename)
+	server.addResponse("257 \"\"\"quote\"\"\" is current directory");
+	cwd = session.getWorkingDirectory();
+	cmd = server.popCommand();
+	assert (cmd == "PWD");
+	assert (cwd == "\"quote\"");
+	
+	// setWorkingDirectory
+	server.addResponse("250 CWD OK");
+	session.setWorkingDirectory("test");
+	cmd = server.popCommand();
+	assert (cmd == "CWD test");
+	
+	server.addResponse("250 CDUP OK");
+	session.cdup();
+	cmd = server.popCommand();
+	assert (cmd == "CDUP");
+	
+	// rename
+	server.addResponse("350 File exists, send destination name");
+	server.addResponse("250 Rename OK");
+	session.rename("old.txt", "new.txt");
+	cmd = server.popCommand();
+	assert (cmd == "RNFR old.txt");
+	cmd = server.popCommand();
+	assert (cmd == "RNTO new.txt");
+	
+	// rename (failing)
+	server.addResponse("550 not found");
+	try
+	{
+		session.rename("old.txt", "new.txt");
+		fail("not found - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.clearCommands();
+	
+	// remove
+	server.addResponse("250 delete ok");
+	session.remove("test.txt");
+	cmd = server.popCommand();
+	assert (cmd == "DELE test.txt");
+
+	// remove (failing)
+	server.addResponse("550 not found");
+	try
+	{
+		session.remove("test.txt");
+		fail("not found - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.clearCommands();
+
+	// createDirectory
+	server.addResponse("257 dir created");
+	session.createDirectory("foo");
+	cmd = server.popCommand();
+	assert (cmd == "MKD foo");
+
+	// createDirectory (failing)
+	server.addResponse("550 exists");
+	try
+	{
+		session.createDirectory("foo");
+		fail("not found - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.clearCommands();
+
+	// removeDirectory
+	server.addResponse("250 RMD OK");
+	session.removeDirectory("foo");
+	cmd = server.popCommand();
+	assert (cmd == "RMD foo");
+
+	// removeDirectory (failing)
+	server.addResponse("550 not found");
+	try
+	{
+		session.removeDirectory("foo");
+		fail("not found - must throw");
+	}
+	catch (FTPException&)
+	{
+	}
+	server.clearCommands();
+		
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testDownloadPORT()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.setPassive(false);
+	session.login("user", "password");
+	server.clearCommands();
+	
+	server.addResponse("500 EPRT not understood");
+	server.addResponse("200 PORT OK");
+	server.addResponse("150 Sending data\r\n226 Transfer complete");
+
+	ActiveDownloader dl(session);
+	ActiveResult<std::string> result = dl.download("test.txt");
+		
+	std::string cmd = server.popCommandWait();
+	assert (cmd.substr(0, 4) == "EPRT");
+	
+	cmd = server.popCommandWait();
+	assert (cmd.substr(0, 4) == "PORT");
+
+	std::string dummy;
+	int x, lo, hi;
+	for (std::string::iterator it = cmd.begin(); it != cmd.end(); ++it)
+	{
+		if (*it == ',') *it = ' ';
+	}
+	std::istringstream istr(cmd);
+	istr >> dummy >> x >> x >> x >> x >> hi >> lo;
+	int port = hi*256 + lo;
+
+	cmd = server.popCommandWait();
+	assert (cmd == "RETR test.txt");
+
+	SocketAddress sa("localhost", (Poco::UInt16) port);
+	DialogSocket dataSock;
+	dataSock.connect(sa);
+
+	std::string data("This is some data");
+	dataSock.sendString(data);
+	dataSock.close();
+
+	result.wait();
+	std::string received = result.data();
+	assert (received == data);
+	
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testDownloadEPRT()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.setPassive(false);
+	session.login("user", "password");
+	server.clearCommands();
+	
+	server.addResponse("200 EPRT OK");
+	server.addResponse("150 Sending data\r\n226 Transfer complete");
+
+	ActiveDownloader dl(session);
+	ActiveResult<std::string> result = dl.download("test.txt");
+		
+	std::string cmd = server.popCommandWait();
+	assert (cmd.substr(0, 4) == "EPRT");
+	
+	std::string dummy;
+	char c;
+	int d;
+	int port;
+	std::istringstream istr(cmd);
+	istr >> dummy >> c >> d >> c >> d >> c >> d >> c >> d >> c >> d >> c >> port >> c;
+	
+	cmd = server.popCommandWait();
+	assert (cmd == "RETR test.txt");
+	
+	SocketAddress sa("localhost", (Poco::UInt16) port);
+	DialogSocket dataSock;
+	dataSock.connect(sa);
+
+	std::string data("This is some data");
+	dataSock.sendString(data);
+	dataSock.close();
+
+	result.wait();
+	std::string received = result.data();
+	assert (received == data);
+	
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testDownloadPASV()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	server.clearCommands();
+
+	server.addResponse("500 EPSV not understood");
+
+	DialogServer dataServer(false);
+	Poco::UInt16 dataServerPort = dataServer.port();
+	dataServer.addResponse("This is some data");
+	std::ostringstream pasv;
+	pasv << "227 Entering Passive Mode (127,0,0,1," << (dataServerPort/256) << "," << (dataServerPort % 256) << ")";
+	server.addResponse(pasv.str());
+	server.addResponse("150 sending data\r\n226 Transfer complete");
+
+	std::istream& istr = session.beginDownload("test.txt");
+	std::ostringstream dataStr;
+	StreamCopier::copyStream(istr, dataStr);
+	session.endDownload();
+	std::string s(dataStr.str());
+	assert (s == "This is some data\r\n");
+	
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testDownloadEPSV()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	server.clearCommands();
+
+	DialogServer dataServer(false);
+	dataServer.addResponse("This is some data");
+	std::ostringstream epsv;
+	epsv << "229 Entering Extended Passive Mode (|||" << dataServer.port() << "|)";
+	server.addResponse(epsv.str());
+	server.addResponse("150 sending data\r\n226 Transfer complete");
+
+	std::istream& istr = session.beginDownload("test.txt");
+	std::ostringstream dataStr;
+	StreamCopier::copyStream(istr, dataStr);
+	session.endDownload();
+	std::string s(dataStr.str());
+	assert (s == "This is some data\r\n");
+	
+	std::string cmd = server.popCommand();
+	assert (cmd.substr(0, 4) == "EPSV");
+	cmd = server.popCommand();
+	assert (cmd == "RETR test.txt");
+	
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::testUpload()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	server.clearCommands();
+
+	DialogServer dataServer;
+	std::ostringstream epsv;
+	epsv << "229 Entering Extended Passive Mode (|||" << dataServer.port() << "|)";
+	server.addResponse(epsv.str());
+	server.addResponse("150 send data\r\n226 Transfer complete");
+
+	std::ostream& ostr = session.beginUpload("test.txt");
+	ostr << "This is some data\r\n";
+	session.endUpload();
+	std::string s(dataServer.popCommandWait());
+	assert (s == "This is some data");
+
+	std::string cmd = server.popCommand();
+	assert (cmd.substr(0, 4) == "EPSV");
+	cmd = server.popCommand();
+	assert (cmd == "STOR test.txt");
+
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+void FTPSClientSessionTest::testUploadSSL()
+{
+	DialogServer server(true, true);
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	server.clearCommands();
+
+	DialogServer dataServer(true, true);	
+	Session::Ptr cSessionSSL = server.getSslSession();
+	dataServer.setSslSession(cSessionSSL);
+
+	std::ostringstream epsv;
+	epsv << "229 Entering Extended Passive Mode (|||" << dataServer.port() << "|)";
+	server.addResponse(epsv.str());
+	server.addResponse("150 send data\r\n226 Transfer complete");
+
+	std::ostream& ostr = session.beginUpload("test.txt");
+	ostr << "This is some data\r\n";
+	session.endUpload();
+	std::string s(dataServer.popCommandWait());
+	assert(s == "This is some data");
+
+	std::string cmd = server.popCommand();
+	assert(cmd.substr(0, 4) == "EPSV");
+	cmd = server.popCommand();
+	assert(cmd == "STOR test.txt");
+
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+void FTPSClientSessionTest::testList()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	server.addResponse("331 Password required");
+	server.addResponse("230 Welcome");
+	server.addResponse("200 Type set to I");
+	FTPSClientSession session("localhost", server.port());
+	session.login("user", "password");
+	server.clearCommands();
+
+	DialogServer dataServer(false);
+	dataServer.addResponse("file1\r\nfile2");
+	std::ostringstream epsv;
+	epsv << "229 Entering Extended Passive Mode (|||" << dataServer.port() << "|)";
+	server.addResponse(epsv.str());
+	server.addResponse("150 sending data\r\n226 Transfer complete");
+
+	std::istream& istr = session.beginList();
+	std::ostringstream dataStr;
+	StreamCopier::copyStream(istr, dataStr);
+	session.endList();
+	std::string s(dataStr.str());
+	assert (s == "file1\r\nfile2\r\n");
+	
+	std::string cmd = server.popCommand();
+	assert (cmd.substr(0, 4) == "EPSV");
+	cmd = server.popCommand();
+	assert (cmd == "NLST");
+	
+	server.addResponse("221 Good Bye");
+	session.close();
+}
+
+
+void FTPSClientSessionTest::setUp()
+{
+}
+
+
+void FTPSClientSessionTest::tearDown()
+{
+}
+
+
+CppUnit::Test* FTPSClientSessionTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("FTPSClientSessionTest");
+
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLogin1);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLogin2);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLogin3);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLoginFailed1);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLoginFailed2);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testCommands);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadPORT);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadEPRT);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadPASV);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadEPSV);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testUpload);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testList);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testUploadSSL);
+
+	return pSuite;
+}

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
@@ -11,8 +11,8 @@
 
 
 #include "FTPSClientSessionTest.h"
-#include "CppUnit/TestCaller.h"
-#include "CppUnit/TestSuite.h"
+#include "Poco/CppUnit/TestCaller.h"
+#include "Poco/CppUnit/TestSuite.h"
 #include "DialogServer.h"
 #include "Poco/Net/FTPSClientSession.h"
 #include "Poco/Net/DialogSocket.h"

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
@@ -94,7 +94,7 @@ void FTPSClientSessionTest::testLogin1()
 {
 	DialogServer server;
 	server.addResponse("220 localhost FTP ready");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	assert (session.isOpen());
 	assert (!session.isLoggedIn());
 	login(server, session);
@@ -128,7 +128,7 @@ void FTPSClientSessionTest::testLogin2()
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
 	Poco::UInt16 serverPort = server.port();
-	FTPSClientSession session("localhost", serverPort, "user", "password");
+	FTPSClientSession session("127.0.0.1", serverPort, "user", "password");
 	assert (session.isOpen());
 	assert (session.isLoggedIn());
 	server.addResponse("221 Good Bye");
@@ -144,7 +144,7 @@ void FTPSClientSessionTest::testLogin2()
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
 	session.tryFTPSmode(true);
-	session.open("localhost", serverPort, "user", "password");
+	session.open("127.0.0.1", serverPort, "user", "password");
 	assert (session.isOpen());
 	assert (session.isLoggedIn());
 	server.addResponse("221 Good Bye");
@@ -164,7 +164,7 @@ void FTPSClientSessionTest::testLogin3()
 	FTPSClientSession session;
 	assert (!session.isOpen());
 	assert (!session.isLoggedIn());
-	session.open("localhost", server.port(), "user", "password");
+	session.open("127.0.0.1", server.port(), "user", "password");
 	server.addResponse("221 Good Bye");
 	session.close();
 	assert (!session.isOpen());
@@ -177,7 +177,7 @@ void FTPSClientSessionTest::testLoginFailed1()
 {
 	DialogServer server;
 	server.addResponse("421 localhost FTP not ready");	
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	try
 	{		
 		session.login("user", "password");
@@ -197,7 +197,7 @@ void FTPSClientSessionTest::testLoginFailed2()
 	server.addResponse("220 localhost FTP ready");
 	server.addResponse("331 Password required");
 	server.addResponse("530 Login incorrect");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	try
 	{
 		session.login("user", "password");
@@ -218,7 +218,7 @@ void FTPSClientSessionTest::testCommands()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	std::string cmd = server.popCommand();
 	assert (cmd == "USER user");
@@ -347,7 +347,7 @@ void FTPSClientSessionTest::testDownloadPORT()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.setPassive(false);
 	session.login("user", "password");
 	server.clearCommands();
@@ -378,7 +378,7 @@ void FTPSClientSessionTest::testDownloadPORT()
 	cmd = server.popCommandWait();
 	assert (cmd == "RETR test.txt");
 
-	SocketAddress sa("localhost", (Poco::UInt16) port);
+	SocketAddress sa("127.0.0.1", (Poco::UInt16) port);
 	DialogSocket dataSock;
 	dataSock.connect(sa);
 
@@ -402,7 +402,7 @@ void FTPSClientSessionTest::testDownloadEPRT()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.setPassive(false);
 	session.login("user", "password");
 	server.clearCommands();
@@ -426,7 +426,7 @@ void FTPSClientSessionTest::testDownloadEPRT()
 	cmd = server.popCommandWait();
 	assert (cmd == "RETR test.txt");
 	
-	SocketAddress sa("localhost", (Poco::UInt16) port);
+	SocketAddress sa("127.0.0.1", (Poco::UInt16) port);
 	DialogSocket dataSock;
 	dataSock.connect(sa);
 
@@ -450,7 +450,7 @@ void FTPSClientSessionTest::testDownloadPASV()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	server.clearCommands();
 
@@ -483,7 +483,7 @@ void FTPSClientSessionTest::testDownloadEPSV()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	server.clearCommands();
 
@@ -518,7 +518,7 @@ void FTPSClientSessionTest::testUpload()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	server.clearCommands();
 
@@ -550,7 +550,7 @@ void FTPSClientSessionTest::testUploadSSL()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	server.clearCommands();
 
@@ -585,7 +585,7 @@ void FTPSClientSessionTest::testList()
 	server.addResponse("331 Password required");
 	server.addResponse("230 Welcome");
 	server.addResponse("200 Type set to I");
-	FTPSClientSession session("localhost", server.port());
+	FTPSClientSession session("127.0.0.1", server.port());
 	session.login("user", "password");
 	server.clearCommands();
 

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
@@ -17,7 +17,7 @@
 
 
 #include "Poco/Net/Net.h"
-#include "CppUnit/TestCase.h"
+#include "Poco/CppUnit/TestCase.h"
 
 
 namespace Poco {

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
@@ -1,0 +1,62 @@
+//
+// FTPClientSessionTest.h
+//
+// $Id: //poco/svn/Net/testsuite/src/FTPClientSessionTest.h#2 $
+//
+// Definition of the FTPClientSessionTest class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef FTPClientSessionTest_INCLUDED
+#define FTPClientSessionTest_INCLUDED
+
+
+#include "Poco/Net/Net.h"
+#include "CppUnit/TestCase.h"
+
+
+namespace Poco {
+namespace Net {
+
+class FTPSClientSession;
+
+} }
+
+class DialogServer;
+
+class FTPSClientSessionTest: public CppUnit::TestCase
+{
+public:
+	FTPSClientSessionTest(const std::string& name);
+	~FTPSClientSessionTest();
+
+	void testLogin1();
+	void testLogin2();
+	void testLogin3();
+	void testLoginFailed1();
+	void testLoginFailed2();
+	void testCommands();
+	void testDownloadPORT();
+	void testDownloadEPRT();
+	void testDownloadPASV();
+	void testDownloadEPSV();
+	void testUpload();
+	void testList();
+	void testUploadSSL();
+	
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+
+private:
+	void login(DialogServer& server, Poco::Net::FTPSClientSession& session);
+};
+
+
+#endif // FTPClientSessionTest_INCLUDED

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.cpp
@@ -1,0 +1,24 @@
+//
+// FTPClientTestSuite.cpp
+//
+// $Id: //poco/svn/Net/testsuite/src/FTPClientTestSuite.cpp#2 $
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "FTPSClientTestSuite.h"
+#include "FTPSClientSessionTest.h"
+
+
+CppUnit::Test* FTPSClientTestSuite::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("FTPSClientTestSuite");
+
+	pSuite->addTest(FTPSClientSessionTest::suite());
+
+	return pSuite;
+}

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.h
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.h
@@ -16,7 +16,7 @@
 #define FTPClientTestSuite_INCLUDED
 
 
-#include "CppUnit/TestSuite.h"
+#include "Poco/CppUnit/TestSuite.h"
 
 
 class FTPSClientTestSuite

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.h
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientTestSuite.h
@@ -1,0 +1,29 @@
+//
+// FTPClientTestSuite.h
+//
+// $Id: //poco/svn/Net/testsuite/src/FTPClientTestSuite.h#2 $
+//
+// Definition of the FTPClientTestSuite class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef FTPClientTestSuite_INCLUDED
+#define FTPClientTestSuite_INCLUDED
+
+
+#include "CppUnit/TestSuite.h"
+
+
+class FTPSClientTestSuite
+{
+public:
+	static CppUnit::Test* suite();
+};
+
+
+#endif // FTPClientTestSuite_INCLUDED

--- a/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
@@ -15,7 +15,7 @@
 #include "HTTPSClientTestSuite.h"
 #include "TCPServerTestSuite.h"
 #include "HTTPSServerTestSuite.h"
-#include "WebSocketTestSuite.h"
+#include "FTPSClientTestSuite.h"
 
 
 CppUnit::Test* NetSSLTestSuite::suite()
@@ -26,7 +26,7 @@ CppUnit::Test* NetSSLTestSuite::suite()
 	pSuite->addTest(HTTPSClientTestSuite::suite());
 	pSuite->addTest(TCPServerTestSuite::suite());
 	pSuite->addTest(HTTPSServerTestSuite::suite());
-	pSuite->addTest(WebSocketTestSuite::suite());
+	pSuite->addTest(FTPSClientTestSuite::suite());
 
 	return pSuite;
 }

--- a/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
@@ -15,6 +15,7 @@
 #include "HTTPSClientTestSuite.h"
 #include "TCPServerTestSuite.h"
 #include "HTTPSServerTestSuite.h"
+#include "WebSocketTestSuite.h"
 #include "FTPSClientTestSuite.h"
 
 
@@ -26,6 +27,7 @@ CppUnit::Test* NetSSLTestSuite::suite()
 	pSuite->addTest(HTTPSClientTestSuite::suite());
 	pSuite->addTest(TCPServerTestSuite::suite());
 	pSuite->addTest(HTTPSServerTestSuite::suite());
+	pSuite->addTest(WebSocketTestSuite::suite());
 	pSuite->addTest(FTPSClientTestSuite::suite());
 
 	return pSuite;


### PR DESCRIPTION
Added FTPSClientSession to handle FTPS (FTP over Explicit SSL connection). I use this class from a couple of year without problem.
Basically FTPClientSession is like original, the only thing I changed are initialization order of variables to deal with gcc warning and put the request reading in a function.
FTPSClientSession extend FTPClientSession adding staff to do SSL connection over FTP

Status:

- [x] FTPS class implementation
- [x] Makefile
- [x] build vs140 32bit and 64bit
- [x] test vs140 64bit 
- [x] FTPSStreamFactory.cpp
- [x] OSX tests
- [x] build vs150
- [x] test vs150