### PR TITLE
Use demangling in GCC family compilers

### DIFF
--- a/CppUnit/include/Poco/CppUnit/TestCaller.h
+++ b/CppUnit/include/Poco/CppUnit/TestCaller.h
@@ -64,8 +64,8 @@ public:
 	// Returns the name of the test case instance
 	virtual std::string toString()
 	{
-		const std::type_info& thisClass = typeid(*this);
-		return std::string(thisClass.name()) + "." + name();
+		std::string className = poco_typeid_name<decltype(*this)>();
+		return className + "." + name();
 	}
 
 

--- a/CppUnit/include/Poco/CppUnit/TestCase.h
+++ b/CppUnit/include/Poco/CppUnit/TestCase.h
@@ -11,6 +11,7 @@
 #include "Poco/CppUnit/Guards.h"
 #include "Poco/CppUnit/Test.h"
 #include "Poco/CppUnit/CppUnitException.h"
+#include "Poco/TypeId.h"
 #include <string>
 #include <typeinfo>
 
@@ -212,8 +213,8 @@ inline void TestCase::tearDown()
 // Returns the name of the test case instance
 inline std::string TestCase::toString()
 {
-	const std::type_info& thisClass = typeid(*this);
-	return std::string(thisClass.name()) + "." + name();
+	std::string className = poco_typeid_name<decltype(*this)>();
+	return className + "." + name();
 }
 
 

--- a/CppUnit/src/TestCase.cpp
+++ b/CppUnit/src/TestCase.cpp
@@ -5,6 +5,7 @@
 
 #include <stdexcept>
 #include <math.h>
+#include "Poco/TypeId.h"
 #include "Poco/CppUnit/TestCase.h"
 #include "Poco/CppUnit/TestResult.h"
 #include "Poco/CppUnit/estring.h"
@@ -122,7 +123,7 @@ void TestCase::run(TestResult *result)
 	}
 	catch (std::exception& e)
 	{
-		std::string msg(typeid(e).name());
+		std::string msg(poco_typeid_name<decltype(e)>());
 		msg.append(": ");
 		msg.append(e.what());
 		result->addError(this, new CppUnitException(msg));

--- a/Crypto/src/CryptoException.cpp
+++ b/Crypto/src/CryptoException.cpp
@@ -76,7 +76,7 @@ const char* OpenSSLException::name() const throw()
 
 const char* OpenSSLException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -532,7 +532,7 @@ ValueType AnyCast(Any& operand)
 			s.append(1, '(');
 			s.append(operand._pHolder->type().name());
 			s.append(" => ");
-			s.append(typeid(ValueType).name());
+			s.append(poco_typeid_name<ValueType>());
 			s.append(1, ')');
 		}
 		throw BadCastException(s);
@@ -572,7 +572,7 @@ const ValueType& RefAnyCast(const Any & operand)
 		s.append(1, '(');
 		s.append(operand._pHolder->type().name());
 		s.append(" => ");
-		s.append(typeid(ValueType).name());
+		s.append(poco_typeid_name<ValueType>());
 		s.append(1, ')');
 	}
 	return *result;
@@ -595,7 +595,7 @@ ValueType& RefAnyCast(Any& operand)
 			s.append(1, '(');
 			s.append(operand._pHolder->type().name());
 			s.append(" => ");
-			s.append(typeid(ValueType).name());
+			s.append(poco_typeid_name<ValueType>());
 			s.append(1, ')');
 		}
 		throw BadCastException(s);

--- a/Foundation/include/Poco/ClassLibrary.h
+++ b/Foundation/include/Poco/ClassLibrary.h
@@ -20,6 +20,7 @@
 
 #include "Poco/Foundation.h"
 #include "Poco/Manifest.h"
+#include "Poco/TypeId.h"
 #include <typeinfo>
 
 
@@ -69,7 +70,7 @@ extern "C"	\
 	{																				\
 		typedef base _Base;															\
 		typedef Poco::Manifest<_Base> _Manifest;									\
-		std::string requiredType(typeid(_Manifest).name());							\
+		std::string requiredType(poco_typeid_name<_Manifest>());					\
 		std::string actualType(pManifest_->className());							\
 		if (requiredType == actualType)												\
 		{																			\

--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -220,7 +220,7 @@ public:
 		else
 			throw BadCastException(format("Can not convert %s to %s.",
 				std::string(pHolder->type().name()),
-				std::string(typeid(T).name())));
+				std::string(poco_typeid_name<T>())));
 	}
 
 	template <typename T>

--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -174,10 +174,10 @@ inline int Exception::code() const
 	POCO_DECLARE_EXCEPTION_CODE(API, CLS, BASE, 0)
 
 #define POCO_IMPLEMENT_EXCEPTION(CLS, BASE, NAME)													\
-	CLS::CLS(int otherCode): BASE(otherCode)																	\
+	CLS::CLS(int otherCode): BASE(otherCode)														\
 	{																								\
 	}																								\
-	CLS::CLS(const std::string& msg, int otherCode): BASE(msg, otherCode)										\
+	CLS::CLS(const std::string& msg, int otherCode): BASE(msg, otherCode)							\
 	{																								\
 	}																								\
 	CLS::CLS(const std::string& msg, const std::string& arg, int otherCode): BASE(msg, arg, otherCode)		\
@@ -186,7 +186,7 @@ inline int Exception::code() const
 	CLS::CLS(const std::string& msg, const Poco::Exception& exc, int otherCode): BASE(msg, exc, otherCode)	\
 	{																								\
 	}																								\
-	CLS::CLS(const CLS& exc): BASE(exc)																\
+	CLS::CLS(const CLS& exc): BASE(exc)															\
 	{																								\
 	}																								\
 	CLS::~CLS() throw()																				\
@@ -203,7 +203,7 @@ inline int Exception::code() const
 	}																								\
 	const char* CLS::className() const throw()														\
 	{																								\
-		return poco_typeid_name<decltype(*this)>();																\
+		return poco_typeid_name<decltype(*this)>();													\
 	}																								\
 	Poco::Exception* CLS::clone() const																\
 	{																								\

--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -19,6 +19,7 @@
 
 
 #include "Poco/Foundation.h"
+#include "Poco/TypeId.h"
 #include <stdexcept>
 
 
@@ -202,7 +203,7 @@ inline int Exception::code() const
 	}																								\
 	const char* CLS::className() const throw()														\
 	{																								\
-		return typeid(*this).name();																\
+		return poco_typeid_name<decltype(*this)>();																\
 	}																								\
 	Poco::Exception* CLS::clone() const																\
 	{																								\

--- a/Foundation/include/Poco/Manifest.h
+++ b/Foundation/include/Poco/Manifest.h
@@ -20,6 +20,7 @@
 
 #include "Poco/Foundation.h"
 #include "Poco/MetaObject.h"
+#include "Poco/TypeId.h"
 #include <map>
 #include <typeinfo>
 
@@ -166,7 +167,7 @@ public:
 
 	const char* className() const
 	{
-		return typeid(*this).name();
+		return poco_typeid_name<decltype(*this)>();
 	}
 
 private:

--- a/Foundation/include/Poco/NestedDiagnosticContext.h
+++ b/Foundation/include/Poco/NestedDiagnosticContext.h
@@ -22,6 +22,7 @@
 
 #include "Poco/Foundation.h"
 #include "Poco/OrderedMap.h"
+#include "Poco/TypeId.h"
 #include <vector>
 #include <ostream>
 #include <typeinfo>
@@ -123,25 +124,7 @@ public:
 		/// Names are demangled for g++ only at this time.
 		/// If full is false, the scope is trimmed off.
 	{
-		std::string name(typeid(T).name());
-#ifdef POCO_HAS_BACKTRACE
-	#ifdef POCO_COMPILER_GCC
-		int status = 0;
-	#if (POCO_OS == POCO_OS_CYGWIN)
-		char* pName = __cxxabiv1::__cxa_demangle(typeid(T).name(), 0, 0, &status);
-	#else
-		char* pName = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
-	#endif
-		if (status == 0) name = pName;
-		free(pName);
-		if (!full) // strip scope, if any
-		{
-			std::size_t pos = name.rfind("::");
-			if (pos != std::string::npos) name = name.substr(pos+2);
-		}
-	#endif // TODO: demangle other compilers
-#endif
-		return name;
+		return poco_typeid_name<T>(full);
 	}
 
 	static std::string backtrace(int skipEnd = 1, int skipBegin = 0, int stackSize = 128, int bufSize = 1024);

--- a/Foundation/include/Poco/TypeId.h
+++ b/Foundation/include/Poco/TypeId.h
@@ -18,6 +18,10 @@
 #define Foundation_TypeId_INCLUDED
 
 
+#include <string>
+#include <typeinfo>
+
+
 #if defined(POCO_COMPILER_GCC) || defined(POCO_COMPILER_MINGW) || POCO_OS == POCO_OS_CYGWIN
 	#define POCO_HAS_CXXABI
 #endif // TODO: demangle other compilers

--- a/Foundation/include/Poco/TypeId.h
+++ b/Foundation/include/Poco/TypeId.h
@@ -19,10 +19,13 @@
 
 
 #if defined(POCO_COMPILER_GCC) || defined(POCO_COMPILER_MINGW) || POCO_OS == POCO_OS_CYGWIN
+	#define POCO_HAS_CXXABI
+#endif // TODO: demangle other compilers
 
 
-#include <cxxabi.h>
-#include <string>
+#ifdef POCO_HAS_CXXABI
+	#include <cxxabi.h>
+#endif
 
 
 template <typename T>
@@ -32,6 +35,8 @@ const char* poco_typeid_name(bool full = true)
 	/// If full is false, the scope is trimmed off.
 {
 	std::string name(typeid(T).name());
+
+#ifdef POCO_HAS_CXXABI
 	int status = 0;
 #if (POCO_OS == POCO_OS_CYGWIN)
 	char* pName = __cxxabiv1::__cxa_demangle(typeid(T).name(), 0, 0, &status);
@@ -45,25 +50,10 @@ const char* poco_typeid_name(bool full = true)
 		std::size_t pos = name.rfind("::");
 		if (pos != std::string::npos) name = name.substr(pos+2);
 	}
+#endif
 
 	return name.c_str();
-} // TODO: demangle other compilers
-
-
-#else
-
-
-template <typename T>
-const char* poco_typeid_name(bool full)
-	/// Returns type name for the provided type.
-	/// Names are demangled for g++ only at this time.
-	/// If full is false, the scope is trimmed off.
-{
-	return typeid(c).name();
 }
-
-
-#endif
 
 
 #endif // Foundation_TypeId_INCLUDED

--- a/Foundation/include/Poco/TypeId.h
+++ b/Foundation/include/Poco/TypeId.h
@@ -1,0 +1,69 @@
+//
+// TypeId.h
+//
+// Library: Foundation
+// Package: Core
+// Module:  poco_typeid_name
+//
+// Definition of poco_typeid_name function.
+//
+// Copyright (c) 2018, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Foundation_TypeId_INCLUDED
+#define Foundation_TypeId_INCLUDED
+
+
+#if defined(POCO_COMPILER_GCC) || defined(POCO_COMPILER_MINGW) || POCO_OS == POCO_OS_CYGWIN
+
+
+#include <cxxabi.h>
+#include <string>
+
+
+template <typename T>
+const char* poco_typeid_name(bool full = true)
+	/// Returns type name for the provided type.
+	/// Names are demangled for g++ only at this time.
+	/// If full is false, the scope is trimmed off.
+{
+	std::string name(typeid(T).name());
+	int status = 0;
+#if (POCO_OS == POCO_OS_CYGWIN)
+	char* pName = __cxxabiv1::__cxa_demangle(typeid(T).name(), 0, 0, &status);
+#else
+	char* pName = abi::__cxa_demangle(typeid(T).name(), 0, 0, &status);
+#endif
+	if (status == 0) name = std::string(pName);
+	free(pName);
+	if (!full) // strip scope, if any
+	{
+		std::size_t pos = name.rfind("::");
+		if (pos != std::string::npos) name = name.substr(pos+2);
+	}
+
+	return name.c_str();
+} // TODO: demangle other compilers
+
+
+#else
+
+
+template <typename T>
+const char* poco_typeid_name(bool full)
+	/// Returns type name for the provided type.
+	/// Names are demangled for g++ only at this time.
+	/// If full is false, the scope is trimmed off.
+{
+	return typeid(c).name();
+}
+
+
+#endif
+
+
+#endif // Foundation_TypeId_INCLUDED

--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -14,6 +14,7 @@
 
 #include "Poco/Exception.h"
 #include "Poco/NestedDiagnosticContext.h"
+#include "Poco/TypeId.h"
 #include <typeinfo>
 
 
@@ -95,7 +96,7 @@ const char* Exception::name() const throw()
 
 const char* Exception::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -14,7 +14,6 @@
 
 #include "Poco/Exception.h"
 #include "Poco/NestedDiagnosticContext.h"
-#include "Poco/TypeId.h"
 #include <typeinfo>
 
 

--- a/Foundation/src/Notification.cpp
+++ b/Foundation/src/Notification.cpp
@@ -31,7 +31,7 @@ Notification::~Notification()
 
 std::string Notification::name() const
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/SQL/MySQL/include/Poco/SQL/MySQL/MySQLException.h
+++ b/SQL/MySQL/include/Poco/SQL/MySQL/MySQLException.h
@@ -19,6 +19,7 @@
 
 #include "Poco/SQL/MySQL/MySQL.h"
 #include "Poco/SQL/SQLException.h"
+#include "Poco/TypeId.h"
 #include <typeinfo>
 #include <string>
 
@@ -137,7 +138,7 @@ inline const char* MySQLException::name() const throw()
 
 inline const char* MySQLException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 inline Poco::Exception* MySQLException::clone() const

--- a/SQL/ODBC/include/Poco/SQL/ODBC/ODBCException.h
+++ b/SQL/ODBC/include/Poco/SQL/ODBC/ODBCException.h
@@ -24,6 +24,7 @@
 #include "Poco/SQL/ODBC/Error.h"
 #include "Poco/SQL/SQLException.h"
 #include "Poco/Format.h"
+#include "Poco/TypeId.h"
 
 
 namespace Poco {
@@ -100,7 +101,7 @@ public:
 	const char* className() const throw()
 		/// Returns the HandleException class name.
 	{
-		return typeid(*this).name();
+		return poco_typeid_name<decltype(*this)>();
 	}
 
 	Poco::Exception* clone() const

--- a/SQL/PostgreSQL/include/Poco/SQL/PostgreSQL/PostgreSQLException.h
+++ b/SQL/PostgreSQL/include/Poco/SQL/PostgreSQL/PostgreSQLException.h
@@ -19,6 +19,7 @@
 
 #include "Poco/SQL/PostgreSQL/PostgreSQL.h"
 #include "Poco/SQL/SQLException.h"
+#include "Poco/TypeId.h"
 
 #include <typeinfo>
 #include <string>
@@ -118,7 +119,7 @@ inline const char* PostgreSQLException::name() const throw()
 
 inline const char* PostgreSQLException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/SQL/include/Poco/SQL/RecordSet.h
+++ b/SQL/include/Poco/SQL/RecordSet.h
@@ -29,6 +29,7 @@
 #include "Poco/String.h"
 #include "Poco/Dynamic/Var.h"
 #include "Poco/Exception.h"
+#include "Poco/TypeId.h"
 #include <ostream>
 #include <limits>
 
@@ -413,7 +414,7 @@ private:
 			throw NotFoundException(Poco::format("Column name: %s", name));
 		else
 			throw NotFoundException(Poco::format("Column type: %s, Container type: %s, name: %s",
-				std::string(typeid(T).name()), std::string(typeid(ExtractionVecPtr).name()), name));
+				std::string(poco_typeid_name<T>()), poco_typeid_name<ExtractionVecPtr>(), name));
 	}
 
 	template <class C, class E>
@@ -447,10 +448,10 @@ private:
 			throw Poco::BadCastException(Poco::format("RecordSet::columnImpl(%z) type cast failed!\nTarget type:\t%s"
 				"\nTarget container type:\t%s\nSource container type:\t%s\nSource abstraction type:\t%s",
 				pos,
-				std::string(typeid(T).name()),
-				std::string(typeid(ExtractionVecPtr).name()),
+				std::string(poco_typeid_name<T>()),
+				std::string(poco_typeid_name<ExtractionVecPtr>()),
 				rExtractions[pos]->type(),
-				std::string(typeid(rExtractions[pos].get()).name())));
+				std::string(poco_typeid_name<decltype(rExtractions[pos].get())>())));
 		}
 	}
 

--- a/Util/include/Poco/Util/Application.h
+++ b/Util/include/Poco/Util/Application.h
@@ -28,6 +28,7 @@
 #include "Poco/Timestamp.h"
 #include "Poco/Timespan.h"
 #include "Poco/AutoPtr.h"
+#include "Poco/TypeId.h"
 #if defined(POCO_VXWORKS)
 #include <cstdarg>
 #endif
@@ -416,7 +417,7 @@ template <class C> C& Application::getSubsystem() const
 		const C* pC = dynamic_cast<const C*>(pSS);
 		if (pC) return *const_cast<C*>(pC);
 	}
-	throw Poco::NotFoundException("The subsystem has not been registered", typeid(C).name());
+	throw Poco::NotFoundException("The subsystem has not been registered", poco_typeid_name<C>());
 }
 
 inline Application::SubsystemVec& Application::subsystems()

--- a/XML/src/DOMException.cpp
+++ b/XML/src/DOMException.cpp
@@ -79,7 +79,7 @@ const char* DOMException::name() const throw()
 
 const char* DOMException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/XML/src/EventException.cpp
+++ b/XML/src/EventException.cpp
@@ -52,7 +52,7 @@ const char* EventException::name() const throw()
 
 const char* EventException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 

--- a/XML/src/SAXException.cpp
+++ b/XML/src/SAXException.cpp
@@ -104,7 +104,7 @@ const char* SAXParseException::name() const throw()
 
 const char* SAXParseException::className() const throw()
 {
-	return typeid(*this).name();
+	return poco_typeid_name<decltype(*this)>();
 }
 
 


### PR DESCRIPTION
Now you can see:
```bash
$ ./PDF-testrunner.exe -all

testDocument: FAILURE
testPage: FAILURE
testImage: FAILURE
testFont: FAILURE
testEncoding: FAILURE
testOutline: FAILURE
testDestination: FAILURE
testAnnotation: FAILURE

!!!FAILURES!!!
Runs: 8   Failures: 8   Errors: 0

There were 8 failures:
 1: CppUnit::TestCaller<PDFTest>.testDocument
    "fail: not implemented"
    in "<unknown>", line -1
 2: CppUnit::TestCaller<PDFTest>.testPage
    "fail: not implemented"
    in "<unknown>", line -1
 3: CppUnit::TestCaller<PDFTest>.testImage
    "fail: not implemented"
    in "<unknown>", line -1
 4: CppUnit::TestCaller<PDFTest>.testFont
    "fail: not implemented"
    in "<unknown>", line -1
 5: CppUnit::TestCaller<PDFTest>.testEncoding
    "fail: not implemented"
    in "<unknown>", line -1
 6: CppUnit::TestCaller<PDFTest>.testOutline
    "fail: not implemented"
    in "<unknown>", line -1
 7: CppUnit::TestCaller<PDFTest>.testDestination
    "fail: not implemented"
    in "<unknown>", line -1
 8: CppUnit::TestCaller<PDFTest>.testAnnotation
    "fail: not implemented"
    in "<unknown>", line -1
```
Instead of:
```bash
$ ./PDF-testrunner.exe -all

testDocument: FAILURE
testPage: FAILURE
testImage: FAILURE
testFont: FAILURE
testEncoding: FAILURE
testOutline: FAILURE
testDestination: FAILURE
testAnnotation: FAILURE

!!!FAILURES!!!
Runs: 8   Failures: 8   Errors: 0

There were 8 failures:
 1: N7CppUnit10TestCallerI7PDFTestEE.testDocument
    "fail: not implemented"
    in "<unknown>", line -1
 2: N7CppUnit10TestCallerI7PDFTestEE.testPage
    "fail: not implemented"
    in "<unknown>", line -1
 3: N7CppUnit10TestCallerI7PDFTestEE.testImage
    "fail: not implemented"
    in "<unknown>", line -1
 4: N7CppUnit10TestCallerI7PDFTestEE.testFont
    "fail: not implemented"
    in "<unknown>", line -1
 5: N7CppUnit10TestCallerI7PDFTestEE.testEncoding
    "fail: not implemented"
    in "<unknown>", line -1
 6: N7CppUnit10TestCallerI7PDFTestEE.testOutline
    "fail: not implemented"
    in "<unknown>", line -1
 7: N7CppUnit10TestCallerI7PDFTestEE.testDestination
    "fail: not implemented"
    in "<unknown>", line -1
 8: N7CppUnit10TestCallerI7PDFTestEE.testAnnotation
    "fail: not implemented"
    in "<unknown>", line -1
```
It works for exceptions messages, `className()` methods and `toString` methods in `CppUnit` library.

Also I want to ask:
* What for `typeid(...).name()` used in AbstractExtraction constructor.
* Maybe best to create `TypeInfo` class as cross-platform analog?