### PR TITLE
respect lib suffix when installing cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ install(
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake
     DESTINATION
-        "lib/cmake/${PROJECT_NAME}"
+        "lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}"
     COMPONENT
         Devel
 )

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -226,14 +226,14 @@ install(
     EXPORT "${target_name}Targets"
     FILE "${PROJECT_NAME}${target_name}Targets.cmake"
     NAMESPACE "${PROJECT_NAME}::"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}"
     )
 
 install(
     FILES
         "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}Config.cmake"
         "${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}${target_name}ConfigVersion.cmake"
-    DESTINATION "lib/cmake/${PROJECT_NAME}"
+    DESTINATION "lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}"
     COMPONENT Devel
     )
 
@@ -267,7 +267,7 @@ if (MSVC)
 # install the targets pdb
   POCO_INSTALL_PDB(${target_name})
 endif()
-  
+
 endmacro()
 
 #  POCO_INSTALL_PDB - Install the given target's companion pdb file (if present)


### PR DESCRIPTION
Some cmake files contain pathes to the lib directory with suffix.
So they should respect the suffix as well.