### PR TITLE
Simplify package extraction command

### DIFF
--- a/README
+++ b/README
@@ -183,8 +183,7 @@ or
 Once you have GNU Make up and running, the rest is quite simple.
 To extract the sources and build all libraries, testsuites and samples, simply
 
-> gunzip poco-X.Y.tar.gz
-> tar -xf poco-X.Y.tar
+> tar -xzf poco-X.Y.tar.gz
 > cd poco-X.Y
 > ./configure
 > gmake -s


### PR DESCRIPTION
No need for two commands, tar can handle .tar.gz.