### PR TITLE
Refactor for checking C++11 availability, besides Apache Server version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ env:
     POCO_VERBOSE=1
 
 before_script:
+ - export PATH=/usr/lib/postgresql/9.4/bin:$PATH
  - echo ${test}
  - chmod 755 ./travis/Linux/runtests.sh
  - chmod 755 ./travis/OSX/runtests.sh


### PR DESCRIPTION
**ApacheConnector** was not compiling on release `1.9.0` when using **Apache 2.4** or later versions.

This changing fix the issue reported here #2379.
I will perform a cherry-pick from `development` into the branch [poco-1.9.1](https://github.com/pocoproject/poco/tree/poco-1.9.1)  to making it available in the next release.