### PR TITLE
PropertyListConfiguration feature (OS X plist)

### DIFF
--- a/Util/Makefile
+++ b/Util/Makefile
@@ -10,7 +10,8 @@ objects = AbstractConfiguration Application ConfigurationMapper \
 	ConfigurationView HelpFormatter IniFileConfiguration LayeredConfiguration \
 	LoggingConfigurator LoggingSubsystem MapConfiguration \
 	Option OptionException OptionProcessor OptionSet \
-	PropertyFileConfiguration Subsystem SystemConfiguration \
+	PropertyFileConfiguration PropertyListConfiguration \
+	Subsystem SystemConfiguration \
 	FilesystemConfiguration ServerApplication \
 	Validator IntValidator RegExpValidator OptionCallback \
 	Timer TimerTask

--- a/Util/include/Poco/Util/PropertyListConfiguration.h
+++ b/Util/include/Poco/Util/PropertyListConfiguration.h
@@ -1,0 +1,94 @@
+//
+// PropertyFileConfiguration.h
+//
+// Library: Util
+// Package: Configuration
+// Module:  PropertyListConfiguration
+//
+// Definition of the PropertyListConfiguration class.
+//
+// Copyright (c) 2017-2018, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Util_PropertyListConfiguration_INCLUDED
+#define Util_PropertyListConfiguration_INCLUDED
+
+
+#include "Poco/Util/Util.h"
+
+
+#ifndef POCO_UTIL_NO_XMLplistCONFIGURATION
+
+
+#include "Poco/Util/AbstractConfiguration.h"
+#include "Poco/DOM/Document.h"
+#include "Poco/DOM/AutoPtr.h"
+
+
+namespace Poco {
+namespace Util {
+
+
+class Util_API PropertyListConfiguration: public AbstractConfiguration
+{
+public:
+	PropertyListConfiguration();
+		/// Creates an empty PropertyListConfiguration.
+
+	PropertyListConfiguration(const std::string& path);
+		/// Creates an PropertyListConfiguration and loads the XMLplist document from
+		/// the given path.
+	PropertyListConfiguration(std::istream& istr);
+		/// Creates an PropertyFileConfiguration and loads the configuration data
+		/// from the given stream, which must be in properties list format.
+
+	void load(const std::string& path);
+		/// Loads the configuration data from the given file, which
+		/// must be in properties list format.
+
+	void load(std::istream& istr);
+		/// Loads the configuration data from the given stream, which
+		/// must be in properties list format.
+
+	void save(std::ostream& ostr) const;
+		/// Writes the configuration data to the given stream.
+
+	void save(const std::string& path) const;
+		/// Writes the configuration data to the given file.
+
+	virtual void setInt(const std::string& key, int value);
+	virtual void setDouble(const std::string& key, double value);
+	virtual void setBool(const std::string& key, bool value);
+
+	virtual void setData(const std::string& key, std::istream &istr);
+		/// set base64 data
+	virtual bool getData(const std::string& key, std::ostream &ostr);
+		/// get base64 data
+protected:
+	virtual bool getRaw(const std::string& key, std::string& value) const;
+	virtual void setRaw(const std::string& key, const std::string& value);
+	virtual void enumerate(const std::string& key, Keys& range) const;
+	virtual void removeRaw(const std::string& key);
+	~PropertyListConfiguration();
+
+private:
+	Poco::XML::Node* findNode(const std::string& key, bool create = false);
+	const Poco::XML::Node* findNode(const std::string& key, bool create = false) const;
+	static Poco::XML::Node* findNode(const std::string& key, Poco::XML::Node* dict, bool create = false);
+
+	Poco::XML::AutoPtr<Poco::XML::Element> _pRoot;
+	Poco::XML::AutoPtr<Poco::XML::Document> _pDocument;		
+};
+
+
+} } // namespace Poco::Util
+
+
+#endif // POCO_UTIL_NO_XMLplistCONFIGURATION
+
+
+#endif // Util_PropertyListConfiguration_INCLUDED

--- a/Util/include/Poco/Util/PropertyListConfiguration.h
+++ b/Util/include/Poco/Util/PropertyListConfiguration.h
@@ -1,5 +1,5 @@
 //
-// PropertyFileConfiguration.h
+// PropertyListConfiguration.h
 //
 // Library: Util
 // Package: Configuration

--- a/Util/include/Poco/Util/PropertyListConfiguration.h
+++ b/Util/include/Poco/Util/PropertyListConfiguration.h
@@ -21,7 +21,7 @@
 #include "Poco/Util/Util.h"
 
 
-#ifndef POCO_UTIL_NO_XMLplistCONFIGURATION
+#ifndef POCO_UTIL_NO_XMLCONFIGURATION
 
 
 #include "Poco/Util/AbstractConfiguration.h"

--- a/Util/src/PropertyListConfiguration.cpp
+++ b/Util/src/PropertyListConfiguration.cpp
@@ -18,7 +18,7 @@
 
 #ifndef POCO_UTIL_NO_XMLCONFIGURATION
 
-#include "poco/DOM/DOMImplementation.h"
+#include "Poco/DOM/DOMImplementation.h"
 #include "Poco/SAX/InputSource.h"
 #include "Poco/DOM/DOMParser.h"
 #include "Poco/DOM/Element.h"

--- a/Util/src/PropertyListConfiguration.cpp
+++ b/Util/src/PropertyListConfiguration.cpp
@@ -1,0 +1,332 @@
+//
+// PropertyListConfiguration.cpp
+//
+//
+// Library: Util
+// Package: Configuration
+// Module:  PropertyListConfiguration
+//
+// Copyright (c) 2017-2018, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/Util/PropertyListConfiguration.h"
+
+
+#ifndef POCO_UTIL_NO_XMLCONFIGURATION
+
+#include "poco/DOM/DOMImplementation.h"
+#include "Poco/SAX/InputSource.h"
+#include "Poco/DOM/DOMParser.h"
+#include "Poco/DOM/Element.h"
+#include "Poco/DOM/Text.h"
+#include "Poco/SAX/XMLReader.h"
+#include "Poco/XML/XMLWriter.h"
+#include "Poco/NumberFormatter.h"
+#include "Poco/DOM/DOMWriter.h"
+#include "Poco/Base64Encoder.h"
+#include "Poco/Base64Decoder.h"
+#include <fstream>
+#include <sstream>
+
+namespace Poco {
+namespace Util {
+
+
+PropertyListConfiguration::PropertyListConfiguration()
+{
+	Poco::XML::DocumentType *doctype = Poco::XML::DOMImplementation::instance().createDocumentType("plist", "-//Apple//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd");
+	_pDocument = new Poco::XML::Document(doctype);
+	_pRoot = _pDocument->createElement("plist");
+	_pRoot->setAttribute("version", "1.0");
+	_pDocument->appendChild(_pRoot);
+	_pRoot->appendChild(_pDocument->createElement("dict"));
+}
+
+PropertyListConfiguration::PropertyListConfiguration(const std::string& path)
+{
+	load(path);
+}
+
+
+PropertyListConfiguration::PropertyListConfiguration(std::istream& istr)
+{
+	load(istr);
+}
+
+PropertyListConfiguration::~PropertyListConfiguration()
+{
+}
+
+
+void PropertyListConfiguration::load(const std::string& path)
+{
+	Poco::XML::InputSource src(path);
+
+	Poco::XML::DOMParser parser;
+	parser.setFeature(Poco::XML::XMLReader::FEATURE_NAMESPACES, false);
+	parser.setFeature(Poco::XML::DOMParser::FEATURE_FILTER_WHITESPACE, true);
+
+	_pDocument = Poco::XML::AutoPtr<Poco::XML::Document>(const_cast<Poco::XML::Document*>(parser.parse(&src)), true);
+	_pRoot = Poco::XML::AutoPtr<Poco::XML::Element>(_pDocument->documentElement(), true);
+}
+
+void PropertyListConfiguration::load(std::istream& istr)
+{
+	Poco::XML::InputSource src(istr);
+
+	Poco::XML::DOMParser parser;
+	parser.setFeature(Poco::XML::XMLReader::FEATURE_NAMESPACES, false);
+	parser.setFeature(Poco::XML::DOMParser::FEATURE_FILTER_WHITESPACE, true);
+
+	_pDocument = Poco::XML::AutoPtr<Poco::XML::Document>(const_cast<Poco::XML::Document*>(parser.parse(&src)), true);
+	_pRoot = Poco::XML::AutoPtr<Poco::XML::Element>(_pDocument->documentElement(), true);
+
+}
+
+void PropertyListConfiguration::save(const std::string& path) const
+{
+	std::ofstream out(path);
+	save(out);
+}
+
+void PropertyListConfiguration::save(std::ostream& ostr) const
+{
+	Poco::XML::DOMWriter writer;
+	writer.setNewLine("\n");
+	writer.setOptions(Poco::XML::XMLWriter::WRITE_XML_DECLARATION | Poco::XML::XMLWriter::PRETTY_PRINT);
+	writer.writeNode(ostr, _pDocument);
+}
+
+void PropertyListConfiguration::setInt(const std::string& key, int value)
+{
+	// set this, so it fires event
+	AbstractConfiguration::setInt(key, value);
+
+	// find the node we just inserted
+	Poco::XML::Node* thekey = findNode(key, true);
+	Poco::XML::Node* thevalue = thekey->nextSibling();
+
+	// change the value to an integer element
+	Poco::XML::Node* pElem = _pDocument->createElement("integer");
+	thevalue->parentNode()->replaceChild(pElem, thevalue);
+	thevalue = pElem;
+	Poco::XML::Node* pText = _pDocument->createTextNode(Poco::NumberFormatter::format(value));
+	thevalue->appendChild(pText);
+}
+
+void PropertyListConfiguration::setDouble(const std::string& key, double value)
+{
+	// set this, so it fires event
+	AbstractConfiguration::setDouble(key, value);
+
+	// find the node we just inserted
+	Poco::XML::Node* thekey = findNode(key, true);
+	Poco::XML::Node* thevalue = thekey->nextSibling();
+
+	// change the value to an integer element
+	Poco::XML::Node* pElem = _pDocument->createElement("real");
+	thevalue->parentNode()->replaceChild(pElem, thevalue);
+	thevalue = pElem;
+	Poco::XML::Node* pText = _pDocument->createTextNode(Poco::NumberFormatter::format(value));
+	thevalue->appendChild(pText);
+}
+
+void PropertyListConfiguration::setBool(const std::string& key, bool value)
+{
+	// set this, so it fires event
+	AbstractConfiguration::setBool(key, value);
+
+	// find the node we just inserted
+	Poco::XML::Node* thekey = findNode(key, true);
+	Poco::XML::Node* thevalue = thekey->nextSibling();
+
+	// change the value to a boolean element
+	Poco::XML::Node* pElem = _pDocument->createElement(value ? "true" : "false");
+	thevalue->parentNode()->replaceChild(pElem, thevalue);
+	thevalue = pElem;
+}
+
+void PropertyListConfiguration::setData(const std::string& key, std::istream &istr)
+{
+	Poco::XML::Node* thekey = findNode(key, true);
+	Poco::XML::Node* thevalue = thekey->nextSibling();
+
+	Poco::XML::Node* pElem = _pDocument->createElement("data");
+	thevalue->parentNode()->replaceChild(pElem, thevalue);
+	thevalue = pElem;
+
+	std::ostringstream ostr;
+	Poco::Base64Encoder encoder(ostr);
+	encoder << istr.rdbuf();
+	encoder.close();
+	Poco::XML::Node* pText = _pDocument->createTextNode(ostr.str());
+	thevalue->appendChild(pText);
+}
+
+bool PropertyListConfiguration::getData(const std::string& key, std::ostream &ostr)
+{
+	const Poco::XML::Node* thekey = findNode(key);
+
+	if (thekey)
+	{
+		Poco::XML::Node* thevalue = thekey->nextSibling();
+		if (thevalue->firstChild())
+		{
+			std::stringstream strs(thevalue->firstChild()->nodeValue());
+			Poco::Base64Decoder decoder(strs);
+			ostr << decoder.rdbuf();
+			return true;
+		}
+		else
+			return false;
+		return true;
+	}
+
+	return false;
+}
+
+bool PropertyListConfiguration::getRaw(const std::string& key, std::string& value) const
+{
+	const Poco::XML::Node* thekey = findNode(key);
+
+	if (thekey)
+	{
+		Poco::XML::Node* thevalue = thekey->nextSibling();
+		if (thevalue->firstChild())
+			value = thevalue->firstChild()->nodeValue();
+		else
+			value = thevalue->nodeName();	// the case for true/false
+		return true;
+	}
+
+	return false;
+}
+
+
+void PropertyListConfiguration::setRaw(const std::string& key, const std::string& value)
+{
+	Poco::XML::Node* thekey = findNode(key, true);
+	Poco::XML::Node* thevalue = thekey->nextSibling();
+
+	Poco::XML::Node* pElem = _pDocument->createElement("string");
+	thevalue->parentNode()->replaceChild(pElem, thevalue);
+	thevalue = pElem;
+	Poco::XML::Node* pText = _pDocument->createTextNode(value);
+	thevalue->appendChild(pText);
+}
+
+void PropertyListConfiguration::enumerate(const std::string& key, Keys& range) const
+{
+	const Poco::XML::Node* thekey = _pRoot->firstChild();
+
+	if (key.length() != 0)
+	{
+		thekey = findNode(key);
+		if (!thekey)
+			return;
+
+		thekey = thekey->nextSibling();
+	}
+
+	if (thekey && thekey->nodeName() == "dict")
+	{
+		Poco::XML::Node* pChild = thekey->firstChild();
+		while (pChild != NULL)
+		{
+			if (pChild->nodeName() == "key")
+			{
+				range.push_back(pChild->firstChild()->nodeValue());
+			}
+			pChild = pChild->nextSibling();
+		}
+	}
+}
+
+void PropertyListConfiguration::removeRaw(const std::string& key)
+{
+	Poco::XML::Node* thekey = findNode(key);
+
+	if (thekey)
+	{
+		Poco::XML::Node* thevalue = thekey->nextSibling();
+		thekey->parentNode()->removeChild(thekey);
+		thevalue->parentNode()->removeChild(thevalue);
+	}
+}
+
+Poco::XML::Node* PropertyListConfiguration::findNode(const std::string& key, bool create)
+{
+	Poco::XML::Node* dict = const_cast<Poco::XML::Node*>(_pRoot->firstChild());
+	return findNode(key, dict, create);
+}
+
+const Poco::XML::Node* PropertyListConfiguration::findNode(const std::string& key, bool create) const
+{
+	Poco::XML::Node* dict = const_cast<Poco::XML::Node*>(_pRoot->firstChild());
+	return findNode(key, dict, create);
+}
+
+Poco::XML::Node* PropertyListConfiguration::findNode(const std::string& key, Poco::XML::Node* dict, bool create)
+{
+	if (!dict) return NULL;
+	if (dict->nodeName() != "dict") return NULL;
+
+	std::string firstkey = key;
+	std::string::size_type dot = key.find('.');
+	if (dot != std::string::npos)
+	{
+		firstkey = key.substr(0, dot);
+	}
+
+	Poco::XML::Node* pNode = dict->firstChild();
+	while (pNode != NULL)
+	{
+		if (pNode->nodeName() == "key" && pNode->firstChild()->nodeValue() == firstkey)
+		{
+			if (dot != std::string::npos)	// keep searching
+				return findNode(key.substr(dot +1), pNode->nextSibling(), create);
+			else
+				return pNode;
+		}
+
+		pNode = pNode->nextSibling();
+	}
+
+	if (create)
+	{
+		Poco::XML::Element *pElem, *pNew;
+		Poco::XML::Node *pText;
+
+		pNew = pElem = dict->ownerDocument()->createElement("key");
+		dict->appendChild(pElem);
+		pText = dict->ownerDocument()->createTextNode(firstkey);
+		pElem->appendChild(pText);
+
+		if (dot != std::string::npos)
+		{
+			pElem = dict->ownerDocument()->createElement("dict");
+			dict->appendChild(pElem);
+
+			return findNode(key.substr(dot + 1), pElem, true);
+		}
+		else
+		{
+			pElem = dict->ownerDocument()->createElement("string");
+			dict->appendChild(pElem);
+			pText = dict->ownerDocument()->createTextNode("");
+			pElem->appendChild(pText);
+
+			return pNew;
+		}
+	}
+
+	return NULL;
+}
+
+} } // namespace Poco::Util
+
+#endif // POCO_UTIL_NO_XMLCONFIGURATION

--- a/Util/testsuite/Makefile
+++ b/Util/testsuite/Makefile
@@ -11,7 +11,7 @@ objects = AbstractConfigurationTest ConfigurationTestSuite \
 	HelpFormatterTest IniFileConfigurationTest LayeredConfigurationTest \
 	LoggingConfiguratorTest MapConfigurationTest \
 	OptionProcessorTest OptionSetTest OptionTest \
-	OptionsTestSuite PropertyFileConfigurationTest PropertyFileConfigurationTest \
+	OptionsTestSuite PropertyFileConfigurationTest PropertyListConfigurationTest \
 	SystemConfigurationTest UtilTestSuite XMLConfigurationTest \
 	FilesystemConfigurationTest ValidatorTest \
 	TimerTestSuite TimerTest \

--- a/Util/testsuite/Makefile
+++ b/Util/testsuite/Makefile
@@ -11,7 +11,7 @@ objects = AbstractConfigurationTest ConfigurationTestSuite \
 	HelpFormatterTest IniFileConfigurationTest LayeredConfigurationTest \
 	LoggingConfiguratorTest MapConfigurationTest \
 	OptionProcessorTest OptionSetTest OptionTest \
-	OptionsTestSuite PropertyFileConfigurationTest \
+	OptionsTestSuite PropertyFileConfigurationTest PropertyFileConfigurationTest \
 	SystemConfigurationTest UtilTestSuite XMLConfigurationTest \
 	FilesystemConfigurationTest ValidatorTest \
 	TimerTestSuite TimerTest \

--- a/Util/testsuite/src/ConfigurationTestSuite.cpp
+++ b/Util/testsuite/src/ConfigurationTestSuite.cpp
@@ -17,6 +17,7 @@
 #include "SystemConfigurationTest.h"
 #include "IniFileConfigurationTest.h"
 #include "PropertyFileConfigurationTest.h"
+#include "PropertyListConfigurationTest.h"
 #include "XMLConfigurationTest.h"
 #include "FilesystemConfigurationTest.h"
 #include "LoggingConfiguratorTest.h"
@@ -34,6 +35,7 @@ CppUnit::Test* ConfigurationTestSuite::suite()
 	pSuite->addTest(SystemConfigurationTest::suite());
 	pSuite->addTest(IniFileConfigurationTest::suite());
 	pSuite->addTest(PropertyFileConfigurationTest::suite());
+	pSuite->addTest(PropertyListConfigurationTest::suite());
 	pSuite->addTest(XMLConfigurationTest::suite());
 	pSuite->addTest(FilesystemConfigurationTest::suite());
 	pSuite->addTest(LoggingConfiguratorTest::suite());

--- a/Util/testsuite/src/PropertyListConfigurationTest.cpp
+++ b/Util/testsuite/src/PropertyListConfigurationTest.cpp
@@ -103,6 +103,7 @@ void PropertyListConfigurationTest::testSave()
 	istr.write("#0", 2);
 	pConf->setData("prop5", istr);
 	pConf->setDouble("prop6", 3.14);
+	pConf->setString("prop7.prop8", "nestedvalue");
 
 	std::ostringstream ostr;
 	pConf->save(ostr);
@@ -124,6 +125,11 @@ void PropertyListConfigurationTest::testSave()
 		"\t\t<data>IzA=</data>\n"
 		"\t\t<key>prop6</key>\n"
 		"\t\t<real>3.14</real>\n"
+		"\t\t<key>prop7</key>\n"
+		"\t\t<dict>\n"
+		"\t\t\t<key>prop8</key>\n"
+		"\t\t\t<string>nestedvalue</string>\n"
+		"\t\t</dict>\n"
 		"\t</dict>\n"
 		"</plist>\n");
 }

--- a/Util/testsuite/src/PropertyListConfigurationTest.cpp
+++ b/Util/testsuite/src/PropertyListConfigurationTest.cpp
@@ -1,0 +1,156 @@
+//
+// PropertyListConfigurationTest.cpp
+//
+// Copyright (c) 2017-2018, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "PropertyListConfigurationTest.h"
+#include "Poco/CppUnit/TestCaller.h"
+#include "Poco/CppUnit/TestSuite.h"
+#include "Poco/Util/PropertyListConfiguration.h"
+#include "Poco/AutoPtr.h"
+#include "Poco/Exception.h"
+#include <sstream>
+
+
+using Poco::Util::PropertyListConfiguration;
+using Poco::Util::AbstractConfiguration;
+using Poco::AutoPtr;
+using Poco::NotImplementedException;
+using Poco::NotFoundException;
+
+
+PropertyListConfigurationTest::PropertyListConfigurationTest(const std::string& name): AbstractConfigurationTest(name)
+{
+}
+
+
+PropertyListConfigurationTest::~PropertyListConfigurationTest()
+{
+}
+
+
+void PropertyListConfigurationTest::testLoad()
+{
+	static const std::string pfileFile =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+		"<plist version=\"1.0\">\n"
+		"<dict>\n"
+		"  <key>prop1</key>\n"
+		"  <string>value1</string>\r\n"
+		"  <key>prop2</key>\r\n"
+		"  <integer>8080</integer>\r\n"
+		"  <key>tree1</key>\n"
+		"  <dict>\n"
+		"	 <key>date1</key>\r\n"
+		"	 <date>2017-06-21T09:42:33Z</date>\r\n"
+		"	 <key>prop3</key>\r\n"
+		"	 <false/>\r\n"
+		"	 <key>prop4</key>\r\n"
+		"	 <data>2g==</data>\r\n"
+		"  </dict>\r\n"
+		"</dict>\r\n"
+		"</plist>\r\n";
+
+	std::istringstream istr(pfileFile);
+	AutoPtr<PropertyListConfiguration> pConf = new PropertyListConfiguration(istr);
+
+	assert (pConf->getString("prop1") == "value1");
+	assert (pConf->getString("prop2") == "8080");
+	assert (pConf->getString("tree1.date1") == "2017-06-21T09:42:33Z");
+	assert (pConf->getString("tree1.prop3") == "false");
+	std::stringstream buf;
+	pConf->getData("tree1.prop4", buf);
+	assert (buf.str() == "\xda");
+
+	AbstractConfiguration::Keys keys;
+	pConf->keys(keys);
+	assert (keys.size() == 3);
+	assert (std::find(keys.begin(), keys.end(), "prop1") != keys.end());
+	assert (std::find(keys.begin(), keys.end(), "prop2") != keys.end());
+	assert (std::find(keys.begin(), keys.end(), "tree1") != keys.end());
+
+	pConf->keys("tree1", keys);
+	assert (keys.size() == 3);
+	assert (std::find(keys.begin(), keys.end(), "date1") != keys.end());
+	assert (std::find(keys.begin(), keys.end(), "prop3") != keys.end());
+	assert(std::find(keys.begin(), keys.end(), "prop4") != keys.end());
+
+	try
+	{
+		std::string s = pConf->getString("foo");
+		fail("No property - must throw");
+	}
+	catch (NotFoundException&)
+	{
+	}
+}
+
+void PropertyListConfigurationTest::testSave()
+{
+	AutoPtr<PropertyListConfiguration> pConf = new PropertyListConfiguration;
+
+	pConf->setString("prop1", "value1");
+	pConf->setInt("prop2", 42);
+	pConf->setString("prop3", "value\\1\txxx<");
+	pConf->setBool("prop4", true);
+	std::stringstream istr;
+	istr.write("#0", 2);
+	pConf->setData("prop5", istr);
+	pConf->setDouble("prop6", 3.14);
+
+	std::ostringstream ostr;
+	pConf->save(ostr);
+	std::string propFile = ostr.str();
+
+	assert(propFile == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		"<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+		"<plist version=\"1.0\">\n"
+		"\t<dict>\n"
+		"\t\t<key>prop1</key>\n"
+		"\t\t<string>value1</string>\n"
+		"\t\t<key>prop2</key>\n"
+		"\t\t<integer>42</integer>\n"
+		"\t\t<key>prop3</key>\n"
+		"\t\t<string>value\\1\txxx&lt;</string>\n"
+		"\t\t<key>prop4</key>\n"
+		"\t\t<true/>\n"
+		"\t\t<key>prop5</key>\n"
+		"\t\t<data>IzA=</data>\n"
+		"\t\t<key>prop6</key>\n"
+		"\t\t<real>3.14</real>\n"
+		"\t</dict>\n"
+		"</plist>\n");
+}
+
+AbstractConfiguration* PropertyListConfigurationTest::allocConfiguration() const
+{
+	return new PropertyListConfiguration;
+}
+
+
+void PropertyListConfigurationTest::setUp()
+{
+}
+
+
+void PropertyListConfigurationTest::tearDown()
+{
+}
+
+
+CppUnit::Test* PropertyListConfigurationTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("PropertyListConfigurationTest");
+
+	AbstractConfigurationTest_addTests(pSuite, PropertyListConfigurationTest);
+	CppUnit_addTest(pSuite, PropertyListConfigurationTest, testLoad);
+	CppUnit_addTest(pSuite, PropertyListConfigurationTest, testSave);
+
+	return pSuite;
+}

--- a/Util/testsuite/src/PropertyListConfigurationTest.h
+++ b/Util/testsuite/src/PropertyListConfigurationTest.h
@@ -1,0 +1,40 @@
+//
+// PropertyListConfigurationTest.h
+//
+// Definition of the PropertyListConfigurationTest class.
+//
+// Copyright (c) 2017-2018, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef PropertyListConfigurationTest_INCLUDED
+#define PropertyListConfigurationTest_INCLUDED
+
+
+#include "AbstractConfigurationTest.h"
+#include "Poco/Util/Util.h"
+
+
+class PropertyListConfigurationTest: public AbstractConfigurationTest
+{
+public:
+	PropertyListConfigurationTest(const std::string& name);
+	virtual ~PropertyListConfigurationTest();
+
+	void testLoad();
+	void testSave();
+
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+
+private:
+	virtual Poco::Util::AbstractConfiguration* allocConfiguration() const;
+};
+
+
+#endif // PropertyListConfigurationTest_INCLUDED


### PR DESCRIPTION
A much more cleaned up version of the plist configuration feature.  This replaces #1762.

new class called PropertyListConfiguration subclassed from AbstractConfiguration
Handles OS X plist file type.
Supports all the types for reading as string data, and the following types for writing: string, data, integer, real.
The plist data type is supported with buffers.
Supports nested array.
Events correctly fired for set*() functions.
Test covers reading and writing to plist that's in a format generated by XCode.
