### PR TITLE
Complete Source IP address binding - combined

### DIFF
--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -130,6 +130,10 @@ public:
 		/// Sets the source IP address and source port for the HTTPClientSession
 		/// socket.
 		///
+		/// Function can be called repeatedly to set one source address value for
+		/// IPv4 and one for IPv6, in the case where it is not known ahead of time
+		/// which type of address family the target host is part of.
+		///
 		/// The source address must not be changed once there
 		/// is an open connection to the server.
 		///
@@ -137,11 +141,17 @@ public:
 		/// using this function, but the typical client use is to set
 		/// the source IP address only and the source port portion
 		/// would normally be passed as 0 meaning that any port value
-		/// can be used on the source side of the socket. 
+		/// can be used on the source side of the socket.
 		///
 
         const SocketAddress& getSourceAddress();
-		/// Returns the source address previously set
+		/// Returns the last source address set with setSourceAddress
+
+        const SocketAddress& getSourceAddress4();
+		/// Returns the last IPv4 source address set with setSourceAddress
+
+        const SocketAddress& getSourceAddress6();
+		/// Returns the last IPV6 source address set with setSourceAddress
 
 	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT);
 		/// Sets the proxy host name and port number.
@@ -322,6 +332,8 @@ private:
 	std::string     _host;
 	Poco::UInt16    _port;
 	Poco::Net::SocketAddress _sourceAddress;
+	Poco::Net::SocketAddress _sourceAddress4;
+	Poco::Net::SocketAddress _sourceAddress6;
 	ProxyConfig     _proxyConfig;
 	Poco::Timespan  _keepAliveTimeout;
 	Poco::Timestamp _lastRequest;

--- a/NetSSL_OpenSSL/samples/SetSourceIP/CMakeLists.txt
+++ b/NetSSL_OpenSSL/samples/SetSourceIP/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(SAMPLE_NAME "SetSourceIP")
 
+# uncomment following line, might solve compiling issues
+#set(CMAKE_CXX_STANDARD 11)
+
 set(LOCAL_SRCS "")
 aux_source_directory(src LOCAL_SRCS)
 


### PR DESCRIPTION
Fixes for:
- HTTPClientSession to support dual IPv4/IPv6 family when setting source IP address #2271
- HTTPClientSession not supporting binding source address for proxy connect #2270