### PR TITLE
CMake: use C11 as standard for all targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(Poco)
 
+set(CMAKE_C_STANDARD 11)
+
 file(STRINGS "${PROJECT_SOURCE_DIR}/libversion" SHARED_LIBRARY_VERSION)
 
 # Read the version information from the VERSION file


### PR DESCRIPTION
This makes the JSON module compile with GCC < 5 where the default was still C90