### PR TITLE
Use proper x86_amd64 for build of x64 architecture

### DIFF
--- a/buildwin.cmd
+++ b/buildwin.cmd
@@ -63,42 +63,42 @@ if not "%PLATFORM%"=="WEC2013" goto usage)))
 if not defined VCINSTALLDIR (
   if %VS_VERSION%==vs90 (
     if %PLATFORM%==x64 (
-      call "%VS90COMNTOOLS%%VS_VARSALL%" amd64
+      call "%VS90COMNTOOLS%%VS_VARSALL%" x86_amd64
     ) else (
       call "%VS90COMNTOOLS%%VS_VARSALL%" x86
     )
   ) else (
     if %VS_VERSION%==vs100 (
       if %PLATFORM%==x64 (
-        call "%VS100COMNTOOLS%%VS_VARSALL%" amd64
+        call "%VS100COMNTOOLS%%VS_VARSALL%" x86_amd64
       ) else (
         call "%VS100COMNTOOLS%%VS_VARSALL%" x86
       )
     ) else (
       if %VS_VERSION%==vs110 (
         if %PLATFORM%==x64 (
-          call "%VS110COMNTOOLS%%VS_VARSALL%" amd64
+          call "%VS110COMNTOOLS%%VS_VARSALL%" x86_amd64
         ) else (
           call "%VS110COMNTOOLS%%VS_VARSALL%" x86
         )
       ) else (
         if %VS_VERSION%==vs120 (
           if %PLATFORM%==x64 (
-            call "%VS120COMNTOOLS%%VS_VARSALL%" amd64
+            call "%VS120COMNTOOLS%%VS_VARSALL%" x86_amd64
           ) else (
             call "%VS120COMNTOOLS%%VS_VARSALL%" x86
           )
         ) else (
           if %VS_VERSION%==vs140 (
             if %PLATFORM%==x64 (
-              call "%VS140COMNTOOLS%%VS_VARSALL%" amd64
+              call "%VS140COMNTOOLS%%VS_VARSALL%" x86_amd64
             ) else (
               call "%VS140COMNTOOLS%%VS_VARSALL%" x86
             )
           ) else (
             if %VS_VERSION%==vs150 (
               if %PLATFORM%==x64 (
-                call "%VS150COMNTOOLS%%VS_VARSALL%" amd64
+                call "%VS150COMNTOOLS%%VS_VARSALL%" x86_amd64
               ) else (
                 call "%VS150COMNTOOLS%%VS_VARSALL%" x86
               )


### PR DESCRIPTION
(cherry picked from commit 3b56f3c73eb61b9114aedf5bc1d67a701f2a1964)

In POCO 1.8.0 and 1.8.1 when building on 64-bit (using x64) fails requesting visual studio version 100. (Tested with 2015 = 140). With this fix build succeeded.