### PR TITLE
Allow adding headers on HTTP response over Apache Connector

### DIFF
--- a/ApacheConnector/src/ApacheServerResponse.cpp
+++ b/ApacheConnector/src/ApacheServerResponse.cpp
@@ -59,6 +59,11 @@ void ApacheServerResponse::initApacheOutputStream()
 		_pApacheRequest->addHeader("Set-Cookie", cookies[c].toString());
 	}
 
+	for (Poco::Net::NameValueCollection::ConstIterator it = begin(); it != end(); ++it)
+	{
+		_pApacheRequest->addHeader(it->first, it->second);
+	}
+
 	_pStream = new ApacheOutputStream(_pApacheRequest);
 }
 


### PR DESCRIPTION
It allows adding of multiple headers on response using Poco::Net::NameValueCollection::set("key", "value") when running application over Apache Connector.