### PR TITLE
Added missing IPv6 methods to SecureSocketImpl

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/SecureServerSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureServerSocketImpl.h
@@ -73,6 +73,23 @@ public:
 		/// If reuseAddress is true, sets the SO_REUSEADDR
 		/// socket option.
 		
+	void bind6(const SocketAddress& address, bool reuseAddress = false, bool ipV6Only = false);
+		/// Bind a local IPv6 address to the socket.
+		///
+		/// This is usually only done when establishing a server
+		/// socket. TCP clients should not bind a socket to a
+		/// specific address.
+		///
+		/// If reuseAddress is true, sets the SO_REUSEADDR
+		/// socket option.
+		///
+		/// The given address must be an IPv6 address. The
+		/// IPPROTO_IPV6/IPV6_V6ONLY option is set on the socket
+		/// according to the ipV6Only parameter.
+		///
+		/// If the library has not been built with IPv6 support,
+		/// a Poco::NotImplementedException will be thrown.
+
 	void listen(int backlog = 64);
 		/// Puts the socket into listening state.
 		///

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -87,7 +87,24 @@ public:
 		///
 		/// If reuseAddress is true, sets the SO_REUSEADDR
 		/// socket option.
-		
+
+	void bind6(const SocketAddress& address, bool reuseAddress = false, bool ipV6Only = false);
+		/// Bind a local IPv6 address to the socket.
+		///
+		/// This is usually only done when establishing a server
+		/// socket. SSL clients should not bind a socket to a
+		/// specific address.
+		///
+		/// If reuseAddress is true, sets the SO_REUSEADDR
+		/// socket option.
+		///
+		/// The given address must be an IPv6 address. The
+		/// IPPROTO_IPV6/IPV6_V6ONLY option is set on the socket
+		/// according to the ipV6Only parameter.
+		///
+		/// If the library has not been built with IPv6 support,
+		/// a Poco::NotImplementedException will be thrown.
+
 	void listen(int backlog = 64);
 		/// Puts the socket into listening state.
 		///

--- a/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureServerSocketImpl.cpp
@@ -68,7 +68,12 @@ void SecureServerSocketImpl::bind(const SocketAddress& address, bool reuseAddres
 	reset(_impl.sockfd());
 }
 
-	
+void SecureServerSocketImpl::bind6(const SocketAddress& address, bool reuseAddress, bool ipV6Only)
+{
+	_impl.bind6(address, reuseAddress, ipV6Only);
+	reset(_impl.sockfd());
+}
+
 void SecureServerSocketImpl::listen(int backlog)
 {
 	_impl.listen(backlog);

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -199,6 +199,12 @@ void SecureSocketImpl::bind(const SocketAddress& address, bool reuseAddress, boo
 	_pSocket->bind(address, reuseAddress, reusePort);
 }
 
+void SecureSocketImpl::bind6(const SocketAddress& address, bool reuseAddress, bool ipV6Only)
+{
+	poco_check_ptr(_pSocket);
+
+	_pSocket->bind6(address, reuseAddress, ipV6Only);
+}
 
 void SecureSocketImpl::listen(int backlog)
 {


### PR DESCRIPTION
Solution for https://github.com/pocoproject/poco/issues/2418
I noticed that bind6 was missing for SecureSocketImpl. Simply a matter of adding the method in a similar manner like bind. Solved it for me