### PR TITLE
Added check for null pointer before accessing and leaving SQLite mutex.

### DIFF
--- a/SQL/SQLite/src/Utility.cpp
+++ b/SQL/SQLite/src/Utility.cpp
@@ -59,15 +59,18 @@ Utility::TypeMap Utility::_types;
 Poco::Mutex Utility::_mutex;
 
 
-Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB): _pMutex(sqlite3_db_mutex(pDB))
+Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB)
 {
-	sqlite3_mutex_enter(_pMutex);
+	_pMutex = (pDB) ? sqlite3_db_mutex(pDB) : NULL;
+	if (_pMutex)
+		sqlite3_mutex_enter(_pMutex);
 }
 
 
 Utility::SQLiteMutex::~SQLiteMutex()
 {
-	sqlite3_mutex_leave(_pMutex);
+	if (_pMutex)
+		sqlite3_mutex_leave(_pMutex);
 }
 
 

--- a/SQL/SQLite/src/Utility.cpp
+++ b/SQL/SQLite/src/Utility.cpp
@@ -59,9 +59,8 @@ Utility::TypeMap Utility::_types;
 Poco::Mutex Utility::_mutex;
 
 
-Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB)
+Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB): _pMutex((pDB) ? sqlite3_db_mutex(pDB) : 0)
 {
-	_pMutex = (pDB) ? sqlite3_db_mutex(pDB) : NULL;
 	if (_pMutex)
 		sqlite3_mutex_enter(_pMutex);
 }

--- a/SQL/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/SQL/SQLite/testsuite/src/SQLiteTest.cpp
@@ -55,6 +55,7 @@ using Poco::SQL::Column;
 using Poco::SQL::Row;
 using Poco::SQL::SQLChannel;
 using Poco::SQL::LimitException;
+using Poco::SQL::ConnectionFailedException;
 using Poco::SQL::CLOB;
 using Poco::SQL::Date;
 using Poco::SQL::Time;
@@ -3708,6 +3709,18 @@ void SQLiteTest::testIncrementVacuum()
 	tmp << "PRAGMA incremental_vacuum(1024);", now;
 }
 
+void SQLiteTest::testIllegalFilePath()
+{
+	try
+	{
+		Session tmp (Poco::SQL::SQLite::Connector::KEY, "\\/some\\/illegal\\/path\\/dummy.db", 1);
+		fail("must fail");
+	}
+	catch (ConnectionFailedException&)
+	{
+	}
+}
+
 CppUnit::Test* SQLiteTest::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("SQLiteTest");
@@ -3801,6 +3814,7 @@ CppUnit::Test* SQLiteTest::suite()
 	CppUnit_addTest(pSuite, SQLiteTest, testTransactor);
 	CppUnit_addTest(pSuite, SQLiteTest, testFTS3);
 	CppUnit_addTest(pSuite, SQLiteTest, testJSONRowFormatter);
+	CppUnit_addTest(pSuite, SQLiteTest, testIllegalFilePath);
 //
 //	To be fixed by dimanikulin
 //	CppUnit_addTest(pSuite, SQLiteTest, testIncrementVacuum);

--- a/SQL/SQLite/testsuite/src/SQLiteTest.h
+++ b/SQL/SQLite/testsuite/src/SQLiteTest.h
@@ -139,6 +139,8 @@ public:
 
 	void testIncrementVacuum();
 
+	void testIllegalFilePath();
+
 	void setUp();
 	void tearDown();
 


### PR DESCRIPTION
A null pointer dereference occurs when a SQLite Session fails to be constructed. This can be recreated with the following code:
```
try
{
	Poco::SQL::Session tmp(Poco::SQL::SQLite::Connector::KEY, "\\/some\\/invalid\\/path\\/sqlite.db", 1);
}
catch (Poco::SQL::ConnectionFailedException&)
{
}
```
The issue occurs when the database cannot be created and attempts to throw an exception. However, since all exceptions invoke a SQLite mutex (since the fix for issue #2012), `sqlite3_db_mutex(pDB)` causes a segmentation fault when `pDB` is null which can occur if the database cannot be created. Checking for a null pointer before entering and leaving the SQLite mutex solves the problem.
