### PR TITLE
Add support for MariaDB client in cmake build system

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -15,6 +15,18 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
         ${BINDIR32}/MySQL/*/include
         $ENV{SystemDrive}/MySQL/*/include)
 
+if (NOT MYSQL_INCLUDE_DIR)
+	find_path(MARIADB_INCLUDE_DIR mysql.h
+			/usr/include/mariadb
+			/usr/local/include/mariadb
+			/opt/mariadb/mariadb/include
+			/opt/mariadb/mariadb/include/mariadb
+			/usr/local/mariadb/include
+			/usr/local/mariadb/include/mariadb
+			$ENV{MARIADB_INCLUDE_DIR}
+			$ENV{MARIADB_DIR}/include)
+endif (NOT MYSQL_INCLUDE_DIR)
+
 if (WIN32)
 	if (CMAKE_BUILD_TYPE STREQUAL Debug)
 		set(libsuffixDist debug)
@@ -49,17 +61,39 @@ else (WIN32)
 				 $ENV{MYSQL_DIR}/libmysql_r/.libs
 				 $ENV{MYSQL_DIR}/lib
 				 $ENV{MYSQL_DIR}/lib/mysql)
+
+	if (NOT MYSQL_LIB)
+		find_library(MARIADB_LIB NAMES mariadbclient
+					PATHS
+					/usr/lib/mariadb
+					/usr/local/lib/mariadb
+					/usr/local/mariadb/lib
+					/usr/local/mariadb/lib/mariadb
+					/opt/mariadb/mariadb/lib
+					/opt/mariadb/mariadb/lib/mariadb
+					$ENV{MARIADB_DIR}/libmariadb/.libs
+					$ENV{MARIADB_DIR}/lib
+					$ENV{MARIADB_DIR}/lib/mariadb)
+	endif (NOT MYSQL_LIB)
 endif (WIN32)
 
-if(MYSQL_LIB)
+if (MYSQL_INCLUDE_DIR AND MYSQL_LIB)
 	get_filename_component(MYSQL_LIB_DIR ${MYSQL_LIB} PATH)
-endif(MYSQL_LIB)
-
-if (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
 	set(MYSQL_FOUND TRUE)
-	message(STATUS "MySQL Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
+	message(STATUS "Found MySQL Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
 	include_directories(${MYSQL_INCLUDE_DIR})
 	link_directories(${MYSQL_LIB_DIR})
-else (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
-	message(STATUS "Couldn't find MySQL")
-endif (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
+elseif((MARIADB_INCLUDE_DIR OR MYSQL_INCLUDE_DIR) AND MARIADB_LIB)
+	get_filename_component(MYSQL_LIB_DIR ${MARIADB_LIB} PATH)
+	set(MYSQL_FOUND TRUE)
+	set(MYSQL_LIB ${MARIADB_LIB})
+	if(MARIADB_INCLUDE_DIR)
+	  set(MYSQL_INCLUDE_DIR ${MARIADB_INCLUDE_DIR})
+	endif(MARIADB_INCLUDE_DIR)
+	message(STATUS "Found MariaDB Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
+	message(STATUS "Use MariaDB for MySQL Support")
+	include_directories(${MYSQL_INCLUDE_DIR} )
+	link_directories(${MYSQL_LIB_DIR})
+else ((MARIADB_INCLUDE_DIR OR MYSQL_INCLUDE_DIR) AND MARIADB_LIB)
+	message(STATUS "Couldn't find MySQL or MariaDB")
+endif (MYSQL_INCLUDE_DIR AND MYSQL_LIB)


### PR DESCRIPTION
To build Poco with MariaDB client library with cmake, I add in FindMySQL.cmake the library name of MariaDB client.
I use and test this change on Ubuntu 17.04 with clang and gcc.
* MySQL tests are running with MariaDB client library.

Support for Windows is still missing. I do not have any Windows system. If somebody can test, I can add also support for Windows.