### PR TITLE
Fix Android port

### DIFF
--- a/Foundation/include/Poco/Mutex.h
+++ b/Foundation/include/Poco/Mutex.h
@@ -22,7 +22,7 @@
 #include "Poco/Exception.h"
 #include "Poco/ScopedLock.h"
 
-#if (POCO_OS == POCO_OS_CYGWIN)
+#if (POCO_OS == POCO_OS_CYGWIN || defined(POCO_ANDROID))
 #include "Poco/Mutex_POSIX.h"
 #else
 #include "Poco/Mutex_STD.h"

--- a/Foundation/src/Mutex.cpp
+++ b/Foundation/src/Mutex.cpp
@@ -13,7 +13,7 @@
 
 
 #include "Poco/Mutex.h"
-#if (POCO_OS == POCO_OS_CYGWIN)
+#if (POCO_OS == POCO_OS_CYGWIN || defined(POCO_ANDROID))
 #include "Mutex_POSIX.cpp"
 #else
 #include "Mutex_STD.cpp"

--- a/build/config/Android
+++ b/build/config/Android
@@ -8,7 +8,7 @@
 # General Settings
 #
 LINKMODE           ?= STATIC
-ANDROID_ABI        ?= armeabi
+ANDROID_ABI        ?= armeabi-v7a
 POCO_TARGET_OSNAME  = Android
 POCO_TARGET_OSARCH  = $(ANDROID_ABI)
 
@@ -33,8 +33,8 @@ endif
 #
 # Define Tools
 #
-CC      = $(TOOL)-gcc
-CXX     = $(TOOL)-g++
+CC      = $(TOOL)-clang
+CXX     = $(TOOL)-clang++
 LINK    = $(CXX)
 STRIP   = $(TOOL)-strip
 LIB     = $(TOOL)-ar -cr
@@ -56,10 +56,10 @@ SHAREDLIBLINKEXT = .so
 #
 # Compiler and Linker Flags
 #
-CFLAGS          = $(ARCHFLAGS) -fpic -ffunction-sections -funwind-tables -fstack-protector -fno-strict-aliasing -finline-limit=64
+CFLAGS          = $(ARCHFLAGS) -fpic -ffunction-sections -funwind-tables -fstack-protector -fno-strict-aliasing
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = $(ARCHFLAGS) -fpic -ffunction-sections -funwind-tables -fstack-protector -fno-strict-aliasing -finline-limit=64 -frtti -fexceptions
+CXXFLAGS        = $(ARCHFLAGS) -fpic -ffunction-sections -funwind-tables -fstack-protector -fno-strict-aliasing -frtti -fexceptions
 CXXFLAGS32      =
 CXXFLAGS64      =
 LINKFLAGS      += 
@@ -87,3 +87,9 @@ SYSFLAGS = -DPOCO_ANDROID -DPOCO_NO_FPENVIRONMENT -DPOCO_NO_WSTRING -DPOCO_NO_SH
 # System Specific Libraries
 #
 SYSLIBS  = -lstdc++ -lsupc++
+
+#
+# C++11/14 detection
+#
+include $(POCO_BASE)/build/script/cpp11-clang
+


### PR DESCRIPTION
- Switch to clang from gcc
- std::timed_mutex is not available on the latest NDK, revert to the POSIX implementation for now
- eabi is deprecated, switch to eabi-v7a by default