### PR TITLE
MSYS support

### DIFF
--- a/Encodings/testsuite/CMakeLists.txt
+++ b/Encodings/testsuite/CMakeLists.txt
@@ -20,9 +20,6 @@ if(ANDROID)
 			COMMAND ${CMAKE_COMMAND} -DANDROID_NDK=${ANDROID_NDK} "-DTEST_FILES=${CMAKE_CURRENT_SOURCE_DIR}/data;" -DLIBRARY_DIR=${CMAKE_BINARY_DIR}/lib -DUNITTEST=${CMAKE_BINARY_DIR}/bin/Encodings-testrunner -DTEST_PARAMETER=-all -P ${CMAKE_SOURCE_DIR}/cmake/ExecuteOnAndroid.cmake)
 else()
 	add_test(NAME Encodings WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND Encodings-testrunner -all)
-	# The test is run in the build directory. So the test data is copied there too
-	add_custom_command(TARGET Encodings-testrunner POST_BUILD
-				   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data )
 endif()
 #set_target_properties(Encodings-testrunner PROPERTIES COMPILE_FLAGS ${RELEASE_CXX_FLAGS} )
 target_link_libraries(Encodings-testrunner PUBLIC Poco::Encodings Poco::CppUnit)

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -8,6 +8,8 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
 		/opt/mysql/mysql/include/mysql
 		/usr/local/mysql/include
 		/usr/local/mysql/include/mysql
+		$ENV{MINGW_PREFIX}/include
+		$ENV{MINGW_PREFIX}/include/mysql
 		$ENV{MYSQL_INCLUDE_DIR}
 		$ENV{MYSQL_DIR}/include
 		$ENV{ProgramFiles}/MySQL/*/include
@@ -15,7 +17,8 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
 		${BINDIR32}/MySQL/*/include
 		$ENV{SystemDrive}/MySQL/*/include
 		${MYSQL_INCLUDE_DIR}
-		${MYSQL_DIR}/include)
+		${MYSQL_DIR}/include
+		${MYSQL_DIR}/include/mysql)
 
 if (NOT MYSQL_INCLUDE_DIR)
 	find_path(MARIADB_INCLUDE_DIR mysql.h
@@ -25,10 +28,12 @@ if (NOT MYSQL_INCLUDE_DIR)
 			/opt/mariadb/mariadb/include/mariadb
 			/usr/local/mariadb/include
 			/usr/local/mariadb/include/mariadb
+			$ENV{MINGW_PREFIX}/include/mariadb
 			$ENV{MARIADB_INCLUDE_DIR}
 			$ENV{MARIADB_DIR}/include
 			${MARIADB_INCLUDE_DIR}
-			${MARIADB_DIR}/include)
+			${MARIADB_DIR}/include
+			${MARIADB_DIR}/include/mariadb)
 endif (NOT MYSQL_INCLUDE_DIR)
 
 if (MSVC)
@@ -61,6 +66,7 @@ else (MSVC)
 				 /usr/local/mysql/lib/mysql
 				 /opt/mysql/mysql/lib
 				 /opt/mysql/mysql/lib/mysql
+				 $ENV{MINGW_PREFIX}/lib
 				 $ENV{MYSQL_DIR}/libmysql_r/.libs
 				 $ENV{MYSQL_DIR}/lib
 				 $ENV{MYSQL_DIR}/lib/mysql
@@ -75,6 +81,7 @@ else (MSVC)
 					/usr/local/mariadb/lib/mariadb
 					/opt/mariadb/mariadb/lib
 					/opt/mariadb/mariadb/lib/mariadb
+					$ENV{MINGW_PREFIX}/lib
 					$ENV{MARIADB_DIR}/libmariadb/.libs
 					$ENV{MARIADB_DIR}/lib
 					$ENV{MARIADB_DIR}/lib/mariadb

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -38,15 +38,17 @@ if (WIN32)
         endif()
       endforeach()
     endif (X64)
+    find_program(CMAKE_MC_COMPILER mc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
+		DOC "path to message compiler")
+  elseif ("${CMAKE_GENERATOR}" MATCHES "MSYS")
+	find_program(CMAKE_MC_COMPILER windmc.exe HINTS "$ENV{MINGW_PREFIX}/bin"
+		DOC "path to message compiler")
   endif ()
-  find_program(CMAKE_MC_COMPILER mc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
-    DOC "path to message compiler")
-  if(NOT CMAKE_MC_COMPILER AND MSVC)
-    message(FATAL_ERROR "message compiler not found: required to build")
-  endif(NOT CMAKE_MC_COMPILER AND MSVC)
   if(CMAKE_MC_COMPILER)
     message(STATUS "Found message compiler: ${CMAKE_MC_COMPILER}")
     mark_as_advanced(CMAKE_MC_COMPILER)
+  else(CMAKE_MC_COMPILER)
+    message(FATAL_ERROR "message compiler not found: required to build")
   endif(CMAKE_MC_COMPILER)
 endif(WIN32)
 
@@ -185,7 +187,7 @@ endmacro()
 
 
 macro(POCO_MESSAGES out name)
-    if (WIN32 AND CMAKE_MC_COMPILER)
+    if (WIN32)
         foreach(msg ${ARGN})
             get_filename_component(msg_name ${msg} NAME)
             get_filename_component(msg_path ${msg} ABSOLUTE)
@@ -214,7 +216,7 @@ macro(POCO_MESSAGES out name)
         source_group("${name}\\Message Files" FILES ${ARGN})
         list(APPEND ${out} ${ARGN})
 
-    endif (WIN32 AND CMAKE_MC_COMPILER)
+    endif (WIN32)
 endmacro()
 
 #===============================================================================


### PR DESCRIPTION
#2356

* Enabled `CMAKE_MC_COMPILER` for all compilers on Windows
* Deleted nonexistent directory copying in `Encodings` package