### PR TITLE
(#2401) Poco::Net::MailMessage::read stucks while reading message 

### DIFF
--- a/Net/src/MessageHeader.cpp
+++ b/Net/src/MessageHeader.cpp
@@ -113,7 +113,10 @@ void MessageHeader::read(std::istream& istr, RecipientList* pRecipients)
 		++fields;
 
 	}
-	istr.putback(static_cast<char>(ch));
+	if (istr.good() && ch != eof)
+	{
+		istr.putback(static_cast<char>(ch));
+	}
 }
 
 

--- a/Net/src/MultipartReader.cpp
+++ b/Net/src/MultipartReader.cpp
@@ -105,6 +105,10 @@ int MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 		*buffer++ = (char) buf.sbumpc(); ++n;
 		ch = buf.sgetc();
 	}
+	if (ch == eof)
+	{
+		_lastPart = true;
+	}
 	return n;
 }
 

--- a/Net/testsuite/src/MailMessageTest.h
+++ b/Net/testsuite/src/MailMessageTest.h
@@ -38,6 +38,7 @@ public:
 	void testReadMultiPart();
 	void testReadMultiPartWithAttachmentNames();
 	void testReadMultiPartDefaultTransferEncoding();
+	void testReadMultiPartNoFinalBoundaryFromFile();
 	void testEncodeWord();
 	void testDecodeWord();
 


### PR DESCRIPTION
without final multipart boundary
https://github.com/pocoproject/poco/issues/2401