### PR TITLE
Fix writing into closed socket from streambuf

### DIFF
--- a/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
+++ b/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
@@ -73,12 +73,12 @@ public:
 	{
 		if (!(_mode & IOS::out)) return char_traits::eof();
 
+		if (flushBuffer() == std::streamsize(-1)) return char_traits::eof();
 		if (c != char_traits::eof())
 		{
 			*this->pptr() = char_traits::to_char_type(c);
 			this->pbump(1);
 		}
-		if (flushBuffer() == std::streamsize(-1)) return char_traits::eof();
 
 		return c;
 	}
@@ -127,7 +127,7 @@ protected:
 	void resetBuffers()
 	{
 		this->setg(_pReadBuffer + 4, _pReadBuffer + 4, _pReadBuffer + 4);
-		this->setp(_pWriteBuffer, _pWriteBuffer + (_bufsize - 1));
+		this->setp(_pWriteBuffer, _pWriteBuffer + _bufsize);
 	}
 
 private:

--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -60,7 +60,7 @@ public:
 		_mode(mode)
 	{
 		this->setg(_pBuffer + 4, _pBuffer + 4, _pBuffer + 4);
-		this->setp(_pBuffer, _pBuffer + (_bufsize - 1));
+		this->setp(_pBuffer, _pBuffer + _bufsize);
 	}
 
 	~BasicBufferedStreamBuf()
@@ -78,12 +78,12 @@ public:
 	{
 		if (!(_mode & IOS::out)) return char_traits::eof();
 
+		if (flushBuffer() == std::streamsize(-1)) return char_traits::eof();
 		if (c != char_traits::eof())
 		{
 			*this->pptr() = char_traits::to_char_type(c);
 			this->pbump(1);
 		}
-		if (flushBuffer() == std::streamsize(-1)) return char_traits::eof();
 
 		return c;
 	}


### PR DESCRIPTION
In case of error occured in writeToDevice pptr may become one byte
farther than epptr. This can lead to crash in streambuf::xsputn from
libstdc++.