### PR TITLE
Fix nullptr deref in isArray and isObject in Poco::JSON::Object

### DIFF
--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -342,8 +342,7 @@ inline bool Object::isArray(const std::string& key) const
 
 inline bool Object::isArray(ConstIterator& it) const
 {
-	const std::type_info& ti = it->second.type();
-	return it != _values.end() && (ti == typeid(Array::Ptr) || ti == typeid(Array));
+	return it != _values.end() && (it->second.type() == typeid(Array::Ptr) || it->second.type() == typeid(Array));
 }
 
 
@@ -363,8 +362,7 @@ inline bool Object::isObject(const std::string& key) const
 
 inline bool Object::isObject(ConstIterator& it) const
 {
-	const std::type_info& ti = it->second.type();
-	return it != _values.end() && (ti == typeid(Object::Ptr) || ti == typeid(Object));
+	return it != _values.end() && (it->second.type() == typeid(Object::Ptr) || it->second.type() == typeid(Object));
 }
 
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -643,6 +643,9 @@ void JSONTest::testObjectProperty()
 	assert (object->isObject("test"));
 	assert (!object->isArray("test"));
 
+	assert (!object->isArray("nonExistentKey"));
+	assert (!object->isObject("nonExistentKey"));
+
 	Var test = object->get("test");
 	assert (test.type() == typeid(Object::Ptr));
 	Object::Ptr subObject = test.extract<Object::Ptr>();


### PR DESCRIPTION
If calling `Poco::JSON::Object::isArray` or `Poco::JSON::Object::isObject` with a non-existent key, the iterator is equal to the `end` iterator, and hence the it is not safe to dereference it to get the `type()` in advance of the comparison with the `end` iterator.

This was introduced in Poco 1.8.0, and a fix in 1.8.2 would be greatly appreciated!