### PR TITLE
Don't include <openssl/fips.h> for later OpenSSL

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -29,7 +29,7 @@
 #include "Poco/SharedPtr.h"
 #include "Poco/Mutex.h"
 #include <openssl/ssl.h>
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS) && OPENSSL_VERSION_NUMBER < 0x010001000L
 #include <openssl/fips.h>
 #endif
 


### PR DESCRIPTION
Stems from https://github.com/pocoproject/poco/issues/2355