### PR TITLE
Add support for (unsigned) long long when long is 64bit

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -187,6 +187,16 @@ public:
 	void convert(unsigned long& val) const;
 		/// Calls convert(UInt32).
 
+#else
+
+	virtual void convert(long long& val) const;
+		/// Throws BadCastException. Must be overriden in a type
+		/// specialization in order to suport the conversion.
+
+	virtual void convert(unsigned long long & val) const;
+		/// Throws BadCastException. Must be overriden in a type
+		/// specialization in order to suport the conversion.
+
 #endif
 
 	virtual void convert(bool& val) const;
@@ -511,6 +521,19 @@ inline void VarHolder::convert(unsigned long& val) const
 	val = tmp;
 }
 
+#else
+
+inline void VarHolder::convert(long long& /*val*/) const
+{
+	throw BadCastException("Can not convert to long long");
+}
+
+
+inline void VarHolder::convert(unsigned long long& /*val*/) const
+{
+	throw BadCastException("Can not convert to unsigned long long");
+}
+
 #endif
 
 inline void VarHolder::convert(bool& /*val*/) const
@@ -724,6 +747,20 @@ public:
 		convertSignedToUnsigned(_val, val);
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != 0);
@@ -866,6 +903,20 @@ public:
 		convertSignedToUnsigned(_val, val);
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != 0);
@@ -1006,6 +1057,20 @@ public:
 		convertSignedToUnsigned(_val, val);
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != 0);
@@ -1143,6 +1208,20 @@ public:
 	{
 		convertSignedToUnsigned(_val, val);
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -1297,6 +1376,20 @@ public:
 		val = _val;
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = static_cast<long long>(_val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val;
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != 0);
@@ -1434,6 +1527,20 @@ public:
 	{
 		val = _val;
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = static_cast<long long>(_val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val;
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -1573,6 +1680,20 @@ public:
 		val = _val;
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val;
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != 0);
@@ -1710,6 +1831,20 @@ public:
 	{
 		val = _val;
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val;
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -1870,6 +2005,20 @@ public:
 		val = static_cast<UInt64>(_val ? 1 : 0);
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = static_cast<long long>(_val ? 1 : 0);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = static_cast<unsigned long long>(_val ? 1 : 0);
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = _val;
@@ -2005,6 +2154,20 @@ public:
 	{
 		convertSignedFloatToUnsigned(_val, val);
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		convertToSmaller(_val, val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedFloatToUnsigned(_val, val);
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -2144,6 +2307,20 @@ public:
 	{
 		convertSignedFloatToUnsigned(_val, val);
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		convertToSmaller(_val, val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedFloatToUnsigned(_val, val);
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -2290,6 +2467,20 @@ public:
 		val = static_cast<UInt8>(_val);
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = static_cast<long long>(_val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = static_cast<unsigned long long>(_val);
+	}
+
+#endif
+
 	void convert(bool& val) const
 	{
 		val = (_val != '\0');
@@ -2433,6 +2624,20 @@ public:
 	{
 		val = NumberParser::parseUnsigned64(_val);
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = NumberParser::parse64(_val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = NumberParser::parseUnsigned64(_val);
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -2611,6 +2816,20 @@ public:
 	{
 		val = NumberParser::parseUnsigned64(toStdString());
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = NumberParser::parse64(toStdString());
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = NumberParser::parseUnsigned64(toStdString());
+	}
+
+#endif
 
 	void convert(bool& val) const
 	{
@@ -3014,6 +3233,305 @@ private:
 };
 
 
+#else // if defined (POCO_LONG_IS_64_BIT)
+
+
+template <>
+class VarHolderImpl<long long>: public VarHolder
+{
+public:
+	VarHolderImpl(long long val): _val(val)
+	{
+	}
+
+	~VarHolderImpl()
+	{
+	}
+
+	const std::type_info& type() const
+	{
+		return typeid(long long);
+	}
+
+	void convert(Int8& val) const
+	{
+		convertToSmaller(_val, val);
+	}
+
+	void convert(Int16& val) const
+	{
+		convertToSmaller(_val, val);
+	}
+
+	void convert(Int32& val) const
+	{
+		convertToSmaller(_val, val);
+	}
+
+	void convert(Int64& val) const
+	{
+		val = static_cast<Int64>(_val);
+	}
+
+	void convert(UInt8& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+	void convert(UInt16& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+	void convert(UInt32& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+	void convert(UInt64& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+	void convert(long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		convertSignedToUnsigned(_val, val);
+	}
+
+	void convert(bool& val) const
+	{
+		val = (_val != 0);
+	}
+
+	void convert(float& val) const
+	{
+		val = static_cast<float>(_val);
+	}
+
+	void convert(double& val) const
+	{
+		val = static_cast<double>(_val);
+	}
+
+	void convert(char& val) const
+	{
+		UInt8 tmp;
+		convert(tmp);
+		val = static_cast<char>(tmp);
+	}
+
+	void convert(std::string& val) const
+	{
+		val = NumberFormatter::format(_val);
+	}
+
+	VarHolder* clone(Placeholder<VarHolder>* pVarHolder = 0) const
+	{
+		return cloneHolder(pVarHolder, _val);
+	}
+
+	const long long& value() const
+	{
+		return _val;
+	}
+
+	bool isArray() const
+	{
+		return false;
+	}
+
+	bool isStruct() const
+	{
+		return false;
+	}
+
+	bool isInteger() const
+	{
+		return std::numeric_limits<long long>::is_integer;
+	}
+
+	bool isSigned() const
+	{
+		return std::numeric_limits<long long>::is_signed;
+	}
+
+	bool isNumeric() const
+	{
+		return std::numeric_limits<long long>::is_specialized;
+	}
+
+	bool isBoolean() const
+	{
+		return false;
+	}
+
+	bool isString() const
+	{
+		return false;
+	}
+
+private:
+	VarHolderImpl();
+	VarHolderImpl(const VarHolderImpl&);
+	VarHolderImpl& operator = (const VarHolderImpl&);
+
+	long long _val;
+};
+
+
+template <>
+class VarHolderImpl<unsigned long long>: public VarHolder
+{
+public:
+	VarHolderImpl(unsigned long long val): _val(val)
+	{
+	}
+
+	~VarHolderImpl()
+	{
+	}
+
+	const std::type_info& type() const
+	{
+		return typeid(unsigned long long);
+	}
+
+	void convert(Int8& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(Int16& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(Int32& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(Int64& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(UInt8& val) const
+	{
+		convertToSmallerUnsigned(_val, val);
+	}
+
+	void convert(UInt16& val) const
+	{
+		convertToSmallerUnsigned(_val, val);
+	}
+
+	void convert(UInt32& val) const
+	{
+		convertToSmallerUnsigned(_val, val);
+	}
+
+	void convert(UInt64& val) const
+	{
+		val = static_cast<UInt64>(_val);
+	}
+
+	void convert(long long& val) const
+	{
+		convertUnsignedToSigned(_val, val);
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val;
+	}
+
+	void convert(bool& val) const
+	{
+		val = (_val != 0);
+	}
+
+	void convert(float& val) const
+	{
+		val = static_cast<float>(_val);
+	}
+
+	void convert(double& val) const
+	{
+		val = static_cast<double>(_val);
+	}
+
+	void convert(char& val) const
+	{
+		UInt8 tmp;
+		convert(tmp);
+		val = static_cast<char>(tmp);
+	}
+
+	void convert(std::string& val) const
+	{
+		val = NumberFormatter::format(_val);
+	}
+
+	VarHolder* clone(Placeholder<VarHolder>* pVarHolder = 0) const
+	{
+		return cloneHolder(pVarHolder, _val);
+	}
+
+	const unsigned long long& value() const
+	{
+		return _val;
+	}
+
+	bool isArray() const
+	{
+		return false;
+	}
+
+	bool isStruct() const
+	{
+		return false;
+	}
+
+	bool isInteger() const
+	{
+		return std::numeric_limits<unsigned long long>::is_integer;
+	}
+
+	bool isSigned() const
+	{
+		return std::numeric_limits<unsigned long long>::is_signed;
+	}
+
+	bool isNumeric() const
+	{
+		return std::numeric_limits<unsigned long long>::is_specialized;
+	}
+
+	bool isBoolean() const
+	{
+		return false;
+	}
+
+	bool isString() const
+	{
+		return false;
+	}
+
+private:
+	VarHolderImpl();
+	VarHolderImpl(const VarHolderImpl&);
+	VarHolderImpl& operator = (const VarHolderImpl&);
+
+	unsigned long long _val;
+};
+
+
 #endif // 64bit
 
 
@@ -3264,6 +3782,20 @@ public:
 		val = _val.timestamp().epochMicroseconds();
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val.timestamp().epochMicroseconds();
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val.timestamp().epochMicroseconds();
+	}
+
+#endif
+
 	void convert(std::string& val) const
 	{
 		val = DateTimeFormatter::format(_val, Poco::DateTimeFormat::ISO8601_FORMAT);
@@ -3365,6 +3897,20 @@ public:
 		val = _val.timestamp().epochMicroseconds();
 	}
 
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val.timestamp().epochMicroseconds();
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val.timestamp().epochMicroseconds();
+	}
+
+#endif
+
 	void convert(std::string& val) const
 	{
 		val = DateTimeFormatter::format(_val, Poco::DateTimeFormat::ISO8601_FORMAT);
@@ -3465,6 +4011,20 @@ public:
 	{
 		val = _val.epochMicroseconds();
 	}
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	void convert(long long& val) const
+	{
+		val = _val.epochMicroseconds();
+	}
+
+	void convert(unsigned long long& val) const
+	{
+		val = _val.epochMicroseconds();
+	}
+
+#endif
 
 	void convert(std::string& val) const
 	{

--- a/Foundation/include/Poco/NumberFormatter.h
+++ b/Foundation/include/Poco/NumberFormatter.h
@@ -150,7 +150,59 @@ public:
 		/// If prefix is true, "0x" prefix is prepended to the 
 		/// resulting string.
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#ifdef POCO_HAVE_INT64
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	static std::string format(long long value);
+		/// Formats a 64-bit integer value in decimal notation.
+
+	static std::string format(long long value, int width);
+		/// Formats a 64-bit integer value in decimal notation,
+		/// right justified in a field having at least the specified width.
+
+	static std::string format0(long long value, int width);
+		/// Formats a 64-bit integer value in decimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width.
+
+	static std::string formatHex(long long value, bool prefix = false);
+		/// Formats a 64-bit integer value in hexadecimal notation.
+		/// If prefix is true, "0x" prefix is prepended to the 
+		/// resulting string.
+		/// The value is treated as unsigned.
+
+	static std::string formatHex(long long value, int width, bool prefix = false);
+		/// Formats a 64-bit integer value in hexadecimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width.
+		/// The value is treated as unsigned.
+		/// If prefix is true, "0x" prefix is prepended to the resulting string.
+
+	static std::string format(unsigned long long value);
+		/// Formats an unsigned 64-bit integer value in decimal notation.
+
+	static std::string format(unsigned long long value, int width);
+		/// Formats an unsigned 64-bit integer value in decimal notation,
+		/// right justified in a field having at least the specified width.
+
+	static std::string format0(unsigned long long value, int width);
+		/// Formats an unsigned 64-bit integer value in decimal notation,
+		/// right justified and zero-padded in a field having at least the
+		/// specified width.
+
+	static std::string formatHex(unsigned long long value, bool prefix = false);
+		/// Formats a 64-bit integer value in hexadecimal notation.
+		/// If prefix is true, "0x" prefix is prepended to the 
+		/// resulting string.
+
+	static std::string formatHex(unsigned long long value, int width, bool prefix = false);
+		/// Formats a 64-bit integer value in hexadecimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width. If prefix is true, "0x" prefix is
+		/// prepended to the resulting string.
+
+#else // ifndef POCO_LONG_IS_64_BIT
 
 	static std::string format(Int64 value);
 		/// Formats a 64-bit integer value in decimal notation.
@@ -200,7 +252,9 @@ public:
 		/// the specified width. If prefix is true, "0x" prefix is
 		/// prepended to the resulting string.
 
-#endif // defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#endif // ifdef POCO_LONG_IS_64_BIT
+
+#endif // ifdef POCO_HAVE_INT64
 
 	static std::string format(float value);
 		/// Formats a float value in decimal floating-point notation,
@@ -325,7 +379,53 @@ public:
 		/// right justified and zero-padded in a field having at least the
 		/// specified width.
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#ifdef POCO_HAVE_INT64
+
+#ifdef POCO_LONG_IS_64_BIT
+
+	static void append(std::string& str, long long value);
+		/// Formats a 64-bit integer value in decimal notation.
+
+	static void append(std::string& str, long long value, int width);
+		/// Formats a 64-bit integer value in decimal notation,
+		/// right justified in a field having at least the specified width.
+
+	static void append0(std::string& str, long long value, int width);
+		/// Formats a 64-bit integer value in decimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width.
+
+	static void appendHex(std::string& str, long long value);
+		/// Formats a 64-bit integer value in hexadecimal notation.
+		/// The value is treated as unsigned.
+
+	static void appendHex(std::string& str, long long value, int width);
+		/// Formats a 64-bit integer value in hexadecimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width.
+		/// The value is treated as unsigned.
+
+	static void append(std::string& str, unsigned long long value);
+		/// Formats an unsigned 64-bit integer value in decimal notation.
+
+	static void append(std::string& str, unsigned long long value, int width);
+		/// Formats an unsigned 64-bit integer value in decimal notation,
+		/// right justified in a field having at least the specified width.
+
+	static void append0(std::string& str, unsigned long long value, int width);
+		/// Formats an unsigned 64-bit integer value in decimal notation,
+		/// right justified and zero-padded in a field having at least the
+		/// specified width.
+
+	static void appendHex(std::string& str, unsigned long long value);
+		/// Formats a 64-bit integer value in hexadecimal notation.
+
+	static void appendHex(std::string& str, unsigned long long value, int width);
+		/// Formats a 64-bit integer value in hexadecimal notation,
+		/// right justified and zero-padded in a field having at least
+		/// the specified width.
+
+#else // ifndef POCO_LONG_IS_64_BIT
 
 	static void append(std::string& str, Int64 value);
 		/// Formats a 64-bit integer value in decimal notation.
@@ -369,7 +469,9 @@ public:
 		/// right justified and zero-padded in a field having at least
 		/// the specified width.
 
-#endif // defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#endif // ifdef POCO_LONG_IS_64_BIT
+
+#endif // ifdef POCO_HAVE_INT64
 
 	static void append(std::string& str, float value);
 		/// Formats a float value in decimal floating-point notation,
@@ -570,7 +672,92 @@ inline std::string NumberFormatter::formatHex(unsigned long value, int width, bo
 }
 
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#ifdef POCO_HAVE_INT64
+
+#ifdef POCO_LONG_IS_64_BIT
+
+
+inline std::string NumberFormatter::format(long long value)
+{
+	std::string result;
+	intToStr(value, 10, result);
+	return result;
+}
+
+
+inline std::string NumberFormatter::format(long long value, int width)
+{
+	std::string result;
+	intToStr(value, 10, result, false, width, ' ');
+	return result;
+}
+
+
+inline std::string NumberFormatter::format0(long long value, int width)
+{
+	std::string result;
+	intToStr(value, 10, result, false, width, '0');
+	return result;
+}
+
+
+inline std::string NumberFormatter::formatHex(long long value, bool prefix)
+{
+	std::string result;
+	uIntToStr(static_cast<unsigned long long>(value), 0x10, result, prefix);
+	return result;
+}
+
+
+inline std::string NumberFormatter::formatHex(long long value, int width, bool prefix)
+{
+	std::string result;
+	uIntToStr(static_cast<unsigned long long>(value), 0x10, result, prefix, width, '0');
+	return result;
+}
+
+
+inline std::string NumberFormatter::format(unsigned long long value)
+{
+	std::string result;
+	uIntToStr(value, 10, result);
+	return result;
+}
+
+
+inline std::string NumberFormatter::format(unsigned long long value, int width)
+{
+	std::string result;
+	uIntToStr(value, 10, result, false, width, ' ');
+	return result;
+}
+
+
+inline std::string NumberFormatter::format0(unsigned long long value, int width)
+{
+	std::string result;
+	uIntToStr(value, 10, result, false, width, '0');
+	return result;
+}
+
+
+inline std::string NumberFormatter::formatHex(unsigned long long value, bool prefix)
+{
+	std::string result;
+	uIntToStr(value, 0x10, result, prefix);
+	return result;
+}
+
+
+inline std::string NumberFormatter::formatHex(unsigned long long value, int width, bool prefix)
+{
+	std::string result;
+	uIntToStr(value, 0x10, result, prefix, width, '0');
+	return result;
+}
+
+
+#else // ifndef POCO_LONG_IS_64_BIT
 
 
 inline std::string NumberFormatter::format(Int64 value)
@@ -653,7 +840,9 @@ inline std::string NumberFormatter::formatHex(UInt64 value, int width, bool pref
 }
 
 
-#endif // defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#endif // ifdef POCO_LONG_IS_64_BIT
+
+#endif // ifdef POCO_HAVE_INT64
 
 
 inline std::string NumberFormatter::format(float value)

--- a/Foundation/src/NumberFormatter.cpp
+++ b/Foundation/src/NumberFormatter.cpp
@@ -234,7 +234,102 @@ void NumberFormatter::appendHex(std::string& str, unsigned long value, int width
 }
 
 
-#if defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#ifdef POCO_HAVE_INT64
+
+#ifdef POCO_LONG_IS_64_BIT
+
+
+void NumberFormatter::append(std::string& str, long long value)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	intToStr(value, 10, result, sz);
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::append(std::string& str, long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	intToStr(value, 10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::append0(std::string& str, long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	intToStr(value, 10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::appendHex(std::string& str, long long value)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(static_cast<unsigned long long>(value), 0x10, result, sz);
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::appendHex(std::string& str, long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(static_cast<unsigned long long>(value), 0x10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::append(std::string& str, unsigned long long value)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(value, 10, result, sz);
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::append(std::string& str, unsigned long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(value, 10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::append0(std::string& str, unsigned long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(value, 10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::appendHex(std::string& str, unsigned long long value)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(value, 0x10, result, sz);
+	str.append(result, sz);
+}
+
+
+void NumberFormatter::appendHex(std::string& str, unsigned long long value, int width)
+{
+	char result[NF_MAX_INT_STRING_LEN];
+	std::size_t sz = NF_MAX_INT_STRING_LEN;
+	uIntToStr(value, 0x10, result, sz, false, width, '0');
+	str.append(result, sz);
+}
+
+
+#else // ifndef POCO_LONG_IS_64_BIT
 
 
 void NumberFormatter::append(std::string& str, Int64 value)
@@ -327,7 +422,9 @@ void NumberFormatter::appendHex(std::string& str, UInt64 value, int width)
 }
 
 
-#endif // defined(POCO_HAVE_INT64) && !defined(POCO_LONG_IS_64_BIT)
+#endif // ifdef POCO_LONG_IS_64_BIT
+
+#endif // ifdef POCO_HAVE_INT64
 
 
 void NumberFormatter::append(std::string& str, float value)

--- a/Foundation/testsuite/src/NumberFormatterTest.cpp
+++ b/Foundation/testsuite/src/NumberFormatterTest.cpp
@@ -58,6 +58,14 @@ void NumberFormatterTest::testFormat()
 
 	assert (NumberFormatter::format((UInt64) 123) == "123");
 	assert (NumberFormatter::format((UInt64) 123, 5) == "  123");	
+#if defined(POCO_LONG_IS_64_BIT)
+	assert (NumberFormatter::format((long long) 123) == "123");
+	assert (NumberFormatter::format((long long) -123) == "-123");
+	assert (NumberFormatter::format((long long) -123, 5) == " -123");
+
+	assert (NumberFormatter::format((unsigned long long) 123) == "123");
+	assert (NumberFormatter::format((unsigned long long) 123, 5) == "  123");
+#endif
 #endif
 
 	if (sizeof(void*) == 4)
@@ -83,6 +91,11 @@ void NumberFormatterTest::testFormat0()
 	assert (NumberFormatter::format0((Int64) 123, 5) == "00123");
 	assert (NumberFormatter::format0((Int64) -123, 5) == "-0123");
 	assert (NumberFormatter::format0((UInt64) 123, 5) == "00123");
+#if defined(POCO_LONG_IS_64_BIT)
+	assert (NumberFormatter::format0((long long) 123, 5) == "00123");
+	assert (NumberFormatter::format0((long long) -123, 5) == "-0123");
+	assert (NumberFormatter::format0((unsigned long long) 123, 5) == "00123");
+#endif
 #endif
 }
 
@@ -130,6 +143,17 @@ void NumberFormatterTest::testFormatHex()
 	assert (NumberFormatter::formatHex((UInt64) 0xab) == "AB");
 	assert (NumberFormatter::formatHex((UInt64) 0x12, 4) == "0012");
 	assert (NumberFormatter::formatHex((UInt64) 0xab, 4) == "00AB");
+#if defined(POCO_LONG_IS_64_BIT)
+	assert (NumberFormatter::formatHex((long long) 0x12) == "12");
+	assert (NumberFormatter::formatHex((long long) 0xab) == "AB");
+	assert (NumberFormatter::formatHex((long long) 0x12, 4) == "0012");
+	assert (NumberFormatter::formatHex((long long) 0xab, 4) == "00AB");
+
+	assert (NumberFormatter::formatHex((unsigned long long) 0x12) == "12");
+	assert (NumberFormatter::formatHex((unsigned long long) 0xab) == "AB");
+	assert (NumberFormatter::formatHex((unsigned long long) 0x12, 4) == "0012");
+	assert (NumberFormatter::formatHex((unsigned long long) 0xab, 4) == "00AB");
+#endif
 #endif
 
 	assert (NumberFormatter::formatHex(0x12, true) == "0x12");
@@ -174,6 +198,21 @@ void NumberFormatterTest::testFormatHex()
 	assert (NumberFormatter::formatHex((UInt64) 0xab, 4, true) == "0xAB");
 	assert (NumberFormatter::formatHex((UInt64) 0x12, 6, true) == "0x0012");
 	assert (NumberFormatter::formatHex((UInt64) 0xab, 6, true) == "0x00AB");
+#if defined(POCO_LONG_IS_64_BIT)
+	assert (NumberFormatter::formatHex((long long) 0x12, true) == "0x12");
+	assert (NumberFormatter::formatHex((long long) 0xab, true) == "0xAB");
+	assert (NumberFormatter::formatHex((long long) 0x12, 4, true) == "0x12");
+	assert (NumberFormatter::formatHex((long long) 0xab, 4, true) == "0xAB");
+	assert (NumberFormatter::formatHex((long long) 0x12, 6, true) == "0x0012");
+	assert (NumberFormatter::formatHex((long long) 0xab, 6, true) == "0x00AB");
+
+	assert (NumberFormatter::formatHex((unsigned long long) 0x12, true) == "0x12");
+	assert (NumberFormatter::formatHex((unsigned long long) 0xab, true) == "0xAB");
+	assert (NumberFormatter::formatHex((unsigned long long) 0x12, 4, true) == "0x12");
+	assert (NumberFormatter::formatHex((unsigned long long) 0xab, 4, true) == "0xAB");
+	assert (NumberFormatter::formatHex((unsigned long long) 0x12, 6, true) == "0x0012");
+	assert (NumberFormatter::formatHex((unsigned long long) 0xab, 6, true) == "0x00AB");
+#endif
 #endif
 }
 

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -100,10 +100,16 @@ void VarTest::testInt8()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -188,10 +194,16 @@ void VarTest::testInt16()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -276,10 +288,16 @@ void VarTest::testInt32()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -364,10 +382,16 @@ void VarTest::testInt64()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -452,10 +476,16 @@ void VarTest::testUInt8()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -540,10 +570,16 @@ void VarTest::testUInt16()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -628,10 +664,16 @@ void VarTest::testUInt32()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -716,10 +758,16 @@ void VarTest::testUInt64()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -804,10 +852,16 @@ void VarTest::testBool()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 1);
 	assert (s15 == 1);
+	assert (s16 == 1);
+	assert (s17 == 1);
 	assert (s1 == "true");
 	assert (s2 == 1);
 	assert (s3 == 1);
@@ -875,10 +929,16 @@ void VarTest::testChar()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == " ");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -949,10 +1009,16 @@ void VarTest::testFloat()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -1041,10 +1107,16 @@ void VarTest::testDouble()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -1129,10 +1201,16 @@ void VarTest::testString()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -1214,10 +1292,16 @@ void VarTest::testLong()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -1302,10 +1386,16 @@ void VarTest::testULong()
 	a1.convert(s13);
 	long s14;
 	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
 	a1.convert(s14);
 	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
 	assert (s14 == 32);
 	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
 	assert (s1 == "32");
 	assert (s2 == 32);
 	assert (s3 == 32);
@@ -1327,6 +1417,193 @@ void VarTest::testULong()
 	unsigned long value = a1.extract<unsigned long>();
 	assert (value == 32);
 	
+	try
+	{
+		Int16 value2; value2 = a1.extract<Int16>();
+		fail("bad cast - must throw");
+	}
+	catch (Poco::BadCastException&)
+	{
+	}
+
+	Var a3 = a1 + 1;
+	assert (a3 == 33);
+	a3 = a1 - 1;
+	assert (a3 == 31);
+	a3 += 1;
+	assert (a3 == 32);
+	a3 -= 1;
+	assert (a3 == 31);
+	a3 = a1 / 2;
+	assert (a3 == 16);
+	a3 = a1 * 2;
+	assert (a3 == 64);
+	a3 /= 2;
+	assert (a3 == 32);
+	a3 *= 2;
+	assert (a3 == 64);
+}
+
+void VarTest::testLongLong()
+{
+	long long src = 32;
+	Var a1 = src;
+
+	assert (a1.type() == typeid(long long));
+
+	std::string s1;
+	Poco::Int8 s2;
+	Poco::Int16 s3;
+	Poco::Int32 s4;
+	Poco::Int64 s5;
+	Poco::UInt8 s6;
+	Poco::UInt16 s7;
+	Poco::UInt32 s8;
+	Poco::UInt64 s9;
+	float s10;
+	double s11;
+	bool s12;
+	char s13;
+	a1.convert(s1);
+	a1.convert(s2);
+	a1.convert(s3);
+	a1.convert(s4);
+	a1.convert(s5);
+	a1.convert(s6);
+	a1.convert(s7);
+	a1.convert(s8);
+	a1.convert(s9);
+	a1.convert(s10);
+	a1.convert(s11);
+	a1.convert(s12);
+	a1.convert(s13);
+	long s14;
+	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
+	a1.convert(s14);
+	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
+	assert (s14 == 32);
+	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
+	assert (s1 == "32");
+	assert (s2 == 32);
+	assert (s3 == 32);
+	assert (s4 == 32);
+	assert (s5 == 32);
+	assert (s6 == 32);
+	assert (s7 == 32);
+	assert (s8 == 32);
+	assert (s9 == 32);
+	assert (s10 == 32.0f);
+	assert (s11 == 32.0);
+	assert (s12);
+	assert (s13 == ' ');
+	Var a2(a1);
+	std::string t2;
+	a2.convert(t2);
+	assert (s1 == t2);
+
+	long long value = a1.extract<long long>();
+	assert (value == 32);
+
+	try
+	{
+		Int16 value2; value2 = a1.extract<Int16>();
+		fail("bad cast - must throw");
+	}
+	catch (Poco::BadCastException&)
+	{
+	}
+
+	Var a3 = a1 + 1;
+	assert (a3 == 33);
+	a3 = a1 - 1;
+	assert (a3 == 31);
+	a3 += 1;
+	assert (a3 == 32);
+	a3 -= 1;
+	assert (a3 == 31);
+	a3 = a1 / 2;
+	assert (a3 == 16);
+	a3 = a1 * 2;
+	assert (a3 == 64);
+	a3 /= 2;
+	assert (a3 == 32);
+	a3 *= 2;
+	assert (a3 == 64);
+}
+
+
+void VarTest::testULongLong()
+{
+	unsigned long long src = 32;
+	Var a1 = src;
+
+	assert (a1.type() == typeid(unsigned long long));
+
+	std::string s1;
+	Poco::Int8 s2;
+	Poco::Int16 s3;
+	Poco::Int32 s4;
+	Poco::Int64 s5;
+	Poco::UInt8 s6;
+	Poco::UInt16 s7;
+	Poco::UInt32 s8;
+	Poco::UInt64 s9;
+	float s10;
+	double s11;
+	bool s12;
+	char s13;
+	a1.convert(s1);
+	a1.convert(s2);
+	a1.convert(s3);
+	a1.convert(s4);
+	a1.convert(s5);
+	a1.convert(s6);
+	a1.convert(s7);
+	a1.convert(s8);
+	a1.convert(s9);
+	a1.convert(s10);
+	a1.convert(s11);
+	a1.convert(s12);
+	a1.convert(s13);
+	long s14;
+	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
+	a1.convert(s14);
+	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
+	assert (s14 == 32);
+	assert (s15 == 32);
+	assert (s16 == 32);
+	assert (s17 == 32);
+	assert (s1 == "32");
+	assert (s2 == 32);
+	assert (s3 == 32);
+	assert (s4 == 32);
+	assert (s5 == 32);
+	assert (s6 == 32);
+	assert (s7 == 32);
+	assert (s8 == 32);
+	assert (s9 == 32);
+	assert (s10 == 32.0f);
+	assert (s11 == 32.0);
+	assert (s12);
+	assert (s13 == ' ');
+	Var a2(a1);
+	std::string t2;
+	a2.convert(t2);
+	assert (s1 == t2);
+
+	unsigned long long value = a1.extract<unsigned long long>();
+	assert (value == 32);
+
 	try
 	{
 		Int16 value2; value2 = a1.extract<Int16>();
@@ -1755,9 +2032,11 @@ void VarTest::testIsStruct()
 	char s13('c');
 	long s14(232323);
 	unsigned long s15(21233232u);
-	std::vector<Var> s16;
-	Struct<std::string> s17;
-	Struct<int> s18;
+	long long s16(-23823838);
+	unsigned long s17(2328328382u);
+	std::vector<Var> s18;
+	Struct<std::string> s19;
+	Struct<int> s20;
 
 	Var d1(s1);
 	Var d2(s2);
@@ -1777,6 +2056,8 @@ void VarTest::testIsStruct()
 	Var d16(s16);
 	Var d17(s17);
 	Var d18(s18);
+	Var d19(s19);
+	Var d20(s20);
 
 	assert (!d1.isStruct());
 	assert (!d2.isStruct());
@@ -1794,8 +2075,10 @@ void VarTest::testIsStruct()
 	assert (!d14.isStruct());
 	assert (!d15.isStruct());
 	assert (!d16.isStruct());
-	assert (d17.isStruct());
-	assert (d18.isStruct());
+	assert (!d17.isStruct());
+	assert (!d18.isStruct());
+	assert (d19.isStruct());
+	assert (d20.isStruct());
 }
 
 
@@ -1816,8 +2099,10 @@ void VarTest::testIsArray()
 	char s13('c');
 	long s14(232323);
 	unsigned long s15(21233232u);
-	std::vector<Var> s16;
-	DynamicStruct s17;
+	long long s16(-23823838);
+	unsigned long long s17(2328328382u);
+	std::vector<Var> s18;
+	DynamicStruct s19;
 
 	Var d0;
 	Var d1(s1);
@@ -1837,6 +2122,8 @@ void VarTest::testIsArray()
 	Var d15(s15);
 	Var d16(s16);
 	Var d17(s17);
+	Var d18(s18);
+	Var d19(s19);
 
 	assert (!d0.isArray());
 	assert (!d1.isArray());
@@ -1854,8 +2141,10 @@ void VarTest::testIsArray()
 	assert (!d13.isArray());
 	assert (!d14.isArray());
 	assert (!d15.isArray());
-	assert (d16.isArray());
+	assert (!d16.isArray());
 	assert (!d17.isArray());
+	assert (d18.isArray());
+	assert (!d19.isArray());
 }
 
 
@@ -1876,10 +2165,12 @@ void VarTest::testArrayIdxOperator()
 	char s13('c');
 	long s14(232323);
 	unsigned long s15(21233232u);
-	std::vector<Var> s16;
-	s16.push_back(s1);
-	s16.push_back(s2);
-	DynamicStruct s17;
+	long long s16(-23823838);
+	unsigned long long s17(2328328382u);
+	std::vector<Var> s18;
+	s18.push_back(s1);
+	s18.push_back(s2);
+	DynamicStruct s19;
 
 	Var d1(s1);
 	Var d2(s2);
@@ -1898,6 +2189,8 @@ void VarTest::testArrayIdxOperator()
 	Var d15(s15);
 	Var d16(s16);
 	Var d17(s17);
+	Var d18(s18);
+	Var d19(s19);
 
 	testGetIdxMustThrow(d1, 0);
 	testGetIdxNoThrow(d2, 0);
@@ -1914,8 +2207,10 @@ void VarTest::testArrayIdxOperator()
 	testGetIdxNoThrow(d13, 0);
 	testGetIdxNoThrow(d14, 0);
 	testGetIdxNoThrow(d15, 0);
-	testGetIdx(d16, 0, s1);
-	testGetIdx(d16, 1, s2);
+	testGetIdxNoThrow(d16, 0);
+	testGetIdxNoThrow(d17, 0);
+	testGetIdx(d18, 0, s1);
+	testGetIdx(d18, 1, s2);
 
 	testGetIdxMustThrow(d1, 1);
 	testGetIdxMustThrow(d2, 1);
@@ -1932,7 +2227,9 @@ void VarTest::testArrayIdxOperator()
 	testGetIdxMustThrow(d13, 1);
 	testGetIdxMustThrow(d14, 1);
 	testGetIdxMustThrow(d15, 1);
+	testGetIdxMustThrow(d16, 1);
 	testGetIdxMustThrow(d17, 1);
+	testGetIdxMustThrow(d19, 1);
 }
 
 
@@ -2498,6 +2795,9 @@ void VarTest::testEmpty()
 #ifdef POCO_LONG_IS_64_BIT
 	testEmptyComparisons<unsigned long>();
 	testEmptyComparisons<long>();
+#else
+	testEmptyComparisons<unsigned long long>();
+	testEmptyComparisons<long long>();
 #endif
 	testEmptyComparisons<float>();
 	testEmptyComparisons<double>();
@@ -2609,6 +2909,8 @@ CppUnit::Test* VarTest::suite()
 	CppUnit_addTest(pSuite, VarTest, testDouble);
 	CppUnit_addTest(pSuite, VarTest, testLong);
 	CppUnit_addTest(pSuite, VarTest, testULong);
+	CppUnit_addTest(pSuite, VarTest, testLongLong);
+	CppUnit_addTest(pSuite, VarTest, testULongLong);
 	CppUnit_addTest(pSuite, VarTest, testString);
 	CppUnit_addTest(pSuite, VarTest, testUDT);
 	CppUnit_addTest(pSuite, VarTest, testConversionOperator);

--- a/Foundation/testsuite/src/VarTest.h
+++ b/Foundation/testsuite/src/VarTest.h
@@ -40,6 +40,8 @@ public:
 	void testDouble();
 	void testLong();
 	void testULong();
+	void testLongLong();
+	void testULongLong();
 	void testString();
 	void testUDT();
 	void testConversionOperator();


### PR DESCRIPTION
This provides a temporary workaround for #1147 by providing `long long` and `unsigned long long` template implementations when `Poco::Int64` and `Poco::UInt64` are `#defined` as `long` and `unsigned long`. This prevents `BadCastException`s when trying to set and extract `int64_t` and `uint64_t` from `Poco::JSON::Object`s. Additional test cases have been added to the relevant tests, and pass on Windows, Mac and Linux (Mac being the key, as it is where the original issue is highlighted by `Poco::Int64` being `long` whilst `int64_t` is `long long`).