### PR TITLE
Add support for sign and verify certification in crypto

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+﻿---
+IndentWidth: '4'
+Language: Cpp
+SpacesInParentheses: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Always
+
+...

--- a/Crypto/Makefile
+++ b/Crypto/Makefile
@@ -14,7 +14,8 @@ objects = Cipher CipherFactory CipherImpl CipherKey CipherKeyImpl \
 	CryptoException CryptoStream CryptoTransform ECDSADigestEngine \
 	ECKey ECKeyImpl EVPPKey KeyPair KeyPairImpl PKCS12Container \
 	RSACipherImpl RSAKey RSAKeyImpl RSADigestEngine DigestEngine \
-	X509Certificate OpenSSLInitializer
+	X509Certificate X509RevocationList X509Extension X509Request \
+	X509Store X509Revoked OpenSSLInitializer
 
 target         = PocoCrypto
 target_version = $(LIBVERSION)

--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -145,7 +145,7 @@ public:
 
 	static EVP_PKEY* duplicate(const EVP_PKEY* pFromKey, EVP_PKEY** pToKey);
 		/// Duplicates pFromKey into *pToKey and returns
-		// the pointer to duplicated EVP_PKEY.
+		/// the pointer to duplicated EVP_PKEY.
 
 private:
 	static int type(const EVP_PKEY* pEVPPKey);

--- a/Crypto/include/Poco/Crypto/RSAKey.h
+++ b/Crypto/include/Poco/Crypto/RSAKey.h
@@ -56,7 +56,7 @@ public:
 	};
 
 	RSAKey(const EVPPKey& key);
-		/// Constructs ECKeyImpl by extracting the EC key.
+		/// Constructs RSAKey by extracting the RSA key from given EVPKey.
 
 	RSAKey(const X509Certificate& cert);
 		/// Extracts the RSA public key from the given certificate.
@@ -97,6 +97,9 @@ public:
 
 	RSAKeyImpl::ByteVec decryptionExponent() const;
 		/// Returns the RSA decryption exponent.
+
+	EVPPKey evppkey() const;
+		/// Return EVPPKey object.
 
 	RSAKeyImpl::Ptr impl() const;
 		/// Returns the impl object.

--- a/Crypto/include/Poco/Crypto/RSAKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/RSAKeyImpl.h
@@ -81,6 +81,9 @@ public:
 	RSA* getRSA();
 		/// Returns the OpenSSL RSA object.
 
+	EVP_PKEY* getEvpPKey() const;
+		/// Return the OpenSSL EVP_PKEY object.
+
 	const RSA* getRSA() const;
 		/// Returns the OpenSSL RSA object.
 

--- a/Crypto/include/Poco/Crypto/X509Extension.h
+++ b/Crypto/include/Poco/Crypto/X509Extension.h
@@ -1,0 +1,132 @@
+//
+// X509Extension.h
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Extension
+//
+// Definition of the X509Extension class.
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Crypto_X509Extension_INCLUDE
+#define Crypto_X509Extension_INCLUDE
+
+
+#include "Poco/Crypto/Crypto.h"
+#include <openssl/x509.h>
+#include <string>
+#include <vector>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+class Crypto_API X509Extension
+{
+public:
+	typedef std::vector<X509Extension> List;
+
+	enum BASIC_CONTRAINTS
+		/// Are used to indicate wehether the certificate belongs to a CA.
+	{
+		CRITICAL_CA_TRUE,
+		CRITICAL_CA_FALSE,
+		CA_TRUE,
+		CA_FALSE
+	};
+
+	static X509Extension createWithBasicConstraints(BASIC_CONTRAINTS type);
+		/// Create the X509Extension with a given basic constraints.
+
+	static X509Extension create(int nid, const std::string& value);
+		/// Create the X509Extension from the given OpenSSL NID and value. Example: create(NID_basic_constraints, "critical, CA:TRUE")
+
+	static X509Extension create(X509V3_CTX *ctx, int nid, const std::string &value);
+		/// Create the X509Extension from the given OpenSSL x509v3 context, openssl NID and value.
+
+	static X509Extension create(int nid, bool critical, void* data, size_t lenght);
+		/// Create the X509Extension from the given OpenSSL NID and pointer to value.
+
+	X509Extension(X509_EXTENSION* pExt);
+		/// Create the X509Extension from an existing OpenSSL X509_EXTENSION pointer.
+
+	X509Extension(const X509Extension& other);
+		/// Creates the extension by copying another one.
+
+	X509Extension& operator = (X509Extension ext);
+		/// Assigns a extension.
+
+	X509Extension(X509Extension&& other);
+		/// Move constructor
+
+	static void swap(X509Extension& first, X509Extension& second);
+		/// Exchanges the certificate with another one.
+
+	~X509Extension();
+		/// Destroys the X509Extension.
+
+	bool isCritical() const;
+		/// Is the x509 extension critical flag set.
+
+	int nid() const;
+		/// Returns the OpenSSL NID.
+
+	const unsigned char* data() const;
+		/// Returns a pointer to the x509 extension raw value.
+		///
+		/// In general it cannot be assumed that the data returned by this function is null
+		/// terminated or does not contain embedded nulls. Use this function together with
+		/// the size() function to get the length of data.
+
+	size_t size() const;
+		/// Returns the length of data.
+		///
+		/// See data() function
+
+	std::string str() const;
+		/// Returns x509 extension value as string.
+
+	operator const X509_EXTENSION*() const;
+		/// Returns pointer to the OpenSSL X509_EXTENSION structure.
+
+	operator X509_EXTENSION*();
+		/// Returns pointer to the OpenSSL X509_EXTENSION structure.
+
+	static X509_EXTENSION* duplicate(const X509_EXTENSION* pFromExtension, X509_EXTENSION** pToExtension);
+		/// Duplicates pFromExtension into *pToExtension and returns
+		/// the pointer to duplicated OpenSSL X509_EXTENSION structure.
+
+private:
+	X509_EXTENSION* _pExt;
+};
+
+
+//
+// inlines
+//
+
+
+inline X509Extension::operator const X509_EXTENSION *() const
+{
+	return _pExt;
+}
+
+
+inline X509Extension::operator X509_EXTENSION *()
+{
+	return _pExt;
+}
+
+
+} } // namespace Poco::Crypto
+
+
+#endif // Crypto_X509Extension_INCLUDE

--- a/Crypto/include/Poco/Crypto/X509Request.h
+++ b/Crypto/include/Poco/Crypto/X509Request.h
@@ -1,0 +1,222 @@
+//
+// X509Request.h
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Request
+//
+// Definition of the X509Request class.
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Crypto_X509Request_INCLUDED
+#define Crypto_X509Request_INCLUDED
+
+
+#include "Poco/Crypto/Crypto.h"
+#include "Poco/Crypto/EVPPKey.h"
+#include "Poco/Crypto/X509Extension.h"
+#include "Poco/Crypto/OpenSSLInitializer.h"
+#include "Poco/DateTime.h"
+#include "Poco/SharedPtr.h"
+#include <openssl/x509.h>
+#include <set>
+#include <vector>
+#include <istream>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+class Crypto_API X509Request
+	/// This class represents a X509 request certificate.
+{
+public:
+	enum NID
+		/// Name identifier for extracting information from
+		/// a certificate subject's or issuer's distinguished name.
+	{
+		NID_COMMON_NAME = 13,
+		NID_COUNTRY = 14,
+		NID_LOCALITY_NAME = 15,
+		NID_STATE_OR_PROVINCE = 16,
+		NID_ORGANIZATION_NAME = 17,
+		NID_ORGANIZATION_UNIT_NAME = 18,
+		NID_PKCS9_EMAIL_ADDRESS = 48,
+		NID_SERIAL_NUMBER = 105
+	};
+
+	X509Request();
+		/// Creates the X509Request object
+	
+	explicit X509Request(std::istream& istr);
+		/// Creates the X509Request object by reading
+		/// a certificate in PEM format from a stream.
+
+	explicit X509Request(const std::string& path);
+		/// Creates the X509Request object by reading
+		/// a certificate in PEM format from a file.
+
+	explicit X509Request(X509_REQ* pReq);
+		/// Creates the X509Request from an existing
+		/// OpenSSL certificate. Ownership is taken of 
+		/// the certificate.
+
+#if OPENSSL_VERSION_NUMBER <= 0x10100000L
+	X509Request(X509_REQ* pReq, bool shared);
+		/// Creates the X509Request from an existing
+		/// OpenSSL certificate. Ownership is taken of 
+		/// the certificate. If shared is true, the 
+		/// certificate's reference count is incremented.
+#endif
+
+	X509Request(const X509Request& other);
+		/// Creates the certificate by copying another one.
+
+	X509Request(X509Request&& other);
+		/// Move constructor
+
+	X509Request& operator = (X509Request req);
+		/// Assigns a certificate.
+ 
+	static void swap(X509Request& first, X509Request& second);
+		/// Exchanges the certificate with another one.
+
+	~X509Request();
+		/// Destroys the X509Request.
+
+	long version() const;
+		/// Get the certificate version
+
+	void addSubject(NID nid, const std::string& name);
+		/// Set the information specified by the given
+		/// NID (name identifier) from the certificate subject's
+		/// distinguished name.
+
+	const std::string& subjectName() const;
+		/// Returns the certificate subject's distinguished name.
+
+	std::string subjectName(NID nid) const;
+		/// Extracts the information specified by the given
+		/// NID (name identifier) from the certificate subject's
+		/// distinguished name.
+		
+	void setCommonName(const std::string& cn);
+		/// Set the common name stored in the certificate
+		/// subject's distinguished name.
+
+	std::string commonName() const;
+		/// Returns the common name stored in the certificate
+		/// subject's distinguished name.
+		
+	void setPublicKey(const EVPPKey& pkey);
+		/// Set public key
+
+	EVPPKey publicKey() const;
+		/// Return public key
+
+    void addExtension(const X509Extension& x509Extension);
+        /// Add a specified extension at the and of the extension table.
+
+	void setExtensions(const X509Extension::List& x509Extensions);
+		/// Add a specified extensions.
+
+	X509Extension::List extensions();
+		/// Get all requested extension.
+
+	void save(std::ostream& stream) const;
+		/// Writes the certificate to the given stream.
+		/// The certificate is written in PEM format.
+
+	void save(const std::string& path) const;
+		/// Writes the certificate to the file given by path.
+		/// The certificate is written in PEM format.
+		
+	bool issuedBy(const X509Request& issuerCertificate) const;
+		/// Checks whether the certificate has been issued by
+		/// the issuer given by issuerCertificate. This can be
+		/// used to validate a certificate chain.
+		///
+		/// Verifies if the certificate has been signed with the
+		/// issuer's private key, using the public key from the issuer
+		/// certificate.
+		///
+		/// Returns true if verification against the issuer certificate
+		/// was successfull, false otherwise.
+
+	int sign(const EVPPKey& pkey, const std::string& mdstr = "default");
+		/// Sign the certificate
+		///
+		/// Return the size of the signature in bytes for success and
+		/// zero for failure.
+
+	void print(std::ostream& out) const;
+		/// Prints the request information to ostream.
+
+	operator const X509_REQ*() const;
+		/// Returns const pointer to the OpenSSL X509_REQ structure.
+
+	operator X509_REQ*();
+		/// Returns pointer to the OpenSSL X509_REQ structure.
+
+	static X509_REQ* duplicate(const X509_REQ* pFromRequest, X509_REQ** pToRequest);
+		/// Duplicates pFromRequest into *pToRequest and returns
+		/// the pointer to duplicated OpenSSL X509_REQ structure.
+
+protected:
+	void load(std::istream& stream);
+		/// Loads the certificate from the given stream. The
+		/// certificate must be in PEM format.
+		
+	void load(const std::string& path);
+		/// Loads the certificate from the given file. The
+		/// certificate must be in PEM format.
+
+	void init();
+		/// Extracts issuer and subject name from the certificate.
+	
+private:
+	enum
+	{
+		NAME_BUFFER_SIZE = 256
+	};
+	
+	std::string _subjectName;
+	X509_REQ*   _pRequest;
+};
+
+
+//
+// inlines
+//
+
+
+inline const std::string& X509Request::subjectName() const
+{
+	return _subjectName;
+}
+
+
+inline X509Request::operator const X509_REQ *() const
+{
+	return _pRequest;
+}
+
+
+inline X509Request::operator X509_REQ *()
+{
+	return _pRequest;
+}
+
+
+} } // namespace Poco::Crypto
+
+
+#endif // Crypto_X509Request_INCLUDED

--- a/Crypto/include/Poco/Crypto/X509RevocationList.h
+++ b/Crypto/include/Poco/Crypto/X509RevocationList.h
@@ -1,0 +1,222 @@
+//
+// X509RevocationList.h
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509RevocationList
+//
+// Definiton of the X509RevocationList class.
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Crypto_X509RevocationList_INCLUDED
+#define Crypto_X509RevocationList_INCLUDED
+
+
+#include "Poco/Crypto/Crypto.h"
+#include "Poco/Crypto/EVPPKey.h"
+#include "Poco/Crypto/X509Extension.h"
+#include "Poco/Crypto/X509Revoked.h"
+#include "Poco/Crypto/X509Certificate.h"
+#include "Poco/DateTime.h"
+#include "Poco/SharedPtr.h"
+#include <openssl/x509.h>
+#include <set>
+#include <vector>
+#include <istream>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+class Crypto_API X509RevocationList
+	/// This class represents a X509 certificate revocation list.
+{
+public:
+	enum NID
+		/// Name identifier for extracting information from
+		/// a certificate revocation list subject's or issuer's distinguished name.
+	{
+		NID_COMMON_NAME = 13,
+		NID_COUNTRY = 14,
+		NID_LOCALITY_NAME = 15,
+		NID_STATE_OR_PROVINCE = 16,
+		NID_ORGANIZATION_NAME = 17,
+		NID_ORGANIZATION_UNIT_NAME = 18,
+		NID_PKCS9_EMAIL_ADDRESS = 48,
+		NID_SERIAL_NUMBER = 105
+	};
+
+	X509RevocationList();
+		/// Creates the X509RevocationList object
+	
+	explicit X509RevocationList(std::istream& istr);
+		/// Creates the X509RevocationList object by reading
+		/// a certificate revocation list in PEM format from a stream.
+
+	explicit X509RevocationList(const std::string& path);
+		/// Creates the X509RevocationList object by reading
+		/// a certificate revocation list in PEM format from a file.
+
+	explicit X509RevocationList(X509_CRL* pCert);
+		/// Creates the X509RevocationList from an existing
+		/// OpenSSL certificate revocation list. Ownership is taken of
+		/// the certificate revocation list.
+
+	X509RevocationList(X509_CRL* pCert, bool shared);
+		/// Creates the X509RevocationList from an existing
+		/// OpenSSL certificate revocation list. Ownership is taken of
+		/// the certificate revocation list. If shared is true, the
+		/// certificate revocation list's reference count is incremented.
+
+	X509RevocationList(const X509RevocationList& cert);
+		/// Creates the certificate revocation list by copying another one.
+
+	X509RevocationList(X509RevocationList&& other);
+		/// Move constructor
+
+	X509RevocationList& operator =(X509RevocationList other);
+		/// Assigns a certificate revocation list.
+ 
+	static void swap(X509RevocationList& first, X509RevocationList& second);
+		/// Exchanges the certificate revocation list with another one.
+
+	~X509RevocationList();
+		/// Destroys the X509RevocationList.
+
+	long version() const;
+		/// Get the certificate revocation list version
+
+	void addIssuer(NID nid, const std::string& name);
+		/// Set certificate revocation list issuer name specified by the given NID (name identifier)
+
+	const std::string& issuerName() const;
+		/// Returns the certificate revocation list issuer's distinguished name.
+		
+	std::string issuerName(NID nid) const;
+		/// Extracts the information specified by the given
+		/// NID (name identifier) from the certificate revocation list issuer's
+		/// distinguished name.
+		
+	void extractNames(std::set<std::string>& domainNames) const;
+		/// Extracts the common name and the alias domain names from the
+		/// certificate revocation list.
+		
+	void setLastUpdate(Poco::DateTime dateTime);
+		/// Set the date and time the certificate revocation list last update.
+
+	Poco::DateTime lastUpdate() const;
+		/// Returns the date and time the certificate revocation list last update.
+		
+	void setNextUpdate(Poco::DateTime expires);
+		/// Set the date and time the certificate revocation list next update.
+
+	Poco::DateTime nextUpdate() const;
+		/// Returns the date and time the certificate revocation list next update.
+		
+	void addExtension(const X509Extension& x509Extension);
+		/// Add a specified extension at the and of the extension table.
+
+	void addRevoked(const X509Revoked& revoked);
+		/// Appends revoked entry to revocation list.
+
+	X509Revoked findRevokedBySerialNumber(long serialNumber);
+		/// Attempts to find a revoked entry in revocation list for serial number.
+
+	X509Revoked findRevokedByCertificate(const X509Certificate& certificate);
+		/// Attempts to find a revoked entry in revocation list for using the serial number of certificate.
+
+	X509Revoked::List getAllRevoked() const;
+		/// Returns a vector of all revoked entries in revocation list.
+
+	X509Extension::List findExtensionByNID(int nid);
+		/// Search and get extension by openssl NID.
+
+	void save(std::ostream& stream) const;
+		/// Writes the certificate revocation list to the given stream.
+		/// The certificate revocation list is written in PEM format.
+
+	void save(const std::string& path) const;
+		/// Writes the certificate revocation list to the file given by path.
+		/// The certificate revocation list is written in PEM format.
+		
+	bool verify(const EVPPKey& key) const;
+		/// Returns true if verification against the key
+		/// was successfull, false otherwise.
+
+	bool sign(const EVPPKey& pkey, const std::string& mdstr = "default");
+		/// Sign the certificate revocation list
+
+	bool equals(const X509RevocationList& otherCertificate) const;
+		/// Checks whether the certificate revocation list is equal to
+		/// the other certificate revocation list, by comparing the hashes
+		/// of both certificates.
+		///
+		/// Returns true if both certificates are identical,
+		/// otherwise false.
+
+	operator const X509_CRL*() const;
+		/// Returns const pointer to the OpenSSL X509_CRL structure.
+
+	operator X509_CRL*();
+		/// Returns pointer to the OpenSSL X509_CRL structure.
+
+	static X509_CRL* duplicate(const X509_CRL* pFromCRL, X509_CRL** pToCRL);
+		/// Duplicates pFromKey into *pToKey and returns
+		/// the pointer to duplicated OpenSSL X509_CRL structure.
+
+protected:
+	void load(std::istream& stream);
+		/// Loads the crl from the given stream. The
+		/// crl must be in PEM format.
+		
+	void load(const std::string& path);
+		/// Loads the crl from the given file. The
+		/// crl must be in PEM format.
+
+	void init();
+		/// Extracts issuer name from the crl.
+	
+private:
+	enum
+	{
+		NAME_BUFFER_SIZE = 256
+	};
+	
+	std::string _issuerName;
+	X509_CRL*       _pCrl;
+};
+
+
+//
+// inlines
+//
+inline const std::string& X509RevocationList::issuerName() const
+{
+	return _issuerName;
+}
+
+
+inline X509RevocationList::operator const X509_CRL *() const
+{
+	return _pCrl;
+}
+
+
+inline X509RevocationList::operator X509_CRL *()
+{
+	return _pCrl;
+}
+
+
+} } // namespace Poco::Crypto
+
+
+#endif // Crypto_X509RevocationList_INCLUDED

--- a/Crypto/include/Poco/Crypto/X509Revoked.h
+++ b/Crypto/include/Poco/Crypto/X509Revoked.h
@@ -1,0 +1,149 @@
+//
+// X509RevocationList.h
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Revoked
+//
+// Definiton of the X509Revoked class
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Crypto_X509Revoked_INCLUDED
+#define Crypto_X509Revoked_INCLUDED
+
+
+#include "Poco/Crypto/Crypto.h"
+#include "Poco/Crypto/X509Extension.h"
+#include "Poco/DateTime.h"
+#include <vector>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+class Crypto_API X509Revoked
+	/// This class represents a X509 revoked certificate
+{
+public:
+	typedef std::vector<X509Revoked> List;
+
+	enum ReasonCode
+		/// Reason codes for the certificate revocation.
+		// From RFC 5280:
+		// CRLReason ::= ENUMERATED {
+		//	unspecified             (0),
+		//	keyCompromise           (1),
+		//	cACompromise            (2),
+		//	affiliationChanged      (3),
+		//	superseded              (4),
+		//	cessationOfOperation    (5),
+		//	certificateHold         (6),
+		//		 -- value 7 is not used
+		//	removeFromCRL           (8),
+		//	privilegeWithdrawn      (9),
+		//	aACompromise           (10) }
+	{
+		UNSPECIFIED = 0,
+		KEY_COMPROMISE,
+		CA_COMPROMISE,
+		AFFILIATION_CHANGED,
+		SUPERSEDED,
+		CESSATION_OF_OPERATION,
+		REMOVE_FROM_CRL = 8
+	};
+
+
+	X509Revoked();
+		/// Constructs the X509Revoked object
+
+	explicit X509Revoked(X509_REVOKED* pRevoked);
+		/// Creates the X509Revoked from an existing
+		/// OpenSSL revoked. Ownership is taken of
+		/// the revoked.
+
+	X509Revoked(const X509Revoked& revoked);
+		/// Constructs the revoked by copying another one.
+
+	X509Revoked(X509Revoked&& other);
+		/// Move constructor
+
+	X509Revoked& operator = (X509Revoked revoked);
+		/// Assigns a revoked.
+
+	static void swap(X509Revoked& first, X509Revoked& second);
+		/// Exchanges the revoked with another one.
+
+	virtual ~X509Revoked();
+		/// Destroys the X509Revoked object
+
+	void setSerialNumber(long serial);
+		/// Set revoked certificate serial number
+
+	void setSerialNumber(const std::string& serial);
+		/// Set revoked certificate serial number
+
+	std::string serialNumber() const;
+		/// Get serial number of revoked certificate
+
+	void setRevocationDate(Poco::DateTime date);
+		/// Set the date the certificate is revoked from.
+
+	Poco::DateTime getRevocationDate() const;
+		/// Get the date the certificate is revoked from.
+
+	bool setReasonCode(ReasonCode code);
+		/// Set revocation reason code why the certificate is revoked.
+
+	ReasonCode getReasonCode() const;
+		/// Get revocation reason code why the certificate is revoked.
+
+	void addExtension(const X509Extension& x509Extension);
+		/// Add a specified extension at the end of the extension table.
+
+	X509Extension::List findExtensionByNID(int nid);
+		/// Search and get extension by openssl NID.
+
+	operator const X509_REVOKED*() const;
+		/// Returns const pointer to the OpenSSL X509_REVOKED structure.
+
+	operator X509_REVOKED*();
+		/// Returns pointer to the OpenSSL X509_REVOKED structure.
+
+	static X509_REVOKED* duplicate(const X509_REVOKED* pFromRevoked, X509_REVOKED** pToRevoked);
+		/// Duplicates pFromRevoked into *pToRevoked and returns
+		/// the pointer to duplicated X509_REVOKED.
+
+private:
+	X509_REVOKED* _pRevoked;
+};
+
+
+//
+// inlines
+//
+
+
+inline X509Revoked::operator const X509_REVOKED *() const
+{
+	return _pRevoked;
+}
+
+
+inline X509Revoked::operator X509_REVOKED *()
+{
+	return _pRevoked;
+}
+
+
+} } // namespace Poco::Crypto
+
+
+#endif // Crypto_X509Revoked_INCLUDED

--- a/Crypto/include/Poco/Crypto/X509Store.h
+++ b/Crypto/include/Poco/Crypto/X509Store.h
@@ -1,0 +1,176 @@
+//
+// X509Store.h
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Store
+//
+// Definition of the X509Store class.
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Crypto_X509Store_INCLUDED
+#define Crypto_X509Store_INCLUDED
+
+
+#include "Poco/Crypto/Crypto.h"
+#include "Poco/Crypto/X509RevocationList.h"
+#include "Poco/Crypto/X509Certificate.h"
+#include <vector>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+class Crypto_API X509Store
+{
+	/// Utility class for a x509 store.
+	/// Currently, only verification of a certificate chain are supported.
+public:
+	class VerifyResult
+		/// Result class after verification of a certificate chain.
+	{
+		friend class X509Store;
+	public:
+		VerifyResult();
+			/// Constructs VerifyResult object with default values.
+
+		const X509Certificate& certificate() const;
+			/// Returns the certificate which caused the error.
+
+		int depth() const;
+			/// Returns the depth of the error in the certificate chain.
+			///
+			/// This is a non-negative integer representing where in the
+			/// certificate chain the error occurred. If it is zero it
+			/// occurred in the end entity certificate, one if it is the
+			/// certificate which signed the end entity certificate and so on.
+
+		int code() const;
+			/// Returns the error code.
+
+		bool isOk() const;
+			/// Returns true if verification of certification chain was successful.
+
+		std::string string() const;
+			/// Returns a human readable error string for verification error.
+
+	private:
+		VerifyResult(const X509Certificate& certificate, int depth, int code, std::string errorString);
+
+		X509Certificate _certificate;
+		int _depth;
+		int _code;
+		std::string _errorString;
+	};
+
+	X509Store();
+		/// Constructs a default X509Store.
+
+	X509Store(X509_STORE* store);
+		/// Creates the X509Store from an existing
+		/// OpenSSL store. Ownership is taken of the store.
+
+	X509Store(const X509Store& store) = delete;
+		// Cannot copy a store.
+
+	X509Store(X509Store&& other);
+		/// Move constructor.
+
+	X509Store& operator =(X509Store other) = delete;
+		// Cannot copy a store.
+
+	static void swap(X509Store& first, X509Store& second);
+		/// Exchanges the first store with the second store.
+
+	~X509Store();
+		/// Destroys the X509Store.
+
+	void setX509Purpose(int purpose);
+		/// Set OpenSSL verification purpose.
+
+	void setX509VerifyFlags(unsigned long flags);
+		/// Set OpenSSL verification flags.
+
+	bool addCa(const X509Certificate& caCertificate);
+		/// Add a certificate into x509 store.
+
+	bool addChain(const X509Certificate::List& chain);
+		/// Add a chain of certificate into x509 store.
+
+	bool addCrl(const X509RevocationList& crl);
+		/// Add a crl into x509 store.
+
+	VerifyResult verifyCertificateChain(const X509Certificate& cert);
+		/// The function attempts to discover and validate a certificate chain
+		/// from a given x509 certificate and stored x509 certificates
+		/// via addCa(), addChain() or addCrl() function.
+
+	operator const X509_STORE*() const;
+		/// Returns const pointer to the OpenSSL X509_STORE structure.
+
+	operator X509_STORE*();
+		/// Returns pointer to the OpenSSL X509_STORE structure.
+
+private:
+	X509_STORE* _pStore;
+	int _purpose;
+};
+
+
+//
+// inlines
+//
+inline const X509Certificate& X509Store::VerifyResult::certificate() const
+{
+	return _certificate;
+}
+
+
+inline int X509Store::VerifyResult::depth() const
+{
+	return _depth;
+}
+
+
+inline int X509Store::VerifyResult::code() const
+{
+	return _code;
+}
+
+
+inline bool X509Store::VerifyResult::isOk() const
+{
+	return _code == 0;
+}
+
+
+inline std::string X509Store::VerifyResult::string() const
+{
+	return _errorString;
+}
+
+
+inline X509Store::operator X509_STORE *()
+{
+	return _pStore;
+}
+
+
+inline X509Store::operator const X509_STORE *() const
+{
+	return _pStore;
+}
+
+
+} } // namespace Poco::Crypto
+
+
+#endif // Crypto_X509Store_INCLUDED

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -41,7 +41,7 @@ ECKeyImpl::ECKeyImpl(const X509Certificate& cert):
 	KeyPairImpl("ec", KT_EC_IMPL),
 	_pEC(0)
 {
-	const X509* pCert = cert.certificate();
+	const X509* pCert = cert;
 	if (pCert)
 	{
 		EVP_PKEY* pKey = X509_get_pubkey(const_cast<X509*>(pCert));

--- a/Crypto/src/RSAKey.cpp
+++ b/Crypto/src/RSAKey.cpp
@@ -84,4 +84,13 @@ RSAKeyImpl::ByteVec RSAKey::decryptionExponent() const
 }
 
 
+EVPPKey RSAKey::evppkey() const
+{
+	EVP_PKEY* k = _pImpl->getEvpPKey();
+	EVPPKey ek(k);
+	EVP_PKEY_free(k);
+	return ek;
+}
+
+
 } } // namespace Poco::Crypto

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -42,7 +42,7 @@ RSAKeyImpl::RSAKeyImpl(const X509Certificate& cert):
 	KeyPairImpl("rsa", KT_RSA_IMPL),
 	_pRSA(0)
 {
-	const X509* pCert = cert.certificate();
+	const X509* pCert = cert;
 	EVP_PKEY* pKey = X509_get_pubkey(const_cast<X509*>(pCert));
 	if (pKey)
 	{
@@ -211,6 +211,13 @@ RSAKeyImpl::RSAKeyImpl(std::istream* pPublicKeyStream,
 RSAKeyImpl::~RSAKeyImpl()
 {
 	freeRSA();
+}
+
+EVP_PKEY* RSAKeyImpl::getEvpPKey() const
+{
+	EVP_PKEY* pkey = EVP_PKEY_new();
+	EVP_PKEY_set1_RSA(pkey, _pRSA);
+	return pkey;
 }
 
 

--- a/Crypto/src/X509Extension.cpp
+++ b/Crypto/src/X509Extension.cpp
@@ -1,0 +1,162 @@
+//
+// X509Extension.cpp
+//
+// $Id: $
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Extension
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Crypto/X509Extension.h"
+#include <openssl/x509v3.h>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+X509Extension X509Extension::createWithBasicConstraints(X509Extension::BASIC_CONTRAINTS type)
+{
+	unsigned char data[] = {0x30, 0x03, 0x01, 0x01, 0xff};
+	bool isCritical = true;
+	switch(type)
+	{
+	case CRITICAL_CA_TRUE:
+		break;
+	case CRITICAL_CA_FALSE:
+		break;
+	case CA_TRUE:
+		isCritical = false;
+		break;
+	case CA_FALSE:
+		isCritical = false;
+		break;
+	}
+	size_t lenght = sizeof (data);
+
+	return create(NID_basic_constraints, isCritical, data, lenght);
+}
+
+
+X509Extension X509Extension::create(int nid, const std::string& value)
+{
+	CONF* conf = nullptr;
+	X509V3_CTX *ctx = nullptr;
+	X509_EXTENSION* ext = X509V3_EXT_nconf_nid(conf, ctx, nid, const_cast<char*>(value.c_str()));
+	return X509Extension(ext);
+}
+
+
+X509Extension X509Extension::create(X509V3_CTX *ctx, int nid, const std::string& value)
+{
+	CONF* conf = nullptr;
+	X509_EXTENSION* ext = X509V3_EXT_nconf_nid(conf, ctx, nid, const_cast<char*>(value.c_str()));
+	return X509Extension(ext);
+}
+
+
+X509Extension X509Extension::create(int nid, bool critical, void* data, size_t lenght)
+{
+	ASN1_STRING* asn1 = ASN1_STRING_new();
+	ASN1_STRING_set(asn1, data, static_cast<int>(lenght));
+	int crit = critical ? 1 : 0;
+	X509_EXTENSION **ex = nullptr;
+	X509_EXTENSION *ext = X509_EXTENSION_create_by_NID(ex, nid, crit, asn1);
+	ASN1_STRING_free(asn1);
+	return X509Extension(ext);
+}
+
+
+X509Extension::X509Extension(X509_EXTENSION* pExt):
+	_pExt(pExt)
+{
+
+}
+
+
+X509Extension::X509Extension(const X509Extension &other):
+	_pExt(nullptr)
+{
+	duplicate(other._pExt, &_pExt);
+}
+
+
+X509Extension::X509Extension(X509Extension&& other):
+	_pExt(nullptr)
+{
+	swap(*this, other);
+}
+
+
+X509Extension &X509Extension::operator =(X509Extension other)
+{
+	swap(*this, other);
+	return *this;
+}
+
+
+void X509Extension::swap(X509Extension& first, X509Extension& second)
+{
+	using std::swap;
+	swap(first._pExt, second._pExt);
+}
+
+
+X509Extension::~X509Extension()
+{
+	X509_EXTENSION_free(_pExt);
+}
+
+
+bool X509Extension::isCritical() const
+{
+	return (X509_EXTENSION_get_critical(_pExt) != 0);
+}
+
+
+int X509Extension::nid() const
+{
+	ASN1_OBJECT* asn1object = X509_EXTENSION_get_object(_pExt);
+	return OBJ_obj2nid(asn1object);
+}
+
+
+const unsigned char* X509Extension::data() const
+{
+	ASN1_OCTET_STRING* asn1 = X509_EXTENSION_get_data(_pExt);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	return ASN1_STRING_get0_data(asn1);
+#else
+	return ASN1_STRING_data(asn1);
+#endif
+}
+
+
+size_t X509Extension::size() const
+{
+	ASN1_OCTET_STRING* asn1 = X509_EXTENSION_get_data(_pExt);
+	return static_cast<size_t>(ASN1_STRING_length(asn1));
+}
+
+
+std::string X509Extension::str() const
+{
+	return std::string(reinterpret_cast<const char*>(data()), size());
+}
+
+
+X509_EXTENSION* X509Extension::duplicate(const X509_EXTENSION *pFromExtension, X509_EXTENSION **pToExtension)
+{
+	*pToExtension = X509_EXTENSION_dup(const_cast<X509_EXTENSION*>(pFromExtension));
+	return *pToExtension;
+}
+
+
+} } // namespace Poco::Crypto

--- a/Crypto/src/X509Request.cpp
+++ b/Crypto/src/X509Request.cpp
@@ -1,0 +1,362 @@
+//
+// X509Request.cpp
+//
+// $Id: $
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Request
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Crypto/X509Request.h"
+#include "Poco/StreamCopier.h"
+#include "Poco/String.h"
+#include "Poco/DateTimeParser.h"
+#include <sstream>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+X509Request::X509Request():
+	_pRequest(X509_REQ_new())
+{
+	X509_REQ_set_version(_pRequest, 2);
+}
+
+X509Request::X509Request(std::istream& istr):
+	_pRequest(nullptr)
+{	
+	load(istr);
+}
+
+
+X509Request::X509Request(const std::string& path):
+	_pRequest(nullptr)
+{
+	load(path);
+}
+
+
+X509Request::X509Request(X509_REQ* pReq):
+	_pRequest(pReq)
+{
+	poco_check_ptr(_pRequest);
+
+	init();
+}
+
+
+#if OPENSSL_VERSION_NUMBER <= 0x10100000L
+X509Request::X509Request(X509_REQ* pReq, bool shared):
+	_pRequest(pReq)
+{
+	poco_check_ptr(_pRequest);
+	
+	if (shared)
+	{
+		_pRequest->references++;
+	}
+
+	init();
+}
+#endif
+
+
+X509Request::X509Request(const X509Request& other):
+	_subjectName(other._subjectName),
+	_pRequest(nullptr)
+{
+	duplicate(other._pRequest, &_pRequest);
+}
+
+
+X509Request::X509Request(X509Request &&other):
+	_subjectName(),
+	_pRequest(nullptr)
+{
+	swap(*this, other);
+}
+
+
+X509Request& X509Request::operator = (X509Request other)
+{
+	swap(*this, other);
+	return *this;
+}
+
+void X509Request::swap(X509Request& first, X509Request& second)
+{
+	using std::swap;
+	swap(first._subjectName, second._subjectName);
+	swap(first._pRequest, second._pRequest);
+}
+
+
+X509Request::~X509Request()
+{
+	X509_REQ_free(_pRequest);
+}
+
+
+void X509Request::load(std::istream& istr)
+{
+	poco_assert (!_pRequest);
+		
+	std::stringstream certStream;
+	Poco::StreamCopier::copyStream(istr, certStream);
+	std::string cert = certStream.str();
+		
+	BIO *pBIO = BIO_new_mem_buf(const_cast<char*>(cert.data()), static_cast<int>(cert.size()));
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading certificate");
+	_pRequest = PEM_read_bio_X509_REQ(pBIO, nullptr, nullptr, nullptr);
+	BIO_free(pBIO);
+	
+	if (!_pRequest) throw Poco::IOException("Faild to load certificate from stream");
+
+	init();
+}
+
+
+void X509Request::load(const std::string& path)
+{
+	poco_assert (!_pRequest);
+
+	BIO *pBIO = BIO_new(BIO_s_file());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading certificate file", path);
+	if (!BIO_read_filename(pBIO, const_cast<char*>(path.c_str())))
+	{
+		BIO_free(pBIO);
+		throw Poco::OpenFileException("Cannot open certificate file for reading", path);
+	}
+	
+	_pRequest = PEM_read_bio_X509_REQ(pBIO, nullptr, nullptr, nullptr);
+	BIO_free(pBIO);
+	
+	if (!_pRequest) throw Poco::ReadFileException("Faild to load certificate from", path);
+
+	init();
+}
+
+
+void X509Request::save(std::ostream& stream) const
+{
+	BIO *pBIO = BIO_new(BIO_s_mem());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for writing certificate");
+	try
+	{
+		if (!PEM_write_bio_X509_REQ(pBIO, _pRequest))
+			throw Poco::IOException("Failed to write certificate to stream");
+
+		char *pData;
+		long size;
+		size = BIO_get_mem_data(pBIO, &pData);
+		stream.write(pData, size);
+	}
+	catch (...)
+	{
+		BIO_free(pBIO);
+		throw;
+	}
+	BIO_free(pBIO);
+}
+
+
+void X509Request::save(const std::string& path) const
+{
+	BIO *pBIO = BIO_new(BIO_s_file());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading certificate file", path);
+	if (!BIO_write_filename(pBIO, const_cast<char*>(path.c_str())))
+	{
+		BIO_free(pBIO);
+		throw Poco::CreateFileException("Cannot create certificate file", path);
+	}
+	try
+	{
+		if (!PEM_write_bio_X509_REQ(pBIO, _pRequest))
+			throw Poco::WriteFileException("Failed to write certificate to file", path);
+	}
+	catch (...)
+	{
+		BIO_free(pBIO);
+		throw;
+	}
+	BIO_free(pBIO);
+}
+
+
+void X509Request::init()
+{
+	char buffer[NAME_BUFFER_SIZE];
+	X509_NAME_oneline(X509_REQ_get_subject_name(_pRequest), buffer, sizeof(buffer));
+	_subjectName = buffer;
+}
+
+
+long X509Request::version() const
+{
+	return X509_REQ_get_version(_pRequest) + 1;
+}
+
+
+std::string X509Request::commonName() const
+{
+	return subjectName(NID_COMMON_NAME);
+}
+
+
+void X509Request::setCommonName(const std::string& cn)
+{
+	addSubject(NID_COMMON_NAME, cn);
+}
+
+
+void X509Request::addSubject(NID nid, const std::string& name)
+{
+	const void* data = name.c_str();
+	unsigned char* bytes = static_cast<unsigned char*>(const_cast<void*>(data));
+	X509_NAME* x509name = X509_REQ_get_subject_name(_pRequest);
+	X509_NAME_add_entry_by_NID(x509name, nid, MBSTRING_ASC, bytes, -1, -1, 0);
+	X509_REQ_set_subject_name(_pRequest, x509name);
+
+	init();
+}
+
+
+std::string X509Request::subjectName(NID nid) const
+{
+	if (X509_NAME* subj = X509_REQ_get_subject_name(_pRequest))
+    {
+		char buffer[NAME_BUFFER_SIZE];
+		if (X509_NAME_get_text_by_NID(subj, nid, buffer, sizeof(buffer)) >= 0)
+			return std::string(buffer);
+    }
+    return std::string();
+}
+
+
+void X509Request::setPublicKey(const EVPPKey &pkey)
+{
+	X509_REQ_set_pubkey(_pRequest, const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(pkey)));
+}
+
+
+EVPPKey X509Request::publicKey() const
+{
+	EVP_PKEY* k = X509_REQ_get_pubkey(_pRequest);
+	return EVPPKey(k);
+}
+
+
+void X509Request::addExtension(const X509Extension &x509Extension)
+{
+	X509Extension::List extList;
+	extList.push_back(x509Extension);
+	setExtensions(extList);
+}
+
+
+void X509Request::setExtensions(const X509Extension::List &x509Extensions)
+{
+	if(x509Extensions.size() > 0)
+	{
+		STACK_OF(X509_EXTENSION)* extensions = nullptr;
+		for (decltype(x509Extensions.size()) i = 0; i < x509Extensions.size(); ++i)
+		{
+			X509_EXTENSION* ext = const_cast<X509_EXTENSION*>(static_cast<const X509_EXTENSION*>(x509Extensions[i]));
+			X509v3_add_ext(&extensions, ext, -1);
+		}
+
+		STACK_OF(X509_EXTENSION)* skOldExt = X509_REQ_get_extensions(_pRequest);
+        for (int i = 0;i < sk_X509_EXTENSION_num(skOldExt); ++i)
+        {
+            X509_EXTENSION* oldExt = sk_X509_EXTENSION_value(skOldExt, i);
+            X509v3_add_ext(&extensions, oldExt, -1);
+        }
+
+		// X509_REQ_add_extensions() adds at every call new NID_ext_req attribute on the x509. Why? I don't know ....
+		// X509_REQ_get_extensions() get only the first NID_ext_req ... so we should delete the NID_ext_req before
+		// we add a extension !!
+		int idx = X509_REQ_get_attr_by_NID(_pRequest, NID_ext_req, -1);
+		if (idx != -1)
+			X509_REQ_delete_attr(_pRequest, idx);
+
+		X509_REQ_add_extensions(_pRequest, extensions);
+		sk_X509_EXTENSION_pop_free(extensions, X509_EXTENSION_free);
+	}
+}
+
+
+X509Extension::List X509Request::extensions()
+{
+	STACK_OF(X509_EXTENSION)* exts = X509_REQ_get_extensions(_pRequest);
+	X509Extension::List extensions;
+	for (int i = 0;i < sk_X509_EXTENSION_num(exts); ++i)
+	{
+		X509_EXTENSION *ext = sk_X509_EXTENSION_value(exts, i);
+		extensions.push_back(X509Extension(ext));
+	}
+	sk_X509_EXTENSION_free(exts);
+	return extensions;
+}
+
+
+bool X509Request::issuedBy(const X509Request& issuerCertificate) const
+{
+	X509_REQ* pCert = const_cast<X509_REQ*>(_pRequest);
+	X509_REQ* pIssuerCert = const_cast<X509_REQ*>(static_cast<const X509_REQ*>(issuerCertificate));
+	EVP_PKEY* pIssuerPublicKey = X509_REQ_get_pubkey(pIssuerCert);
+	if (!pIssuerPublicKey) throw Poco::InvalidArgumentException("Issuer certificate has no public key");
+	int rc = X509_REQ_verify(pCert, pIssuerPublicKey);
+	EVP_PKEY_free(pIssuerPublicKey);
+	return rc == 1;
+}
+
+
+int X509Request::sign(const EVPPKey &pkey, const std::string& mdstr)
+{
+	const char* mdc = mdstr.c_str();
+	if(std::string("default").compare(mdstr) == 0)
+	{
+		int defNid = 0;
+		EVP_PKEY_get_default_digest_nid(const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(pkey)), &defNid);
+		mdc = OBJ_nid2sn(defNid);
+	}
+	const EVP_MD* md = EVP_get_digestbyname(mdc);
+	return X509_REQ_sign(_pRequest, const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(pkey)), md);
+}
+
+void X509Request::print(std::ostream &out) const
+{
+	out << "subjectName: " << subjectName() << std::endl;
+	out << "commonName: " << commonName() << std::endl;
+	out << "country: " << subjectName(X509Request::NID_COUNTRY) << std::endl;
+	out << "localityName: " << subjectName(X509Request::NID_LOCALITY_NAME) << std::endl;
+	out << "stateOrProvince: " << subjectName(X509Request::NID_STATE_OR_PROVINCE) << std::endl;
+	out << "organizationName: " << subjectName(X509Request::NID_ORGANIZATION_NAME) << std::endl;
+	out << "organizationUnitName: " << subjectName(X509Request::NID_ORGANIZATION_UNIT_NAME) << std::endl;
+	out << "emailAddress: " << subjectName(X509Request::NID_PKCS9_EMAIL_ADDRESS) << std::endl;
+	out << "serialNumber: " << subjectName(X509Request::NID_SERIAL_NUMBER) << std::endl;
+}
+
+
+X509_REQ* X509Request::duplicate(const X509_REQ *pFromRequest, X509_REQ **pToRequest)
+{
+	*pToRequest = X509_REQ_dup(const_cast<X509_REQ*>(pFromRequest));
+	return *pToRequest;
+}
+
+
+} } // namespace Poco::Crypto

--- a/Crypto/src/X509RevocationList.cpp
+++ b/Crypto/src/X509RevocationList.cpp
@@ -1,0 +1,424 @@
+//
+// X509RevocationList.cpp
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509RevocationList
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Crypto/X509RevocationList.h"
+#include "Poco/StreamCopier.h"
+#include "Poco/String.h"
+#include "Poco/DateTimeParser.h"
+#include <sstream>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+X509RevocationList::X509RevocationList():
+	_issuerName(),
+	_pCrl(X509_CRL_new())
+{
+	X509_CRL_set_version(_pCrl, 2);
+}
+
+X509RevocationList::X509RevocationList(std::istream& istr):
+	_issuerName(),
+	_pCrl(nullptr)
+{	
+	load(istr);
+}
+
+
+X509RevocationList::X509RevocationList(const std::string& path):
+	_issuerName(),
+	_pCrl(nullptr)
+{
+	load(path);
+}
+
+
+X509RevocationList::X509RevocationList(X509_CRL* pCert):
+	_issuerName(),
+	_pCrl(pCert)
+{
+	poco_check_ptr(_pCrl);
+
+	init();
+}
+
+
+X509RevocationList::X509RevocationList(X509_CRL* pCert, bool shared):
+	_issuerName(),
+	_pCrl(pCert)
+{
+	poco_check_ptr(_pCrl);
+	
+	if (shared)
+	{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		X509_CRL_up_ref(_pCrl);
+#else
+		_pCrl->references++;
+#endif
+	}
+
+	init();
+}
+
+
+X509RevocationList::X509RevocationList(const X509RevocationList& cert):
+	_issuerName(cert._issuerName),
+	_pCrl(nullptr)
+{
+	duplicate(cert._pCrl, &_pCrl);
+}
+
+
+X509RevocationList::X509RevocationList(X509RevocationList&& other):
+	_issuerName(),
+	_pCrl(nullptr)
+{
+	swap(*this, other);
+}
+
+
+X509RevocationList& X509RevocationList::operator = (X509RevocationList other)
+{
+	swap(*this, other);
+	return *this;
+}
+
+
+void X509RevocationList::swap(X509RevocationList& first, X509RevocationList& second)
+{
+	using std::swap;
+	swap(first._issuerName, second._issuerName);
+	swap(first._pCrl, second._pCrl);
+}
+
+
+X509RevocationList::~X509RevocationList()
+{
+	X509_CRL_free(_pCrl);
+}
+
+
+void X509RevocationList::load(std::istream& istr)
+{
+	poco_assert (!_pCrl);
+		
+	std::stringstream certStream;
+	Poco::StreamCopier::copyStream(istr, certStream);
+	std::string cert = certStream.str();
+		
+	BIO *pBIO = BIO_new_mem_buf(const_cast<char*>(cert.data()), static_cast<int>(cert.size()));
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading crl");
+	_pCrl = PEM_read_bio_X509_CRL(pBIO, nullptr, nullptr, nullptr);
+	BIO_free(pBIO);
+	
+	if (!_pCrl) throw Poco::IOException("Faild to load crl from stream");
+
+	init();
+}
+
+
+void X509RevocationList::load(const std::string& path)
+{
+	poco_assert (!_pCrl);
+
+	BIO *pBIO = BIO_new(BIO_s_file());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading crl file", path);
+	if (!BIO_read_filename(pBIO, const_cast<char*>(path.c_str())))
+	{
+		BIO_free(pBIO);
+		throw Poco::OpenFileException("Cannot open crl file for reading", path);
+	}
+	
+	_pCrl = PEM_read_bio_X509_CRL(pBIO, nullptr, nullptr, nullptr);
+	BIO_free(pBIO);
+	
+	if (!_pCrl) throw Poco::ReadFileException("Faild to load crl from", path);
+
+	init();
+}
+
+
+void X509RevocationList::save(std::ostream& stream) const
+{
+	BIO *pBIO = BIO_new(BIO_s_mem());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for writing crl");
+	try
+	{
+		if (!PEM_write_bio_X509_CRL(pBIO, _pCrl))
+			throw Poco::IOException("Failed to write crl to stream");
+
+		char *pData;
+		long size;
+		size = BIO_get_mem_data(pBIO, &pData);
+		stream.write(pData, size);
+	}
+	catch (...)
+	{
+		BIO_free(pBIO);
+		throw;
+	}
+	BIO_free(pBIO);
+}
+
+
+void X509RevocationList::save(const std::string& path) const
+{
+	BIO *pBIO = BIO_new(BIO_s_file());
+	if (!pBIO) throw Poco::IOException("Cannot create BIO for reading crl file", path);
+	if (!BIO_write_filename(pBIO, const_cast<char*>(path.c_str())))
+	{
+		BIO_free(pBIO);
+		throw Poco::CreateFileException("Cannot create crl file", path);
+	}
+	try
+	{
+		if (!PEM_write_bio_X509_CRL(pBIO, _pCrl))
+			throw Poco::WriteFileException("Failed to write crl to file", path);
+	}
+	catch (...)
+	{
+		BIO_free(pBIO);
+		throw;
+	}
+	BIO_free(pBIO);
+}
+
+
+void X509RevocationList::init()
+{
+	char buffer[NAME_BUFFER_SIZE];
+	X509_NAME_oneline(X509_CRL_get_issuer(_pCrl), buffer, sizeof(buffer));
+	_issuerName = buffer;
+}
+
+
+long X509RevocationList::version() const
+{
+	return X509_CRL_get_version(_pCrl) + 1;
+}
+
+
+void X509RevocationList::addIssuer(X509RevocationList::NID nid, const std::string& name)
+{
+	const void* data = name.c_str();
+	unsigned char* bytes = static_cast<unsigned char*>(const_cast<void*>(data));
+	X509_NAME* x509name = X509_CRL_get_issuer(_pCrl);
+	X509_NAME_add_entry_by_NID(x509name, nid, MBSTRING_ASC, bytes, -1, -1, 0);
+	X509_CRL_set_issuer_name(_pCrl, x509name);
+
+	init();
+}
+
+
+std::string X509RevocationList::issuerName(NID nid) const
+{
+	if (X509_NAME* issuer = X509_CRL_get_issuer(_pCrl))
+    {
+		char buffer[NAME_BUFFER_SIZE];
+		if (X509_NAME_get_text_by_NID(issuer, nid, buffer, sizeof(buffer)) >= 0)
+			return std::string(buffer);
+    }
+    return std::string();
+}
+
+
+void X509RevocationList::extractNames(std::set<std::string>& domainNames) const
+{
+	domainNames.clear(); 
+	if (STACK_OF(GENERAL_NAME)* names = static_cast<STACK_OF(GENERAL_NAME)*>(X509_CRL_get_ext_d2i(_pCrl, NID_subject_alt_name, nullptr, nullptr)))
+    {
+		for (int i = 0; i < sk_GENERAL_NAME_num(names); ++i)
+        {
+			const GENERAL_NAME* name = sk_GENERAL_NAME_value(names, i);
+			if (name->type == GEN_DNS)
+			{
+				const char* data = reinterpret_cast<char*>(ASN1_STRING_data(name->d.ia5));
+				std::size_t len = static_cast<std::size_t>(ASN1_STRING_length(name->d.ia5));
+				domainNames.insert(std::string(data, len));
+            }
+		}
+		GENERAL_NAMES_free(names);
+	}
+}
+
+
+void X509RevocationList::setLastUpdate(DateTime dateTime)
+{
+	Timestamp timestamp = dateTime.timestamp();
+	time_t time = timestamp.epochTime();
+	ASN1_TIME* asn1time = ASN1_TIME_new();
+	ASN1_TIME_set(asn1time, time);
+	X509_CRL_set_lastUpdate(_pCrl, asn1time);
+	ASN1_TIME_free(asn1time);
+}
+
+
+Poco::DateTime X509RevocationList::lastUpdate() const
+{
+	ASN1_TIME* certTime = X509_CRL_get_lastUpdate(_pCrl);
+	std::string dateTime(reinterpret_cast<char*>(certTime->data));
+	std::string fmt = "%y%m%d%H%M%S";
+	if(certTime->type == V_ASN1_GENERALIZEDTIME)
+	{
+		fmt = "%Y%m%d%H%M%S";
+	}
+	int tzd;
+	return DateTimeParser::parse(fmt, dateTime, tzd);
+}
+    
+
+void X509RevocationList::setNextUpdate(DateTime expires)
+{
+	Timestamp timestamp = expires.timestamp();
+	time_t time = timestamp.epochTime();
+	ASN1_TIME* asn1time = ASN1_TIME_new();
+	ASN1_TIME_set(asn1time, time);
+	X509_CRL_set_nextUpdate(_pCrl, asn1time);
+	ASN1_TIME_free(asn1time);
+}
+
+	
+Poco::DateTime X509RevocationList::nextUpdate() const
+{
+	ASN1_TIME* certTime = X509_CRL_get_nextUpdate(_pCrl);
+	std::string dateTime(reinterpret_cast<char*>(certTime->data));
+	std::string fmt = "%y%m%d%H%M%S";
+	if(certTime->type == V_ASN1_GENERALIZEDTIME)
+	{
+		fmt = "%Y%m%d%H%M%S";
+	}
+	int tzd;
+	return DateTimeParser::parse(fmt, dateTime, tzd);
+}
+
+
+void X509RevocationList::addExtension(const X509Extension &x509Extension)
+{
+	X509_EXTENSION* ext = const_cast<X509_EXTENSION*>(static_cast<const X509_EXTENSION*>(x509Extension));
+	X509_CRL_add_ext(_pCrl, ext, -1);
+}
+
+
+void X509RevocationList::addRevoked(const X509Revoked &revoked)
+{
+	X509_REVOKED* rev = const_cast<X509_REVOKED*>(static_cast<const X509_REVOKED*>(revoked));
+	X509_REVOKED* newRev;
+	X509Revoked::duplicate(rev, &newRev);
+	X509_CRL_add0_revoked(_pCrl, newRev);
+}
+
+
+X509Revoked X509RevocationList::findRevokedBySerialNumber(long serialNumber)
+{
+	ASN1_INTEGER* asn1Serial = ASN1_INTEGER_new();
+	ASN1_INTEGER_set(asn1Serial, serialNumber);
+	X509_REVOKED *ret;
+	int rc = X509_CRL_get0_by_serial(_pCrl, &ret, asn1Serial);
+	X509Revoked rev;
+	if(rc)
+	{
+		rev = X509Revoked(ret);
+	}
+	return rev;
+}
+
+
+X509Revoked X509RevocationList::findRevokedByCertificate(const X509Certificate &certificate)
+{
+	X509* x509 = const_cast<X509*>(static_cast<const X509*>(certificate));
+	X509_REVOKED *ret;
+	int rc = X509_CRL_get0_by_cert(_pCrl, &ret, x509);
+	X509Revoked rev;
+	if(rc)
+	{
+		rev = X509Revoked(ret);
+	}
+	return rev;
+}
+
+
+X509Revoked::List X509RevocationList::getAllRevoked() const
+{
+	X509Revoked::List revokedList;
+	STACK_OF(X509_REVOKED)* revs = X509_CRL_get_REVOKED(_pCrl);
+	for (int i = 0; i < sk_X509_REVOKED_num(revs); i++)
+	{
+		X509_REVOKED *rv = sk_X509_REVOKED_value(revs, i);
+		revokedList.push_back(X509Revoked(rv));
+	}
+	return revokedList;
+}
+
+
+X509Extension::List X509RevocationList::findExtensionByNID(int nid)
+{
+	X509Extension::List extensions;
+	int index = -1;
+	do {
+		index = X509_CRL_get_ext_by_NID(_pCrl, nid, index);
+		X509_EXTENSION* ext = X509_CRL_get_ext(_pCrl, index);
+		extensions.push_back(X509Extension(ext));
+	}
+	while(index >= 0);
+
+	return extensions;
+}
+
+
+bool X509RevocationList::verify(const EVPPKey &key) const
+{
+	EVP_PKEY* pIssuerPublicKey = const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(key));
+	int rc = X509_CRL_verify(_pCrl, pIssuerPublicKey);
+	return rc == 1;
+}
+
+
+bool X509RevocationList::sign(const EVPPKey &pkey, const std::string& mdstr)
+{
+	const char* mdc = mdstr.c_str();
+	if(std::string("default").compare(mdstr))
+	{
+		int defNid = 0;
+		EVP_PKEY_get_default_digest_nid(const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(pkey)), &defNid);
+		mdc = OBJ_nid2sn(defNid);
+	}
+	const EVP_MD* md = EVP_get_digestbyname(mdc);
+	X509_CRL_sign(_pCrl, const_cast<EVP_PKEY*>(static_cast<const EVP_PKEY*>(pkey)), md);
+	return true;
+}
+
+
+bool X509RevocationList::equals(const X509RevocationList& otherCertificate) const
+{
+	const X509_CRL* pOtherCert = otherCertificate;
+	return X509_CRL_cmp(_pCrl, pOtherCert) == 0;
+}
+
+X509_CRL* X509RevocationList::duplicate(const X509_CRL *pFromCRL, X509_CRL **pToCRL)
+{
+	*pToCRL = X509_CRL_dup(const_cast<X509_CRL*>(pFromCRL));
+	return *pToCRL;
+}
+
+
+} } // namespace Poco::Crypto

--- a/Crypto/src/X509Revoked.cpp
+++ b/Crypto/src/X509Revoked.cpp
@@ -1,0 +1,263 @@
+//
+// X509Revoked.cpp
+//
+//
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Revoked
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Crypto/X509Revoked.h"
+#include "Poco/DateTimeParser.h"
+#include <openssl/x509v3.h>
+
+namespace Poco {
+namespace Crypto {
+
+
+X509Revoked::X509Revoked():
+	_pRevoked(X509_REVOKED_new())
+{
+
+}
+
+
+X509Revoked::X509Revoked(X509_REVOKED *pRevoked):
+	_pRevoked(pRevoked)
+{
+	poco_check_ptr(_pRevoked);
+}
+
+X509Revoked::X509Revoked(const X509Revoked &revoked):
+	_pRevoked(nullptr)
+{
+	duplicate(revoked._pRevoked, &_pRevoked);
+}
+
+X509Revoked::X509Revoked(X509Revoked&& other):
+	_pRevoked(nullptr)
+{
+	swap(*this, other);
+}
+
+
+X509Revoked& X509Revoked::operator =(X509Revoked other)
+{
+	swap(*this, other);
+	return *this;
+}
+
+void X509Revoked::swap(X509Revoked &first, X509Revoked& second)
+{
+	using std::swap;
+	swap(first._pRevoked, second._pRevoked);
+}
+
+
+X509Revoked::~X509Revoked()
+{
+	X509_REVOKED_free(_pRevoked);
+}
+
+
+void X509Revoked::setSerialNumber(long serial)
+{
+	ASN1_INTEGER* asn1Serial = ASN1_INTEGER_new();
+	ASN1_INTEGER_set(asn1Serial, serial);
+	X509_REVOKED_set_serialNumber(_pRevoked, asn1Serial);
+	ASN1_INTEGER_free(asn1Serial);
+}
+
+
+void X509Revoked::setSerialNumber(const std::string &serial)
+{
+	BIGNUM *bn = BN_new();
+	int rc = BN_hex2bn(&bn, serial.data());
+	if (rc)
+	{
+		ASN1_INTEGER* asn1Serial = ASN1_INTEGER_new();
+		BN_to_ASN1_INTEGER(bn, asn1Serial);
+		X509_REVOKED_set_serialNumber(_pRevoked, asn1Serial);
+		ASN1_INTEGER_free(asn1Serial);
+	}
+	BN_free(bn);
+}
+
+
+std::string X509Revoked::serialNumber() const
+{
+	std::string result;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	const ASN1_INTEGER* asn1serialNr = X509_REVOKED_get0_serialNumber(_pRevoked);
+#else
+	ASN1_INTEGER* asn1serialNr = _pRevoked->serialNumber;
+#endif
+	if (asn1serialNr)
+	{
+		BIGNUM* pBN = ASN1_INTEGER_to_BN(asn1serialNr, nullptr);
+		if (pBN)
+		{
+			char* p = BN_bn2hex(pBN);
+			if (p)
+			{
+				result = std::string(p);
+				OPENSSL_free(p);
+			}
+			BN_free(pBN);
+		}
+	}
+	return result;
+}
+
+
+void X509Revoked::setRevocationDate(DateTime date)
+{
+	Timestamp timestamp = date.timestamp();
+	time_t time = timestamp.epochTime();
+	ASN1_UTCTIME* asn1utctime = ASN1_UTCTIME_new();
+	ASN1_UTCTIME_set(asn1utctime, time);
+	X509_REVOKED_set_revocationDate(_pRevoked, asn1utctime);
+	ASN1_UTCTIME_free(asn1utctime);
+}
+
+
+DateTime X509Revoked::getRevocationDate() const
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	const ASN1_TIME* revokeTime = X509_REVOKED_get0_revocationDate(_pRevoked);
+#else
+	const ASN1_TIME* revokeTime = _pRevoked->revocationDate;
+#endif
+	std::string dateTime(reinterpret_cast<char*>(revokeTime->data));
+	std::string fmt = "%y%m%d%H%M%S";
+	if(revokeTime->type == V_ASN1_GENERALIZEDTIME)
+	{
+		fmt = "%Y%m%d%H%M%S";
+	}
+	int tzd;
+	return DateTimeParser::parse(fmt, dateTime, tzd);
+}
+
+
+bool X509Revoked::setReasonCode(ReasonCode code)
+{
+	bool result = false;
+	ASN1_ENUMERATED* asn1enum = ASN1_ENUMERATED_new();
+	if (!asn1enum || !ASN1_ENUMERATED_set(asn1enum, code))
+	{
+		return result;
+	}
+	result = X509_REVOKED_add1_ext_i2d(_pRevoked, NID_crl_reason, asn1enum, 0, 0);
+	if(asn1enum)
+	{
+		ASN1_ENUMERATED_free(asn1enum);
+	}
+	return result;
+}
+
+X509Revoked::ReasonCode X509Revoked::getReasonCode() const
+{
+	ReasonCode result = ReasonCode::UNSPECIFIED;
+	int index = -1;
+	ASN1_ENUMERATED* reason = static_cast<ASN1_ENUMERATED*>(X509_REVOKED_get_ext_d2i(_pRevoked, NID_crl_reason, &index, nullptr));
+	if(!reason && (index == -1))
+	{
+		return result;
+	}
+
+	switch(ASN1_ENUMERATED_get(reason))
+	{
+	case 1:
+		result = ReasonCode::KEY_COMPROMISE;
+		break;
+	case 2:
+		result = ReasonCode::CA_COMPROMISE;
+		break;
+	case 3:
+		result = ReasonCode::AFFILIATION_CHANGED;
+		break;
+	case 4:
+		result = ReasonCode::SUPERSEDED;
+		break;
+	case 5:
+		result = ReasonCode::CESSATION_OF_OPERATION;
+		break;
+	case 8:
+		result = ReasonCode::REMOVE_FROM_CRL;
+		break;
+	default:
+		result = ReasonCode::UNSPECIFIED;
+	}
+
+	ASN1_ENUMERATED_free(reason);
+	return result;
+}
+
+
+void X509Revoked::addExtension(const X509Extension& x509Extension)
+{
+	X509_EXTENSION* ext = const_cast<X509_EXTENSION*>(static_cast<const X509_EXTENSION*>(x509Extension));
+	X509_REVOKED_add_ext(_pRevoked, ext, -1);
+}
+
+
+X509Extension::List X509Revoked::findExtensionByNID(int nid)
+{
+	X509Extension::List extensions;
+	int index = -1;
+	do {
+		index = X509_REVOKED_get_ext_by_NID(_pRevoked, nid, index);
+		if (index == -1)
+			break;
+
+		X509_EXTENSION* ext = X509_REVOKED_get_ext(_pRevoked, index);
+		ext = X509_EXTENSION_dup(ext);
+		extensions.push_back(X509Extension(ext));
+	}
+	while(index >= 0);
+
+	return extensions;
+}
+
+
+X509_REVOKED *X509Revoked::duplicate(const X509_REVOKED *pFromRevoked, X509_REVOKED **pToRevoked)
+{
+	X509_REVOKED* rev = const_cast<X509_REVOKED*>(pFromRevoked);
+#if (OPENSSL_VERSION_NUMBER >=  0x1000200fL)
+	*pToRevoked = X509_REVOKED_dup(rev);
+#else
+	*pToRevoked = X509_REVOKED_new();
+
+	(*pToRevoked)->reason = rev->reason;
+	(*pToRevoked)->sequence = rev->sequence;
+
+	X509_REVOKED_set_serialNumber(*pToRevoked, rev->serialNumber);
+	X509_REVOKED_set_revocationDate(*pToRevoked, rev->revocationDate);
+
+	int size = sk_X509_EXTENSION_num(rev->extensions);
+	for(int i = 0; i < size; i++ )
+	{
+		X509_EXTENSION* ex = sk_X509_EXTENSION_value(rev->extensions, i);
+		X509_EXTENSION* newEx;
+		X509Extension::duplicate(ex, &newEx);
+		X509_REVOKED_add_ext(*pToRevoked, newEx, -1);
+	}
+
+	size = sk_GENERAL_NAME_num(rev->issuer);
+	for(int i = 0; i < size; i++ )
+	{
+		GENERAL_NAME* na = sk_GENERAL_NAME_value(rev->issuer, i);
+		GENERAL_NAME* newNa = GENERAL_NAME_dup(na);
+		sk_GENERAL_NAME_push((*pToRevoked)->issuer, newNa);
+	}
+#endif
+	return *pToRevoked;
+}
+
+} } // namespace Poco::Crypto

--- a/Crypto/src/X509Store.cpp
+++ b/Crypto/src/X509Store.cpp
@@ -1,0 +1,150 @@
+//
+// X509Store.cpp
+//
+// $Id: $
+// Library: Crypto
+// Package: Certificate
+// Module:  X509Engine
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Crypto/X509Store.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/buffer.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/pem.h>
+#include <cstring>
+
+
+namespace Poco {
+namespace Crypto {
+
+
+X509Store::X509Store():
+	_pStore(X509_STORE_new()),
+	_purpose(0)
+{
+
+}
+
+
+X509Store::X509Store(X509_STORE* store):
+	_pStore(store)
+{
+	poco_check_ptr(_pStore);
+}
+
+
+X509Store::X509Store(X509Store&& other):
+	_pStore(nullptr)
+{
+	swap(*this, other);
+}
+
+
+void X509Store::swap(X509Store& first, X509Store& second)
+{
+	using std::swap;
+
+	swap(first._pStore, second._pStore);
+}
+
+
+X509Store::~X509Store()
+{
+	X509_STORE_free(_pStore);
+}
+
+
+void X509Store::setX509Purpose(int purpose)
+{
+	_purpose = purpose;
+}
+
+
+void X509Store::setX509VerifyFlags(unsigned long flags)
+{
+	X509_STORE_set_flags(_pStore, flags);
+}
+
+
+bool X509Store::addCa(const X509Certificate& caCertificate)
+{
+	return X509_STORE_add_cert(_pStore, const_cast<X509*>(static_cast<const X509*>(caCertificate)));
+}
+
+bool X509Store::addChain(const X509Certificate::List &chain)
+{
+	bool result = false;
+	for(size_t x = 0; x < chain.size(); ++x)
+	{
+		result = X509_STORE_add_cert(_pStore, const_cast<X509*>(static_cast<const X509*>(chain[x])));
+	}
+	return result;
+}
+
+
+bool X509Store::addCrl(const X509RevocationList& crl)
+{
+	return X509_STORE_add_crl(_pStore, const_cast<X509_CRL*>(static_cast<const X509_CRL*>(crl)));
+}
+
+
+X509Store::VerifyResult X509Store::verifyCertificateChain(const X509Certificate& cert)
+{
+	X509_STORE_set_flags(_pStore, 0);
+	X509_STORE_CTX *csc = X509_STORE_CTX_new();
+	X509_STORE_CTX_init(csc,_pStore,const_cast<X509*>(static_cast<const X509*>(cert)),nullptr);
+	if (_purpose)
+	{
+		X509_STORE_CTX_set_purpose(csc, _purpose);
+	}
+	VerifyResult result;
+	int rc = X509_verify_cert(csc);
+	if (rc != 1)
+	{
+		int code = X509_STORE_CTX_get_error(csc);
+		int depth = X509_STORE_CTX_get_error_depth(csc);
+		const char* errorChar = X509_verify_cert_error_string(code);
+		std::string errorString(errorChar);
+		X509* x509cert = X509_STORE_CTX_get_current_cert(csc);
+		x509cert = X509_dup(x509cert);
+		X509Certificate certificate;
+		if(x509cert)
+		{
+			certificate = X509Certificate(x509cert);
+		}
+		result = VerifyResult(certificate, depth, code, errorString);
+	}
+	X509_STORE_CTX_free(csc);
+	return result;
+}
+
+
+X509Store::VerifyResult::VerifyResult() :
+	_certificate(),
+	_depth(-1),
+	_code(X509_V_OK),
+	_errorString("Verification of certification chain was successful")
+{
+}
+
+X509Store::VerifyResult::VerifyResult(const X509Certificate &certificate, int depth, int code, std::string errorString) :
+	_certificate(certificate),
+	_depth(depth),
+	_code(code),
+	_errorString(errorString)
+{
+
+}
+
+
+} // namespace Crypto
+} // namespace Poco

--- a/Crypto/testsuite/src/CryptoTest.h
+++ b/Crypto/testsuite/src/CryptoTest.h
@@ -40,6 +40,10 @@ public:
 	void testEncryptInterop();
 	void testDecryptInterop();
 	void testCertificate();
+	void testSignCertificate();
+	void testSignRequestCertificate();
+	void testVerifyCertificate();
+	void testRevokeCertificate();
 
 	void setUp();
 	void tearDown();

--- a/Crypto/testsuite/src/EVPTest.cpp
+++ b/Crypto/testsuite/src/EVPTest.cpp
@@ -59,7 +59,8 @@ void EVPTest::testRSAEVPPKey()
 		assertTrue (key->type() == Poco::Crypto::KeyPair::KT_RSA);
 		// construct EVPPKey from RSAKey*
 		pKey = new EVPPKey(key);
-		assertTrue (pKey->type() == EVP_PKEY_RSA);
+		delete key;
+		assert (pKey->type() == EVP_PKEY_RSA);
 
 		BIO* bioPriv1 = BIO_new(BIO_s_mem());
 		BIO* bioPub1 = BIO_new(BIO_s_mem());

--- a/NetSSL_OpenSSL/include/Poco/Net/X509Certificate.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/X509Certificate.h
@@ -60,7 +60,7 @@ public:
 	X509Certificate(const Poco::Crypto::X509Certificate& cert);
 		/// Creates the certificate by copying another one.
 
-	X509Certificate& operator = (const Poco::Crypto::X509Certificate& cert);
+	X509Certificate& operator = (Poco::Crypto::X509Certificate cert);
 		/// Assigns a certificate.
 
 	~X509Certificate();

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -187,7 +187,7 @@ void Context::init(const Params& params)
 
 void Context::useCertificate(const Poco::Crypto::X509Certificate& certificate)
 {
-	int errCode = SSL_CTX_use_certificate(_pSSLContext, const_cast<X509*>(certificate.certificate()));
+	int errCode = SSL_CTX_use_certificate(_pSSLContext, const_cast<X509*>(static_cast<const X509*>(certificate)));
 	if (errCode != 1)
 	{
 		std::string msg = Utility::getLastError();
@@ -198,7 +198,8 @@ void Context::useCertificate(const Poco::Crypto::X509Certificate& certificate)
 	
 void Context::addChainCertificate(const Poco::Crypto::X509Certificate& certificate)
 {
-	int errCode = SSL_CTX_add_extra_chain_cert(_pSSLContext, certificate.certificate());
+	X509* cert = const_cast<X509*>(static_cast<const X509*>(certificate));
+	int errCode = SSL_CTX_add_extra_chain_cert(_pSSLContext, cert);
 	if (errCode != 1)
 	{
 		std::string msg = Utility::getLastError();

--- a/NetSSL_OpenSSL/src/X509Certificate.cpp
+++ b/NetSSL_OpenSSL/src/X509Certificate.cpp
@@ -61,10 +61,9 @@ X509Certificate::X509Certificate(const Poco::Crypto::X509Certificate& cert):
 }
 
 
-X509Certificate& X509Certificate::operator = (const Poco::Crypto::X509Certificate& cert)
+X509Certificate& X509Certificate::operator = (Poco::Crypto::X509Certificate other)
 {
-	X509Certificate tmp(cert);
-	swap(tmp);
+	Poco::Crypto::X509Certificate::swap(*this, other);
 	return *this;
 }
 
@@ -133,7 +132,7 @@ bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, c
 	}
 	return ok;
 #else
-	if (X509_check_host(const_cast<X509*>(certificate.certificate()), hostName.c_str(), hostName.length(), 0, NULL) == 1)
+	if (X509_check_host(const_cast<X509*>(static_cast<const X509*>(certificate)), hostName.c_str(), hostName.length(), 0, NULL) == 1)
 	{
 		return true;
 	}
@@ -142,7 +141,7 @@ bool X509Certificate::verify(const Poco::Crypto::X509Certificate& certificate, c
 		IPAddress ip;
 		if (IPAddress::tryParse(hostName, ip))
 		{
-		    return (X509_check_ip_asc(const_cast<X509*>(certificate.certificate()), hostName.c_str(), 0) == 1);
+			return (X509_check_ip_asc(const_cast<X509*>(static_cast<const X509*>(certificate)), hostName.c_str(), 0) == 1);
 		}
 	}
 	return false;


### PR DESCRIPTION
Some time ago, I added support for signing and verification of x509 certificate in crypto and I wanted to contribute to poco.
To see how signing and verification works, see in CryptoTest. I add and extend there the tests for signing and verification of x509 certificate.
I develop, build and test on Ubuntu 17.04 with clang and gcc. As build system I use cmake.

I read C++ Coding Style Guide carefully and I hopefully met all rules. Please review.
Also the API. 
- X509Crl, X509Request and X509Certificate are very similar. I was thinking to create one base class for this, or maybe a template or interface.
- I'm not sure if X509Store is the right class name. I use for all the same name from OpenSSL. Maybe X509Verify or X509Chain is better?

Comments, fixes, test, ideas are very welcome.