### PR TITLE
Support templated array parameter syntax

### DIFF
--- a/Foundation/include/Poco/SharedPtr.h
+++ b/Foundation/include/Poco/SharedPtr.h
@@ -337,6 +337,45 @@ protected:
 	std::shared_ptr<C> _ptr;
 };
 
+/// Provide a simple way of using SharedPtr to dynamically allocate array.
+/// ex, SharedPtr<class_A[]> p(new class_A[10]);
+/// For non-promitive type it prevents from crash.
+template <class C>
+class SharedPtr<C[]>
+{
+public:
+	typedef C  element_type;
+	typedef C* pointer;
+
+	SharedPtr(C* ptr):
+		_uni_ptr(ptr), _ptr(std::move(_uni_ptr)), m_pT(ptr)
+	{
+	}
+
+	SharedPtr& assign(C* ptr)
+	{
+		_uni_ptr.reset(ptr);
+		_ptr = std::move(_uni_ptr);
+		m_pT = ptr;
+		return *this;
+	}
+
+	element_type& operator [] (size_t i) const
+	{
+		return m_pT[i];
+	}
+
+	~SharedPtr()
+	{
+	}
+
+protected:
+	/// do NOT change the order!
+	std::unique_ptr<C[]> _uni_ptr;
+	std::shared_ptr<C>   _ptr;
+
+	pointer m_pT;
+};
 
 template <class C>
 inline void swap(SharedPtr<C>& p1, SharedPtr<C>& p2)

--- a/Foundation/src/SharedMemory_POSIX.cpp
+++ b/Foundation/src/SharedMemory_POSIX.cpp
@@ -32,7 +32,7 @@ SharedMemoryImpl::SharedMemoryImpl(const std::string& name, std::size_t size, Sh
 	_access(mode),
 	_name("/"),
 	_fileMapped(false),
-	_server(server)
+	_server((mode == SharedMemory::AM_WRITE))
 {
 #if POCO_OS == POCO_OS_HPUX
 	_name.append("tmp/");
@@ -58,6 +58,17 @@ SharedMemoryImpl::SharedMemoryImpl(const std::string& name, std::size_t size, Sh
 		_fd = -1;
 		::shm_unlink(_name.c_str());
 		throw SystemException("Cannot resize shared memory object", _name);
+	} else {
+		struct stat buf;
+		if (fstat(_fd, &buf) == -1) {
+			::close(_fd);
+			_fd = -1;
+			::shm_unlink(_name.c_str());
+			throw SystemException("Cannot check file information", _name);
+		}
+		if (_size > buf.st_size) {
+			_size = buf.st_size;
+		}
 	}
 	map(addrHint);
 }


### PR DESCRIPTION
Although SharedPtr has become only a wrapper now, it sill stands there.

The removal of ReleasePolicy will bring up potential dangerous for people who are not familiar with the usage & history about SharedPtr.

For example, a simple program will make system crash.
```
{
    ....
    SharedPtr<myClass> p = new myClass[10];
    /// crash when p is out of the life scope.
}
```
As the result, here provides a small wrapper to use templated array parameter.
Ex, for the same logic above:
```
{
    ....
     /// declare by myClass[] to indicate it is an array.
    SharedPtr<myClass[]> p = new myClass[10];
    /// no crash
}
```
It provides SharedPtr<**T[]**> syntax to distinguish from original SharedPtr<**T**>.
It avoids the complex usage of deleter & provides a compromised way to support SharedPtr. 

Thanks
