### PR TITLE
Fix #2277

### DIFF
--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -59,15 +59,17 @@ Utility::TypeMap Utility::_types;
 Poco::Mutex Utility::_mutex;
 
 
-Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB): _pMutex(sqlite3_db_mutex(pDB))
+Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB): _pMutex((pDB) ? sqlite3_db_mutex(pDB) : 0)
 {
-	sqlite3_mutex_enter(_pMutex);
+	if (_pMutex)
+		sqlite3_mutex_enter(_pMutex);
 }
 
 
 Utility::SQLiteMutex::~SQLiteMutex()
 {
-	sqlite3_mutex_leave(_pMutex);
+	if (_pMutex)
+		sqlite3_mutex_leave(_pMutex);
 }
 
 

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -52,6 +52,7 @@ using Poco::Data::Column;
 using Poco::Data::Row;
 using Poco::Data::SQLChannel;
 using Poco::Data::LimitException;
+using Poco::Data::ConnectionFailedException;
 using Poco::Data::CLOB;
 using Poco::Data::Date;
 using Poco::Data::Time;
@@ -3362,6 +3363,19 @@ void SQLiteTest::testFTS3()
 }
 
 
+void SQLiteTest::testIllegalFilePath()
+{
+	try
+	{
+		Session tmp (Poco::Data::SQLite::Connector::KEY, "\\/some\\/illegal\\/path\\/dummy.db", 1);
+		fail("must fail");
+	}
+	catch (ConnectionFailedException&)
+	{
+	}
+}
+
+
 void SQLiteTest::setUp()
 {
 }
@@ -3462,6 +3476,7 @@ CppUnit::Test* SQLiteTest::suite()
 	CppUnit_addTest(pSuite, SQLiteTest, testTransaction);
 	CppUnit_addTest(pSuite, SQLiteTest, testTransactor);
 	CppUnit_addTest(pSuite, SQLiteTest, testFTS3);
+	CppUnit_addTest(pSuite, SQLiteTest, testIllegalFilePath);
 
 	return pSuite;
 }

--- a/Data/SQLite/testsuite/src/SQLiteTest.h
+++ b/Data/SQLite/testsuite/src/SQLiteTest.h
@@ -133,6 +133,8 @@ public:
 
 	void testFTS3();
 
+	void testIllegalFilePath();
+
 	void setUp();
 	void tearDown();
 


### PR DESCRIPTION
Similar to #2276. Fix for Poco 1.9.1 which uses Poco::Data instead of the upcoming Poco::SQL.