### PR TITLE
Start POCO as Windows service with parameters fix #2190

### DIFF
--- a/Util/include/Poco/Util/ServerApplication.h
+++ b/Util/include/Poco/Util/ServerApplication.h
@@ -195,7 +195,13 @@ private:
 #endif
 
 	bool hasConsole();
-	bool isService();
+	bool isService(const ArgVec& args);
+#if defined(POCO_WIN32_UTF8) && !defined(POCO_NO_WSTRING)
+	bool isService(int argc, wchar_t** argv);
+#else
+	bool isService(int argc, char** argv);
+#endif
+
 	void beService();
 	void registerService();
 	void unregisterService();
@@ -209,6 +215,7 @@ private:
 	std::string _displayName;
 	std::string _description;
 	std::string _startup;
+	static ArgVec _argsSvc;
 
 	static Poco::Event           _terminated;
 	static SERVICE_STATUS        _serviceStatus; 


### PR DESCRIPTION
Args are passed to _argsSvc member using isService, params are appended to params of "Path to executable" service property.