### PR TITLE
 SecureSocket: Allow bind with reusePort

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/SecureServerSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureServerSocketImpl.h
@@ -63,7 +63,7 @@ public:
 		///
 		/// Throws a Poco::InvalidAccessException.
 	
-	void bind(const SocketAddress& address, bool reuseAddress = false);
+	void bind(const SocketAddress& address, bool reuseAddress = false, bool reusePort = false);
 		/// Bind a local address to the socket.
 		///
 		/// This is usually only done when establishing a server

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -78,7 +78,7 @@ public:
 		/// the TCP server at the given address. Prior to opening the
 		/// connection the socket is set to nonblocking mode.
 
-	void bind(const SocketAddress& address, bool reuseAddress = false);
+	void bind(const SocketAddress& address, bool reuseAddress = false, bool reusePort = false);
 		/// Bind a local address to the socket.
 		///
 		/// This is usually only done when establishing a server

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
@@ -61,7 +61,7 @@ public:
 		/// the TCP server at the given address. Prior to opening the
 		/// connection the socket is set to nonblocking mode.
 
-	void bind(const SocketAddress& address, bool reuseAddress);
+	void bind(const SocketAddress& address, bool reuseAddress, bool reusePort = false);
 		/// Bind a local address to the socket.
 		///
 		/// This is usually only done when establishing a server

--- a/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
@@ -62,9 +62,9 @@ void SecureServerSocketImpl::connectNB(const SocketAddress& address)
 }
 	
 
-void SecureServerSocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SecureServerSocketImpl::bind(const SocketAddress& address, bool reuseAddress, bool reusePort)
 {
-	_impl.bind(address, reuseAddress);
+	_impl.bind(address, reuseAddress, reusePort);
 	reset(_impl.sockfd());
 }
 

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -192,11 +192,11 @@ void SecureSocketImpl::connectSSL(bool performHandshake)
 }
 
 
-void SecureSocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SecureSocketImpl::bind(const SocketAddress& address, bool reuseAddress, bool reusePort)
 {
 	poco_check_ptr (_pSocket);
 
-	_pSocket->bind(address, reuseAddress);
+	_pSocket->bind(address, reuseAddress, reusePort);
 }
 
 

--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -91,7 +91,7 @@ void SecureStreamSocketImpl::connectSSL()
 
 void SecureStreamSocketImpl::bind(const SocketAddress& address, bool reuseAddress, bool reusePort)
 {
-	_impl.bind(address, reuseAddress);
+	_impl.bind(address, reuseAddress, reusePort);
 	reset(_impl.sockfd());
 }
 

--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -89,7 +89,7 @@ void SecureStreamSocketImpl::connectSSL()
 }
 	
 
-void SecureStreamSocketImpl::bind(const SocketAddress& address, bool reuseAddress)
+void SecureStreamSocketImpl::bind(const SocketAddress& address, bool reuseAddress, bool reusePort)
 {
 	_impl.bind(address, reuseAddress);
 	reset(_impl.sockfd());


### PR DESCRIPTION
im not sure about reusePort = false , maybe =true is closer to default SocketImpl::bind 