### PR TITLE
Improve openssl verify callback handler

### DIFF
--- a/NetSSL_OpenSSL/Makefile
+++ b/NetSSL_OpenSSL/Makefile
@@ -11,12 +11,13 @@ SYSLIBS += -lssl -lcrypto
 objects = AcceptCertificateHandler RejectCertificateHandler ConsoleCertificateHandler \
 	CertificateHandlerFactory CertificateHandlerFactoryMgr \
 	Context HTTPSClientSession HTTPSStreamFactory HTTPSSessionInstantiator \
-	InvalidCertificateHandler KeyConsoleHandler \
+	CertificateHandler KeyConsoleHandler \
 	KeyFileHandler PrivateKeyFactory PrivateKeyFactoryMgr \
 	PrivateKeyPassphraseHandler SecureServerSocket SecureServerSocketImpl \
 	SecureSocketImpl SecureStreamSocket SecureStreamSocketImpl \
 	SSLException SSLManager Utility VerificationErrorArgs \
-	X509Certificate Session SecureSMTPClientSession
+	X509Certificate Session SecureSMTPClientSession \
+	VerificationArgs
 
 target         = PocoNetSSL
 target_version = $(LIBVERSION)

--- a/NetSSL_OpenSSL/include/Poco/Net/AcceptCertificateHandler.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/AcceptCertificateHandler.h
@@ -19,7 +19,7 @@
 
 
 #include "Poco/Net/NetSSL.h"
-#include "Poco/Net/InvalidCertificateHandler.h"
+#include "Poco/Net/CertificateHandler.h"
 
 
 namespace Poco {

--- a/NetSSL_OpenSSL/include/Poco/Net/CertificateHandlerFactory.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/CertificateHandlerFactory.h
@@ -25,7 +25,7 @@ namespace Poco {
 namespace Net {
 
 
-class InvalidCertificateHandler;
+class CertificateHandler;
 
 
 class NetSSL_API CertificateHandlerFactory
@@ -42,7 +42,7 @@ public:
 	virtual ~CertificateHandlerFactory();
 		/// Destroys the CertificateHandlerFactory.
 
-	virtual InvalidCertificateHandler* create(bool server) const = 0;
+	virtual CertificateHandler* create(bool server) const = 0;
 		/// Creates a new InvalidCertificateHandler. Set server to true if the certificate handler is used on the server side.
 };
 
@@ -74,7 +74,7 @@ public:
 	{
 	}
 
-	InvalidCertificateHandler* create(bool server) const
+	CertificateHandler* create(bool server) const
 	{
 		return new T(server);
 	}

--- a/NetSSL_OpenSSL/include/Poco/Net/ConsoleCertificateHandler.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/ConsoleCertificateHandler.h
@@ -19,7 +19,7 @@
 
 
 #include "Poco/Net/NetSSL.h"
-#include "Poco/Net/InvalidCertificateHandler.h"
+#include "Poco/Net/CertificateHandler.h"
 
 
 namespace Poco {

--- a/NetSSL_OpenSSL/include/Poco/Net/RejectCertificateHandler.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/RejectCertificateHandler.h
@@ -19,7 +19,7 @@
 
 
 #include "Poco/Net/NetSSL.h"
-#include "Poco/Net/InvalidCertificateHandler.h"
+#include "Poco/Net/CertificateHandler.h"
 
 
 namespace Poco {

--- a/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -23,7 +23,7 @@
 #include "Poco/Net/Context.h"
 #include "Poco/Net/PrivateKeyFactoryMgr.h"
 #include "Poco/Net/CertificateHandlerFactoryMgr.h"
-#include "Poco/Net/InvalidCertificateHandler.h"
+#include "Poco/Net/CertificateHandler.h"
 #include "Poco/Util/AbstractConfiguration.h"
 #include "Poco/BasicEvent.h"
 #include "Poco/SharedPtr.h"
@@ -154,7 +154,13 @@ class NetSSL_API SSLManager
 {
 public:
 	typedef Poco::SharedPtr<PrivateKeyPassphraseHandler> PrivateKeyPassphraseHandlerPtr;
-	typedef Poco::SharedPtr<InvalidCertificateHandler> InvalidCertificateHandlerPtr;
+	typedef Poco::SharedPtr<CertificateHandler> CertificateHandlerPtr;
+
+	Poco::BasicEvent<VerificationArgs> ServerVerification;
+		/// Fired whenever a certificate verification is called by the server during a handshake.
+
+	Poco::BasicEvent<VerificationArgs> ClientVerification;
+		/// Fired whenever a certificate verification is called by the client during a handshake.
 
 	Poco::BasicEvent<VerificationErrorArgs> ServerVerificationError;
 		/// Fired whenever a certificate verification error is detected by the server during a handshake.
@@ -169,7 +175,7 @@ public:
 	static SSLManager& instance();
 		/// Returns the instance of the SSLManager singleton.
 
-	void initializeServer(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, InvalidCertificateHandlerPtr ptrCertificateHandler, Context::Ptr ptrContext);
+	void initializeServer(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, CertificateHandlerPtr ptrCertificateHandler, Context::Ptr ptrContext);
 		/// Initializes the server side of the SSLManager with a default passphrase handler, a default invalid certificate handler and a default context. If this method
 		/// is never called the SSLmanager will try to initialize its members from an application configuration.
 		///
@@ -181,11 +187,11 @@ public:
 		///
 		/// Valid initialization code would be:
 		///     SharedPtr<PrivateKeyPassphraseHandler> pConsoleHandler = new KeyConsoleHandler;
-		///     SharedPtr<InvalidCertificateHandler> pInvalidCertHandler = new ConsoleCertificateHandler;
+		///     SharedPtr<CertificateHandler> pInvalidCertHandler = new ConsoleCertificateHandler;
 		///     Context::Ptr pContext = new Context(Context::SERVER_USE, "any.pem", "any.pem", "rootcert.pem", Context::VERIFY_RELAXED, 9, false, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
 		///     SSLManager::instance().initializeServer(pConsoleHandler, pInvalidCertHandler, pContext);
 
-	void initializeClient(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, InvalidCertificateHandlerPtr ptrHandler, Context::Ptr ptrContext);
+	void initializeClient(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, CertificateHandlerPtr ptrHandler, Context::Ptr ptrContext);
 		/// Initializes the client side of the SSLManager with a default passphrase handler, a default invalid certificate handler and a default context. If this method
 		/// is never called the SSLmanager will try to initialize its members from an application configuration.
 		///
@@ -197,7 +203,7 @@ public:
 		///
 		/// Valid initialization code would be:
 		///     SharedPtr<PrivateKeyPassphraseHandler> pConsoleHandler = new KeyConsoleHandler;
-		///     SharedPtr<InvalidCertificateHandler> pInvalidCertHandler = new ConsoleCertificateHandler;
+		///     SharedPtr<CertificateHandler> pInvalidCertHandler = new ConsoleCertificateHandler;
 		///     Context::Ptr pContext = new Context(Context::CLIENT_USE, "", "", "rootcert.pem", Context::VERIFY_RELAXED, 9, false, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
 		///     SSLManager::instance().initializeClient(pConsoleHandler, pInvalidCertHandler, pContext);
 
@@ -217,7 +223,7 @@ public:
 		/// Returns the configured passphrase handler of the server. If none is set, the method will create a default one
 		/// from an application configuration.
 
-	InvalidCertificateHandlerPtr serverCertificateHandler();
+	CertificateHandlerPtr serverCertificateHandler();
 		/// Returns an initialized certificate handler (used by the server to verify client cert) which determines how invalid certificates are treated.
 		/// If none is set, it will try to auto-initialize one from an application configuration.
 
@@ -225,7 +231,7 @@ public:
 		/// Returns the configured passphrase handler of the client. If none is set, the method will create a default one
 		/// from an application configuration.
 
-	InvalidCertificateHandlerPtr clientCertificateHandler();
+	CertificateHandlerPtr clientCertificateHandler();
 		/// Returns an initialized certificate handler (used by the client to verify server cert) which determines how invalid certificates are treated.
 		/// If none is set, it will try to auto-initialize one from an application configuration.
 
@@ -302,10 +308,10 @@ private:
 	CertificateHandlerFactoryMgr     _certHandlerFactoryMgr;
 	Context::Ptr                     _ptrDefaultServerContext;
 	PrivateKeyPassphraseHandlerPtr   _ptrServerPassphraseHandler;
-	InvalidCertificateHandlerPtr     _ptrServerCertificateHandler;
+	CertificateHandlerPtr            _ptrServerCertificateHandler;
 	Context::Ptr                     _ptrDefaultClientContext;
 	PrivateKeyPassphraseHandlerPtr   _ptrClientPassphraseHandler;
-	InvalidCertificateHandlerPtr     _ptrClientCertificateHandler;
+	CertificateHandlerPtr            _ptrClientCertificateHandler;
 	Poco::FastMutex                  _mutex;
 
 	static const std::string CFG_PRIV_KEY_FILE;

--- a/NetSSL_OpenSSL/include/Poco/Net/VerificationArgs.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/VerificationArgs.h
@@ -1,0 +1,127 @@
+//
+// VerificationArgs.h
+//
+// Library: NetSSL_OpenSSL
+// Package: SSLCore
+// Module:  VerificationArgs
+//
+// Definition of the VerificationArgs class.
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef NetSSL_VerificationArgs_INCLUDED
+#define NetSSL_VerificationArgs_INCLUDED
+
+
+#include "Poco/Net/NetSSL.h"
+#include "Poco/Net/X509Certificate.h"
+
+
+namespace Poco {
+namespace Net {
+
+
+class NetSSL_API VerificationArgs
+	/// A utility class for certificate handling.
+{
+public:
+	VerificationArgs(const X509Certificate& cert, const X509Certificate& certToCheck, int depth, int code, const std::string& msg);
+		/// Creates the VerificationArgs. _error is per default set to false.
+
+	~VerificationArgs();
+		/// Destroys the VerificationArgs.
+
+	const X509Certificate& certificate() const;
+		/// Returns the current certificate from X509 store.
+
+	const X509Certificate& certificateToVerify() const;
+		/// Returns the certificate to verify.
+
+	int depth() const;
+		/// Returns the position of the certificate in the certificate chain.
+
+	int errorNumber() const;
+		/// Returns the openssl x509 store ctx return code. See also X509_STORE_CTX_get_error
+
+	void setErrorNumber(int osslErrorCode);
+		/// Sets the error code of openssl x509 store ctx to osslErrorCode. See also X509_STORE_CTX_set_error.
+
+	const std::string& message() const;
+		/// Returns the textual presentation of the openssl return code.
+
+	void setError(bool error);
+		/// setError to true, if a verification error is judged by the user.
+
+	bool isError() const;
+		/// is error set.
+
+private:
+	X509Certificate	_cert;
+	X509Certificate _certToCheck;
+	int             _depth;
+	int             _code;
+	std::string     _message; /// Textual representation of the _code
+	bool            _error;
+};
+
+
+//
+// inlines
+//
+inline const X509Certificate& VerificationArgs::certificate() const
+{
+	return _cert;
+}
+
+
+inline const X509Certificate& VerificationArgs::certificateToVerify() const
+{
+	return _certToCheck;
+}
+
+
+inline int VerificationArgs::depth() const
+{
+	return _depth;
+}
+
+
+inline int VerificationArgs::errorNumber() const
+{
+	return _code;
+}
+
+
+inline void VerificationArgs::setErrorNumber(int osslErrorCode)
+{
+	_code = osslErrorCode;
+}
+
+
+inline const std::string& VerificationArgs::message() const
+{
+	return _message;
+}
+
+
+inline void VerificationArgs::setError(bool error)
+{
+	_error = error;
+}
+
+
+inline bool VerificationArgs::isError() const
+{
+	return _error;
+}
+
+
+} } // namespace Poco::Net
+
+
+#endif // NetSSL_VerificationArgs_INCLUDED

--- a/NetSSL_OpenSSL/include/Poco/Net/VerificationErrorArgs.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/VerificationErrorArgs.h
@@ -30,7 +30,7 @@ class NetSSL_API VerificationErrorArgs
 	/// A utility class for certificate error handling.
 {
 public:
-	VerificationErrorArgs(const X509Certificate& cert, int errDepth, int errNum, const std::string& errMsg);
+	VerificationErrorArgs(const X509Certificate& cert, const X509Certificate& certToCheck, int errDepth, int errNum, const std::string& errMsg);
 		/// Creates the VerificationErrorArgs. _ignoreError is per default set to false.
 
 	~VerificationErrorArgs();
@@ -39,11 +39,17 @@ public:
 	const X509Certificate& certificate() const;
 		/// Returns the certificate that caused the error.
 
+	const X509Certificate& certificateToVerify() const;
+		/// Returns the certificate to verify.
+
 	int errorDepth() const;
 		/// Returns the position of the certificate in the certificate chain.
 
 	int errorNumber() const;
-		/// Returns the id of the error
+		/// Returns the openssl x509 store ctx return code. See also X509_STORE_CTX_get_error.
+
+	void setErrorNumber(int osslErrorCode);
+		/// Sets the error code of x509 store ctx to osslErrorCode. See also X509_STORE_CTX_set_error.
 
 	const std::string& errorMessage() const;
 		/// Returns the textual presentation of the errorNumber.
@@ -56,6 +62,7 @@ public:
 
 private:
 	X509Certificate	_cert;
+	X509Certificate _certToCheck;
 	int             _errorDepth;
 	int             _errorNumber;
 	std::string     _errorMessage; /// Textual representation of the _errorNumber
@@ -72,6 +79,12 @@ inline const X509Certificate& VerificationErrorArgs::certificate() const
 }
 
 
+inline const X509Certificate& VerificationErrorArgs::certificateToVerify() const
+{
+	return _certToCheck;
+}
+
+
 inline int VerificationErrorArgs::errorDepth() const
 {
 	return _errorDepth;
@@ -81,6 +94,12 @@ inline int VerificationErrorArgs::errorDepth() const
 inline int VerificationErrorArgs::errorNumber() const
 {
 	return _errorNumber;
+}
+
+
+inline void VerificationErrorArgs::setErrorNumber(int osslErrorCode)
+{
+	_errorNumber = osslErrorCode;
 }
 
 

--- a/NetSSL_OpenSSL/src/CertificateHandler.cpp
+++ b/NetSSL_OpenSSL/src/CertificateHandler.cpp
@@ -1,9 +1,9 @@
 //
-// InvalidCertificateHandler.cpp
+// CertificateHandler.cpp
 //
 // Library: NetSSL_OpenSSL
 // Package: SSLCore
-// Module:  InvalidCertificateHandler
+// Module:  CertificateHandler
 //
 // Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
 // and Contributors.
@@ -12,7 +12,7 @@
 //
 
 
-#include "Poco/Net/InvalidCertificateHandler.h"
+#include "Poco/Net/CertificateHandler.h"
 #include "Poco/Net/SSLManager.h"
 #include "Poco/Delegate.h"
 
@@ -24,23 +24,35 @@ namespace Poco {
 namespace Net {
 
 
-InvalidCertificateHandler::InvalidCertificateHandler(bool handleErrorsOnServerSide): _handleErrorsOnServerSide(handleErrorsOnServerSide)
+CertificateHandler::CertificateHandler(bool handleErrorsOnServerSide): _handleErrorsOnServerSide(handleErrorsOnServerSide)
 {
 	if (_handleErrorsOnServerSide)
+	{
+		SSLManager::instance().ServerVerification += Delegate<CertificateHandler, VerificationArgs>(this, &CertificateHandler::onValidCertificate);
 		SSLManager::instance().ServerVerificationError += Delegate<InvalidCertificateHandler, VerificationErrorArgs>(this, &InvalidCertificateHandler::onInvalidCertificate);
+	}
 	else
+	{
+		SSLManager::instance().ClientVerification += Delegate<CertificateHandler, VerificationArgs>(this, &CertificateHandler::onValidCertificate);
 		SSLManager::instance().ClientVerificationError += Delegate<InvalidCertificateHandler, VerificationErrorArgs>(this, &InvalidCertificateHandler::onInvalidCertificate);
+	}
 }
 
 
-InvalidCertificateHandler::~InvalidCertificateHandler()
+CertificateHandler::~CertificateHandler()
 {
 	try
 	{
 		if (_handleErrorsOnServerSide)
+		{
+			SSLManager::instance().ServerVerification -= Delegate<CertificateHandler, VerificationArgs>(this, &CertificateHandler::onValidCertificate);
 			SSLManager::instance().ServerVerificationError -= Delegate<InvalidCertificateHandler, VerificationErrorArgs>(this, &InvalidCertificateHandler::onInvalidCertificate);
+		}
 		else
+		{
+			SSLManager::instance().ClientVerification -= Delegate<CertificateHandler, VerificationArgs>(this, &CertificateHandler::onValidCertificate);
 			SSLManager::instance().ClientVerificationError -= Delegate<InvalidCertificateHandler, VerificationErrorArgs>(this, &InvalidCertificateHandler::onInvalidCertificate);
+		}
 	}
 	catch (...)
 	{

--- a/NetSSL_OpenSSL/src/VerificationArgs.cpp
+++ b/NetSSL_OpenSSL/src/VerificationArgs.cpp
@@ -1,0 +1,38 @@
+//
+// VerificationArgs.cpp
+//
+// Library: NetSSL_OpenSSL
+// Package: SSLCore
+// Module:  VerificationArgs
+//
+// Copyright (c) 2006-2009, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Net/VerificationArgs.h"
+
+
+namespace Poco {
+namespace Net {
+
+
+VerificationArgs::VerificationArgs(const X509Certificate& cert, const X509Certificate& certToCheck, int depth, int code, const std::string& msg):
+	_cert(cert),
+	_certToCheck(certToCheck),
+	_depth(depth),
+	_code(code),
+	_message(msg),
+	_error(false)
+{
+}
+
+
+VerificationArgs::~VerificationArgs()
+{
+}
+
+
+} } // namespace Poco::Net

--- a/NetSSL_OpenSSL/src/VerificationErrorArgs.cpp
+++ b/NetSSL_OpenSSL/src/VerificationErrorArgs.cpp
@@ -19,8 +19,9 @@ namespace Poco {
 namespace Net {
 
 
-VerificationErrorArgs::VerificationErrorArgs(const X509Certificate& cert, int errDepth, int errNum, const std::string& errMsg):
+VerificationErrorArgs::VerificationErrorArgs(const X509Certificate& cert, const X509Certificate &certToCheck, int errDepth, int errNum, const std::string& errMsg):
 	_cert(cert),
+	_certToCheck(certToCheck),
 	_errorDepth(errDepth),
 	_errorNumber(errNum),
 	_errorMessage(errMsg),


### PR DESCRIPTION
At the moment in https://github.com/pocoproject/poco/blob/e5f71bb08526f2feeb514a4c9f569302be98e6ac/NetSSL_OpenSSL/src/SSLManager.cpp#L202 the certification handler is called when pre verification in openssl fails.
I need the possibility to extend the x509 certification verification with my own "checks"/code when pre verification was successful in openssl. I create first a proposal how we can implement this. I think it needs improvements.
My first idea was to add another function like "onValidCertificate()" in https://github.com/pocoproject/poco/blob/e5f71bb08526f2feeb514a4c9f569302be98e6ac/NetSSL_OpenSSL/include/Poco/Net/InvalidCertificateHandler.h#L29 but the interface is named **Invalid**CertificateHandler and this interface is the "base interface" in https://github.com/pocoproject/poco/blob/e5f71bb08526f2feeb514a4c9f569302be98e6ac/NetSSL_OpenSSL/include/Poco/Net/CertificateHandlerFactory.h#L45
The next idea was to add a CertificateHandler interface and **Invalid**CertificateHandler is inherited from CertificateHandler but then I think I break the API.
So I decided to add a new CertificateHandler "structure" (it is more or less a copy of the InvalidCertificateHandler structure) and create a proposal to discuss with the poco team :-)
Btw. CertificateHandler is implemented as NVI pattern.