### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version
-        - ./configure --config=Linux32-gcc --everything --omit=PDF,Crypto,NetSSL_OpenSSL
+        - ./configure --config=Linux32-gcc --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    test="gcc 5.4 x64 (make) bundled"
@@ -155,7 +155,7 @@ matrix:
         - export CC="clang-4.0"
         - export CXX="clang++-4.0"
         - $CXX --version
-        - ./configure --config=Linux32-clang --everything --omit=PDF,Crypto,NetSSL_OpenSSL
+        - ./configure --config=Linux32-clang --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    test="clang 4.0 x64 (make) bundled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ notifications:
 env:
   global:
     TEST_NAME=""
+    POCO_VERBOSE=1
 
 before_script:
  - echo ${TEST_NAME}

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
         - export CXX="clang++"
         - $CXX --version
         - $CXX -x c++ /dev/null -dM -E
-        - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && export OSARCH=i386 && ./travis/OSX/runtests.sh
 
     - env:    test="clang x64 (make) bundled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         - $CXX --version
         - $CXX -x c++ /dev/null -dM -E
         - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
-        - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
+        - make -s -j2 && sudo make install && export OSARCH=i386 && ./travis/OSX/runtests.sh
 
     - env:    test="clang x64 (make) bundled"
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,22 @@ matrix:
         - ./configure --everything --omit=PDF 
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="gcc 5.4 (make) bundled"
+    - env:    test="gcc 5.4 x86 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version
-        - ./configure --everything --omit=PDF
+        - ./configure --config=Linux32-gcc --everything --omit=PDF
+        - make -s -j2 && ./travis/Linux/runtests.sh
+
+    - env:    test="gcc 5.4 amd64 (make) bundled"
+      compiler: gcc
+      script:
+        - export CC="gcc-5"
+        - export CXX="g++-5"
+        - $CXX --version
+        - ./configure --config=Linux64-gcc --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     #- env:    test="gcc 5.4 (make) unbundled"
@@ -133,7 +142,7 @@ matrix:
         - export CXX="clang++"
         - $CXX --version
         - $CXX -x c++ /dev/null -dM -E
-        - ./configure --config=Darwin32-clang --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
 
     - env:    test="clang amd64 (make) bundled"
@@ -144,7 +153,7 @@ matrix:
         - export CXX="clang++"
         - $CXX --version
         - $CXX -x c++ /dev/null -dM -E
-        - ./configure --config=Darwin64-clang --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - ./configure --config=Darwin64-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
 
@@ -167,7 +176,7 @@ matrix:
         - export CC="clang-4.0"
         - export CXX="clang++-4.0"
         - $CXX --version
-        - ./configure --config=Linux-clang --everything --omit=PDF
+        - ./configure --config=Linux64-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    test="clang 5.0 (make) bundled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,16 +85,6 @@ matrix:
         - ./configure --config=Darwin64-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
-    - env:    test="gcc 4.9 (make) bundled"
-      compiler: gcc
-      script:
-        - sudo apt-get install -qq -y gcc-4.9 g++-4.9
-        - export CC="gcc-4.9"
-        - export CXX="g++-4.9"
-        - $CXX --version
-        - ./configure --everything --omit=PDF 
-        - make -s -j2 && ./travis/Linux/runtests.sh
-
     - env:    test="gcc 5.4 x86 (make) bundled"
       compiler: gcc
       script:
@@ -102,7 +92,7 @@ matrix:
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version
-        - ./configure --config=Linux32-gcc --everything --omit=PDF
+        - ./configure --config=Linux32-gcc --everything --omit=PDF,Crypto,NetSSL_OpenSSL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    test="gcc 5.4 x64 (make) bundled"
@@ -165,7 +155,7 @@ matrix:
         - export CC="clang-4.0"
         - export CXX="clang++-4.0"
         - $CXX --version
-        - ./configure --config=Linux32-clang --everything --omit=PDF
+        - ./configure --config=Linux32-clang --everything --omit=PDF,Crypto,NetSSL_OpenSSL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     - env:    test="clang 4.0 x64 (make) bundled"

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
         - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
 
-    - env:    test="clang amd64 (make) bundled"
+    - env:    test="clang x64 (make) bundled"
       os: osx
       compiler: clang
       script:
@@ -98,7 +98,7 @@ matrix:
     - env:    test="gcc 5.4 x86 (make) bundled"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y lib32gcc-5.4-dev
+        - sudo apt-get install -qq -y g++-5-multilib
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,28 @@ matrix:
   fast_finish: true
 
   include:
+    - env:    test="clang x86 (make) bundled"
+      os: osx
+      compiler: clang
+      script:
+        - export CC="clang"
+        - export CXX="clang++"
+        - $CXX --version
+        - $CXX -x c++ /dev/null -dM -E
+        - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
+
+    - env:    test="clang amd64 (make) bundled"
+      os: osx
+      compiler: clang
+      script:
+        - export CC="clang"
+        - export CXX="clang++"
+        - $CXX --version
+        - $CXX -x c++ /dev/null -dM -E
+        - ./configure --config=Darwin64-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
+
     - env:    test="gcc 4.9 (make) bundled"
       compiler: gcc
       script:
@@ -76,13 +98,14 @@ matrix:
     - env:    test="gcc 5.4 x86 (make) bundled"
       compiler: gcc
       script:
+        - sudo apt-get install -qq -y lib32gcc-5.4-dev
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version
         - ./configure --config=Linux32-gcc --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="gcc 5.4 amd64 (make) bundled"
+    - env:    test="gcc 5.4 x64 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc-5"
@@ -134,29 +157,6 @@ matrix:
         - mkdir cmake-build && cd cmake-build && cmake  -DENABLE_PDF=OFF -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
  
 
-    - env:    test="clang x86 (make) bundled"
-      os: osx
-      compiler: clang
-      script:
-        - export CC="clang"
-        - export CXX="clang++"
-        - $CXX --version
-        - $CXX -x c++ /dev/null -dM -E
-        - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
-        - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
-
-    - env:    test="clang amd64 (make) bundled"
-      os: osx
-      compiler: clang
-      script:
-        - export CC="clang"
-        - export CXX="clang++"
-        - $CXX --version
-        - $CXX -x c++ /dev/null -dM -E
-        - ./configure --config=Darwin64-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
-        - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
-
-
     - env:    test="clang 4.0 x86 (make) bundled"
       compiler: clang
       script:
@@ -168,7 +168,7 @@ matrix:
         - ./configure --config=Linux32-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="clang 4.0 amd64 (make) bundled"
+    - env:    test="clang 4.0 x64 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
@@ -187,7 +187,7 @@ matrix:
         - export CC="clang-5.0"
         - export CXX="clang++-5.0"
         - $CXX --version
-        - ./configure --config=Linux-clang --everything --omit=PDF
+        - ./configure --config=Linux64-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
     #- env:    test="arm-linux-gnueabi-g++ (make)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ matrix:
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
+        - sudo apt-get install -qq -y g++-5-multilib
         - export CLANG_VERSTION="-4.0"
         - export CC="clang-4.0"
         - export CXX="clang++-4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ notifications:
 
 env:
   global:
-    TEST_NAME=""
+    test=""
     POCO_VERBOSE=1
 
 before_script:
- - echo ${TEST_NAME}
+ - echo ${test}
  - chmod 755 ./travis/Linux/runtests.sh
  - chmod 755 ./travis/OSX/runtests.sh
  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mysql -u root -e 'create database pocotestdb;'; fi
@@ -63,26 +63,26 @@ matrix:
   fast_finish: true
 
   include:
-    - env:    TEST_NAME="gcc 4.9 (make) bundled"
+    - env:    test="gcc 4.9 (make) bundled"
       compiler: gcc
       script:
         - sudo apt-get install -qq -y gcc-4.9 g++-4.9
         - export CC="gcc-4.9"
         - export CXX="g++-4.9"
         - $CXX --version
-        - ./configure --everything --omit=PDF && source config.make && cat build/config/$POCO_CONFIG 
+        - ./configure --everything --omit=PDF 
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    TEST_NAME="gcc 5.4 (make) bundled"
+    - env:    test="gcc 5.4 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc-5"
         - export CXX="g++-5"
         - $CXX --version
-        - ./configure --everything --omit=PDF && source config.make && cat build/config/$POCO_CONFIG 
+        - ./configure --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    #- env:    TEST_NAME="gcc 5.4 (make) unbundled"
+    #- env:    test="gcc 5.4 (make) unbundled"
     #  ======================================= unit tests fail ures due to unbundled pcre
     # There was 1 error:
     #  1: N7CppUnit10TestCallerI21RegularExpressionTestEE.testSubst2
@@ -113,7 +113,7 @@ matrix:
     #    - $CXX --version
     #    - ./configure --everything --omit=PDF --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
     
-    - env:    TEST_NAME="gcc 4.9 (CMake)"
+    - env:    test="gcc 4.9 (CMake)"
       compiler: gcc
       script:
         - sudo apt-get install -qq -y gcc-4.9 g++-4.9
@@ -125,7 +125,7 @@ matrix:
         - mkdir cmake-build && cd cmake-build && cmake  -DENABLE_PDF=OFF -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
  
 
-    - env:    TEST_NAME="clang (make) bundled"
+    - env:    test="clang x86 (make) bundled"
       os: osx
       compiler: clang
       script:
@@ -133,10 +133,22 @@ matrix:
         - export CXX="clang++"
         - $CXX --version
         - $CXX -x c++ /dev/null -dM -E
-        - ./configure --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL && source config.make && cat build/config/$POCO_CONFIG 
+        - ./configure --config=Darwin32-clang --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
+        - make -s -j2 && sudo make install && export OSARCH=x86 && ./travis/OSX/runtests.sh
+
+    - env:    test="clang amd64 (make) bundled"
+      os: osx
+      compiler: clang
+      script:
+        - export CC="clang"
+        - export CXX="clang++"
+        - $CXX --version
+        - $CXX -x c++ /dev/null -dM -E
+        - ./configure --config=Darwin64-clang --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
-    - env:    TEST_NAME="clang 4.0 (make) bundled"
+
+    - env:    test="clang 4.0 x86 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
@@ -144,10 +156,21 @@ matrix:
         - export CC="clang-4.0"
         - export CXX="clang++-4.0"
         - $CXX --version
-        - ./configure --config=Linux-clang --everything --omit=PDF && source config.make && cat build/config/$POCO_CONFIG 
+        - ./configure --config=Linux32-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    TEST_NAME="clang 5.0 (make) bundled"
+    - env:    test="clang 4.0 amd64 (make) bundled"
+      compiler: clang
+      script:
+        - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
+        - export CLANG_VERSTION="-4.0"
+        - export CC="clang-4.0"
+        - export CXX="clang++-4.0"
+        - $CXX --version
+        - ./configure --config=Linux-clang --everything --omit=PDF
+        - make -s -j2 && ./travis/Linux/runtests.sh
+
+    - env:    test="clang 5.0 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-5.0 lldb-5.0 libc++-dev libc++abi-dev
@@ -155,23 +178,10 @@ matrix:
         - export CC="clang-5.0"
         - export CXX="clang++-5.0"
         - $CXX --version
-        - ./configure --config=Linux-clang --everything --omit=PDF && source config.make && cat build/config/$POCO_CONFIG 
+        - ./configure --config=Linux-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    #- env:    TEST_NAME="clang 3.5.0 (make) unbundled"
-    #  ======================================= compiler error on generating debug info for auto return
-    # error: debug information for auto is not yet supported
-    # error: debug information for auto is not yet supported
-    # ** Creating dependency info for src/Timespan.cpp
-    # make[1]: *** [/home/travis/build/Kampbell/poco/CppUnit/obj/Linux/x86_64/debug_shared/TestRunner.o] Error 1   #  compiler: clang
-    #  =======================================
-    #  script:
-    #    - export CC="clang"
-    #    - export CXX="clang++"
-    #    - $CXX --version
-    #    - ./configure --config=Linux-clang --everything --omit=PDF --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
-    
-    #- env:    TEST_NAME="arm-linux-gnueabi-g++ (make)"
+    #- env:    test="arm-linux-gnueabi-g++ (make)"
     #  compiler: gcc
     #  script:
     #    - sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf
@@ -179,14 +189,14 @@ matrix:
     #    - arm-linux-gnueabi-g++ -x c++ /dev/null -dM -E
     #    - ./configure --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL,Crypto,NetSSL,PageCompiler && make -s -j2  CROSS_COMPILE=arm-linux-gnueabi- POCO_TARGET_OSARCH=armv7l
 
-    #- env:    TEST_NAME="clang (CMake)"
+    #- env:    test="clang (CMake)"
     #  compiler: clang
     #  script:
     #    - source ./travis/ignored.sh
     #    - export POCO_BASE=`pwd`
     #    - mkdir cmake-build && cd cmake-build && cmake  -DENABLE_PDF=OFF -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
 
-    #- env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
+    #- env:    test="arm-linux-gnueabi-g++ (CMake)"
     #  ======================================= "arm-linux-gnueabi-g++: version 4.7.0: non compliant to c++11
     #  compiler: gcc
     #  script:
@@ -199,7 +209,7 @@ matrix:
     #    - mkdir cmake-build 
     #    - cd cmake-build && cmake  -DENABLE_PDF=OFF -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -s -j2 && cd ..
 
-    - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
+    - env:    test="arm-linux-gnueabihf-g++ (CMake)"
       compiler: gcc
       script:
         - sudo apt-get install -qq -y g++-arm-linux-gnueabi g++-arm-linux-gnueabihf
@@ -214,24 +224,24 @@ matrix:
 
     # QA jobs for code analytics and metrics
     # build documentation and release
-    - env:    TEST_NAME="documentation & release"
+    - env:    test="documentation & release"
       compiler: gcc
       script:
         - $CXX --version
         - . env.sh && mkdoc all && mkrel all
 
     # static code analysis with cppcheck (we can add --enable=all later)
-    - env:    TEST_NAME="cppcheck"
+    - env:    test="cppcheck"
       script: cppcheck --force --quiet --inline-suppr -j2 -iData/SQLite/src/sqlite3.c .
     # search for TODO within source tree
-    - env:    TEST_NAME="TODO"
+    - env:    test="TODO"
       script: grep -r TODO *
     # search for FIXME within source tree
-    - env:    TEST_NAME="FIXME"
+    - env:    test="FIXME"
       script: grep -r FIXME *
     # search for HACK within source tree
-    - env:    TEST_NAME="HACK"
+    - env:    test="HACK"
       script: grep -r HACK *
     # some statistics about the code base
-    - env:    TEST_NAME="sloccount"
+    - env:    test="sloccount"
       script: sloccount .

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
   fast_finish: true
 
   include:
-    - env:    test="clang x86 (make) bundled"
+    - env:    test="x86 (make) bundled"
       os: osx
       compiler: clang
       script:
@@ -74,7 +74,7 @@ matrix:
         - ./configure --config=Darwin32-clang-libc++ --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && export OSARCH=i386 && ./travis/OSX/runtests.sh
 
-    - env:    test="clang x64 (make) bundled"
+    - env:    test="x64 (make) bundled"
       os: osx
       compiler: clang
       script:
@@ -85,7 +85,7 @@ matrix:
         - ./configure --config=Darwin64-clang-libc++ --everything --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && sudo make install && ./travis/OSX/runtests.sh
 
-    - env:    test="gcc 5.4 x86 (make) bundled"
+    - env:    test="5.4 x86 (make) bundled"
       compiler: gcc
       script:
         - sudo apt-get install -qq -y g++-5-multilib
@@ -95,7 +95,7 @@ matrix:
         - ./configure --config=Linux32-gcc --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="gcc 5.4 x64 (make) bundled"
+    - env:    test="5.4 x64 (make) bundled"
       compiler: gcc
       script:
         - export CC="gcc-5"
@@ -104,7 +104,7 @@ matrix:
         - ./configure --config=Linux64-gcc --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    #- env:    test="gcc 5.4 (make) unbundled"
+    #- env:    test="5.4 (make) unbundled"
     #  ======================================= unit tests fail ures due to unbundled pcre
     # There was 1 error:
     #  1: N7CppUnit10TestCallerI21RegularExpressionTestEE.testSubst2
@@ -135,7 +135,7 @@ matrix:
     #    - $CXX --version
     #    - ./configure --everything --omit=PDF --unbundled && make -s -j2 && ./travis/Linux/runtests.sh
     
-    - env:    test="gcc 4.9 (CMake)"
+    - env:    test="4.9 x64 (CMake)"
       compiler: gcc
       script:
         - sudo apt-get install -qq -y gcc-4.9 g++-4.9
@@ -147,7 +147,7 @@ matrix:
         - mkdir cmake-build && cd cmake-build && cmake  -DENABLE_PDF=OFF -DENABLE_TESTS=ON .. && make -s -j2 && ctest -VV -E Data && cd ..
  
 
-    - env:    test="clang 4.0 x86 (make) bundled"
+    - env:    test="4.0 x86 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
@@ -159,7 +159,7 @@ matrix:
         - ./configure --config=Linux32-clang --everything --omit=PDF,Crypto,NetSSL_OpenSSL,Data/ODBC,Data/MySQL,Data/PostgreSQL
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="clang 4.0 x64 (make) bundled"
+    - env:    test="4.0 x64 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-4.0 lldb-4.0 libc++-dev libc++abi-dev
@@ -170,7 +170,7 @@ matrix:
         - ./configure --config=Linux64-clang --everything --omit=PDF
         - make -s -j2 && ./travis/Linux/runtests.sh
 
-    - env:    test="clang 5.0 (make) bundled"
+    - env:    test="5.0 x64 (make) bundled"
       compiler: clang
       script:
         - sudo apt-get install -qq -y clang-5.0 lldb-5.0 libc++-dev libc++abi-dev
@@ -189,7 +189,7 @@ matrix:
     #    - arm-linux-gnueabi-g++ -x c++ /dev/null -dM -E
     #    - ./configure --omit=PDF,Data/ODBC,Data/MySQL,Data/PostgreSQL,Crypto,NetSSL,PageCompiler && make -s -j2  CROSS_COMPILE=arm-linux-gnueabi- POCO_TARGET_OSARCH=armv7l
 
-    #- env:    test="clang (CMake)"
+    #- env:    test="(CMake)"
     #  compiler: clang
     #  script:
     #    - source ./travis/ignored.sh

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,9 @@ ifndef POCO_BASE
 $(warning WARNING: POCO_BASE is not defined. Assuming current directory.)
 export POCO_BASE=$(shell pwd)
 endif
-ifdef POCO_VERBOSE
-$(info POCO_BASE           = $(POCO_BASE))
-endif
 
 ifndef POCO_BUILD
 export POCO_BUILD=$(POCO_BASE)
-endif
-ifdef POCO_VERBOSE
-$(info POCO_BUILD          = $(POCO_BUILD))
 endif
 
 #
@@ -41,9 +35,6 @@ POCO_HOST_OSARCH ?= $(subst /,-,$(shell uname -m | tr ' ' _))
 ifndef POCO_CONFIG
 POCO_CONFIG = $(POCO_HOST_OSNAME)
 endif
-ifdef POCO_VERBOSE
-$(info POCO_CONFIG         = $(POCO_CONFIG))
-endif
 
 #
 # Include System Specific Settings
@@ -58,17 +49,11 @@ OSNAME   := $(POCO_HOST_OSNAME)
 else
 OSNAME   := $(POCO_TARGET_OSNAME)
 endif
-ifdef POCO_VERBOSE
-$(info OSNAME              = $(OSNAME))
-endif
 
 ifndef POCO_TARGET_OSARCH
 OSARCH   := $(POCO_HOST_OSARCH)
 else
 OSARCH   := $(POCO_TARGET_OSARCH)
-endif
-ifdef POCO_VERBOSE
-$(info OSARCH              = $(OSARCH))
 endif
 
 .PHONY: poco all libexecs cppunit tests samples cleans clean distclean install uninstall
@@ -81,7 +66,7 @@ INSTALLDIR = $(DESTDIR)$(POCO_PREFIX)
 
 COMPONENTS =  CppUnit Foundation XML JSON Util Net Crypto NetSSL_OpenSSL
 COMPONENTS += Data Data/ODBC Data/SQLite Data/MySQL Data/PostgreSQL
-COMPONENTS += MongoDB Redis Zip PageCompiler PageCompiler/File2Page CppParser PDF
+COMPONENTS += MongoDB Redis Zip PageCompiler PageCompiler/File2Page CppParser 
 
 cppunit:
 	$(MAKE) -C $(POCO_BASE)/CppUnit
@@ -121,22 +106,22 @@ endif
 # -------------------------------------------------------------------------------------------------------------------------------------
 libexecs =  Foundation-libexec XML-libexec JSON-libexec Util-libexec Net-libexec Crypto-libexec NetSSL_OpenSSL-libexec
 libexecs += Data-libexec  Data/ODBC-libexec Data/SQLite-libexec Data/MySQL-libexec Data/PostgreSQL-libexec
-libexecs += MongoDB-libexec Redis-libexec Zip-libexec PageCompiler-libexec PageCompiler/File2Page-libexec CppParser-libexec PDF-libexec
+libexecs += MongoDB-libexec Redis-libexec Zip-libexec PageCompiler-libexec PageCompiler/File2Page-libexec CppParser-libexec 
 
 # -------------------------------------------------------------------------------------------------------------------------------------
 tests    =  Foundation-tests XML-tests JSON-tests Util-tests Net-tests Crypto-tests NetSSL_OpenSSL-tests
 tests    += Data-tests Data/ODBC-tests  Data/SQLite-tests Data/MySQL-tests Data/PostgreSQL-tests
-tests	 += MongoDB-tests Redis-tests Zip-tests CppParser-tests PDF-tests
+tests	 += MongoDB-tests Redis-tests Zip-tests CppParser-tests 
 
 # -------------------------------------------------------------------------------------------------------------------------------------
 samples  =  Foundation-samples XML-samples JSON-samples Util-samples Net-samples Crypto-samples NetSSL_OpenSSL-samples
 samples  += Data-samples
-samples  += MongoDB-samples Zip-samples PageCompiler-samples PDF-samples
+samples  += MongoDB-samples Zip-samples PageCompiler-samples 
 
 # -------------------------------------------------------------------------------------------------------------------------------------
 cleans   =  Foundation-clean XML-clean JSON-clean Util-clean Net-clean Crypto-clean NetSSL_OpenSSL-clean
 cleans   += Data-clean Data/ODBC-clean Data/SQLite-clean Data/MySQL-clean Data/PostgreSQL-clean
-cleans	 += MongoDB-clean Redis-clean Zip-clean PageCompiler-clean PageCompiler/File2Page-clean CppParser-clean PDF-clean
+cleans	 += MongoDB-clean Redis-clean Zip-clean PageCompiler-clean PageCompiler/File2Page-clean CppParser-clean 
 
 # -------------------------------------------------------------------------------------------------------------------------------------
 .PHONY: $(libexecs)

--- a/build/config/Linux-clang
+++ b/build/config/Linux-clang
@@ -71,6 +71,19 @@ SYSFLAGS = -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=6
 SYSLIBS  += -lpthread -ldl -lrt
 
 #
+# Auto-detect architecture if not specified
+#
+ifndef OSARCH_64BITS
+  LBITS := $(shell getconf LONG_BIT)
+  ifeq ($(LBITS),64)
+    OSARCH_64BITS = 1
+  else
+    OSARCH_64BITS = 0
+  endif
+endif
+
+#
+#
 # C++11/14 detection
 #
 include $(POCO_BASE)/build/script/cpp11-clang

--- a/build/config/Linux32-clang
+++ b/build/config/Linux32-clang
@@ -1,0 +1,23 @@
+#
+# Linux
+#
+# Make settings for crossbuilding Poco Linux x86 on a Linux x86_64 OS.
+#
+#
+
+include $(POCO_BASE)/build/config/Linux-clang
+
+#
+# Crossbuild Settings
+#
+POCO_TARGET_OSNAME  = Linux
+POCO_TARGET_OSARCH  = x86
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS64        += --target=i386-pc-linux
+CXXFLAGS64      += --target=i386-pc-linux
+SHLIBFLAGS64    += --target=i386-pc-linux
+LINKFLAGS64     += --target=i386-pc-linux
+

--- a/build/config/Linux64-clang
+++ b/build/config/Linux64-clang
@@ -1,0 +1,89 @@
+#
+# $Id$
+#
+# Linux
+#
+# Make settings for Linux/clang
+#
+#
+
+#
+# General Settings
+#
+LINKMODE ?= SHARED
+
+#
+# Define Tools
+#
+CC     ?= clang
+CXX    ?= clang++
+LINK    = $(CXX)
+LIB     = ${CROSS_COMPILE}ar -cr
+RANLIB  = ${CROSS_COMPILE}ranlib
+SHLIB   = $(CXX) -shared -Wl,-soname,$(notdir $@) -o $@
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   = ${CROSS_COMPILE}strip
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .so.$(target_version)
+SHAREDLIBLINKEXT = .so
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          =
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = -Wall -Wno-sign-compare -stdlib=libstdc++ -ftemplate-depth=340
+CXXFLAGS32      =
+CXXFLAGS64      =
+LINKFLAGS       =
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  = -static
+SHAREDOPT_CC    = -fPIC
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = -Wl,-rpath,$(LIBPATH)
+DEBUGOPT_CC     = -D_DEBUG
+DEBUGOPT_CXX    = -D_DEBUG
+DEBUGOPT_LINK   =
+RELEASEOPT_CC   = -O2 -DNDEBUG
+RELEASEOPT_CXX  = -O2 -DNDEBUG
+RELEASEOPT_LINK = -O2
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DPOCO_HAVE_FD_EPOLL -DPOCO_HAVE_ADDRINFO -DPOCO_HAVE_LIBRESOLV
+
+#
+# System Specific Libraries
+#
+SYSLIBS  += -lpthread -ldl -lrt
+
+#
+# Auto-detect architecture if not specified
+#
+ifndef OSARCH_64BITS
+  LBITS := $(shell getconf LONG_BIT)
+  ifeq ($(LBITS),64)
+    OSARCH_64BITS = 1
+  else
+    OSARCH_64BITS = 0
+  endif
+endif
+
+#
+#
+# C++11/14 detection
+#
+include $(POCO_BASE)/build/script/cpp11-clang

--- a/build/config/Linux64-gcc
+++ b/build/config/Linux64-gcc
@@ -1,0 +1,100 @@
+#
+# Linux
+#
+# Make settings for Linux 2.6/gcc 3.3
+#
+#
+
+#
+# General Settings
+#
+LINKMODE ?= SHARED
+
+#
+# Define Tools
+#
+ifeq ($(origin CROSS_COMPILE), undefined)
+	CC	    ?=gcc
+	CXX	    ?=g++
+	LIB     = ar -cr
+	RANLIB  = ranlib
+	STRIP   = strip
+else
+	CC      = ${CROSS_COMPILE}gcc
+	CXX     = ${CROSS_COMPILE}g++
+	LIB     = ${CROSS_COMPILE}ar -cr
+	RANLIB  = ${CROSS_COMPILE}ranlib
+	STRIP   = ${CROSS_COMPILE}strip
+endif
+LINK    = $(CXX)
+SHLIB   = $(CXX) -shared -Wl,-soname,$(notdir $@) -o $@
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .so.$(target_version)
+SHAREDLIBLINKEXT = .so
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          = -std=c99
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = -Wall -Wno-sign-compare
+CXXFLAGS32      =
+CXXFLAGS64      =
+SHLIBFLAGS      =
+SHLIBFLAGS32    =
+SHLIBFLAGS64    =
+LIBFLAGS        =
+LIBFLAGS32      =
+LIBFLAGS64      =
+LINKFLAGS       =
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  =
+SHAREDOPT_CC    = -fPIC
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = -Wl,-rpath,$(LIBPATH)
+DEBUGOPT_CC     = -g -D_DEBUG
+DEBUGOPT_CXX    = -g -D_DEBUG
+DEBUGOPT_LINK   = -g
+RELEASEOPT_CC   = -O2 -DNDEBUG
+RELEASEOPT_CXX  = -O2 -DNDEBUG
+RELEASEOPT_LINK = -O2
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -D_XOPEN_SOURCE=600 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DPOCO_HAVE_FD_EPOLL -DPOCO_HAVE_ADDRINFO -DPOCO_HAVE_LIBRESOLV
+
+#
+# System Specific Libraries
+#
+SYSLIBS  = -lrt -lpthread -ldl
+
+#
+# Auto-detect architecture if not specified
+#
+ifndef OSARCH_64BITS
+  LBITS := $(shell getconf LONG_BIT)
+  ifeq ($(LBITS),64)
+    OSARCH_64BITS = 1
+  else
+    OSARCH_64BITS = 0
+  endif
+endif
+
+#
+# C++11/14 detection
+#
+include $(POCO_BASE)/build/script/cpp11-gcc

--- a/build/rules/global
+++ b/build/rules/global
@@ -32,9 +32,6 @@ ifndef PROJECT_BASE
 PROJECT_BASE = $(POCO_BASE)
 endif
 export PROJECT_BASE
-ifdef POCO_VERBOSE
-$(info PROJECT_BASE        = $(PROJECT_BASE))
-endif
 
 #
 # Check for POCO_BUILD
@@ -43,9 +40,6 @@ ifndef POCO_BUILD
 POCO_BUILD = $(PROJECT_BASE)
 endif
 export POCO_BUILD
-ifdef POCO_VERBOSE
-$(info POCO_BUILD          = $(POCO_BUILD))
-endif
 
 #
 # POCO_BASE/POCO_BUILD/cwd sanity checks
@@ -81,14 +75,8 @@ endif
 ifeq ($(findstring MINGW,$(POCO_HOST_OSNAME)),MINGW)
 POCO_HOST_OSNAME = MinGW
 endif
-ifdef POCO_VERBOSE
-$(info POCO_HOST_OSNAME    = $(POCO_HOST_OSNAME))
-endif
 
 POCO_HOST_OSARCH ?= $(subst /,-,$(shell uname -m | tr ' ' _))
-ifdef POCO_VERBOSE
-$(info POCO_HOST_OSARCH    = $(POCO_HOST_OSARCH))
-endif
 
 #
 # Begin Sun platforms
@@ -124,9 +112,6 @@ endif
 ifndef POCO_CONFIG
 POCO_CONFIG = $(POCO_HOST_OSNAME)
 endif
-ifdef POCO_VERBOSE
-$(info POCO_CONFIG         = $(POCO_CONFIG))
-endif
 
 #
 # Include System Specific Settings
@@ -141,17 +126,11 @@ OSNAME   := $(POCO_HOST_OSNAME)
 else
 OSNAME   := $(POCO_TARGET_OSNAME)
 endif
-ifdef POCO_VERBOSE
-$(info OSNAME              = $(OSNAME))
-endif
 
 ifndef POCO_TARGET_OSARCH
 OSARCH   := $(subst /,-,$(shell uname -m | tr ' ' _))
 else
 OSARCH   := $(POCO_TARGET_OSARCH)
-endif
-ifdef POCO_VERBOSE
-$(info OSARCH              = $(OSARCH))
 endif
 
 HOSTNAME := $(shell hostname)
@@ -221,9 +200,6 @@ ifdef POCO_PREFIX
 POCO_LIB_INSTALLDIR = $(POCO_PREFIX)/lib
 else
 POCO_LIB_INSTALLDIR = $(LIBPATH)
-endif
-ifdef POCO_VERBOSE
-$(info POCO_LIB_INSTALLDIR = $(POCO_LIB_INSTALLDIR))
 endif
 
 ifeq ($(POCO_BASE),$(PROJECT_BASE))
@@ -332,3 +308,5 @@ export CC
 export CXX
 export LINK
 
+
+include $(POCO_BASE)/build/rules/verbose

--- a/build/rules/verbose
+++ b/build/rules/verbose
@@ -1,0 +1,17 @@
+ifdef POCO_VERBOSE
+$(info ----------------------------------------------------)
+$(info CXX                  = $(CXX))
+$(info CXXVERSION           = $(CXXVERSION))
+$(info CXXFLAGS             = $(CXXFLAGS))
+$(info ----------------------------------------------------)
+$(info POCO_BASE            = $(POCO_BASE))
+$(info POCO_BUILD           = $(POCO_BUILD))
+$(info POCO_CONFIG          = $(POCO_CONFIG))
+$(info POCO_HOST_OSNAME     = $(POCO_HOST_OSNAME))
+$(info POCO_HOST_OSARCH     = $(POCO_HOST_OSARCH))
+$(info OSNAME               = $(OSNAME))
+$(info OSARCH               = $(OSARCH))
+$(info POCO_LIB_INSTALLDIR  = $(POCO_LIB_INSTALLDIR))
+$(info ----------------------------------------------------)
+endif
+

--- a/build/script/cpp11-appleclang
+++ b/build/script/cpp11-appleclang
@@ -5,12 +5,12 @@
 # Detect compatible AppleClang version and add c++11/14 flags
 #
 
-CLANGVERSION   := $(shell $(CXX) -E -dM - < /dev/null | grep __apple_build_version__ | sed -e 's/^.* //g')
+CXXVERSION   := $(shell $(CXX) -E -dM - < /dev/null | grep __apple_build_version__ | sed -e 's/^.* //g')
 
 # C++14 needs AppleClang 500.x
-ifeq ($(shell test $(CLANGVERSION) -ge 5000275 && echo 1), 1)
+ifeq ($(shell test $(CXXVERSION) -ge 5000275 && echo 1), 1)
 	CXXFLAGS += -std=c++1y
 # C++11 needs AppleClang 503.x
-else ifeq ($(shell test $(CLANGVERSION) -ge 5030038 && echo 1), 1)
+else ifeq ($(shell test $(CXXVERSION) -ge 5030038 && echo 1), 1)
 	CXXFLAGS += -std=c++0x
 endif

--- a/build/script/cpp11-clang
+++ b/build/script/cpp11-clang
@@ -5,20 +5,20 @@
 # Detect compatible Clang version and add c++11/14 flags
 #
 
-CLANGMAJOR   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_major__ | sed -e 's/^.* //g')
-CLANGMINOR   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_minor__ | sed -e 's/^.* //g')
-CLANGPATCH   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_patchlevel__ | sed -e 's/^.* //g')
-CLANGVERSION := $(CLANGMAJOR)$(CLANGMINOR)$(CLANGPATCH)
+CXXMAJOR   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_major__ | sed -e 's/^.* //g')
+CXXMINOR   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_minor__ | sed -e 's/^.* //g')
+CXXPATCH   := $(shell $(CXX) -x c++ /dev/null -dM -E | grep __clang_patchlevel__ | sed -e 's/^.* //g')
+CXXVERSION := $(CXXMAJOR)$(CXXMINOR)$(CXXPATCH)
 
 #
 # Clang 3.4 doesn't accept -std=c++14, only -std=c++1y.
 #
 
 # C++14 needs Clang 3.4
-ifeq ($(shell test $(CLANGVERSION) -ge 340 && echo 1), 1)
+ifeq ($(shell test $(CXXVERSION) -ge 340 && echo 1), 1)
 	CXXFLAGS += -std=c++1y
 # C++11 needs Clang 3.3
-else ifeq ($(shell test $(CLANGVERSION) -ge 330 && echo 1), 1)
+else ifeq ($(shell test $(CXXVERSION) -ge 330 && echo 1), 1)
 	CXXFLAGS += -std=c++0x
 endif
 

--- a/build/script/cpp11-gcc
+++ b/build/script/cpp11-gcc
@@ -5,12 +5,12 @@
 # Detect compatible GCC version and add c++11/14 flags
 #
 # From the online doc
-# __GNUC__
-# __GNUC_MINOR__
-# __GNUC_PATCHLEVEL__
-# These macros are defined by all GNU compilers that use the C preprocessor: C, C++, Objective-C and Fortran.
+# __CXXC__
+# __CXXC_MINOR__
+# __CXXC_PATCHLEVEL__
+# These macros are defined by all CXX compilers that use the C preprocessor: C, C++, Objective-C and Fortran.
 # Their values are the major version, minor version, and patch level of the compiler, as integer constants.
-# For example, GCC 3.2.1 will define __GNUC__ to 3, __GNUC_MINOR__ to 2, and __GNUC_PATCHLEVEL__ to 1. i
+# For example, GCC 3.2.1 will define __CXXC__ to 3, __CXXC_MINOR__ to 2, and __CXXC_PATCHLEVEL__ to 1. i
 # These macros are also defined if you invoke the preprocessor directly.
 #
 # __VERSION__
@@ -20,20 +20,20 @@
 #
 
 
-GNUMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.* //g')
-GNUMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g')
-GNUPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g')
-GCCVERSION := $(GNUMAJOR)$(GNUMINOR)$(GNUPATCH)
+CXXMAJOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC__ | sed -e 's/^.* //g')
+CXXMINOR   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_MINOR__ | sed -e 's/^.* //g')
+CXXPATCH   := $(shell $(CXX) -E -dM - < /dev/null | grep __GNUC_PATCHLEVEL__ | sed -e 's/^.* //g')
+CXXVERSION := $(CXXMAJOR)$(CXXMINOR)$(CXXPATCH)
 
 
 #
 # GCC 4.8 (or 4.6?) doesn't accept -std=c++11, only -std=c++0x.
 #
 # C++14 needs GCC 4.9.2
-ifeq ($(shell test $(GCCVERSION) -ge 492 && echo 1), 1)
+ifeq ($(shell test $(CXXVERSION) -ge 492 && echo 1), 1)
 	CXXFLAGS += -std=c++14
 # C++11 needs GCC 4.8.1
-else ifeq ($(shell test $(GCCVERSION) -ge 481 && echo 1), 1)
+else ifeq ($(shell test $(CXXVERSION) -ge 481 && echo 1), 1)
 	CXXFLAGS += -std=c++11
 else
 	CXXFLAGS += -std=c++03

--- a/travis/OSX/ignored.sh
+++ b/travis/OSX/ignored.sh
@@ -13,5 +13,9 @@ export CPPUNIT_IGNORE="\
   N7CppUnit10TestCallerI8FileTestEE.testFileAttributes2, \
   N7CppUnit10TestCallerI9TimerTestEE.testTimer, \
   N7CppUnit10TestCallerI9TimerTestEE.testScheduleAtFixedRate, \
+  N7CppUnit10TestCallerI9TimerTestEE.testScheduleInterval, \
+  N7CppUnit10TestCallerI9TimerTestEE.testScheduleIntervalTimestamp, \
+  N7CppUnit10TestCallerI9TimerTestEE.testScheduleIntervalClock, \
+ 
   "
 

--- a/travis/OSX/ignored.sh
+++ b/travis/OSX/ignored.sh
@@ -1,0 +1,17 @@
+export CPPUNIT_IGNORE="\
+  N7CppUnit10TestCallerI8PathTestEE.testExpand, \
+  N7CppUnit10TestCallerI13RawSocketTestEE.testEchoIPv4, \
+  N7CppUnit10TestCallerI13RawSocketTestEE.testSendToReceiveFromIPv4, \
+  N7CppUnit10TestCallerI14ICMPClientTestEE.testPing, \
+  N7CppUnit10TestCallerI14ICMPClientTestEE.testBigPing, \
+  N7CppUnit10TestCallerI22HTTPSClientSessionTestEE.testProxy, \
+  N7CppUnit10TestCallerI22HTTPSStreamFactoryTestEE.testProxy, \
+  N7CppUnit10TestCallerI19MulticastSocketTestEE.testMulticast, \
+  N7CppUnit10TestCallerI13NTPClientTestEE.testTimeSync, \
+  N7CppUnit10TestCallerI9TimerTestEE.testTimer, \
+  N7CppUnit10TestCallerI15FileChannelTestEE.testPurgeAge, \
+  N7CppUnit10TestCallerI8FileTestEE.testFileAttributes2, \
+  N7CppUnit10TestCallerI9TimerTestEE.testTimer, \
+  N7CppUnit10TestCallerI9TimerTestEE.testScheduleAtFixedRate, \
+  "
+

--- a/travis/OSX/ignored.sh
+++ b/travis/OSX/ignored.sh
@@ -16,6 +16,6 @@ export CPPUNIT_IGNORE="\
   N7CppUnit10TestCallerI9TimerTestEE.testScheduleInterval, \
   N7CppUnit10TestCallerI9TimerTestEE.testScheduleIntervalTimestamp, \
   N7CppUnit10TestCallerI9TimerTestEE.testScheduleIntervalClock, \
- 
+  N7CppUnit10TestCallerI10ThreadTestEE.testSleep, \
   "
 

--- a/travis/OSX/runtests.sh
+++ b/travis/OSX/runtests.sh
@@ -3,7 +3,7 @@ set -ev
 export POCO_BASE=`pwd`
 export PATH=$PATH:.
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
-source ./travis/ignored.sh
+source ./travis/OSX/ignored.sh
 source ./travis/OSX/excluded.sh
 build/script/runtests.sh
 


### PR DESCRIPTION
Hi

This PR updates the Travis CI jobs by adding the cross compilation toward x86 arch on ax86_64 host. Both clang and gcc are involved int those new jobs. Also POCO_VERBOSE is on so that the major variables of the build are displayed in the log. New variable to disply can be added in the new file build/rules/verbose.