### PR TITLE
Omit ContentLength in WebSocket accept response

### DIFF
--- a/Net/src/WebSocket.cpp
+++ b/Net/src/WebSocket.cpp
@@ -153,7 +153,7 @@ WebSocketImpl* WebSocket::accept(HTTPServerRequest& request, HTTPServerResponse&
 		response.set("Upgrade", "websocket");
 		response.set("Connection", "Upgrade");
 		response.set("Sec-WebSocket-Accept", computeAccept(key));
-		response.setContentLength(0);
+		response.setContentLength(HTTPResponse::UNKNOWN_CONTENT_LENGTH);
 		response.send().flush();
 
 		HTTPServerRequestImpl& requestImpl = static_cast<HTTPServerRequestImpl&>(request);


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7230#section-3.3.2
(see https://stackoverflow.com/a/44553521/8647581 for details)