### PR TITLE
Fix building POCO::JSON under MinGW

### DIFF
--- a/JSON/src/pd_json.c
+++ b/JSON/src/pd_json.c
@@ -17,7 +17,7 @@
 
 #define STACK_INC 4
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define strerror_r(err, buf, len) strerror_s(buf, len, err)
 #endif
 


### PR DESCRIPTION
`strerror_r` is not available when compiling with `mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1`
re-apply "fix" for MSVS compiler for MinGW as well