### PR TITLE
Allow building with LibreSSL

### DIFF
--- a/Crypto/src/DigestEngine.cpp
+++ b/Crypto/src/DigestEngine.cpp
@@ -48,7 +48,7 @@ std::size_t DigestEngine::digestLength() const
 
 void DigestEngine::reset()
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	EVP_MD_CTX_free(_pContext);
 	_pContext = EVP_MD_CTX_create();
 #else

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -229,7 +229,7 @@ int RSAKeyImpl::size() const
 
 RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	const BIGNUM* n = 0;
 	const BIGNUM* e = 0;
 	const BIGNUM* d = 0;
@@ -243,7 +243,7 @@ RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
 
 RSAKeyImpl::ByteVec RSAKeyImpl::encryptionExponent() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	const BIGNUM* n = 0;
 	const BIGNUM* e = 0;
 	const BIGNUM* d = 0;
@@ -257,7 +257,7 @@ RSAKeyImpl::ByteVec RSAKeyImpl::encryptionExponent() const
 
 RSAKeyImpl::ByteVec RSAKeyImpl::decryptionExponent() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 	const BIGNUM* n = 0;
 	const BIGNUM* e = 0;
 	const BIGNUM* d = 0;

--- a/Crypto/src/X509Certificate.cpp
+++ b/Crypto/src/X509Certificate.cpp
@@ -313,7 +313,7 @@ std::string X509Certificate::signatureAlgorithm() const
 {
 	int sigNID = NID_undef;
 
-#if (OPENSSL_VERSION_NUMBER >=  0x1010000fL)
+#if (OPENSSL_VERSION_NUMBER >=  0x1010000fL) && !defined(LIBRESSL_VERSION_NUMBER)
 	sigNID = X509_get_signature_nid(_pCert);
 #else
 	poco_check_ptr(_pCert->sig_alg);

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -492,7 +492,7 @@ void Context::initDH(const std::string& dhParamsFile)
 			std::string msg = Utility::getLastError();
 			throw SSLContextException("Error creating Diffie-Hellman parameters", msg);
 		}
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		BIGNUM* p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), 0);
 		BIGNUM* g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), 0);
 		DH_set0_pqg(dh, p, 0, g);


### PR DESCRIPTION
Building with LibreSSL defines a higher OpenSSL version but does not
provide some of the newer symbols. The necessary alternative code
is already available in the Poco code base and just needs additional
precompiler checks.