### PR TITLE
FTPClientSession read welcome message with external socket

### DIFF
--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -63,7 +63,7 @@ public:
 		///
 		/// Passive mode will be used for data transfers.
 
-	explicit FTPClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true);
+	explicit FTPClientSession(const StreamSocket& socket, bool readWelcomeMessage = true);
 		/// Creates an FTPClientSession using the given
 		/// connected socket for the control connection.
 		///
@@ -359,7 +359,7 @@ private:
 	bool	   _isLoggedIn = false;
 	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
 	std::string _welcomeMessage;
-	Poco::FastMutex _fmWelcomeMessage;	
+	Poco::FastMutex _wmMutex;	
 };
 
 
@@ -414,7 +414,7 @@ inline bool FTPClientSession::isSecure() const
 
 inline const std::string& FTPClientSession::welcomeMessage()
 {
-	Poco::FastMutex::ScopedLock lock(_fmWelcomeMessage);
+	Poco::FastMutex::ScopedLock lock(_wmMutex);
 	return _welcomeMessage;
 }
 

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -304,7 +304,10 @@ public:
 
 	bool isSecure() const;
 		/// Returns true if the session is FTPS.
-
+		
+	const std::string& welcomeMessage();
+	/// Returns welcome message.
+	
 protected:
 	virtual void receiveServerReadyReply();
 		/// Function that read server welcome message after connetion
@@ -355,6 +358,8 @@ private:
 	bool	   _serverReady = false;
 	bool	   _isLoggedIn = false;
 	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
+	std::string _welcomeMessage;
+	Poco::FastMutex _fmWelcomeMessage;	
 };
 
 
@@ -405,6 +410,12 @@ inline bool FTPClientSession::isLoggedIn() const
 inline bool FTPClientSession::isSecure() const
 {
 	return false;
+}
+
+inline const std::string& FTPClientSession::welcomeMessage()
+{
+	Poco::FastMutex::ScopedLock lock(_fmWelcomeMessage);
+	return _welcomeMessage;
 }
 
 } } // namespace Poco::Net

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -63,7 +63,7 @@ public:
 		///
 		/// Passive mode will be used for data transfers.
 
-	explicit FTPClientSession(const StreamSocket& socket);
+	explicit FTPClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true);
 		/// Creates an FTPClientSession using the given
 		/// connected socket for the control connection.
 		///

--- a/Net/include/Poco/Net/FTPPasswordProvider.h
+++ b/Net/include/Poco/Net/FTPPasswordProvider.h
@@ -1,0 +1,46 @@
+//
+// FTPPasswordProvider.h
+//
+// Library: Net
+// Package: FTP
+// Module:  FTPPasswordProvider
+//
+// Definition of the FTPPasswordProvider class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Net_FTPPasswordProvider_INCLUDED
+#define Net_FTPPasswordProvider_INCLUDED
+
+
+#include <string>
+
+
+namespace Poco {
+namespace Net {
+
+
+class Net_API FTPPasswordProvider
+	/// The base class for all password providers.
+	/// An instance of a subclass of this class can be
+	/// registered with the FTPPasswordProvider to
+	/// provide a password
+{
+public:
+	virtual std::string password(const std::string& username, const std::string& host) = 0;
+		/// Provide the password for the given user on the given host.
+
+protected:
+	FTPPasswordProvider();
+	virtual ~FTPPasswordProvider();
+};
+
+} } // namespace Poco::Net
+
+
+#endif // Net_FTPPasswordProvider_INCLUDED

--- a/Net/include/Poco/Net/FTPStreamFactory.h
+++ b/Net/include/Poco/Net/FTPStreamFactory.h
@@ -21,27 +21,11 @@
 #include "Poco/Net/Net.h"
 #include "Poco/Net/HTTPSession.h"
 #include "Poco/URIStreamFactory.h"
+#include "Poco/Net/FTPPasswordProvider.h"
 
 
 namespace Poco {
 namespace Net {
-
-
-class Net_API FTPPasswordProvider
-	/// The base class for all password providers.
-	/// An instance of a subclass of this class can be
-	/// registered with the FTPStreamFactory to
-	/// provide a password
-{
-public:
-	virtual std::string password(const std::string& username, const std::string& host) = 0;
-		/// Provide the password for the given user on the given host.
-
-protected:
-	FTPPasswordProvider();
-	virtual ~FTPPasswordProvider();
-};
-
 
 class Net_API FTPStreamFactory: public Poco::URIStreamFactory
 	/// An implementation of the URIStreamFactory interface

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -42,7 +42,7 @@ FTPClientSession::FTPClientSession():
 }
 
 	
-FTPClientSession::FTPClientSession(const StreamSocket& socket):
+FTPClientSession::FTPClientSession(const StreamSocket& socket, bool bReadWelcomeMessage):
 	_pControlSocket(new DialogSocket(socket)),
 	_pDataStream(0),
 	_host(socket.address().host().toString()),
@@ -55,6 +55,13 @@ FTPClientSession::FTPClientSession(const StreamSocket& socket):
 	_timeout(DEFAULT_TIMEOUT)
 {
 	_pControlSocket->setReceiveTimeout(_timeout);
+	if (bReadWelcomeMessage) 
+	{
+		receiveServerReadyReply();
+	}
+	else {
+		_serverReady = true;
+	}	
 }
 
 

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -156,7 +156,11 @@ void  FTPClientSession::receiveServerReadyReply()
 	int status = _pControlSocket->receiveStatusMessage(response);
 	if (!isPositiveCompletion(status))
 		throw FTPException("Cannot receive status message", response, status);
-
+		
+	{
+		Poco::FastMutex::ScopedLock lock(_fmWelcomeMessage);
+		_welcomeMessage = response;
+	}
 	_serverReady = true;
 }
 

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -42,7 +42,7 @@ FTPClientSession::FTPClientSession():
 }
 
 	
-FTPClientSession::FTPClientSession(const StreamSocket& socket, bool bReadWelcomeMessage):
+FTPClientSession::FTPClientSession(const StreamSocket& socket, bool readWelcomeMessage):
 	_pControlSocket(new DialogSocket(socket)),
 	_pDataStream(0),
 	_host(socket.address().host().toString()),
@@ -55,11 +55,12 @@ FTPClientSession::FTPClientSession(const StreamSocket& socket, bool bReadWelcome
 	_timeout(DEFAULT_TIMEOUT)
 {
 	_pControlSocket->setReceiveTimeout(_timeout);
-	if (bReadWelcomeMessage) 
+	if (readWelcomeMessage) 
 	{
 		receiveServerReadyReply();
 	}
-	else {
+	else 
+	{
 		_serverReady = true;
 	}	
 }
@@ -158,7 +159,7 @@ void  FTPClientSession::receiveServerReadyReply()
 		throw FTPException("Cannot receive status message", response, status);
 		
 	{
-		Poco::FastMutex::ScopedLock lock(_fmWelcomeMessage);
+		Poco::FastMutex::ScopedLock lock(_wmMutex);
 		_welcomeMessage = response;
 	}
 	_serverReady = true;

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -1,66 +1,98 @@
-#pragma once
+//
+// FTPSClientSession.h
+//
+// Library: Net
+// Package: FTP
+// Module:  FTPSClientSession
+//
+// Definition of the FTPSClientSession class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef NetSSL_FTPSClientSession_INCLUDED
+#define NetSSL_FTPSClientSession_INCLUDED
+
+
+#include "Poco/Net/NetSSL.h"
 #include "Poco/Net/FTPClientSession.h"
 
+
 namespace Poco {
-namespace Net {
+	namespace Net {
 
-class FTPSClientSession :
-	public Poco::Net::FTPClientSession
-{
-public:
-	FTPSClientSession();
-	/// Creates an FTPSClientSession.
-	///
-	/// Passive mode will be used for data transfers.
 
-	explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true, bool bTryUseFTPS = true);
-	/// Creates an FTPSClientSession using the given
-	/// connected socket for the control connection.
-	///
-	/// Passive mode will be used for data transfers.
+		class NetSSL_API FTPSClientSession :
+			public Poco::Net::FTPClientSession
+		{
+		public:
+			FTPSClientSession();
+			/// Creates an FTPSClientSession.
+			///
+			/// Passive mode will be used for data transfers.
 
-	FTPSClientSession(const std::string& host,
-		Poco::UInt16 port = FTP_PORT,
-		const std::string& username = "",
-		const std::string& password = "");
-	/// Creates an FTPSClientSession using a socket connected
-	/// to the given host and port. If username is supplied,
-	/// login is attempted.
-	///
-	/// Passive mode will be used for data transfers.
+			explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true, bool bTryUseFTPS = true);
+			/// Creates an FTPSClientSession using the given
+			/// connected socket for the control connection.
+			///
+			/// Passive mode will be used for data transfers.
 
-	virtual ~FTPSClientSession();	
+			FTPSClientSession(const std::string& host,
+				Poco::UInt16 port = FTP_PORT,
+				const std::string& username = "",
+				const std::string& password = "");
+			/// Creates an FTPSClientSession using a socket connected
+			/// to the given host and port. If username is supplied,
+			/// login is attempted.
+			///
+			/// Passive mode will be used for data transfers.
 
-	void tryFTPSmode(bool bTryFTPS);
-		/// avoid or require TLS mode
+			virtual ~FTPSClientSession();
 
-	bool isSecure() const;
-		/// Returns true if the session is FTPS.
+			void tryFTPSmode(bool bTryFTPS);
+			/// avoid or require TLS mode
 
-protected:
-	virtual StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
-		/// Create secure data connection
+			bool isSecure() const;
+			/// Returns true if the session is FTPS.
 
-	virtual void receiveServerReadyReply();
-		/// Function that read server welcome message after connetion and set and make secure socket
+		protected:
+			virtual StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
+			/// Create secure data connection
 
-private:
-	bool _bTryFTPS = true;
+			virtual void receiveServerReadyReply();
+			/// Function that read server welcome message after connetion and set and make secure socket
 
-	void beforeCreateDataSocket();
-		///Send commands to check if we can encrypt data socket
+		private:
+			bool _bTryFTPS = true;
 
-	void afterCreateControlSocket();
-		///Send commands to make SSL negotiating of control channel
+			void beforeCreateDataSocket();
+			///Send commands to check if we can encrypt data socket
 
-	bool _bSecureDataConnection = false;
-};
+			void afterCreateControlSocket();
+			///Send commands to make SSL negotiating of control channel
 
-inline bool FTPSClientSession::isSecure() const
-{
-	if (_pControlSocket != nullptr)
-		return _pControlSocket->secure();
-	return false;
-}
+			bool _bSecureDataConnection = false;
+		};
 
-}} // namespace Poco::Net
+
+		//
+		// inlines
+		//
+
+		inline bool FTPSClientSession::isSecure() const
+		{
+			if (_pControlSocket != nullptr)
+				return _pControlSocket->secure();
+			return false;
+		}
+
+
+	}
+} // namespace Poco::Net
+
+
+#endif // #define NetSSL_FTPSClientSession_INCLUDED

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -35,7 +35,7 @@ namespace Poco {
 			///
 			/// Passive mode will be used for data transfers.
 
-			explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true, bool bTryUseFTPS = true);
+			explicit FTPSClientSession(const StreamSocket& socket, bool readWelcomeMessage = true, bool tryUseFTPS = true);
 			/// Creates an FTPSClientSession using the given
 			/// connected socket for the control connection.
 			///
@@ -67,7 +67,7 @@ namespace Poco {
 			/// Function that read server welcome message after connetion and set and make secure socket
 
 		private:
-			bool _bTryFTPS = true;
+			bool _tryFTPS = true;
 
 			void beforeCreateDataSocket();
 			///Send commands to check if we can encrypt data socket
@@ -75,7 +75,7 @@ namespace Poco {
 			void afterCreateControlSocket();
 			///Send commands to make SSL negotiating of control channel
 
-			bool _bSecureDataConnection = false;
+			bool _secureDataConnection = false;
 		};
 
 

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -1,32 +1,10 @@
-//
-// FTPSClientSession.h
-//
-// Library: Net
-// Package: FTP
-// Module:  FTPSClientSession
-//
-// Definition of the FTPSClientSession class.
-//
-// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
-// and Contributors.
-//
-// SPDX-License-Identifier:	BSL-1.0
-//
-
-
-#ifndef NetSSL_FTPSClientSession_INCLUDED
-#define NetSSL_FTPSClientSession_INCLUDED
-
-
-#include "Poco/Net/NetSSL.h"
+#pragma once
 #include "Poco/Net/FTPClientSession.h"
-
 
 namespace Poco {
 namespace Net {
 
-
-class NetSSL_API FTPSClientSession :
+class FTPSClientSession :
 	public Poco::Net::FTPClientSession
 {
 public:
@@ -35,7 +13,7 @@ public:
 	///
 	/// Passive mode will be used for data transfers.
 
-	explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true);
+	explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true, bool bTryUseFTPS = true);
 	/// Creates an FTPSClientSession using the given
 	/// connected socket for the control connection.
 	///
@@ -78,11 +56,6 @@ private:
 	bool _bSecureDataConnection = false;
 };
 
-
-//
-// inlines
-//
-
 inline bool FTPSClientSession::isSecure() const
 {
 	if (_pControlSocket != nullptr)
@@ -90,8 +63,4 @@ inline bool FTPSClientSession::isSecure() const
 	return false;
 }
 
-
 }} // namespace Poco::Net
-
-
-#endif // #define NetSSL_FTPSClientSession_INCLUDED

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -35,7 +35,7 @@ public:
 	///
 	/// Passive mode will be used for data transfers.
 
-	explicit FTPSClientSession(const StreamSocket& socket);
+	explicit FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage = true);
 	/// Creates an FTPSClientSession using the given
 	/// connected socket for the control connection.
 	///

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
@@ -22,7 +22,7 @@
 #include "Poco/Net/HTTPSession.h"
 #include "Poco/URIStreamFactory.h"
 #include "Poco/Net/FTPStreamFactory.h"
-
+#include "Poco/Net/FTPPasswordProvider.h"
 
 namespace Poco {
 namespace Net {

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSStreamFactory.h
@@ -21,26 +21,11 @@
 #include "Poco/Net/NetSSL.h"
 #include "Poco/Net/HTTPSession.h"
 #include "Poco/URIStreamFactory.h"
+#include "Poco/Net/FTPStreamFactory.h"
 
 
 namespace Poco {
 namespace Net {
-
-
-class NetSSL_API FTPPasswordProvider
-	/// The base class for all password providers.
-	/// An instance of a subclass of this class can be
-	/// registered with the FTPSStreamFactory to
-	/// provide a password
-{
-public:
-	virtual std::string password(const std::string& username, const std::string& host) = 0;
-		/// Provide the password for the given user on the given host.
-
-protected:
-	FTPPasswordProvider();
-	virtual ~FTPPasswordProvider();
-};
 
 
 class NetSSL_API FTPSStreamFactory: public Poco::URIStreamFactory

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -31,8 +31,8 @@ FTPSClientSession::~FTPSClientSession()
 {
 }
 
-FTPSClientSession::FTPSClientSession(const StreamSocket& socket) :
-	FTPClientSession(socket)
+FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage) :
+	FTPClientSession(socket, bReadWelcomeMessage)
 {
 }
 

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -1,3 +1,17 @@
+//
+// FTPSClientSession.cpp
+//
+// Library: Net
+// Package: FTP
+// Module:  FTPSClientSession
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
 #include "Poco/Net/FTPSClientSession.h"
 #include "Poco/Net/SecureStreamSocket.h"
 #include "Poco/Net/SecureStreamSocketImpl.h"
@@ -5,113 +19,112 @@
 #include "Poco/Net/NetException.h"
 
 namespace Poco {
-namespace Net {
+	namespace Net {
 
-FTPSClientSession::FTPSClientSession() :
-	FTPClientSession()
-{
-}
-
-
-FTPSClientSession::~FTPSClientSession()
-{
-}
-
-FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage, bool bTryUseFTPS) :
-	FTPClientSession(socket, bReadWelcomeMessage), _bTryFTPS(bTryUseFTPS)
-{
-}
-
-
-FTPSClientSession::FTPSClientSession(const std::string& host,
-										Poco::UInt16 port,
-										const std::string& username,
-										const std::string& password) :
-	FTPClientSession(host, port)
-{
-	if(!username.empty())
-		login(username, password);	
-}
-
-void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
-{
-	_bTryFTPS = bTryFTPS;
-}
-
-void FTPSClientSession::beforeCreateDataSocket()
-{
-	if (_bSecureDataConnection)
-		return;
-	_bSecureDataConnection = false;
-	if (!_pControlSocket->secure())
-		return;
-	std::string sResponse;
-	int status = sendCommand("PBSZ 0", sResponse);
-	if (isPositiveCompletion(status)) 
-	{
-		status = sendCommand("PROT P", sResponse);
-		if (isPositiveCompletion(status)) 
-			_bSecureDataConnection = true;
-	}
-}
-
-void FTPSClientSession::afterCreateControlSocket()
-{
-	if (!_bTryFTPS)
-		return;
-	_pControlSocket->setNoDelay(true);
-	if (_pControlSocket->secure())
-		return;
-
-	std::string sResponse;
-	int status = sendCommand("AUTH TLS", sResponse);
-	if (!isPositiveCompletion(status))
-		status = sendCommand("AUTH SSL", sResponse);
-
-	if (isPositiveCompletion(status))
-	{
-		//Server support FTPS
-		try
+		FTPSClientSession::FTPSClientSession() :
+			FTPClientSession()
 		{
-			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(*_pControlSocket, Poco::Net::SSLManager::instance().defaultClientContext()));
-			*_pControlSocket = sss;
 		}
-		catch (Poco::Exception&)
+
+
+		FTPSClientSession::~FTPSClientSession()
 		{
-			throw;
 		}
-	}
-	else
-	{
-		_bTryFTPS = false;
-	}
-}
 
-StreamSocket FTPSClientSession::establishDataConnection(const std::string& command, const std::string& arg)
-{
-	beforeCreateDataSocket();
-
-	StreamSocket ss = FTPClientSession::establishDataConnection(command, arg);
-	ss.setNoDelay(true);
-
-	//SSL nogotiating of data socket
-	if ((_bSecureDataConnection) && (_pControlSocket->secure()))
-	{
-		//We need to reuse the control socket SSL session so the server can ensure that client that opened control socket is the same using data socket
-		Poco::Net::SecureStreamSocketImpl* pSecure = dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(_pControlSocket->impl());
-		if (pSecure != nullptr)
+		FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage, bool bTryUseFTPS) :
+			FTPClientSession(socket, bReadWelcomeMessage), _bTryFTPS(bTryUseFTPS)
 		{
-			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
-			ss = sss;
 		}
+
+
+		FTPSClientSession::FTPSClientSession(const std::string& host,
+			Poco::UInt16 port,
+			const std::string& username,
+			const std::string& password) :
+			FTPClientSession(host, port, username, password)
+		{
+		}
+
+		void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
+		{
+			_bTryFTPS = bTryFTPS;
+		}
+
+		void FTPSClientSession::beforeCreateDataSocket()
+		{
+			if (_bSecureDataConnection)
+				return;
+			_bSecureDataConnection = false;
+			if (!_pControlSocket->secure())
+				return;
+			std::string sResponse;
+			int status = sendCommand("PBSZ 0", sResponse);
+			if (isPositiveCompletion(status))
+			{
+				status = sendCommand("PROT P", sResponse);
+				if (isPositiveCompletion(status))
+					_bSecureDataConnection = true;
+			}
+		}
+
+		void FTPSClientSession::afterCreateControlSocket()
+		{
+			if (!_bTryFTPS)
+				return;
+			_pControlSocket->setNoDelay(true);
+			if (_pControlSocket->secure())
+				return;
+
+			std::string sResponse;
+			int status = sendCommand("AUTH TLS", sResponse);
+			if (!isPositiveCompletion(status))
+				status = sendCommand("AUTH SSL", sResponse);
+
+			if (isPositiveCompletion(status))
+			{
+				//Server support FTPS
+				try
+				{
+					Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(*_pControlSocket, Poco::Net::SSLManager::instance().defaultClientContext()));
+					*_pControlSocket = sss;
+				}
+				catch (Poco::Exception&)
+				{
+					throw;
+				}
+			}
+			else
+			{
+				_bTryFTPS = false;
+			}
+		}
+
+		StreamSocket FTPSClientSession::establishDataConnection(const std::string& command, const std::string& arg)
+		{
+			beforeCreateDataSocket();
+
+			StreamSocket ss = FTPClientSession::establishDataConnection(command, arg);
+			ss.setNoDelay(true);
+
+			//SSL nogotiating of data socket
+			if ((_bSecureDataConnection) && (_pControlSocket->secure()))
+			{
+				//We need to reuse the control socket SSL session so the server can ensure that client that opened control socket is the same using data socket
+				Poco::Net::SecureStreamSocketImpl* pSecure = dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(_pControlSocket->impl());
+				if (pSecure != nullptr)
+				{
+					Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
+					ss = sss;
+				}
+			}
+			return ss;
+		}
+
+		void FTPSClientSession::receiveServerReadyReply()
+		{
+			FTPClientSession::receiveServerReadyReply();
+			afterCreateControlSocket();
+		}
+
 	}
-	return ss;
-}
-
-void FTPSClientSession::receiveServerReadyReply()
-{
-	FTPClientSession::receiveServerReadyReply();
-	afterCreateControlSocket();
-}
-
-}} // namespace Poco::Net
+} // namespace Poco::Net

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -19,112 +19,112 @@
 #include "Poco/Net/NetException.h"
 
 namespace Poco {
-	namespace Net {
+namespace Net {
 
-		FTPSClientSession::FTPSClientSession() :
-			FTPClientSession()
-		{
-		}
-
-
-		FTPSClientSession::~FTPSClientSession()
-		{
-		}
-
-		FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage, bool bTryUseFTPS) :
-			FTPClientSession(socket, bReadWelcomeMessage), _bTryFTPS(bTryUseFTPS)
-		{
-		}
+FTPSClientSession::FTPSClientSession() :
+	FTPClientSession()
+{
+}
 
 
-		FTPSClientSession::FTPSClientSession(const std::string& host,
-			Poco::UInt16 port,
-			const std::string& username,
-			const std::string& password) :
-			FTPClientSession(host, port, username, password)
-		{
-		}
+FTPSClientSession::~FTPSClientSession()
+{
+}
 
-		void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
-		{
-			_bTryFTPS = bTryFTPS;
-		}
+FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool readWelcomeMessage, bool tryUseFTPS) :
+	FTPClientSession(socket, readWelcomeMessage), _tryFTPS(tryUseFTPS)
+{
+}
 
-		void FTPSClientSession::beforeCreateDataSocket()
-		{
-			if (_bSecureDataConnection)
-				return;
-			_bSecureDataConnection = false;
-			if (!_pControlSocket->secure())
-				return;
-			std::string sResponse;
-			int status = sendCommand("PBSZ 0", sResponse);
-			if (isPositiveCompletion(status))
-			{
-				status = sendCommand("PROT P", sResponse);
-				if (isPositiveCompletion(status))
-					_bSecureDataConnection = true;
-			}
-		}
 
-		void FTPSClientSession::afterCreateControlSocket()
-		{
-			if (!_bTryFTPS)
-				return;
-			_pControlSocket->setNoDelay(true);
-			if (_pControlSocket->secure())
-				return;
+FTPSClientSession::FTPSClientSession(const std::string& host,
+	Poco::UInt16 port,
+	const std::string& username,
+	const std::string& password) :
+	FTPClientSession(host, port, username, password)
+{
+}
 
-			std::string sResponse;
-			int status = sendCommand("AUTH TLS", sResponse);
-			if (!isPositiveCompletion(status))
-				status = sendCommand("AUTH SSL", sResponse);
+void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
+{
+	_tryFTPS = bTryFTPS;
+}
 
-			if (isPositiveCompletion(status))
-			{
-				//Server support FTPS
-				try
-				{
-					Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(*_pControlSocket, Poco::Net::SSLManager::instance().defaultClientContext()));
-					*_pControlSocket = sss;
-				}
-				catch (Poco::Exception&)
-				{
-					throw;
-				}
-			}
-			else
-			{
-				_bTryFTPS = false;
-			}
-		}
-
-		StreamSocket FTPSClientSession::establishDataConnection(const std::string& command, const std::string& arg)
-		{
-			beforeCreateDataSocket();
-
-			StreamSocket ss = FTPClientSession::establishDataConnection(command, arg);
-			ss.setNoDelay(true);
-
-			//SSL nogotiating of data socket
-			if ((_bSecureDataConnection) && (_pControlSocket->secure()))
-			{
-				//We need to reuse the control socket SSL session so the server can ensure that client that opened control socket is the same using data socket
-				Poco::Net::SecureStreamSocketImpl* pSecure = dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(_pControlSocket->impl());
-				if (pSecure != nullptr)
-				{
-					Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
-					ss = sss;
-				}
-			}
-			return ss;
-		}
-
-		void FTPSClientSession::receiveServerReadyReply()
-		{
-			FTPClientSession::receiveServerReadyReply();
-			afterCreateControlSocket();
-		}
-
+void FTPSClientSession::beforeCreateDataSocket()
+{
+	if (_secureDataConnection)
+		return;
+	_secureDataConnection = false;
+	if (!_pControlSocket->secure())
+		return;
+	std::string sResponse;
+	int status = sendCommand("PBSZ 0", sResponse);
+	if (isPositiveCompletion(status))
+	{
+		status = sendCommand("PROT P", sResponse);
+		if (isPositiveCompletion(status))
+			_secureDataConnection = true;
 	}
+}
+
+void FTPSClientSession::afterCreateControlSocket()
+{
+	if (!_tryFTPS)
+		return;
+	_pControlSocket->setNoDelay(true);
+	if (_pControlSocket->secure())
+		return;
+
+	std::string sResponse;
+	int status = sendCommand("AUTH TLS", sResponse);
+	if (!isPositiveCompletion(status))
+		status = sendCommand("AUTH SSL", sResponse);
+
+	if (isPositiveCompletion(status))
+	{
+		//Server support FTPS
+		try
+		{
+			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(*_pControlSocket, Poco::Net::SSLManager::instance().defaultClientContext()));
+			*_pControlSocket = sss;
+		}
+		catch (Poco::Exception&)
+		{
+			throw;
+		}
+	}
+	else
+	{
+		_tryFTPS = false;
+	}
+}
+
+StreamSocket FTPSClientSession::establishDataConnection(const std::string& command, const std::string& arg)
+{
+	beforeCreateDataSocket();
+
+	StreamSocket ss = FTPClientSession::establishDataConnection(command, arg);
+	ss.setNoDelay(true);
+
+	//SSL nogotiating of data socket
+	if ((_secureDataConnection) && (_pControlSocket->secure()))
+	{
+		//We need to reuse the control socket SSL session so the server can ensure that client that opened control socket is the same using data socket
+		Poco::Net::SecureStreamSocketImpl* pSecure = dynamic_cast<Poco::Net::SecureStreamSocketImpl*>(_pControlSocket->impl());
+		if (pSecure != nullptr)
+		{
+			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
+			ss = sss;
+		}
+	}
+	return ss;
+}
+
+void FTPSClientSession::receiveServerReadyReply()
+{
+	FTPClientSession::receiveServerReadyReply();
+	afterCreateControlSocket();
+}
+
+}
 } // namespace Poco::Net

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -1,17 +1,3 @@
-//
-// FTPSClientSession.cpp
-//
-// Library: Net
-// Package: FTP
-// Module:  FTPSClientSession
-//
-// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
-// and Contributors.
-//
-// SPDX-License-Identifier:	BSL-1.0
-//
-
-
 #include "Poco/Net/FTPSClientSession.h"
 #include "Poco/Net/SecureStreamSocket.h"
 #include "Poco/Net/SecureStreamSocketImpl.h"
@@ -31,8 +17,8 @@ FTPSClientSession::~FTPSClientSession()
 {
 }
 
-FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage) :
-	FTPClientSession(socket, bReadWelcomeMessage)
+FTPSClientSession::FTPSClientSession(const StreamSocket& socket, bool bReadWelcomeMessage, bool bTryUseFTPS) :
+	FTPClientSession(socket, bReadWelcomeMessage), _bTryFTPS(bTryUseFTPS)
 {
 }
 
@@ -41,8 +27,10 @@ FTPSClientSession::FTPSClientSession(const std::string& host,
 										Poco::UInt16 port,
 										const std::string& username,
 										const std::string& password) :
-	FTPClientSession(host, port, username, password)
+	FTPClientSession(host, port)
 {
+	if(!username.empty())
+		login(username, password);	
 }
 
 void FTPSClientSession::tryFTPSmode(bool bTryFTPS)
@@ -59,10 +47,10 @@ void FTPSClientSession::beforeCreateDataSocket()
 		return;
 	std::string sResponse;
 	int status = sendCommand("PBSZ 0", sResponse);
-	if (isPositiveCompletion(status))
+	if (isPositiveCompletion(status)) 
 	{
 		status = sendCommand("PROT P", sResponse);
-		if (isPositiveCompletion(status))
+		if (isPositiveCompletion(status)) 
 			_bSecureDataConnection = true;
 	}
 }

--- a/NetSSL_OpenSSL/src/FTPSStreamFactory.cpp
+++ b/NetSSL_OpenSSL/src/FTPSStreamFactory.cpp
@@ -99,19 +99,8 @@ private:
 };
 
 
-FTPPasswordProvider::FTPPasswordProvider()
-{
-}
-
-
-FTPPasswordProvider::~FTPPasswordProvider()
-{
-}
-
-
-std::string          FTPSStreamFactory::_anonymousPassword("poco@localhost");
+std::string FTPSStreamFactory::_anonymousPassword("poco@localhost");
 FTPPasswordProvider* FTPSStreamFactory::_pPasswordProvider(0);
-
 
 FTPSStreamFactory::FTPSStreamFactory()
 {

--- a/PDF/src/Document.cpp
+++ b/PDF/src/Document.cpp
@@ -195,12 +195,12 @@ const Image& Document::loadPNGImageImpl(const std::string& fileName, bool doLoad
 		std::pair<ImageContainer::iterator, bool> it;
 		if (doLoad)
 		{
-			Image image(&_pdf, HPDF_LoadPngImageFromFile(_pdf, fileName.c_str()));
+			Image image(&_pdf, HPDF_LoadPngImageFromFile(_pdf, Poco::Path::transcode(fileName).c_str()));
 			it = _images.insert(ImageContainer::value_type(path.getBaseName(), image));
 		}
 		else
 		{
-			Image image(&_pdf, HPDF_LoadPngImageFromFile2(_pdf, fileName.c_str()));
+			Image image(&_pdf, HPDF_LoadPngImageFromFile2(_pdf, Poco::Path::transcode(fileName).c_str()));
 			it = _images.insert(ImageContainer::value_type(path.getBaseName(), image));
 		}
 		if (it.second) return it.first->second;
@@ -216,7 +216,7 @@ const Image& Document::loadBMPImageImpl(const std::string& fileName, bool /*doLo
 
 	if (File(path).exists())
 	{		
-		Image image(&_pdf, LoadBMPImageFromFile(_pdf, fileName.c_str()));
+		Image image(&_pdf, LoadBMPImageFromFile(_pdf, Poco::Path::transcode(fileName).c_str()));
 		std::pair<ImageContainer::iterator, bool> it =
 			_images.insert(ImageContainer::value_type(path.getBaseName(), image));
 		if (it.second) return it.first->second;
@@ -233,7 +233,7 @@ const Image& Document::loadJPEGImage(const std::string& fileName)
 
 	if (File(path).exists())
 	{
-		Image image(&_pdf, HPDF_LoadJpegImageFromFile(_pdf, fileName.c_str()));
+		Image image(&_pdf, HPDF_LoadJpegImageFromFile(_pdf, Poco::Path::transcode(fileName).c_str()));
 		std::pair<ImageContainer::iterator, bool> it =
 			_images.insert(ImageContainer::value_type(path.getBaseName(), image));
 		if (it.second) return it.first->second;


### PR DESCRIPTION
Add method to configure if the FTPClientSession should read welcome message from FTP server when you use external socket. Otherwise you could end up in a desyncronization of FTP commands