### PR TITLE
This is a fix for the "invalid new-expression of abstract class type ApacheServerRequest" issue

### DIFF
--- a/ApacheConnector/include/ApacheConnector.h
+++ b/ApacheConnector/include/ApacheConnector.h
@@ -48,14 +48,20 @@ public:
 
 	void sendErrorResponse(int status);
 		/// Sends an error response with the given HTTP status code.
-		
+
 	int sendFile(const std::string& path, unsigned int fileSize, const std::string& mediaType);
 		/// Sends the file given by fileName as response.
 
 	void copyHeaders(ApacheServerRequest& request);
 		/// Copies the request uri and header fields from the Apache request
 		/// to the ApacheServerRequest.
-		
+
+	bool secure();
+		/// Returns true if the request is using a secure
+		/// connection. Returns false if no secure connection
+		/// is used, or if it is not known whether a secure
+		/// connection is used.
+
 private:
 	request_rec* _pRec;
 };

--- a/ApacheConnector/include/ApacheServerRequest.h
+++ b/ApacheConnector/include/ApacheServerRequest.h
@@ -58,6 +58,12 @@ public:
 	Poco::Net::HTTPServerResponse& response() const;
 		/// Returns a reference to the associated response
 
+	bool secure() const;
+		/// Returns true if the request is using a secure
+		/// connection. Returns false if no secure connection
+		/// is used, or if it is not known whether a secure
+		/// connection is used.
+
 protected:
 	void setResponse(ApacheServerResponse* pResponse);
 

--- a/ApacheConnector/src/ApacheServerRequest.cpp
+++ b/ApacheConnector/src/ApacheServerRequest.cpp
@@ -35,7 +35,7 @@ ApacheServerRequest::~ApacheServerRequest()
 	delete _pStream;
 }
 
-	
+
 const Poco::Net::HTTPServerParams& ApacheServerRequest::serverParams() const
 {
 	throw Poco::NotImplementedException("No HTTPServerParams available in Apache modules.");
@@ -57,4 +57,10 @@ void ApacheServerRequest::setResponse(ApacheServerResponse* pResponse)
 bool ApacheServerRequest::expectContinue() const
 {
 	return false;
+}
+
+
+bool ApacheServerRequest::secure() const
+{
+	return _pApacheRequest->secure();
 }


### PR DESCRIPTION
The following changes were made:
 - abstract method "bool secure() const" defined in HTTPServerRequest was implemented in ApacheServerRequest, one of its derived classes
 - a ap_log_error had one of its parameters changed for fixing a warning "passing NULL to non-pointer argument"
 - minor indentation problems corrected