### PR TITLE
Add support to using HTTP Status Code through Poco::Net::HTTPResponse

### DIFF
--- a/ApacheConnector/include/ApacheConnector.h
+++ b/ApacheConnector/include/ApacheConnector.h
@@ -62,6 +62,9 @@ public:
 		/// is used, or if it is not known whether a secure
 		/// connection is used.
 
+	void setStatus(int status);
+		/// Set specific HTTP status code for the request.
+
 private:
 	request_rec* _pRec;
 };

--- a/ApacheConnector/src/ApacheConnector.cpp
+++ b/ApacheConnector/src/ApacheConnector.cpp
@@ -137,6 +137,12 @@ bool ApacheRequestRec::secure()
 }
 
 
+void ApacheRequestRec::setStatus(int status)
+{
+	_pRec->status = status;
+}
+
+
 void ApacheRequestRec::copyHeaders(ApacheServerRequest& request)
 {
 	const apr_array_header_t* arr = apr_table_elts(_pRec->headers_in);

--- a/ApacheConnector/src/ApacheServerResponse.cpp
+++ b/ApacheConnector/src/ApacheServerResponse.cpp
@@ -47,6 +47,9 @@ void ApacheServerResponse::initApacheOutputStream()
 
 	_pApacheRequest->setContentType(getContentType());
 
+	int statusCode = static_cast<std::underlying_type<Poco::Net::HTTPResponse::HTTPStatus>::type>(getStatus());
+	_pApacheRequest->setStatus(statusCode);
+
 	std::vector<HTTPCookie> cookies;
 	getCookies(cookies);
 	


### PR DESCRIPTION
It adds support to using **Poco::Net::HTTPResponse::HTTPStatus** through **Poco::Net::HTTPResponse** with **ApacheConnector**. Thus, a **Poco** application running with **ApacheConnector** can answer with multiple status codes the client requesting from **Apache Server**.