### PR TITLE
Json unicode escape && preserveOrder keys sync

### DIFF
--- a/Foundation/include/Poco/JSONString.h
+++ b/Foundation/include/Poco/JSONString.h
@@ -24,15 +24,19 @@
 namespace Poco {
 
 
-void Foundation_API toJSON(const std::string& value, std::ostream& out, bool wrap = true);
+void Foundation_API toJSON(const std::string& value, std::ostream& out, bool wrap = true, bool escapeAllUnicode = false);
 	/// Formats string value into the supplied output stream by
 	/// escaping control characters.
 	/// If wrap is true, the resulting string is enclosed in double quotes
+	/// If escapeAllUnicode is true, all unicode characters will be escaped, otherwise only the compulsory ones.
 
-std::string Foundation_API toJSON(const std::string& value, bool wrap = true);
+
+std::string Foundation_API toJSON(const std::string& value, bool wrap = true, bool escapeAllUnicode = false);
 	/// Formats string value by escaping control characters.
 	/// If wrap is true, the resulting string is enclosed in double quotes
 	/// Returns formatted string.
+	/// If escapeAllUnicode is true, all unicode characters will be escaped, otherwise only the compulsory ones.
+
 
 
 } // namespace Poco

--- a/Foundation/src/JSONString.cpp
+++ b/Foundation/src/JSONString.cpp
@@ -17,19 +17,51 @@
 
 namespace Poco {
 
-void toJSON(const std::string& value, std::ostream& out, bool wrap)
+void toJSON(const std::string& value, std::ostream& out, bool wrap, bool escapeAllUnicode)
 {
 	if (wrap) out << '"';
-	out << UTF8::escape(value.begin(), value.end());
+	if (escapeAllUnicode)
+	{
+		out << UTF8::escape(value.begin(), value.end());
+	}
+	else
+	{
+		for (std::string::const_iterator it = value.begin(),
+			end = value.end(); it != end; ++it)
+		{
+			// Forward slash isn't strictly required by JSON spec, but some parsers expect it
+			if ((*it >= 0 && *it <= 31) ||  (*it == '"') || (*it == '\\') || (*it == '/'))
+			{
+				out << UTF8::escape(it, it+1);
+			}
+			else out << *it;
+		}
+	}
 	if (wrap) out << '"';
 }
 
 
-std::string toJSON(const std::string& value, bool wrap)
+std::string toJSON(const std::string& value, bool wrap, bool escapeAllUnicode)
 {
 	std::string ret;
 	if (wrap) ret.append(1, '"');
-	ret.append(UTF8::escape(value.begin(), value.end()));
+	if (escapeAllUnicode)
+	{
+		ret.append(UTF8::escape(value.begin(), value.end()));
+	}
+	else
+	{
+		for (std::string::const_iterator it = value.begin(),
+			end = value.end(); it != end; ++it)
+		{
+			// Forward slash isn't strictly required by JSON spec, but some parsers expect it
+			if ((*it >= 0 && *it <= 31) ||  (*it == '"') || (*it == '\\') || (*it == '/'))
+			{
+				ret.append(UTF8::escape(it, it+1));
+			}
+			else ret.append(1, *it);
+		}
+	}
 	if (wrap) ret.append(1, '"');
 	return ret;
 }

--- a/Foundation/src/VarHolder.cpp
+++ b/Foundation/src/VarHolder.cpp
@@ -14,7 +14,7 @@
 
 #include "Poco/Dynamic/VarHolder.h"
 #include "Poco/Dynamic/Var.h"
-#include "Poco/UTF8String.h"
+#include "Poco/JSONString.h"
 
 
 namespace Poco {
@@ -36,7 +36,7 @@ namespace Impl {
 
 void escape(std::string& target, const std::string& source)
 {
-	target = UTF8::escape(source.begin(), source.end());
+	target = toJSON(source);
 }
 
 
@@ -53,11 +53,9 @@ bool isJSONString(const Var& any)
 
 void appendJSONString(std::string& val, const Var& any)
 {
-	std::string json(val);
-	val.append(1, '"');
+	std::string json;
 	escape(json, any.convert<std::string>());
 	val.append(json);
-	val.append(1, '"');
 }
 
 

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1203,6 +1203,8 @@ void StringTest::testJSONString()
 	assert (toJSON("\t", false) == "\\t");
 	assert (toJSON("\v", false) == "\\v");
 	assert (toJSON("a", false) == "a");
+	assert (toJSON("\xD0\x82", false) == "\xD0\x82");
+	assert (toJSON("\xD0\x82", false, true) == "\\u0402");
 
 	// ??? on MSVC, the assert macro expansion
 	// fails to compile when this string is inline ???
@@ -1215,6 +1217,8 @@ void StringTest::testJSONString()
 	assert (toJSON("bs\b") == "\"bs\\b\"");
 	assert (toJSON("nl\n") == "\"nl\\n\"");
 	assert (toJSON("tb\t") == "\"tb\\t\"");
+	assert (toJSON("\xD0\x82", true) == "\"\xD0\x82\"");
+	assert (toJSON("\xD0\x82", true, true) == "\"\\u0402\"");
 
 	std::ostringstream ostr;
 	toJSON("foo\\", ostr);
@@ -1238,6 +1242,12 @@ void StringTest::testJSONString()
 	ostr.str("");
 	toJSON("tb\t", ostr);
 	assert(ostr.str() == "\"tb\\t\"");
+	ostr.str("");
+	toJSON("\xD0\x82", ostr);
+	assert(ostr.str() == "\"\xD0\x82\"");
+	ostr.str("");
+	toJSON("\xD0\x82", ostr, true, true);
+	assert(ostr.str() == "\"\\u0402\"");
 	ostr.str("");
 }
 

--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -63,8 +63,11 @@ public:
 	typedef std::vector<Dynamic::Var>::const_iterator ConstIterator;
 	typedef SharedPtr<Array> Ptr;
 
-	Array();
+	Array(bool escapeUnicode = false);
 		/// Creates an empty Array.
+		///
+		/// If escapeUnicode is true, when the object is stringified, all unicode
+		/// characters will be escaped in the resulting string.
 
 	Array(const Array& copy);
 		/// Creates an Array by copying another one.
@@ -80,6 +83,12 @@ public:
 
 	virtual ~Array();
 		/// Destroys the Array.
+
+	void setEscapeUnicode(bool escape = true);
+		/// Sets the flag for escaping unicode.
+
+	bool getEscapeUnicode() const;
+		/// Returns the flag for escaping unicode.
 
 	ValueVec::const_iterator begin() const;
 		/// Returns the begin iterator for values.
@@ -188,12 +197,30 @@ private:
 	ValueVec         _values;
 	mutable ArrayPtr _pArray;
 	mutable bool     _modified;
+	// Note:
+	//  The reason we have this flag here (rather than as argument to stringify())
+	//  is because Array can be returned stringified from a Dynamic::Var:toString(),
+	//  so it must know whether to escape unicode or not.
+	bool             _escapeUnicode;
 };
 
 
 //
 // inlines
 //
+
+inline void Array::setEscapeUnicode(bool escape)
+{
+	_escapeUnicode = true;
+}
+
+
+inline bool Array::getEscapeUnicode() const
+{
+	return _escapeUnicode;
+}
+
+
 inline Array::ValueVec::const_iterator Array::begin() const
 {
 	return _values.begin();

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -37,8 +37,8 @@ namespace JSON {
 
 
 class JSON_API Object
-	/// Represents a JSON object. Object provides a representation
-	/// based on shared pointers and optimized for performance. It is possible to
+	/// Represents a JSON object. Object provides a representation based on
+	/// shared pointers and optimized for performance. It is possible to
 	/// convert Object to DynamicStruct. Conversion requires copying and therefore
 	/// has performance penalty; the benefit is in improved syntax, eg:
 	///
@@ -56,7 +56,7 @@ class JSON_API Object
 	///    // copy/convert to Poco::DynamicStruct
 	///    Poco::DynamicStruct ds = *object;
 	///    val = ds["test"]["property"]; // val holds "value"
-	/// ----
+	///
 {
 public:
 	typedef SharedPtr<Object>                   Ptr;
@@ -66,14 +66,29 @@ public:
 	typedef ValueMap::const_iterator            ConstIterator;
 	typedef std::vector<std::string>            NameList;
 
-	explicit Object(bool preserveInsertionOrder = false, bool escapeUnicode = false);
+	enum Options
+	{
+		JSON_PRESERVE_KEY_ORDER = 1,
+			/// If specified, the object will preserve the items
+			/// insertion order. Otherwise, items will be sorted
+			/// by keys.
+
+		JSON_ESCAPE_UNICODE = 2
+			/// If specified, when the object is stringified, all
+			/// unicode characters will be escaped in the resulting
+			/// string.
+	};
+
+	explicit Object(int options = 0);
 		/// Creates an empty Object.
 		///
-		/// If preserveInsertionOrder, object will preserve the items insertion
-		/// order. Otherwise, items will be sorted by keys.
+		/// If JSON_PRESERVE_KEY_ORDER is specified, the object will
+		/// preserve the items insertion order. Otherwise, items will be
+		/// sorted by keys.
 		///
-		/// If escapeUnicode is true, when the object is stringified, all unicode
-		/// characters will be escaped in the resulting string.
+		/// If JSON_ESCAPE_UNICODE is specified, when the object is
+		/// stringified, all unicode characters will be escaped in the
+		/// resulting string.
 
 	Object(const Object& copy);
 		/// Creates an Object by copying another one.
@@ -271,8 +286,8 @@ private:
 	KeyList           _keys;
 	bool              _preserveInsOrder;
 	// Note:
-	//  The reason we have this flag here (rather than as argument to stringify())
-	//  is because Object can be returned stringified from a Dynamic::Var:toString(),
+	//  The reason for this flag (rather than as argument to stringify()) is
+	//  because Object can be returned stringified from Dynamic::Var::toString(),
 	//  so it must know whether to escape unicode or not.
 	bool              _escapeUnicode;
 	mutable StructPtr _pStruct;

--- a/JSON/include/Poco/JSON/Stringifier.h
+++ b/JSON/include/Poco/JSON/Stringifier.h
@@ -31,26 +31,29 @@ class JSON_API Stringifier
 	/// Helper class for creating a string from a JSON object or array.
 {
 public:
-	static void condense(const Dynamic::Var& any, std::ostream& out);
+	static void condense(const Dynamic::Var& any, std::ostream& out, bool escapeUnicode = false);
 		/// Writes a condensed string representation of the value to the output stream while preserving the insertion order.
 		///
 		/// This is just a "shortcut" to stringify(any, out) with name indicating the function effect.
 
-	static void stringify(const Dynamic::Var& any, std::ostream& out, unsigned int indent = 0, int step = -1);
+	static void stringify(const Dynamic::Var& any, std::ostream& out, unsigned int indent = 0, int step = -1, bool escapeUnicode = false);
 		/// Writes a string representation of the value to the output stream.
 		///
 		/// When indent is 0, the string will be created as small as possible.
-		/// When preserveInsertionOrder is true, the original string object members order will be preserved;
-		/// otherwise, object members are sorted by their names.
+		/// Indentation is increased/decreased using number of spaces defined in step.
+		/// The default value -1 for step indicates that step will be equal to the
+		/// indent size.
+		/// If escapeUnicode is true, all unicode characers will be escaped in the
+		/// resulting string.
 
-	static void formatString(const std::string& value, std::ostream& out);
+	static void formatString(const std::string& value, std::ostream& out, bool escapeUnicode = false);
 		/// Formats the JSON string and streams it into ostream.
 };
 
 
-inline void Stringifier::condense(const Dynamic::Var& any, std::ostream& out)
+inline void Stringifier::condense(const Dynamic::Var& any, std::ostream& out, bool escapeUnicode)
 {
-	stringify(any, out, 0, -1);
+	stringify(any, out, 0, -1, escapeUnicode);
 }
 
 

--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -24,7 +24,8 @@ namespace Poco {
 namespace JSON {
 
 
-Array::Array(): _modified(false)
+Array::Array(bool escapeUnicode): _modified(false),
+	_escapeUnicode(escapeUnicode)
 {
 }
 
@@ -158,7 +159,7 @@ void Array::stringify(std::ostream& out, unsigned int indent, int step) const
 	{
 		for (int i = 0; i < indent; i++) out << ' ';
 
-		Stringifier::stringify(*it, out, indent + step, step);
+		Stringifier::stringify(*it, out, indent + step, step, _escapeUnicode);
 
 		if (++it != _values.end())
 		{
@@ -171,8 +172,7 @@ void Array::stringify(std::ostream& out, unsigned int indent, int step) const
 
 	if (indent >= step) indent -= step;
 
-	for (int i = 0; i < indent; i++)
-		out << ' ';
+	for (int i = 0; i < indent; i++) out << ' ';
 
 	out << "]";
 }

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -32,22 +32,13 @@ Object::Object(bool preserveInsOrder, bool escapeUnicode):
 }
 
 
-Object::Object(const Object& copy) : _values(copy._values),
-	_preserveInsOrder(copy._preserveInsOrder),
-	_escapeUnicode(copy._escapeUnicode),
-	_pStruct(!copy._modified ? copy._pStruct : 0),
-	_modified(copy._modified)
+Object::Object(const Object& other) : _values(other._values),
+	_preserveInsOrder(other._preserveInsOrder),
+	_escapeUnicode(other._escapeUnicode),
+	_pStruct(!other._modified ? other._pStruct : 0),
+	_modified(other._modified)
 {
-	if (_preserveInsOrder)
-	{
-		// need to update pointers in _keys to point to copied _values
-		for (KeyPtrList::const_iterator it = copy._keys.begin(); it != copy._keys.end(); ++it)
-		{
-			ValueMap::const_iterator itv = _values.find(**it);
-			poco_assert (itv != _values.end());
-			_keys.push_back(&itv->first);
-		}
-	}
+	syncKeys(other._keys);
 }
 
 
@@ -59,8 +50,7 @@ Object::Object(Object&& other) :
 	_pStruct(!other._modified ? other._pStruct : 0),
 	_modified(other._modified)
 {
-	other._values.clear();
-	other._keys.clear();
+	other.clear();
 }
 
 
@@ -74,7 +64,7 @@ Object &Object::operator= (const Object &other)
 	if (&other != this)
 	{
 		_values = other._values;
-		_keys = other._keys;
+		syncKeys(other._keys);
 		_preserveInsOrder = other._preserveInsOrder;
 		_escapeUnicode = other._escapeUnicode;
 		_pStruct = !other._modified ? other._pStruct : 0;
@@ -90,14 +80,28 @@ Object &Object::operator= (Object &&other)
 	{
 		_values = std::move(other._values);
 		_keys = std::move(other._keys);
-		other._values.clear();
-		other._keys.clear();
 		_preserveInsOrder = other._preserveInsOrder;
 		_escapeUnicode = other._escapeUnicode;
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;
+		other.clear();
 	}
 	return *this;
+}
+
+
+void Object::syncKeys(const KeyList& keys)
+{
+	if(_preserveInsOrder)
+	{
+		// need to update pointers in _keys to point to copied _values
+		for(KeyList::const_iterator it = keys.begin(); it != keys.end(); ++it)
+		{
+			ValueMap::const_iterator itv = _values.find((*it)->first);
+			poco_assert (itv != _values.end());
+			_keys.push_back(itv);
+		}
+	}
 }
 
 
@@ -137,13 +141,31 @@ Object::Ptr Object::getObject(const std::string& key) const
 }
 
 
-void Object::getNames(std::vector<std::string>& names) const
+void Object::getNames(NameList& names) const
 {
 	names.clear();
-	for (ValueMap::const_iterator it = _values.begin(); it != _values.end(); ++it)
+	if (_preserveInsOrder)
 	{
-		names.push_back(it->first);
+		for(KeyList::const_iterator it = _keys.begin(); it != _keys.end(); ++it)
+		{
+			names.push_back((*it)->first);
+		}
 	}
+	else
+	{
+		for(ValueMap::const_iterator it = _values.begin(); it != _values.end(); ++it)
+		{
+			names.push_back(it->first);
+		}
+	}
+}
+
+
+Object::NameList Object::getNames() const
+{
+	NameList names;
+	getNames(names);
+	return names;
 }
 
 
@@ -158,16 +180,16 @@ void Object::stringify(std::ostream& out, unsigned int indent, int step) const
 }
 
 
-const std::string& Object::getKey(KeyPtrList::const_iterator& iter) const
+const std::string& Object::getKey(KeyList::const_iterator& iter) const
 {
 	ValueMap::const_iterator it = _values.begin();
 	ValueMap::const_iterator end = _values.end();
 	for (; it != end; ++it)
 	{
-		if (it->first == **iter) return it->first;
+		if (it == *iter) return it->first;
 	}
 
-	throw NotFoundException(**iter);
+	throw NotFoundException((*iter)->first);
 }
 
 
@@ -177,13 +199,13 @@ void Object::set(const std::string& key, const Dynamic::Var& value)
 	if (!ret.second) ret.first->second = value;
 	if (_preserveInsOrder)
 	{
-		KeyPtrList::iterator it = _keys.begin();
-		KeyPtrList::iterator end = _keys.end();
+		KeyList::iterator it = _keys.begin();
+		KeyList::iterator end = _keys.end();
 		for (; it != end; ++it)
 		{
-			if (key == **it) return;
+			if (key == (*it)->first) return;
 		}
-		_keys.push_back(&ret.first->first);
+		_keys.push_back(ret.first);
 	}
 	_modified = true;
 }

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -64,8 +64,8 @@ Object &Object::operator= (const Object &other)
 	if (&other != this)
 	{
 		_values = other._values;
-		syncKeys(other._keys);
 		_preserveInsOrder = other._preserveInsOrder;
+		syncKeys(other._keys);
 		_escapeUnicode = other._escapeUnicode;
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -24,8 +24,9 @@ namespace Poco {
 namespace JSON {
 
 
-Object::Object(bool preserveInsOrder):
+Object::Object(bool preserveInsOrder, bool escapeUnicode):
 	_preserveInsOrder(preserveInsOrder),
+	_escapeUnicode(escapeUnicode),
 	_modified(false)
 {
 }
@@ -33,6 +34,7 @@ Object::Object(bool preserveInsOrder):
 
 Object::Object(const Object& copy) : _values(copy._values),
 	_preserveInsOrder(copy._preserveInsOrder),
+	_escapeUnicode(copy._escapeUnicode),
 	_pStruct(!copy._modified ? copy._pStruct : 0),
 	_modified(copy._modified)
 {
@@ -53,9 +55,12 @@ Object::Object(Object&& other) :
 	_values(std::move(other._values)),
 	_keys(std::move(other._keys)),
 	_preserveInsOrder(other._preserveInsOrder),
+	_escapeUnicode(other._escapeUnicode),
 	_pStruct(!other._modified ? other._pStruct : 0),
 	_modified(other._modified)
 {
+	other._values.clear();
+	other._keys.clear();
 }
 
 
@@ -71,6 +76,7 @@ Object &Object::operator= (const Object &other)
 		_values = other._values;
 		_keys = other._keys;
 		_preserveInsOrder = other._preserveInsOrder;
+		_escapeUnicode = other._escapeUnicode;
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;
 	}
@@ -84,7 +90,10 @@ Object &Object::operator= (Object &&other)
 	{
 		_values = std::move(other._values);
 		_keys = std::move(other._keys);
+		other._values.clear();
+		other._keys.clear();
 		_preserveInsOrder = other._preserveInsOrder;
+		_escapeUnicode = other._escapeUnicode;
 		_pStruct = !other._modified ? other._pStruct : 0;
 		_modified = other._modified;
 	}

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -24,9 +24,10 @@ namespace Poco {
 namespace JSON {
 
 
-Object::Object(bool preserveInsOrder, bool escapeUnicode):
-	_preserveInsOrder(preserveInsOrder),
-	_escapeUnicode(escapeUnicode),
+
+Object::Object(int options):
+	_preserveInsOrder(options & JSON_PRESERVE_KEY_ORDER),
+	_escapeUnicode(options & JSON_ESCAPE_UNICODE),
 	_modified(false)
 {
 }

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -94,7 +94,7 @@ void Object::syncKeys(const KeyList& keys)
 {
 	if(_preserveInsOrder)
 	{
-		// need to update pointers in _keys to point to copied _values
+		// update iterators in _keys to point to copied _values
 		for(KeyList::const_iterator it = keys.begin(); it != keys.end(); ++it)
 		{
 			ValueMap::const_iterator itv = _values.find((*it)->first);

--- a/JSON/src/Stringifier.cpp
+++ b/JSON/src/Stringifier.cpp
@@ -26,28 +26,32 @@ namespace Poco {
 namespace JSON {
 
 
-void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int indent, int step)
+void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int indent, int step, bool escapeUnicode)
 {
 	if (step == -1) step = indent;
 
 	if (any.type() == typeid(Object))
 	{
-		const Object& o = any.extract<Object>();
+		Object& o = const_cast<Object&>(any.extract<Object>());
+		o.setEscapeUnicode(escapeUnicode);
 		o.stringify(out, indent == 0 ? 0 : indent, step);
 	}
 	else if (any.type() == typeid(Array))
 	{
-		const Array& a = any.extract<Array>();
+		Array& a = const_cast<Array&>(any.extract<Array>());
+		a.setEscapeUnicode(escapeUnicode);
 		a.stringify(out, indent == 0 ? 0 : indent, step);
 	}
 	else if (any.type() == typeid(Object::Ptr))
 	{
-		const Object::Ptr& o = any.extract<Object::Ptr>();
+		Object::Ptr& o = const_cast<Object::Ptr&>(any.extract<Object::Ptr>());
+		o->setEscapeUnicode(escapeUnicode);
 		o->stringify(out, indent == 0 ? 0 : indent, step);
 	}
 	else if (any.type() == typeid(Array::Ptr))
 	{
-		const Array::Ptr& a = any.extract<Array::Ptr>();
+		Array::Ptr& a = const_cast<Array::Ptr&>(any.extract<Array::Ptr>());
+		a->setEscapeUnicode(escapeUnicode);
 		a->stringify(out, indent == 0 ? 0 : indent, step);
 	}
 	else if (any.isEmpty())
@@ -57,13 +61,13 @@ void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int inde
 	else if (any.isNumeric() || any.isBoolean())
 	{
 		std::string value = any.convert<std::string>();
-		if (any.type() == typeid(char)) formatString(value, out);
+		if (any.type() == typeid(char)) formatString(value, out, escapeUnicode);
 		else out << value;
 	}
 	else if (any.isString() || any.isDateTime() || any.isDate() || any.isTime())
 	{
 		std::string value = any.convert<std::string>();
-		formatString(value, out);
+		formatString(value, out, escapeUnicode);
 	}
 	else
 	{
@@ -72,9 +76,9 @@ void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int inde
 }
 
 
-void Stringifier::formatString(const std::string& value, std::ostream& out)
+void Stringifier::formatString(const std::string& value, std::ostream& out, bool escapeUnicode)
 {
-	Poco::toJSON(value, out);
+	Poco::toJSON(value, out, true, escapeUnicode);
 }
 
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -1373,7 +1373,7 @@ void JSONTest::testStringify()
 
 	std::string str1 = "\r";
 	std::string str2 = "\n";
-	Poco::JSON::Object obj1, obj2;
+	Object obj1, obj2;
 	obj1.set("payload", str1);
 	obj2.set("payload", str2);
 	std::ostringstream oss1, oss2;
@@ -1525,7 +1525,7 @@ void JSONTest::testStringify()
 
 void JSONTest::testStringifyPreserveOrder()
 {
-	Object presObj(true);
+	Object presObj(Object::JSON_PRESERVE_KEY_ORDER);
 	presObj.set("foo", 0);
 	presObj.set("bar", 0);
 	presObj.set("baz", 0);
@@ -2009,7 +2009,7 @@ std::string JSONTest::getTestFilesPath(const std::string& type)
 
 void JSONTest::testCopy()
 {
-	Object obj1(true);
+	Object obj1(Object::JSON_PRESERVE_KEY_ORDER);
 	obj1.set("foo", 0);
 	obj1.set("bar", 0);
 	obj1.set("baz", 0);
@@ -2022,7 +2022,6 @@ void JSONTest::testCopy()
 
 	Object obj2;
 	obj2 = obj1;
-
 	nl = obj2.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "foo");
@@ -2033,7 +2032,6 @@ void JSONTest::testCopy()
 	obj3.set("foo", 0);
 	obj3.set("bar", 0);
 	obj3.set("baz", 0);
-
 	nl = obj3.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "bar");
@@ -2042,7 +2040,6 @@ void JSONTest::testCopy()
 
 	Object obj4;
 	obj4 = obj3;
-
 	nl = obj4.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "bar");
@@ -2050,8 +2047,14 @@ void JSONTest::testCopy()
 	assert (nl[2] == "foo");
 
 	obj4 = obj1;
-
 	nl = obj4.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	Object obj5(obj1);
+	nl = obj5.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "foo");
 	assert (nl[1] == "bar");
@@ -2061,7 +2064,7 @@ void JSONTest::testCopy()
 
 void JSONTest::testMove()
 {
-	Object obj1(true);
+	Object obj1(Object::JSON_PRESERVE_KEY_ORDER);
 	obj1.set("foo", 0);
 	obj1.set("bar", 0);
 	obj1.set("baz", 0);
@@ -2086,7 +2089,6 @@ void JSONTest::testMove()
 	obj3.set("foo", 0);
 	obj3.set("bar", 0);
 	obj3.set("baz", 0);
-
 	nl = obj3.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "bar");
@@ -2103,11 +2105,10 @@ void JSONTest::testMove()
 	assert (nl[1] == "baz");
 	assert (nl[2] == "foo");
 
-	Object obj5(true);
+	Object obj5(Object::JSON_PRESERVE_KEY_ORDER);
 	obj5.set("foo", 0);
 	obj5.set("bar", 0);
 	obj5.set("baz", 0);
-
 	nl = obj5.getNames();
 	assert (nl.size() == 3);
 	assert (nl[0] == "foo");

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -2061,7 +2061,67 @@ void JSONTest::testCopy()
 
 void JSONTest::testMove()
 {
+	Object obj1(true);
+	obj1.set("foo", 0);
+	obj1.set("bar", 0);
+	obj1.set("baz", 0);
 
+	Object::NameList nl = obj1.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	Object obj2;
+	obj2 = std::move(obj1);
+	assert (obj1.getNames().size() == 0);
+
+	nl = obj2.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	Object obj3;
+	obj3.set("foo", 0);
+	obj3.set("bar", 0);
+	obj3.set("baz", 0);
+
+	nl = obj3.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "bar");
+	assert (nl[1] == "baz");
+	assert (nl[2] == "foo");
+
+	Object obj4;
+	obj4 = std::move(obj3);
+	assert (obj3.getNames().size() == 0);
+
+	nl = obj4.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "bar");
+	assert (nl[1] == "baz");
+	assert (nl[2] == "foo");
+
+	Object obj5(true);
+	obj5.set("foo", 0);
+	obj5.set("bar", 0);
+	obj5.set("baz", 0);
+
+	nl = obj5.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	obj4 = std::move(obj5);
+	assert (obj5.getNames().size() == 0);
+
+	nl = obj4.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
 }
 
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -481,6 +481,13 @@ void JSONTest::testComplexObject()
 	Object::Ptr object = result.extract<Object::Ptr>();
 	assert(object->size() > 0);
 
+	Object::NameList names = object->getNames();
+	assert (names.size() == 4);
+	assert (names[0] == "id");
+	assert (names[1] == "jsonrpc");
+	assert (names[2] == "result");
+	assert (names[3] == "total");
+
 	DynamicStruct ds = *object;
 	assert (ds.size() > 0);
 	assert (ds["id"] == 1);
@@ -1525,6 +1532,12 @@ void JSONTest::testStringifyPreserveOrder()
 	std::stringstream ss;
 	presObj.stringify(ss);
 	assert(ss.str() == "{\"foo\":0,\"bar\":0,\"baz\":0}");
+	Object::NameList nl = presObj.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
 	ss.str("");
 	Stringifier::stringify(presObj, ss);
 	assert(ss.str() == "{\"foo\":0,\"bar\":0,\"baz\":0}");

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -1924,7 +1924,7 @@ void JSONTest::testEscapeUnicode()
 	std::stringstream ss;
 	object->stringify(ss);
 
-	assert(ss.str().compare("{\"name\":\"\\u4E2D\"}") == 0);
+	assert(ss.str().compare("{\"name\":\"\xE4\xB8\xAD\"}") == 0);
 
 	const unsigned char utf8Chars[]   = {'{', '"', 'n', 'a', 'm', 'e', '"', ':',
 		'"', 'g', 195, 188, 'n', 't', 'e', 'r', '"', '}', 0};
@@ -1933,7 +1933,7 @@ void JSONTest::testEscapeUnicode()
 	result = parser.parse(utf8Text);
 	object = result.extract<Object::Ptr>();
 	ss.str(""); object->stringify(ss);
-	assert (ss.str() == "{\"name\":\"g\\u00FCnter\"}");
+	assert (ss.str() == "{\"name\":\"g\xC3\xBCnter\"}");
 }
 
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -2007,6 +2007,64 @@ std::string JSONTest::getTestFilesPath(const std::string& type)
 }
 
 
+void JSONTest::testCopy()
+{
+	Object obj1(true);
+	obj1.set("foo", 0);
+	obj1.set("bar", 0);
+	obj1.set("baz", 0);
+
+	Object::NameList nl = obj1.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	Object obj2;
+	obj2 = obj1;
+
+	nl = obj2.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+
+	Object obj3;
+	obj3.set("foo", 0);
+	obj3.set("bar", 0);
+	obj3.set("baz", 0);
+
+	nl = obj3.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "bar");
+	assert (nl[1] == "baz");
+	assert (nl[2] == "foo");
+
+	Object obj4;
+	obj4 = obj3;
+
+	nl = obj4.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "bar");
+	assert (nl[1] == "baz");
+	assert (nl[2] == "foo");
+
+	obj4 = obj1;
+
+	nl = obj4.getNames();
+	assert (nl.size() == 3);
+	assert (nl[0] == "foo");
+	assert (nl[1] == "bar");
+	assert (nl[2] == "baz");
+}
+
+
+void JSONTest::testMove()
+{
+
+}
+
+
 CppUnit::Test* JSONTest::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("JSONTest");
@@ -2055,6 +2113,8 @@ CppUnit::Test* JSONTest::suite()
 	CppUnit_addTest(pSuite, JSONTest, testEscape0);
 	CppUnit_addTest(pSuite, JSONTest, testNonEscapeUnicode);
 	CppUnit_addTest(pSuite, JSONTest, testEscapeUnicode);
+	CppUnit_addTest(pSuite, JSONTest, testCopy);
+	CppUnit_addTest(pSuite, JSONTest, testMove);
 
 	return pSuite;
 }

--- a/JSON/testsuite/src/JSONTest.h
+++ b/JSON/testsuite/src/JSONTest.h
@@ -77,6 +77,7 @@ public:
 	void testInvalidUnicodeJanssonFiles();
 	void testSmallBuffer();
 	void testEscape0();
+	void testNonEscapeUnicode();
 	void testEscapeUnicode();
 	void setUp();
 	void tearDown();

--- a/JSON/testsuite/src/JSONTest.h
+++ b/JSON/testsuite/src/JSONTest.h
@@ -78,6 +78,10 @@ public:
 	void testEscape0();
 	void testNonEscapeUnicode();
 	void testEscapeUnicode();
+
+	void testCopy();
+	void testMove();
+
 	void setUp();
 	void tearDown();
 

--- a/JSON/testsuite/src/JSONTest.h
+++ b/JSON/testsuite/src/JSONTest.h
@@ -72,7 +72,6 @@ public:
 	void testValidJanssonFiles();
 	void testInvalidJanssonFiles();
 	void testTemplate();
-	void testItunes();
 	void testUnicode();
 	void testInvalidUnicodeJanssonFiles();
 	void testSmallBuffer();


### PR DESCRIPTION
- [x] JSON Stringify Unicode Escape functionality breaking change with 1.8.0 #2137
- [x] JSON::Object preserveOrder keys not synced on assignment #2142