### PR TITLE
Fix clang build error in poco 1.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,6 @@ else()
     endif()
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif()
-
-
 if(NOT MSVC_IDE)
   if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING

--- a/cmake/CXX1x.cmake
+++ b/cmake/CXX1x.cmake
@@ -22,12 +22,21 @@
 macro(check_for_cxx11_compiler _VAR)
     message(STATUS "Checking for C++11 compiler")
     set(${_VAR})
-    if((MSVC AND (MSVC10 OR MSVC11 OR MSVC12 OR MSVC14)) OR
+    try_compile(_COMPILER_TEST_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
+    if(NOT _COMPILER_TEST_RESULT AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      try_compile(_COMPILER_TEST_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
+      if(_COMPILER_TEST_RESULT)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+      else()
+	message(STATUS "To enable C++11 install libc++ standard library from https://libcxx.llvm.org/")
+      endif()
+    endif()
+    if(_COMPILER_TEST_RESULT AND ((MSVC AND (MSVC10 OR MSVC11 OR MSVC12 OR MSVC14)) OR
     (CMAKE_COMPILER_IS_GNUCXX AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.8.1) OR
     (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.3) OR
-    (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+    (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")))
         set(${_VAR} 1)
-        message(STATUS "Checking for C++11 compiler - available")
+	message(STATUS "Checking for C++11 compiler - available")
     else()
         message(STATUS "Checking for C++11 compiler - unavailable")
     endif()
@@ -44,10 +53,19 @@ endmacro()
 macro(check_for_cxx14_compiler _VAR)
     message(STATUS "Checking for C++14 compiler")
     set(${_VAR})
-    if((MSVC AND (MSVC14)) OR
+    try_compile(_COMPILER_TEST_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_STANDARD=14 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
+    if(NOT _COMPILER_TEST_RESULT AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      try_compile(_COMPILER_TEST_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_CXX_STANDARD=14 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
+      if(_COMPILER_TEST_RESULT)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+      else()
+	message(STATUS "To enable C++14 install libc++ standard library from https://libcxx.llvm.org/")
+      endif()
+    endif()
+    if(_COMPILER_TEST_RESULT AND ((MSVC AND (MSVC14)) OR
     (CMAKE_COMPILER_IS_GNUCXX AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.9.2) OR
     (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.4) OR
-    (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+    (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")))
         set(${_VAR} 1)
         message(STATUS "Checking for C++14 compiler - available")
     else()

--- a/cmake/test_compiler.cpp
+++ b/cmake/test_compiler.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <string>
+
+int main()
+{
+  std::string str = "Try to compile";
+  std::cout << str << '\n';
+  return 0;
+}


### PR DESCRIPTION
Try to fix clang build error in poco 1.8.0 to get rid off to set libc++ for clang. See also issue #1973 