### PR TITLE
Foundation/src/utils.h: backport double-conversion change for AArch64…

### DIFF
--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -62,7 +62,7 @@
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
     defined(_MIPS_ARCH_MIPS32R2) || \
-    defined(__AARCH64EL__) || \
+    defined(__AARCH64EL__) || defined(__aarch64__) || \
     defined(__riscv) || \
     defined(nios2) || defined(__nios2) || defined(__nios2__) || defined(__EMSCRIPTEN__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1


### PR DESCRIPTION
… BE support

This commit, identical to upstream double-conversion commit
https://github.com/google/double-conversion/commit/cb2beeb6771025377c665d1c3ea08388bc6e619a
allows Poco to build on AArch64 big-endian.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>