### PR TITLE
Set pthread min stack size in android

### DIFF
--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -173,10 +173,8 @@ void ThreadImpl::setStackSizeImpl(int size)
 		const int STACK_PAGE_SIZE = 4096;
 		size = ((size + STACK_PAGE_SIZE - 1)/STACK_PAGE_SIZE)*STACK_PAGE_SIZE;
 #endif
-#if !defined(POCO_ANDROID)
  		if (size < PTHREAD_STACK_MIN)
  			size = PTHREAD_STACK_MIN;
-#endif
 	}
  	_pData->stackSize = size;
 #endif


### PR DESCRIPTION
Remove preprocessor if  not POCO_ANDROID to set minimum stack size in android.

This line was added on commit id:
c349742cf532d862c5d78bc74666171e56b2ca74

> Author Marian Krivos<nezmar@tutok.sk>
> Author date 23.08.11 09:12
> 
> trunk/branch integration: VxWorks & Wince

I didn't found why this preprocessor if not android is added.
This line breaks following foundation tests:
- testThreadPool: ERROR
- testThreadStackSize: FAILURE
- testTimer: FAILURE

See also pull request #1981 
