### PR TITLE
Poco 1.9.1 version of #2088 - Fix for TCPServerDispatcher race/crash

### DIFF
--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -96,7 +96,7 @@ void TCPServerDispatcher::release()
 
 void TCPServerDispatcher::run()
 {
-	AutoPtr<TCPServerDispatcher> guard(this, true); // ensure object stays alive
+	AutoPtr<TCPServerDispatcher> guard(this); // ensure _rc is decreased when function exits; it was incremented in enqueue()
 
 	int idleTime = (int) _pParams->getThreadIdleTime().totalMilliseconds();
 
@@ -149,6 +149,10 @@ void TCPServerDispatcher::enqueue(const StreamSocket& socket)
 			{
 				_threadPool.startWithPriority(_pParams->getThreadPriority(), *this, threadName);
 				++_currentThreads;
+				// Ensure this object lives at least until run() starts
+				// Small chance of leaking if threadpool is stopped before this
+				// work runs, but better than a dangling pointer and crash!
+				++_rc;
 			}
 			catch (Poco::Exception&)
 			{


### PR DESCRIPTION
#2088 was not compatible with the changes missing from 1.9.1 but in develop. This is a 1.9.1 friendly version. Fixes #2085 