### PR TITLE
POCO_UNBUNDLED fine tuning

### DIFF
--- a/Data/SQLite/CMakeLists.txt
+++ b/Data/SQLite/CMakeLists.txt
@@ -9,7 +9,10 @@ POCO_SOURCES_AUTO( SQLITE_SRCS ${SRCS_G})
 file(GLOB_RECURSE HDRS_G "include/*.h" )
 POCO_HEADERS_AUTO( SQLITE_SRCS ${HDRS_G})
 
-if (POCO_UNBUNDLED)
+option(POCO_UNBUNDLED_SQLITE
+  "Set to OFF|ON (default is OFF) to control linking sqlite as external" ${POCO_UNBUNDLED})
+
+if (POCO_UNBUNDLED_SQLITE)
     find_package(SQLite3)
     set(DATASQLITELIBS ${SQLITE3_LIBRARIES})
     include_directories("${SQLITE3_INCLUDE_DIRS}")

--- a/Data/SQLite/src/Connector.cpp
+++ b/Data/SQLite/src/Connector.cpp
@@ -15,7 +15,7 @@
 #include "Poco/Data/SQLite/Connector.h"
 #include "Poco/Data/SQLite/SessionImpl.h"
 #include "Poco/Data/SessionFactory.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_SQLITE)
 #include <sqlite3.h>
 #else
 #include "sqlite3.h"

--- a/Data/SQLite/src/Extractor.cpp
+++ b/Data/SQLite/src/Extractor.cpp
@@ -20,7 +20,7 @@
 #include "Poco/Data/DataException.h"
 #include "Poco/DateTimeParser.h"
 #include "Poco/Exception.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_SQLITE)
 #include <sqlite3.h>
 #else
 #include "sqlite3.h"

--- a/Data/SQLite/src/SQLiteStatementImpl.cpp
+++ b/Data/SQLite/src/SQLiteStatementImpl.cpp
@@ -18,7 +18,7 @@
 #include "Poco/String.h"
 #include <cstdlib>
 #include <cstring>
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_SQLITE)
 #include <sqlite3.h>
 #else
 #include "sqlite3.h"

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -22,7 +22,7 @@
 #include "Poco/String.h"
 #include "Poco/Mutex.h"
 #include "Poco/Data/DataException.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_SQLITE)
 #include <sqlite3.h>
 #else
 #include "sqlite3.h"

--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -20,7 +20,7 @@
 #include "Poco/String.h"
 #include "Poco/Any.h"
 #include "Poco/Exception.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_SQLITE)
 #include <sqlite3.h>
 #else
 #include "sqlite3.h"

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -37,10 +37,15 @@ POCO_MESSAGES( SRCS Logging src/pocomsg.mc)
 
 # If POCO_UNBUNDLED is enabled we try to find the required packages
 # The configuration will fail if the packages are not found
-if (POCO_UNBUNDLED)
+option(POCO_UNBUNDLED_PCRE
+  "Set to OFF|ON (default is OFF) to control linking pcre as external" ${POCO_UNBUNDLED})
+
+if (POCO_UNBUNDLED_PCRE)
 	find_package(PCRE REQUIRED)
 	set(SYSLIBS ${SYSLIBS} ${PCRE_LIBRARIES})
 	include_directories(${PCRE_INCLUDE_DIRS})
+
+	add_definitions(-DPOCO_UNBUNDLED_PCRE)
 
 	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
 	POCO_SOURCES( SRCS RegExp
@@ -48,9 +53,6 @@ if (POCO_UNBUNDLED)
 		src/pcre_tables.c
 	)
 
-	find_package(ZLIB REQUIRED)
-	set(SYSLIBS ${SYSLIBS} ${ZLIB_LIBRARIES})
-	include_directories(${ZLIB_INCLUDE_DIRS})
 else()
 	# pcre
 	POCO_SOURCES( SRCS pcre
@@ -76,6 +78,18 @@ else()
 		src/pcre_valid_utf8.c
 		src/pcre_xclass.c
 	)
+endif (POCO_UNBUNDLED_PCRE)
+
+option(POCO_UNBUNDLED_ZLIB
+  "Set to OFF|ON (default is OFF) to control linking zlib as external" ${POCO_UNBUNDLED})
+
+if (POCO_UNBUNDLED_ZLIB)
+	find_package(ZLIB REQUIRED)
+	set(SYSLIBS ${SYSLIBS} ${ZLIB_LIBRARIES})
+	include_directories(${ZLIB_INCLUDE_DIRS})
+
+	add_definitions(-DPOCO_UNBUNDLED_ZLIB)
+else()
 
 	# zlib
 	POCO_HEADERS( SRCS zlib
@@ -95,7 +109,7 @@ else()
 		src/trees.c
 		src/zutil.c
 	)
-endif (POCO_UNBUNDLED)
+endif (POCO_UNBUNDLED_ZLIB)
 
 if(WIN32)
 	set(SYSLIBS ${SYSLIBS} iphlpapi)

--- a/Foundation/include/Poco/DeflatingStream.h
+++ b/Foundation/include/Poco/DeflatingStream.h
@@ -22,7 +22,7 @@
 #include "Poco/BufferedStreamBuf.h"
 #include <istream>
 #include <ostream>
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_ZLIB)
 #include <zlib.h>
 #else
 #include "Poco/zlib.h"

--- a/Foundation/include/Poco/InflatingStream.h
+++ b/Foundation/include/Poco/InflatingStream.h
@@ -22,7 +22,7 @@
 #include "Poco/BufferedStreamBuf.h"
 #include <istream>
 #include <ostream>
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_ZLIB)
 #include <zlib.h>
 #else
 #include "Poco/zlib.h"

--- a/Foundation/src/Checksum.cpp
+++ b/Foundation/src/Checksum.cpp
@@ -13,7 +13,7 @@
 
 
 #include "Poco/Checksum.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_PCRE)
 #include <zlib.h>
 #else
 #include "Poco/zlib.h"

--- a/Foundation/src/RegularExpression.cpp
+++ b/Foundation/src/RegularExpression.cpp
@@ -15,7 +15,7 @@
 #include "Poco/RegularExpression.h"
 #include "Poco/Exception.h"
 #include <sstream>
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_PCRE)
 #include <pcre.h>
 #else
 #include "pcre_config.h"

--- a/PDF/CMakeLists.txt
+++ b/PDF/CMakeLists.txt
@@ -11,7 +11,9 @@ POCO_HEADERS_AUTO( SRCS ${HDRS_G})
 
 # If POCO_UNBUNDLED is enabled we try to find the required packages
 # The configuration will fail if the packages are not found
-if (POCO_UNBUNDLED)
+option(POCO_UNBUNDLED_ZLIB
+  "Set to OFF|ON (default is OFF) to control linking dependencies as external" ${POCO_UNBUNDLED})
+if (POCO_UNBUNDLED_ZLIB)
     find_package(ZLIB REQUIRED)
     set(SYSLIBS ${SYSLIBS} ${ZLIB_LIBRARIES})
     include_directories(${ZLIB_INCLUDE_DIRS})
@@ -30,7 +32,7 @@ else()
         src/trees.c
         src/zutil.c
     )
-endif (POCO_UNBUNDLED)
+endif (POCO_UNBUNDLED_ZLIB)
 
 # TODO: Currently only bundled is supported, in future this should also be possible
 # with an unbundled version of hpdf

--- a/XML/CMakeLists.txt
+++ b/XML/CMakeLists.txt
@@ -16,7 +16,11 @@ POCO_HEADERS_AUTO( SRCS ${HDRS_G})
 
 # If POCO_UNBUNDLED is enabled we try to find the required packages
 # The configuration will fail if the packages are not found
-if (POCO_UNBUNDLED)
+
+option(POCO_UNBUNDLED_EXPAT
+  "Set to OFF|ON (default is OFF) to control linking expat as external" ${POCO_UNBUNDLED})
+
+if (POCO_UNBUNDLED_EXPAT)
     find_package(EXPAT REQUIRED)
     set(SYSLIBS ${SYSLIBS} ${EXPAT_LIBRARIES})
     include_directories(${EXPAT_INCLUDE_DIRS})
@@ -28,7 +32,7 @@ else()
     src/xmltok_impl.c
     src/xmltok_ns.c
     )
-endif (POCO_UNBUNDLED)
+endif (POCO_UNBUNDLED_EXPAT)
 
 if(WIN32)
 #TODO: Is XML_STATIC only required with Windows? What does it do?

--- a/XML/include/Poco/XML/ParserEngine.h
+++ b/XML/include/Poco/XML/ParserEngine.h
@@ -18,7 +18,7 @@
 
 
 #include "Poco/XML/XML.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_EXPAT)
 #include <expat.h>
 #else
 #include "Poco/XML/expat.h"

--- a/Zip/src/ZipStream.cpp
+++ b/Zip/src/ZipStream.cpp
@@ -21,7 +21,7 @@
 #include "Poco/Exception.h"
 #include "Poco/InflatingStream.h"
 #include "Poco/DeflatingStream.h"
-#if defined(POCO_UNBUNDLED)
+#if defined(POCO_UNBUNDLED_ZLIB)
 #include <zlib.h>
 #else
 #include "Poco/zlib.h"


### PR DESCRIPTION
Our project uses zlib-ng library, and we need to unbundle only zlib.

Added cmake options:
POCO_UNBUNDLED_PCRE
POCO_UNBUNDLED_ZLIB
POCO_UNBUNDLED_EXPAT
POCO_UNBUNDLED_SQLITE

all defaults to POCO_UNBUNDLED