### PR TITLE
Find certificate from Windows store using its thumbprint

### DIFF
--- a/NetSSL_Win/include/Poco/Net/Context.h
+++ b/NetSSL_Win/include/Poco/Net/Context.h
@@ -111,11 +111,13 @@ public:
 		OPT_LOAD_CERT_FROM_FILE         = 0x10,
 			/// Load certificate and private key from a PKCS #12 (.pfx) file, 
 			/// and not from the certificate store.
+		OPT_USE_CERT_HASH               = 0x20,
+			/// Find the certificate using thumbprint.
 		OPT_DEFAULTS                    = OPT_PERFORM_REVOCATION_CHECK | OPT_TRUST_ROOTS_WIN_CERT_STORE | OPT_USE_STRONG_CRYPTO
 	};
 
 	Context(Usage usage,
-		const std::string& certificateNameOrPath, 
+		const std::string& certificateInfoOrPath,
 		VerificationMode verMode = VERIFY_RELAXED,
 		int options = OPT_DEFAULTS,
 		const std::string& certificateStoreName = CERT_STORE_MY);
@@ -123,7 +125,7 @@ public:
 			/// 
 			///   * usage specifies whether the context is used by a client or server,
 			///     as well as which protocol to use.
-			///   * certificateNameOrPath specifies either the subject name of the certificate to use,
+			///   * certificateInfoOrPath specifies either the subject name or thumbprint of the certificate to use,
 			///     or the path of a PKCS #12 file containing the certificate and corresponding private key.
 			///     If a subject name is specified, the certificate must be located in the certificate 
 			///     store specified by certificateStoreName. If a path is given, the OPT_LOAD_CERT_FROM_FILE
@@ -208,7 +210,7 @@ private:
 	Context::VerificationMode  _mode;
 	int                        _options;
 	bool                       _extendedCertificateVerification;
-	std::string                _certNameOrPath;
+	std::string                _certInfoOrPath;
 	std::string                _certStoreName;
 	HCERTSTORE                 _hMemCertStore;
 	HCERTSTORE                 _hCollectionCertStore;

--- a/NetSSL_Win/include/Poco/Net/SSLManager.h
+++ b/NetSSL_Win/include/Poco/Net/SSLManager.h
@@ -71,6 +71,8 @@ class NetSSL_Win_API SSLManager
 	///       <schannel>
 	///          <server|client>
 	///            <certificateName>cert Id</certificateName>
+	///            <certificateHash>cert thumbprint</certificateHash>
+	///            <certificatePath>path of a certificate</certificatePath>
 	///            <certificateStore>MY</certificateStore>
 	///            <verificationMode>none|relaxed|strict</verificationMode>
 	///            <revocationCheck>true|false</revocationCheck>
@@ -101,6 +103,8 @@ class NetSSL_Win_API SSLManager
 	/// 
 	///    - certificateName (string): The subject name of the certificate to use. The certificate must
 	///      be available in the Windows user or machine certificate store.  
+	///    - certificateHash (string): The thumbprint of the certificate to use. Alternative for certificateName.
+	///      The certificate must be available in the Windows user or machine certificate store.
 	///    - certificatePath (string): The path of a certificate and private key file in PKCS #12 format.
 	///    - certificateStore (string): The certificate store location to use. 
 	///      Valid values are "MY", "Root", "Trust" or "CA". Defaults to "MY".
@@ -267,6 +271,8 @@ private:
 
 	static const std::string CFG_CERT_NAME;
 	static const std::string VAL_CERT_NAME;
+	static const std::string CFG_CERT_HASH;
+	static const std::string VAL_CERT_HASH;
 	static const std::string CFG_CERT_PATH;
 	static const std::string VAL_CERT_PATH;
 	static const std::string CFG_CERT_STORE;

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -23,7 +23,6 @@
 #include "Poco/MemoryStream.h"
 #include "Poco/Base64Decoder.h"
 #include "Poco/Buffer.h"
-#include "Poco/HexBinaryDecoder.h"
 #include <sstream>
 #include <algorithm>
 #include <cctype>
@@ -180,7 +179,7 @@ void Context::loadCertificate()
 	if(_options & OPT_USE_CERT_HASH)
 	{
 		// Sanity check for the hash value.
-		if(_certInfoOrPath.size() % 2) throw CertificateException(Poco::format("Invalid certificate hash %s", _certInfoOrPath));
+		if(_certInfoOrPath.size() < 40 || _certInfoOrPath.size() % 2) throw CertificateException(Poco::format("Invalid certificate hash %s", _certInfoOrPath));
 
 		// Convert hex to binary.
 		BYTE buffer[256] = {};

--- a/NetSSL_Win/src/SSLManager.cpp
+++ b/NetSSL_Win/src/SSLManager.cpp
@@ -29,6 +29,8 @@ namespace Net {
 
 const std::string SSLManager::CFG_CERT_NAME("certificateName");
 const std::string SSLManager::VAL_CERT_NAME("");
+const std::string SSLManager::CFG_CERT_HASH("certificateHash");
+const std::string SSLManager::VAL_CERT_HASH("");
 const std::string SSLManager::CFG_CERT_PATH("certificatePath");
 const std::string SSLManager::VAL_CERT_PATH("");
 const std::string SSLManager::CFG_CERT_STORE("certificateStore");
@@ -188,7 +190,8 @@ void SSLManager::initDefaultContext(bool server)
 
 	const std::string prefix = server ? CFG_SERVER_PREFIX : CFG_CLIENT_PREFIX;
 	Poco::Util::AbstractConfiguration& config = appConfig();
-	std::string certName = config.getString(prefix + CFG_CERT_NAME, VAL_CERT_NAME);
+	std::string certInfo = config.getString(prefix + CFG_CERT_NAME, VAL_CERT_NAME);
+	std::string certHash = config.getString(prefix + CFG_CERT_HASH, VAL_CERT_HASH);
 	std::string certPath = config.getString(prefix + CFG_CERT_PATH, VAL_CERT_PATH);
 	std::string certStore = config.getString(prefix + CFG_CERT_STORE, VAL_CERT_STORE);
 
@@ -217,7 +220,12 @@ void SSLManager::initDefaultContext(bool server)
 	if (!certPath.empty()) 
 	{
 		options |= Context::OPT_LOAD_CERT_FROM_FILE;
-		certName = certPath;
+		certInfo = certPath;
+	}
+	if (certInfo.empty() && !certHash.empty())
+	{
+		options |= Context::OPT_USE_CERT_HASH;
+		certInfo = certHash;
 	}
 
 	Context::Usage usage;
@@ -231,7 +239,7 @@ void SSLManager::initDefaultContext(bool server)
 			usage = Context::TLSV1_SERVER_USE;
 		else
 			usage = Context::SERVER_USE;
-		_ptrDefaultServerContext = new Context(usage, certName, verMode, options, certStore);
+		_ptrDefaultServerContext = new Context(usage, certInfo, verMode, options, certStore);
 	}
 	else
 	{
@@ -243,7 +251,7 @@ void SSLManager::initDefaultContext(bool server)
 			usage = Context::TLSV1_CLIENT_USE;
 		else
 			usage = Context::CLIENT_USE;
-		_ptrDefaultClientContext = new Context(usage, certName, verMode, options, certStore);
+		_ptrDefaultClientContext = new Context(usage, certInfo, verMode, options, certStore);
 	}
 }
 


### PR DESCRIPTION
Trying to find a certificate using **certificateName** turned out to be really difficult. It's always giving **Failed to find certificate** error, so I added the possibility to search a certificate using its SHA1 hash.