### PR TITLE
Add libcrypto.lib and libssl.lib for VS2017 debug/release_shared targets

### DIFF
--- a/Crypto/Crypto_x64_vs150.vcxproj
+++ b/Crypto/Crypto_x64_vs150.vcxproj
@@ -144,7 +144,7 @@ exit 0</Command>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoCrypto64d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -181,7 +181,7 @@ exit 0</Command>
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoCrypto64.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>false</GenerateDebugInformation>

--- a/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj
+++ b/NetSSL_OpenSSL/NetSSL_OpenSSL_x64_vs150.vcxproj
@@ -138,7 +138,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoNetSSL64d.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -170,7 +170,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;iphlpapi.lib;libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>..\bin64\PocoNetSSL64.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>false</GenerateDebugInformation>


### PR DESCRIPTION
I failed to build poco on VS2017 for release_shared target. My build batch snippet:
```
echo ===== Building POCO
cd /d %DEPSRC%poco
cd
set INCLUDE=%INCLUDE%;%DEPSRC%poco\openssl\VS_120\include;%DEPSRC%mysql\include
set LIB=%LIB%;%DEPSRC%poco\openssl\VS_120\win64\lib\release;%DEPSRC%mysql\lib
call buildwin 150 rebuild shared release x64 nosamples notests msbuild
```
It failed as Crypto and NetSSL_OpenSSL does not link openssl libraries for release_shared (and debug_shared) target.
It looks like the "Automatically link Crypto and OpenSSL libraries" mechanism in Crypto\include\Poco\Crypto\Crypto.h does not work as expected for release_shared (and debug_shared) target.

My patch fixed vs150.vcxproj as example only.
I suggest to fuse the vcxproj files into one, using MSBuild "/p:PlatformToolset=" option in buildwin.cmd to override the settings in vcxproj file, like this:
```
set MSBUILD=MSBuild.exe /m /p:Configuration=Release;Platform=x64;PlatformToolset=v141;WindowsTargetPlatformVersion=%UCRTVersion%;CharacterSet=MultiByte
set MSBUILDDBG=MSBuild.exe /m /p:Configuration=Debug;Platform=x64;PlatformToolset=v141;WindowsTargetPlatformVersion=%UCRTVersion%;CharacterSet=MultiByte
set MSBUILD32=MSBuild.exe /m /p:Configuration=Release;Platform=Win32;PlatformToolset=v141;WindowsTargetPlatformVersion=%UCRTVersion%;CharacterSet=MultiByte
set MSBUILD32DBG=MSBuild.exe /m /p:Configuration=Debug;Platform=Win32;PlatformToolset=v141;WindowsTargetPlatformVersion=%UCRTVersion%;CharacterSet=MultiByte
```
I see no reason to have so many .sln and .vcxproj files for different win32/x64 and VS version combinations.