### PR TITLE
HTTPClientSession to support dual IPv4/IPv6 family when setting source IP address #2271

### DIFF
--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -130,6 +130,10 @@ public:
 		/// Sets the source IP address and source port for the HTTPClientSession
 		/// socket.
 		///
+		/// Function can be called repeatedly to set one source address value for
+		/// IPv4 and one for IPv6, in the case where it is not known ahead of time
+		/// which type of address family the target host is part of.
+		///
 		/// The source address must not be changed once there
 		/// is an open connection to the server.
 		///
@@ -137,11 +141,17 @@ public:
 		/// using this function, but the typical client use is to set
 		/// the source IP address only and the source port portion
 		/// would normally be passed as 0 meaning that any port value
-		/// can be used on the source side of the socket. 
+		/// can be used on the source side of the socket.
 		///
 
         const SocketAddress& getSourceAddress();
-		/// Returns the source address previously set
+		/// Returns the last source address set with setSourceAddress
+
+        const SocketAddress& getSourceAddress4();
+		/// Returns the last IPv4 source address set with setSourceAddress
+
+        const SocketAddress& getSourceAddress6();
+		/// Returns the last IPV6 source address set with setSourceAddress
 
 	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT);
 		/// Sets the proxy host name and port number.
@@ -322,6 +332,8 @@ private:
 	std::string     _host;
 	Poco::UInt16    _port;
 	Poco::Net::SocketAddress _sourceAddress;
+	Poco::Net::SocketAddress _sourceAddress4;
+	Poco::Net::SocketAddress _sourceAddress6;
 	ProxyConfig     _proxyConfig;
 	Poco::Timespan  _keepAliveTimeout;
 	Poco::Timestamp _lastRequest;

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -403,19 +403,16 @@ int HTTPClientSession::write(const char* buffer, std::streamsize length)
 
 void HTTPClientSession::reconnect()
 {
+	SocketAddress addr;
 	if (_proxyConfig.host.empty() || bypassProxy())
-	{
-		SocketAddress addr(_host, _port);
-		if ((!_sourceAddress.host().isWildcard()) || (_sourceAddress.port() != 0))
-			connect(addr, _sourceAddress);
-		else
-			connect(addr);
-	}
+		addr = SocketAddress(_host, _port);
 	else
-	{
-		SocketAddress addr(_proxyConfig.host, _proxyConfig.port);
+		addr = SocketAddress(_proxyConfig.host, _proxyConfig.port);
+
+	if ((!_sourceAddress.host().isWildcard()) || (_sourceAddress.port() != 0))
+		connect(addr, _sourceAddress);
+	else
 		connect(addr);
-	}
 }
 
 
@@ -470,6 +467,7 @@ StreamSocket HTTPClientSession::proxyConnect()
 	proxyRequest.set("Host", getHost());
 	proxyAuthenticateImpl(proxyRequest);
 	proxySession.setKeepAlive(true);
+	proxySession.setSourceAddress(_sourceAddress);
 	proxySession.sendRequest(proxyRequest);
 	proxySession.receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)

--- a/NetSSL_OpenSSL/samples/SetSourceIP/CMakeLists.txt
+++ b/NetSSL_OpenSSL/samples/SetSourceIP/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SAMPLE_NAME "SetSourceIP")
 
+# uncomment following line, might solve compiling issues
+#set(CMAKE_CXX_STANDARD 11)
+
 set(LOCAL_SRCS "")
 aux_source_directory(src LOCAL_SRCS)
 

--- a/NetSSL_OpenSSL/samples/SetSourceIP/src/SetSourceIP.cpp
+++ b/NetSSL_OpenSSL/samples/SetSourceIP/src/SetSourceIP.cpp
@@ -39,15 +39,24 @@ void usage(std::string errorMessage)
 	std::cerr << "ERROR: " << errorMessage << std::endl;
 	std::cerr << std::endl;
 	std::cerr << "   syntax: " << std::endl;
-	std::cerr << "           " << programName.getBaseName() << " [--sourceip <source IP address>] uri" << std::endl;
+
+	std::cerr << "           " << programName.getBaseName() << " OPTIONS uri" << std::endl;
 	std::cerr << std::endl;
-	std::cerr << "           supported uri schemes are http and https" << std::endl;
+	std::cerr << "              OPTIONS:" << std::endl;
+	std::cerr << "                      --sourceip <source IP address>" << std::endl;
+	std::cerr << "                      --proxyuri <proxy uri>" << std::endl;
+
+	std::cerr << std::endl;
+	std::cerr << "           supported uri schemes for target are http and https" << std::endl;
+	std::cerr << "           supported uri scheme for proxy is http" << std::endl;
 	std::cerr << std::endl;
 	std::cerr << "   examples: " << std::endl;
 	std::cerr << "           " << programName.getBaseName() << " http://www.example.com/" << std::endl;
 	std::cerr << "           " << programName.getBaseName() << " https://www.example.com/" << std::endl;
 	std::cerr << "           " << programName.getBaseName() << " --sourceip 10.2.5.6 http://www.example.com/" << std::endl;
 	std::cerr << "           " << programName.getBaseName() << " --sourceip 192.168.15.122 https://www.example.com/" << std::endl;
+	std::cerr << "           " << programName.getBaseName() << " --proxyuri http://localhost:3128 https://www.example.com/" << std::endl;
+	std::cerr << "           " << programName.getBaseName() << " --sourceip 192.168.15.122 --proxyuri http://localhost:3128 https://www.example.com/" << std::endl;
 	std::cerr << std::endl;
 	exit(1);
 }
@@ -58,26 +67,48 @@ int main(int argc, char **argv)
 	// save program name in case usage() gets called
 	programName = argv[0];
 
-	if ((argc != 2) && (argc != 4))
+	std::string uriString;
+	std::string sourceIpString;
+	std::string proxyUriString;
+
+	for (int i = 1; i < argc; ++i)
 	{
-		usage("incorrect number of parameters.");
+		std::string optionName = argv[i];
+
+		if (optionName == "--sourceip")
+		{
+			++i;
+			if (i >= argc)
+			{
+				usage("Missing option arguments");
+			}
+
+			sourceIpString = argv[i];
+			continue;
+		}
+
+		if (optionName == "--proxyuri")
+		{
+			++i;
+			if (i >= argc)
+			{
+				usage("Missing option arguments");
+			}
+
+			proxyUriString = argv[i];
+			continue;
+		}
+
+		// last argument??
+		if ((i+1) == argc)
+			uriString = argv[i];
+		else
+			usage("Unknown option");
 	}
 
-	std::string uriString = argv[1];
-	std::string sourceIpString;
-	bool sourceIpSet = false;
-
-	if (argc == 4)
+	if (uriString.empty())
 	{
-		std::string optionName = argv[1];
-		sourceIpString = argv[2];
-		sourceIpSet = true;
-		uriString = argv[3];
-
-		if (optionName != "--sourceip")
-		{
-			usage("Invalid option specified");
-		}
+		usage("URI not specified");
 	}
 
 	Poco::SharedPtr<Poco::Net::HTTPClientSession> session;
@@ -110,14 +141,33 @@ int main(int argc, char **argv)
 		}
 		else
 		{
-			usage("wrong scheme '" + uri.getScheme() + "',  expected http or https");
+			usage("wrong scheme '" + uri.getScheme() + "' for target uri, expected http or https");
 		}
 
-		if (sourceIpSet)
+		if (!sourceIpString.empty())
 		{
 			// Set the sourceIP address, but leave the source port to 0 so ANY port can be used
 			Poco::Net::SocketAddress sa = Poco::Net::SocketAddress(sourceIpString, 0);
 			session->setSourceAddress(sa);
+
+			std::cout << "Using source IP address" << std::endl;
+			std::cout << "source IP address : " << sa.toString() << std::endl;
+			std::cout << std::endl;
+		}
+
+		if (!proxyUriString.empty())
+		{
+			Poco::URI proxyUri(proxyUriString);
+
+			if (proxyUri.getScheme() == "http")
+				session->setProxy(proxyUri.getHost(), proxyUri.getPort());
+			else
+				usage("wrong scheme '" + proxyUri.getScheme() + "' for proxy uri, expected http");
+
+			std::cout << "Using proxy" << std::endl;
+			std::cout << "Proxy Host: " << proxyUri.getHost() << std::endl;
+			std::cout << "Proxy Port: " << proxyUri.getPort() << std::endl;
+			std::cout << std::endl;
 		}
 
 		std::string path(uri.getPathAndQuery());

--- a/NetSSL_OpenSSL/samples/SetSourceIP/src/SetSourceIP.cpp
+++ b/NetSSL_OpenSSL/samples/SetSourceIP/src/SetSourceIP.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
 	programName = argv[0];
 
 	std::string uriString;
-	std::string sourceIpString;
+	std::list<std::string> sourceIpList;
 	std::string proxyUriString;
 
 	for (int i = 1; i < argc; ++i)
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
 				usage("Missing option arguments");
 			}
 
-			sourceIpString = argv[i];
+			sourceIpList.push_back(argv[i]);
 			continue;
 		}
 
@@ -144,8 +144,11 @@ int main(int argc, char **argv)
 			usage("wrong scheme '" + uri.getScheme() + "' for target uri, expected http or https");
 		}
 
-		if (!sourceIpString.empty())
+		while (!sourceIpList.empty())
 		{
+			std::string sourceIpString = sourceIpList.front();
+			sourceIpList.pop_front();
+
 			// Set the sourceIP address, but leave the source port to 0 so ANY port can be used
 			Poco::Net::SocketAddress sa = Poco::Net::SocketAddress(sourceIpString, 0);
 			session->setSourceAddress(sa);


### PR DESCRIPTION
Fix for issue: HTTPClientSession to support dual IPv4/IPv6 family when setting source IP address https://github.com/pocoproject/poco/issues/2271