### PR TITLE
Fix in close and open

### DIFF
--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -204,9 +204,12 @@ void FTPClientSession::close()
 	try { logout(); }
 	catch(...){ }
 	_serverReady = false;
-	_pControlSocket->close();	
-	delete _pControlSocket;
-	_pControlSocket = 0;	
+	if (_pControlSocket)
+	{
+		_pControlSocket->close();
+		delete _pControlSocket;
+		_pControlSocket = 0;
+	}
 }
 
 

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -75,13 +75,7 @@ FTPClientSession::FTPClientSession(const std::string& host,
 {
 	_pControlSocket->setReceiveTimeout(_timeout);
 	if (!username.empty())
-	{
 		login(username, password);
-	}
-	else
-	{
-		receiveServerReadyReply();
-	}
 }
 
 

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -41,10 +41,8 @@ FTPSClientSession::FTPSClientSession(const std::string& host,
 										Poco::UInt16 port,
 										const std::string& username,
 										const std::string& password) :
-	FTPClientSession(host, port)
+	FTPClientSession(host, port, username, password)
 {
-	if(!username.empty())
-		login(username, password);	
 }
 
 void FTPSClientSession::tryFTPSmode(bool bTryFTPS)


### PR DESCRIPTION
- close(): fix possible throw on broken socket that could lead in CLOSE_WAIT leak (especially under linux OS). I moved variable that keep track of logged in and server ready before the instruction that can throw

- open(): fix open function to deal with control socket created from outside and login without user. Do not recreate the controlsocket if it's already done and just be sure we read the server connection reply
