### PR TITLE
Add missing ::std namespace

### DIFF
--- a/Crypto/src/EVPPKey.cpp
+++ b/Crypto/src/EVPPKey.cpp
@@ -309,9 +309,9 @@ int EVPPKey::passCB(char* buf, int size, int, void* pass)
 {
 	if (pass)
 	{
-		int len = (int)strlen((char*)pass);
+		int len = (int)std::strlen((char*)pass);
 		if(len > size) len = size;
-		memcpy(buf, pass, len);
+		std::memcpy(buf, pass, len);
 		return len;
 	}
 	return 0;

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -317,7 +317,7 @@ bool intToStr(T value,
 
 	size = ptr - result;
 	poco_assert_dbg (size <= ptr.span());
-	poco_assert_dbg ((-1 == width) || (size >= size_t(width)));
+	poco_assert_dbg ((-1 == width) || (size >= std::size_t(width)));
 	*ptr-- = '\0';
 
 	char* ptrr = result;
@@ -392,7 +392,7 @@ bool uIntToStr(T value,
 	
 	size = ptr - result;
 	poco_assert_dbg (size <= ptr.span());
-	poco_assert_dbg ((-1 == width) || (size >= size_t(width)));
+	poco_assert_dbg ((-1 == width) || (size >= std::size_t(width)));
 	*ptr-- = '\0';
 	
 	char* ptrr = result;

--- a/Foundation/include/Poco/String.h
+++ b/Foundation/include/Poco/String.h
@@ -644,7 +644,7 @@ struct i_char_traits : public std::char_traits<charT>
 		return Ascii::toLower(c1) < Ascii::toLower(c2);
 	}
 
-	static int compare(const charT* s1, const charT* s2, size_t n)
+	static int compare(const charT* s1, const charT* s2, std::size_t n)
 	{
 		for (int i = 0; i < n && s1 && s2; ++i, ++s1, ++s2)
 		{

--- a/Foundation/include/Poco/UTFString.h
+++ b/Foundation/include/Poco/UTFString.h
@@ -50,7 +50,7 @@ struct UTF16CharTraits
 		return c1 < c2;
 	}
 
-	static int compare(const char_type* s1, const char_type* s2, size_t n)
+	static int compare(const char_type* s1, const char_type* s2, std::size_t n)
 	{
 		for (; n; --n, ++s1, ++s2)
 		{
@@ -62,15 +62,15 @@ struct UTF16CharTraits
 		return 0;
 	}
 
-	static size_t length(const char_type* s)
+	static std::size_t length(const char_type* s)
 	{
-		size_t len = 0;
+		std::size_t len = 0;
 		for (; !eq(*s, char_type(0)); ++s)
 			++len;
 		return len;
 	}
 
-	static const char_type* find(const char_type* s, size_t n, const char_type& a)
+	static const char_type* find(const char_type* s, std::size_t n, const char_type& a)
 	{
 		for (; n; --n)
 		{
@@ -81,7 +81,7 @@ struct UTF16CharTraits
 		return 0;
 	}
 
-	static char_type* move(char_type* s1, const char_type* s2, size_t n)
+	static char_type* move(char_type* s1, const char_type* s2, std::size_t n)
 	{
 		char_type* r = s1;
 		if (s1 < s2)
@@ -99,7 +99,7 @@ struct UTF16CharTraits
 		return r;
 	}
 
-	static char_type* copy(char_type* s1, const char_type* s2, size_t n)
+	static char_type* copy(char_type* s1, const char_type* s2, std::size_t n)
 	{
 		poco_assert(s2 < s1 || s2 >= s1 + n);
 		char_type* r = s1;
@@ -108,7 +108,7 @@ struct UTF16CharTraits
 		return r;
 	}
 
-	static char_type* assign(char_type* s, size_t n, char_type a)
+	static char_type* assign(char_type* s, std::size_t n, char_type a)
 	{
 		char_type* r = s;
 		for (; n; --n, ++s)
@@ -167,7 +167,7 @@ struct UTF32CharTraits
 		return c1 < c2;
 	}
 
-	static int compare(const char_type* s1, const char_type* s2, size_t n)
+	static int compare(const char_type* s1, const char_type* s2, std::size_t n)
 	{
 		for (; n; --n, ++s1, ++s2)
 		{
@@ -179,15 +179,15 @@ struct UTF32CharTraits
 		return 0;
 	}
 
-	static size_t length(const char_type* s)
+	static std::size_t length(const char_type* s)
 	{
-		size_t len = 0;
+		std::size_t len = 0;
 		for (; !eq(*s, char_type(0)); ++s)
 			++len;
 		return len;
 	}
 
-	static const char_type* find(const char_type* s, size_t n, const char_type& a)
+	static const char_type* find(const char_type* s, std::size_t n, const char_type& a)
 	{
 		for (; n; --n)
 		{
@@ -198,7 +198,7 @@ struct UTF32CharTraits
 		return 0;
 	}
 
-	static char_type* move(char_type* s1, const char_type* s2, size_t n)
+	static char_type* move(char_type* s1, const char_type* s2, std::size_t n)
 	{
 		char_type* r = s1;
 		if (s1 < s2)
@@ -216,7 +216,7 @@ struct UTF32CharTraits
 		return r;
 	}
 
-	static char_type* copy(char_type* s1, const char_type* s2, size_t n)
+	static char_type* copy(char_type* s1, const char_type* s2, std::size_t n)
 	{
 		poco_assert(s2 < s1 || s2 >= s1 + n);
 		char_type* r = s1;
@@ -225,7 +225,7 @@ struct UTF32CharTraits
 		return r;
 	}
 
-	static char_type* assign(char_type* s, size_t n, char_type a)
+	static char_type* assign(char_type* s, std::size_t n, char_type a)
 	{
 		char_type* r = s;
 		for (; n; --n, ++s)

--- a/Foundation/src/UTF8String.cpp
+++ b/Foundation/src/UTF8String.cpp
@@ -302,7 +302,7 @@ std::string UTF8::unescape(const std::string::const_iterator& begin, const std::
 			else if (*it == 'u')
 			{
 				char digs[5];
-				memset(digs, 0, 5);
+				std::memset(digs, 0, 5);
 				unsigned int dno = 0;
 
 				it++;
@@ -310,7 +310,7 @@ std::string UTF8::unescape(const std::string::const_iterator& begin, const std::
 				while (it != end && Ascii::isHexDigit(*it) && dno < 4) digs[dno++] = *it++;
 				if (dno > 0)
 				{
-					ch = strtol(digs, NULL, 16);
+					ch = std::strtol(digs, NULL, 16);
 				}
 
 				if( ch >= 0xD800 && ch <= 0xDBFF )
@@ -333,12 +333,12 @@ std::string UTF8::unescape(const std::string::const_iterator& begin, const std::
 					}
 
 					// UTF-16 surrogate pair. Go fetch other half
-					memset(digs, 0, 5);
+					std::memset(digs, 0, 5);
 					dno = 0;
 					while (it != end && Ascii::isHexDigit(*it) && dno < 4) digs[dno++] = *it++;
 					if (dno > 0)
 					{
-						Poco::UInt32 temp = strtol(digs, NULL, 16);
+						Poco::UInt32 temp = std::strtol(digs, NULL, 16);
 						if( temp >= 0xDC00 && temp <= 0xDFFF )
 						{
 							ch = ( ( ( ch - 0xD800 ) << 10 ) | ( temp - 0xDC00 ) ) + 0x10000;
@@ -349,7 +349,7 @@ std::string UTF8::unescape(const std::string::const_iterator& begin, const std::
 			else if (*it == 'U')
 			{
 				char digs[9];
-				memset(digs, 0, 9);
+				std::memset(digs, 0, 9);
 				unsigned int dno = 0;
 
 				it++;
@@ -359,7 +359,7 @@ std::string UTF8::unescape(const std::string::const_iterator& begin, const std::
 				}
 				if (dno > 0)
 				{
-					ch = strtol(digs, NULL, 16);
+					ch = std::strtol(digs, NULL, 16);
 				}
 			}
 		}


### PR DESCRIPTION
On some function, std:: namespace is missing. 
For example in String.h line 672 -> std::size_t but in line 647 -> size_t.
