### PR TITLE
HTTP Authentication Schemes

### DIFF
--- a/Net/src/HTTPAuthenticationParams.cpp
+++ b/Net/src/HTTPAuthenticationParams.cpp
@@ -210,7 +210,7 @@ void HTTPAuthenticationParams::parse(std::string::const_iterator first, std::str
 		switch (state) 
 		{
 		case STATE_SPACE:
-			if (Ascii::isAlphaNumeric(*it) || *it == '_') 
+			if (Ascii::isAlphaNumeric(*it) || *it == '_' || *it == '-')
 			{
 				token += *it;
 				state = STATE_TOKEN;
@@ -227,7 +227,7 @@ void HTTPAuthenticationParams::parse(std::string::const_iterator first, std::str
 			{
 				state = STATE_EQUALS;
 			} 
-			else if (Ascii::isAlphaNumeric(*it) || *it == '_') 
+			else if (Ascii::isAlphaNumeric(*it) || *it == '_' || *it == '-')
 			{
 				token += *it;
 			} 


### PR DESCRIPTION
Allow hyphen in authenticate param token to implement other HTTP authentication schemes. See [HTTP Authentication Schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
)