### PR TITLE
check length of UUID when parsing

### DIFF
--- a/Foundation/src/UUID.cpp
+++ b/Foundation/src/UUID.cpp
@@ -134,11 +134,13 @@ bool UUID::tryParse(const std::string& uuid)
 	bool haveHyphens = false;
 	if (uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-')
 	{
-		if (uuid.size() >= 36) 
+		if (uuid.size() == 36)
 			haveHyphens = true;
 		else
 			return false;
 	}
+	else if (uuid.size() != 32)
+		return false;
 	
 	UUID newUUID;
 	std::string::const_iterator it = uuid.begin();

--- a/Foundation/testsuite/src/UUIDTest.cpp
+++ b/Foundation/testsuite/src/UUIDTest.cpp
@@ -92,6 +92,24 @@ void UUIDTest::testParse()
 	catch (Poco::SyntaxException&)
 	{
 	}
+
+	try
+	{
+		uuid.parse("6ba7b8109dad11d180b400c04fd430c81234");
+		fail("invalid UUID - must throw");
+	}
+	catch (Poco::SyntaxException&)
+	{
+	}
+
+	try
+	{
+		uuid.parse("6ba7b810-9dad-11d1-80b4-00c04fd430c81234");
+		fail("invalid UUID - must throw");
+	}
+	catch (Poco::SyntaxException&)
+	{
+	}
 }
 
 


### PR DESCRIPTION
If passing a longer UUID the trailing characters are ignored.
UUID must have 32 (without hyphens) or 36 (with hyphens) characters to be valid.