### PR TITLE
Fix EVPTest on RHEL/Fedora by switching to different EC curve

### DIFF
--- a/Crypto/testsuite/src/EVPTest.cpp
+++ b/Crypto/testsuite/src/EVPTest.cpp
@@ -330,7 +330,7 @@ void EVPTest::testECEVPSaveLoadStream()
 			/*TODO: figure out why EVP_PKEY_cmp() fails for identical public keys
 			assert (key == key2);
 			assert (!(key != key2));*/
-			ECKey ecKeyNE("secp112r2");
+			ECKey ecKeyNE(curveName);
 			EVPPKey keyNE(&ecKeyNE);
 			assert (key != keyNE);
 			assert (!(key == keyNE));
@@ -386,7 +386,7 @@ void EVPTest::testECEVPSaveLoadStreamNoPass()
 			/*TODO: figure out why EVP_PKEY_cmp() fails for identical public keys
 			assert (key == key2);
 			assert (!(key != key2));*/
-			ECKey ecKeyNE("secp112r2");
+			ECKey ecKeyNE(curveName);
 			EVPPKey keyNE(&ecKeyNE);
 			assert (key != keyNE);
 			assert (!(key == keyNE));
@@ -444,7 +444,7 @@ void EVPTest::testECEVPSaveLoadFile()
 			/*TODO: figure out why EVP_PKEY_cmp() fails for identical public keys
 			assert (key == key2);
 			assert (!(key != key2));*/
-			ECKey ecKeyNE("secp112r2");
+			ECKey ecKeyNE(curveName);
 			EVPPKey keyNE(&ecKeyNE);
 			assert (key != keyNE);
 			assert (!(key == keyNE));


### PR DESCRIPTION
RHEL/Fedora seem to have a much more limited set of EC curves available by
default.  secp384p1 seems to be available on Fedora, RHEL6, and RHEL7.