### PR TITLE
cmake: add missing options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,16 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set( CMAKE_BUILD_TYPE "RelWithDebInfo" )
 endif()
 
+option(ENABLE_WSTRING "Enable std::wstring support" ON)
+if (NOT ENABLE_WSTRING)
+    add_definitions(-DPOCO_NO_WSTRING)
+endif()
+
+option(ENABLE_FPENVIRONMENT "Enable floating-point support" ON)
+if (NOT ENABLE_FPENVIRONMENT)
+    add_definitions(-DPOCO_NO_FPENVIRONMENT)
+endif()
+
 # Include some common macros to simpilfy Poco CMake files
 include(PocoMacros)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,16 +73,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set( CMAKE_BUILD_TYPE "RelWithDebInfo" )
 endif()
 
-option(ENABLE_WSTRING "Enable std::wstring support" ON)
-if (NOT ENABLE_WSTRING)
-    add_definitions(-DPOCO_NO_WSTRING)
-endif()
-
-option(ENABLE_FPENVIRONMENT "Enable floating-point support" ON)
-if (NOT ENABLE_FPENVIRONMENT)
-    add_definitions(-DPOCO_NO_FPENVIRONMENT)
-endif()
-
 # Include some common macros to simpilfy Poco CMake files
 include(PocoMacros)
 
@@ -96,6 +86,9 @@ option(ENABLE_MONGODB "Enable MongoDB" ON)
 option(ENABLE_PDF "Enable PDF" OFF)
 option(ENABLE_UTIL "Enable Util" ON)
 option(ENABLE_NET "Enable Net" ON)
+
+option(POCO_ENABLE_WSTRING "Enable std::wstring support" ON)
+option(POCO_ENABLE_FPENVIRONMENT "Enable floating-point support" ON)
 
 if(POCO_STATIC)
     message(WARNING "POCO_STATIC is deprecated and will be removed! Use BUILD_SHARED_LIBS instead")

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -173,6 +173,14 @@ target_include_directories( "${LIBNAME}"
 	)
 target_compile_definitions("${LIBNAME}" PUBLIC ${LIB_MODE_DEFINITIONS})
 
+if (NOT POCO_ENABLE_WSTRING)
+    target_compile_definitions("${LIBNAME}" PUBLIC POCO_NO_WSTRING)
+endif()
+
+if (NOT POCO_ENABLE_FPENVIRONMENT)
+    target_compile_definitions("${LIBNAME}" PUBLIC POCO_NO_FPENVIRONMENT)
+endif()
+
 POCO_INSTALL("${LIBNAME}")
 POCO_GENERATE_PACKAGE("${LIBNAME}")
 


### PR DESCRIPTION
Both --no-fpenvironment and --no-wstring are not covered within
CMakeLists.txt. Add both options but with the reversed logic, i.e.
ENABLE_WSTRING and ENABLE_FPENVIRONMENT.

If the option is not enabled, then the related define will be added.