### PR TITLE
Fix making POCO for MinGW - add message compiler

### DIFF
--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -11,7 +11,7 @@
 #  CMAKE_MC_COMPILER - where to find mc.exe
 if (WIN32)
   # cmake has CMAKE_RC_COMPILER, but no message compiler
-  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" OR "${CMAKE_GENERATOR}" MATCHES "MinGW")
     # this path is only present for 2008+, but we currently require PATH to
     # be set up anyway
     get_filename_component(sdk_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]" REALPATH)


### PR DESCRIPTION
When making targets for `mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1`
MinGW needs `message compiler` (`mc.exe`) from Windows Kits, just like MSVS does;

CMake Log:
```
-- Checking for C++14 compiler - available
CMake Error at third_party/poco/cmake/PocoMacros.cmake:45 (message):
  message compiler not found: required to build
Call Stack (most recent call first):
  third_party/poco/CMakeLists.txt:77 (include)
```