### PR TITLE
 detach underlying native socket from SocketImpl

### DIFF
--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -475,7 +475,7 @@ inline poco_socket_t SocketImpl::sockfd() const
 	return _sockfd;
 }
 
-inline poco_socket_t SocketImpl::detachSocket() const
+inline poco_socket_t SocketImpl::detachSocket()
 {
 	poco_socket_t sock = sockfd();
 	reset(POCO_INVALID_SOCKET);

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -379,7 +379,8 @@ public:
 		
 	poco_socket_t detachSocket();
 		/// Returns the socket descriptor for the
-		/// underlying native socket and reset current SocketImpl socket descriptor
+		/// underlying native socket and resets the
+		/// current SocketImpl socket descriptor.
 
 	void ioctl(poco_ioctl_request_t request, int& arg);
 		/// A wrapper for the ioctl system call.

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -376,6 +376,10 @@ public:
 	poco_socket_t sockfd() const;
 		/// Returns the socket descriptor for the
 		/// underlying native socket.
+		
+	poco_socket_t detachSocket();
+		/// Returns the socket descriptor for the
+		/// underlying native socket and reset current SocketImpl socket descriptor
 
 	void ioctl(poco_ioctl_request_t request, int& arg);
 		/// A wrapper for the ioctl system call.
@@ -471,6 +475,12 @@ inline poco_socket_t SocketImpl::sockfd() const
 	return _sockfd;
 }
 
+inline poco_socket_t SocketImpl::detachSocket() const
+{
+	poco_socket_t sock = sockfd();
+	reset(POCO_INVALID_SOCKET);
+	return sock;
+}
 
 inline bool SocketImpl::initialized() const
 {


### PR DESCRIPTION
Some time you need to handle a socket accepted from PocoLib Socket library in another way/lib. I need a method to extract from StreamSocket the socket descriptor