### PR TITLE
If openssl > 1.0.2, use it to verify cert matches hostname. Fix GH #1817

### DIFF
--- a/NetSSL_OpenSSL/src/X509Certificate.cpp
+++ b/NetSSL_OpenSSL/src/X509Certificate.cpp
@@ -5,7 +5,7 @@
 // Package: SSLCore
 // Module:  X509Certificate
 //
-// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// Copyright (c) 2006-2017, Applied Informatics Software Engineering GmbH.
 // and Contributors.
 //
 // SPDX-License-Identifier:	BSL-1.0
@@ -81,7 +81,8 @@ bool X509Certificate::verify(const std::string& hostName) const
 
 
 bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, const std::string& hostName)
-{		
+{
+#if OPENSSL_VERSION_NUMBER < 0x10002000L
 	std::string commonName;
 	std::set<std::string> dnsNames;
 	certificate.extractNames(commonName, dnsNames);
@@ -131,6 +132,21 @@ bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, c
 		}
 	}
 	return ok;
+#else
+	if (X509_check_host(const_cast<X509*>(certificate.certificate()), hostName.c_str(), hostName.length(), 0, NULL) == 1)
+	{
+		return true;
+	}
+	else
+	{
+		IPAddress ip;
+		if (IPAddress::tryParse(hostName, ip))
+		{
+		    return (X509_check_ip_asc(const_cast<X509*>(certificate.certificate()), hostName.c_str(), 0) == 1);
+		}
+	}
+	return false;
+#endif
 }
 
 

--- a/NetSSL_OpenSSL/testsuite/Makefile
+++ b/NetSSL_OpenSSL/testsuite/Makefile
@@ -16,7 +16,8 @@ endif
 objects = NetSSLTestSuite Driver \
 	HTTPSClientSessionTest HTTPSClientTestSuite HTTPSServerTest HTTPSServerTestSuite \
 	HTTPSStreamFactoryTest HTTPSTestServer TCPServerTest TCPServerTestSuite \
-	WebSocketTest WebSocketTestSuite FTPSClientSessionTest FTPSClientTestSuite DialogServer
+	WebSocketTest WebSocketTestSuite FTPSClientSessionTest FTPSClientTestSuite DialogServer \
+	X509CertificateTest X509CertificateTestSuite
 
 target         = testrunner
 target_version = 1

--- a/NetSSL_OpenSSL/testsuite/TestSuite_CE_vs90.vcproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_CE_vs90.vcproj
@@ -568,6 +568,23 @@
 					RelativePath=".\src\WebSocketTestSuite.h"/>
 			</Filter>
 		</Filter>
+		<Filter
+			Name="X509Certificate">
+			<Filter
+				Name="Header Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.h"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.h"/>
+			</Filter>
+			<Filter
+				Name="Source Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.cpp"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.cpp"/>
+			</Filter>
+		</Filter>
 	</Files>
 	<Globals/>
 </VisualStudioProject>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs110.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs110.vcxproj
@@ -12,6 +12,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>TestSuite</ProjectName>
@@ -49,6 +51,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs110.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs110.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{a57d9066-6181-4e53-bc44-1b1c22d70930}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs120.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs120.vcxproj
@@ -12,6 +12,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectName>TestSuite</ProjectName>
@@ -49,6 +51,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs120.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_WEC2013_vs120.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{e94c146d-f540-4b14-bf90-880e6520522d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs100.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs100.vcxproj
@@ -323,6 +323,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -337,6 +339,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs100.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs100.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{6cf002c3-41de-4fdc-9e42-79a8082befa2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs110.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs110.vcxproj
@@ -323,6 +323,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -337,6 +339,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs110.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs110.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{f4dd1d4d-80b4-4392-8075-2525d574d167}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs120.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs120.vcxproj
@@ -315,6 +315,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -329,6 +331,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs120.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs120.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{f9f789d7-0c50-4acc-a1fc-43c73dfc337b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs140.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs140.vcxproj
@@ -315,6 +315,8 @@
     <ClInclude Include="src\TCPServerTestSuite.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Driver.cpp"/>
@@ -329,6 +331,8 @@
     <ClCompile Include="src\TCPServerTestSuite.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs140.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{0b09c7ce-5036-4bb6-a3cd-fa80199fc035}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj
@@ -318,6 +318,8 @@
     <ClInclude Include="src\TCPServerTestSuite.h" />
     <ClInclude Include="src\WebSocketTest.h" />
     <ClInclude Include="src\WebSocketTestSuite.h" />
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogServer.cpp" />
@@ -335,6 +337,8 @@
     <ClCompile Include="src\TCPServerTestSuite.cpp" />
     <ClCompile Include="src\WebSocketTest.cpp" />
     <ClCompile Include="src\WebSocketTestSuite.cpp" />
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs150.vcxproj.filters
@@ -70,6 +70,15 @@
     <Filter Include="FTPSClient\Source files">
       <UniqueIdentifier>{ac5da877-65bb-4219-8a5c-640bdeeb2ba0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -113,6 +122,12 @@
     </ClInclude>
     <ClInclude Include="src\FTPSClientTestSuite.h">
       <Filter>FTPSClient\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -160,6 +175,12 @@
     </ClCompile>
     <ClCompile Include="src\FTPSClientTestSuite.cpp">
       <Filter>FTPSClient\Source files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_vs90.vcproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_vs90.vcproj
@@ -549,6 +549,23 @@
 					RelativePath=".\src\WebSocketTestSuite.h"/>
 			</Filter>
 		</Filter>
+		<Filter
+			Name="X509Certificate">
+			<Filter
+				Name="Header Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.h"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.h"/>
+			</Filter>
+			<Filter
+				Name="Source Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.cpp"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.cpp"/>
+			</Filter>
+		</Filter>
 	</Files>
 	<Globals/>
 </VisualStudioProject>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs100.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs100.vcxproj
@@ -323,6 +323,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -337,6 +339,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs100.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs100.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{d8cbf3fe-9c89-406d-9395-6b0d9039fcdd}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs110.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs110.vcxproj
@@ -323,6 +323,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -337,6 +339,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs110.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs110.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{d89bf884-eaa4-49bc-84e3-e1699d8bc875}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs120.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs120.vcxproj
@@ -315,6 +315,8 @@
     <ClInclude Include="src\HTTPSStreamFactoryTest.h"/>
     <ClInclude Include="src\WebSocketTest.h"/>
     <ClInclude Include="src\WebSocketTestSuite.h"/>
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\HTTPSTestServer.cpp"/>
@@ -329,6 +331,8 @@
     <ClCompile Include="src\HTTPSStreamFactoryTest.cpp"/>
     <ClCompile Include="src\WebSocketTest.cpp"/>
     <ClCompile Include="src\WebSocketTestSuite.cpp"/>
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets"/>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs120.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs120.vcxproj.filters
@@ -61,6 +61,15 @@
     <Filter Include="WebSocket\Header Files">
       <UniqueIdentifier>{c6065f75-0803-4e55-9975-4eb6ab22243b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -95,6 +104,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -133,6 +148,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj
@@ -318,6 +318,8 @@
     <ClInclude Include="src\TCPServerTestSuite.h" />
     <ClInclude Include="src\WebSocketTest.h" />
     <ClInclude Include="src\WebSocketTestSuite.h" />
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogServer.cpp" />
@@ -335,6 +337,8 @@
     <ClCompile Include="src\TCPServerTestSuite.cpp" />
     <ClCompile Include="src\WebSocketTest.cpp" />
     <ClCompile Include="src\WebSocketTestSuite.cpp" />
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs140.vcxproj.filters
@@ -70,6 +70,15 @@
     <Filter Include="WebSocket\Source Files">
       <UniqueIdentifier>{3b14eae2-2b25-4f69-b6e5-64bf3f8770bb}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -113,6 +122,12 @@
     </ClInclude>
     <ClInclude Include="src\WebSocketTestSuite.h">
       <Filter>WebSocket\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -160,6 +175,12 @@
     </ClCompile>
     <ClCompile Include="src\WebSocketTestSuite.cpp">
       <Filter>WebSocket\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj
@@ -318,6 +318,8 @@
     <ClInclude Include="src\TCPServerTestSuite.h" />
     <ClInclude Include="src\WebSocketTest.h" />
     <ClInclude Include="src\WebSocketTestSuite.h" />
+    <ClInclude Include="src\X509CertificateTest.h"/>
+    <ClInclude Include="src\X509CertificateTestSuite.h"/>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\DialogServer.cpp" />
@@ -335,6 +337,8 @@
     <ClCompile Include="src\TCPServerTestSuite.cpp" />
     <ClCompile Include="src\WebSocketTest.cpp" />
     <ClCompile Include="src\WebSocketTestSuite.cpp" />
+    <ClCompile Include="src\X509CertificateTest.cpp"/>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj.filters
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs150.vcxproj.filters
@@ -70,6 +70,15 @@
     <Filter Include="FTPSClient\Source Files">
       <UniqueIdentifier>{ce729123-5eef-4fc5-a105-a89de5b91454}</UniqueIdentifier>
     </Filter>
+    <Filter Include="X509Certificate">
+      <UniqueIdentifier>{01efc196-f7e7-4700-9e0e-a50df884a114}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Header Files">
+      <UniqueIdentifier>{721cad2c-4a3c-47f9-ae35-8abcfd629fe1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="X509Certificate\Source Files">
+      <UniqueIdentifier>{d863807d-abe4-408b-8143-a4dfd71ec1f0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\HTTPSTestServer.h">
@@ -113,6 +122,12 @@
     </ClInclude>
     <ClInclude Include="src\FTPSClientSessionTest.h">
       <Filter>FTPSClient\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTest.h">
+      <Filter>X509Certificate\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\X509CertificateTestSuite.h">
+      <Filter>X509Certificate\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -160,6 +175,12 @@
     </ClCompile>
     <ClCompile Include="src\FTPSClientSessionTest.cpp">
       <Filter>FTPSClient\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTest.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\X509CertificateTestSuite.cpp">
+      <Filter>X509Certificate\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs90.vcproj
+++ b/NetSSL_OpenSSL/testsuite/TestSuite_x64_vs90.vcproj
@@ -549,6 +549,23 @@
 					RelativePath=".\src\WebSocketTestSuite.h"/>
 			</Filter>
 		</Filter>
+		<Filter
+			Name="X509Certificate">
+			<Filter
+				Name="Header Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.h"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.h"/>
+			</Filter>
+			<Filter
+				Name="Source Files">
+				<File
+					RelativePath=".\src\X509CertificateTest.cpp"/>
+				<File
+					RelativePath=".\src\X509CertificateTestSuite.cpp"/>
+			</Filter>
+		</Filter>
 	</Files>
 	<Globals/>
 </VisualStudioProject>

--- a/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/NetSSLTestSuite.cpp
@@ -15,6 +15,7 @@
 #include "HTTPSServerTestSuite.h"
 #include "WebSocketTestSuite.h"
 #include "FTPSClientTestSuite.h"
+#include "X509CertificateTestSuite.h"
 
 
 CppUnit::Test* NetSSLTestSuite::suite()
@@ -27,6 +28,7 @@ CppUnit::Test* NetSSLTestSuite::suite()
 	pSuite->addTest(HTTPSServerTestSuite::suite());
 	pSuite->addTest(WebSocketTestSuite::suite());
 	pSuite->addTest(FTPSClientTestSuite::suite());
+	pSuite->addTest(X509CertificateTestSuite::suite());
 
 	return pSuite;
 }

--- a/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.cpp
@@ -1,0 +1,110 @@
+//
+// X509CertificateTest.cpp
+//
+// $Id: //poco/1.4/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.cpp#1 $
+//
+// Copyright (c) 2017, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "X509CertificateTest.h"
+#include "Poco/CppUnit/TestCaller.h"
+#include "Poco/CppUnit/TestSuite.h"
+#include "Poco/Net/X509Certificate.h"
+#include <openssl/opensslv.h>
+#include <sstream>
+
+using namespace Poco::Net;
+
+
+static const std::string BADSSL_PEM(
+	"-----BEGIN CERTIFICATE-----\n"
+	"MIIHGjCCBgKgAwIBAgIQC2as9L3V1BSoMGn+fB4NRjANBgkqhkiG9w0BAQ0FADBN\n"
+	"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5E\n"
+	"aWdpQ2VydCBTSEEyIFNlY3VyZSBTZXJ2ZXIgQ0EwHhcNMTcwMzE4MDAwMDAwWhcN\n"
+	"MjAwMzI1MTIwMDAwWjBnMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5p\n"
+	"YTEVMBMGA1UEBxMMV2FsbnV0IENyZWVrMRUwEwYDVQQKEwxMdWNhcyBHYXJyb24x\n"
+	"FTATBgNVBAMMDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC\n"
+	"AQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2PmzAS2BMTOqy\n"
+	"tMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMWhyefdOsKnRFS\n"
+	"JiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3AxPxTuW1CrbV8\n"
+	"/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqveww9HdFxBIuGa\n"
+	"+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SYQCeFxxC7c3Dv\n"
+	"aRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaOCA9owggPWMB8GA1UdIwQYMBaA\n"
+	"FA+AYRyCMWHVLyjnjUY4tCzhxtniMB0GA1UdDgQWBBSd7sF7gQs6R2lxGH0RN5O8\n"
+	"pRs/+zAjBgNVHREEHDAaggwqLmJhZHNzbC5jb22CCmJhZHNzbC5jb20wDgYDVR0P\n"
+	"AQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjBrBgNVHR8E\n"
+	"ZDBiMC+gLaArhilodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vc3NjYS1zaGEyLWc1\n"
+	"LmNybDAvoC2gK4YpaHR0cDovL2NybDQuZGlnaWNlcnQuY29tL3NzY2Etc2hhMi1n\n"
+	"NS5jcmwwTAYDVR0gBEUwQzA3BglghkgBhv1sAQEwKjAoBggrBgEFBQcCARYcaHR0\n"
+	"cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAIBgZngQwBAgMwfAYIKwYBBQUHAQEE\n"
+	"cDBuMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wRgYIKwYB\n"
+	"BQUHMAKGOmh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJT\n"
+	"ZWN1cmVTZXJ2ZXJDQS5jcnQwDAYDVR0TAQH/BAIwADCCAfcGCisGAQQB1nkCBAIE\n"
+	"ggHnBIIB4wHhAHcApLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BAAAAFa\n"
+	"37GUmAAABAMASDBGAiEAlzAI5gaOsmMH2II7yr08jlqKgxeZT5zAtd9obFeUfMgC\n"
+	"IQChMLfMCBbgv8Fo+7YoGzXJrNJJXDDBC+R/miHp2PA8BwB2AFYUBpov18Ls0/Xh\n"
+	"vUSyPsdGdrm8mRFcwO+UmFXWidDdAAABWt+xlX0AAAQDAEcwRQIgWBrOlMeBTCBJ\n"
+	"ezx+6OwzmD1QSl7/Vq2k/xACoGInSjsCIQCii59Rjt8rZxNIHMQE6/lnYHWyCqEv\n"
+	"rNAJiUOrJAxJ3QB1AO5Lvbd1zmC64UJpH6vhnmajD35fsHLYgwDEe4l6qP3LAAAB\n"
+	"Wt+xlqkAAAQDAEYwRAIgEklGobMohZiTQwTgizi4Sfy2CQ/fL1K1EM2yZGrvSCAC\n"
+	"IGkDXy8uSUh3S09pAODVLHeyMYX8fdGM3UU1uv8ReNH3AHcAu9nfvB+KcbWTlCOX\n"
+	"qpJ7RzhXlQqrUugakJZkNo4e0YUAAAFa37GUwQAABAMASDBGAiEA2wazyXDaD1k3\n"
+	"4UVG0AJH+HhNBb728PHxuTJYGffXCckCIQDOb7subG8AQJFc5zWKeKPhnHhP2R56\n"
+	"28tXqM8mzCQGzzANBgkqhkiG9w0BAQ0FAAOCAQEAyA7NyduD8+zjNI/uclW9WkvG\n"
+	"6Oolon0vvbs+BGvCl5iY/3BBIxNTWPeRBDE0P+zOkceqGqjENce/d1O5I/H+oFZR\n"
+	"Y0fLjtILwg/BH5QKoRWJF/rqvu7wlSqnxlYGDducs2hY2WgtIl/BntMaDQXcyzXP\n"
+	"O+Pjbq0JLb6/Enss558t3DNIKvtspDidxnQIPBzKBVx8prG1C0ng4S+HmZYg166W\n"
+	"mShTOeNNQMYPIUr44ICQkw82gYuAsjsgxEEjAHo0zrkHlA3cnwXeERAX3qEUQ8WH\n"
+	"Dw/Py3T1TqiODDqvLLE/sFYUwqDaSdaaOo/geYvJmfqOYXQoaz2t1ptYXdvsfg==\n"
+	"-----END CERTIFICATE-----\n"
+);
+
+
+X509CertificateTest::X509CertificateTest(const std::string& name): CppUnit::TestCase(name)
+{
+}
+
+
+X509CertificateTest::~X509CertificateTest()
+{
+}
+
+
+void X509CertificateTest::testVerify()
+{
+	std::istringstream certStream(BADSSL_PEM);
+	X509Certificate cert(certStream);
+
+	assert (cert.verify("badssl.com"));
+	assert (cert.verify("host.badssl.com"));
+
+#if OPENSSL_VERSION_NUMBER < 0x10002000L
+	assert (cert.verify("wrong.host.badssl.com"));
+#else
+	assert (!cert.verify("wrong.host.badssl.com"));
+#endif
+}
+
+
+void X509CertificateTest::setUp()
+{
+}
+
+
+void X509CertificateTest::tearDown()
+{
+}
+
+
+CppUnit::Test* X509CertificateTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("X509CertificateTest");
+
+	CppUnit_addTest(pSuite, X509CertificateTest, testVerify);
+
+	return pSuite;
+}

--- a/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.h
@@ -1,0 +1,39 @@
+//
+// X509CertificateTest.h
+//
+// $Id: //poco/1.4/NetSSL_OpenSSL/testsuite/src/X509CertificateTest.h#1 $
+//
+// Definition of the X509CertificateTest class.
+//
+// Copyright (c) 2017, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef X509CertificateTest_INCLUDED
+#define X509CertificateTest_INCLUDED
+
+
+#include "Poco/CppUnit/TestCase.h"
+
+
+class X509CertificateTest: public CppUnit::TestCase
+{
+public:
+	X509CertificateTest(const std::string& name);
+	~X509CertificateTest();
+
+	void testVerify();
+
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+
+private:
+};
+
+
+#endif // X509CertificateTest_INCLUDED

--- a/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.cpp
@@ -1,0 +1,24 @@
+//
+// X509CertificateTestSuite.cpp
+//
+// $Id: //poco/1.4/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.cpp#1 $
+//
+// Copyright (c) 2017, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "X509CertificateTestSuite.h"
+#include "X509CertificateTest.h"
+
+
+CppUnit::Test* X509CertificateTestSuite::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("X509CertificateTestSuite");
+
+	pSuite->addTest(X509CertificateTest::suite());
+
+	return pSuite;
+}

--- a/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.h
+++ b/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.h
@@ -1,0 +1,29 @@
+//
+// X509CertificateTestSuite.h
+//
+// $Id: //poco/1.4/NetSSL_OpenSSL/testsuite/src/X509CertificateTestSuite.h#1 $
+//
+// Definition of the X509CertificateTestSuite class.
+//
+// Copyright (c) 2017, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef X509CertificateTestSuite_INCLUDED
+#define X509CertificateTestSuite_INCLUDED
+
+
+#include "Poco/CppUnit/TestSuite.h"
+
+
+class X509CertificateTestSuite
+{
+public:
+	static CppUnit::Test* suite();
+};
+
+
+#endif // X509CertificateTestSuite_INCLUDED


### PR DESCRIPTION
This provides an implementation and tests for using OpenSSL's `X509_check_host` and `X509_check_ip_asc` if Poco is being compiled against a version >= 1.0.2, or falling back to the previous implementation if not. The test covers both cases, and the different behaviour between them. Fixes #1817. Note that applications which link against Poco when it has been compiled with a newer version of OpenSSL also need to link against that newer version at both build time and runtime. 