### PR TITLE
Add support for MariaDB client in cmake build system for poco 1.8.0

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -14,6 +14,18 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
 		${BINDIR32}/MySQL/include
 		$ENV{SystemDrive}/MySQL/*/include)
 
+if (NOT MYSQL_INCLUDE_DIR)
+	find_path(MARIADB_INCLUDE_DIR mysql.h
+			/usr/include/mariadb
+			/usr/local/include/mariadb
+			/opt/mariadb/mariadb/include
+			/opt/mariadb/mariadb/include/mariadb
+			/usr/local/mariadb/include
+			/usr/local/mariadb/include/mariadb
+			$ENV{MARIADB_INCLUDE_DIR}
+			$ENV{MARIADB_DIR}/include)
+endif (NOT MYSQL_INCLUDE_DIR)
+
 if (WIN32)
 	if (CMAKE_BUILD_TYPE STREQUAL Debug)
 		set(libsuffixDist debug)
@@ -44,17 +56,39 @@ else (WIN32)
 				 $ENV{MYSQL_DIR}/libmysql_r/.libs
 				 $ENV{MYSQL_DIR}/lib
 				 $ENV{MYSQL_DIR}/lib/mysql)
+
+	if (NOT MYSQL_LIB)
+		find_library(MARIADB_LIB NAMES mariadbclient
+					PATHS
+					/usr/lib/mariadb
+					/usr/local/lib/mariadb
+					/usr/local/mariadb/lib
+					/usr/local/mariadb/lib/mariadb
+					/opt/mariadb/mariadb/lib
+					/opt/mariadb/mariadb/lib/mariadb
+					$ENV{MARIADB_DIR}/libmariadb/.libs
+					$ENV{MARIADB_DIR}/lib
+					$ENV{MARIADB_DIR}/lib/mariadb)
+	endif (NOT MYSQL_LIB)
 endif (WIN32)
 
-if(MYSQL_LIB)
+if (MYSQL_INCLUDE_DIR AND MYSQL_LIB)
 	get_filename_component(MYSQL_LIB_DIR ${MYSQL_LIB} PATH)
-endif(MYSQL_LIB)
-
-if (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
 	set(MYSQL_FOUND TRUE)
-	message(STATUS "MySQL Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
+	message(STATUS "Found MySQL Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
 	include_directories(${MYSQL_INCLUDE_DIR})
 	link_directories(${MYSQL_LIB_DIR})
-else (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
-	message(STATUS "Couldn't find MySQL")
-endif (MYSQL_INCLUDE_DIR AND MYSQL_LIB_DIR)
+elseif((MARIADB_INCLUDE_DIR OR MYSQL_INCLUDE_DIR) AND MARIADB_LIB)
+	get_filename_component(MYSQL_LIB_DIR ${MARIADB_LIB} PATH)
+	set(MYSQL_FOUND TRUE)
+	set(MYSQL_LIB ${MARIADB_LIB})
+	if(MARIADB_INCLUDE_DIR)
+	  set(MYSQL_INCLUDE_DIR ${MARIADB_INCLUDE_DIR})
+	endif(MARIADB_INCLUDE_DIR)
+	message(STATUS "Found MariaDB Include directory: ${MYSQL_INCLUDE_DIR}  library directory: ${MYSQL_LIB_DIR}")
+	message(STATUS "Use MariaDB for MySQL Support")
+	include_directories(${MYSQL_INCLUDE_DIR} )
+	link_directories(${MYSQL_LIB_DIR})
+else ((MARIADB_INCLUDE_DIR OR MYSQL_INCLUDE_DIR) AND MARIADB_LIB)
+	message(STATUS "Couldn't find MySQL or MariaDB")
+endif (MYSQL_INCLUDE_DIR AND MYSQL_LIB)


### PR DESCRIPTION
MariaDB support in cmake build system is already merged into develop (see #1971 and 178b1d605c40d6e4104fb3567ea9261b71b5471f) but I needed for the upcoming 1.8.0 as well.