### PR TITLE
Added static function for current OS thread ID.

### DIFF
--- a/Foundation/include/Poco/Thread.h
+++ b/Foundation/include/Poco/Thread.h
@@ -214,6 +214,9 @@ public:
 	static TID currentTid();
 		/// Returns the native thread ID for the current thread.
 
+	static long currentOsTid();
+		/// Returns the operating system specific thread ID for the current thread.
+
 protected:
 	ThreadLocalStorage& tls();
 		/// Returns a reference to the thread's local storage.
@@ -370,6 +373,12 @@ inline int Thread::getStackSize() const
 inline Thread::TID Thread::currentTid()
 {
 	return currentTidImpl();
+}
+
+
+inline long Thread::currentOsTid()
+{
+	return currentOsTidImpl();
 }
 
 

--- a/Foundation/include/Poco/Thread_STD.h
+++ b/Foundation/include/Poco/Thread_STD.h
@@ -84,6 +84,7 @@ public:
 	static void yieldImpl();
 	static ThreadImpl* currentImpl();
 	static TIDImpl currentTidImpl();
+	static long currentOsTidImpl();
 
 protected:
 	static void* runnableEntry(void* pThread);

--- a/Foundation/samples/Logger/src/Logger.cpp
+++ b/Foundation/samples/Logger/src/Logger.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
 {
 	// set up two channel chains - one to the
 	// console and the other one to a log file.
-	AutoPtr<PatternFormatter> pPatternFormatter(new PatternFormatter("%s: %p: %t"));
+	AutoPtr<PatternFormatter> pPatternFormatter(new PatternFormatter("[%O] %s: %p: %t"));
 	AutoPtr<FormattingChannel> pFCConsole(new FormattingChannel(pPatternFormatter));
 	AutoPtr<ConsoleChannel> pConsoleChannel(new ConsoleChannel());
 	pFCConsole->setChannel(pConsoleChannel);

--- a/Foundation/src/Message.cpp
+++ b/Foundation/src/Message.cpp
@@ -92,6 +92,7 @@ Message::Message(Message&& msg) :
 	_prio(std::move(msg._prio)),
 	_time(std::move(msg._time)),
 	_tid(std::move(msg._tid)),
+	_ostid(std::move(msg._ostid)),
 	_thread(std::move(msg._thread)),
 	_pid(std::move(msg._pid)),
 	_file(std::move(msg._file)),
@@ -132,7 +133,7 @@ void Message::init()
 #if !defined(POCO_VXWORKS)
 	_pid = Process::id();
 #endif
-	_ostid = (IntPtr)Thread::currentTid();
+	_ostid = (IntPtr)Thread::currentOsTid();
 	Thread* pThread = Thread::current();
 	if (pThread)
 	{
@@ -162,6 +163,7 @@ Message& Message::operator = (Message&& msg)
 		_prio = std::move(msg._prio);
 		_time = std::move(msg._time);
 		_tid = std::move(msg._tid);
+		_ostid = std::move(msg._ostid);
 		_thread = std::move(msg._thread);
 		_pid = std::move(msg._pid);
 		_file = std::move(msg._file);
@@ -182,6 +184,7 @@ void Message::swap(Message& msg)
 	swap(_prio, msg._prio);
 	swap(_time, msg._time);
 	swap(_tid, msg._tid);
+	swap(_ostid, msg._ostid);
 	swap(_thread, msg._thread);
 	swap(_pid, msg._pid);
 	swap(_file, msg._file);

--- a/Foundation/src/Thread_STD_POSIX.cpp
+++ b/Foundation/src/Thread_STD_POSIX.cpp
@@ -237,5 +237,16 @@ int ThreadImpl::getAffinityImpl() const
 	return cpuSet;
 }
 
+long ThreadImpl::currentOsTidImpl()
+{
+#if POCO_OS == POCO_OS_LINUX
+    return syscall(SYS_gettid);
+#elif POCO_OS == POCO_OS_MAC_OS_X
+    return pthread_mach_thread_np(pthread_self());
+#else
+    return pthread_self();
+#endif
+}
+
 
 } // namespace Poco

--- a/Foundation/src/Thread_STD_VX.cpp
+++ b/Foundation/src/Thread_STD_VX.cpp
@@ -84,4 +84,10 @@ int ThreadImpl::getAffinityImpl() const
 }
 
 
+long ThreadImpl::currentOsTidImpl()
+{
+	return taskIdSelf();
+}
+
+
 } // namespace Poco

--- a/Foundation/src/Thread_STD_WIN32.cpp
+++ b/Foundation/src/Thread_STD_WIN32.cpp
@@ -85,4 +85,10 @@ int ThreadImpl::getAffinityImpl() const
 }
 
 
+long ThreadImpl::currentOsTidImpl()
+{
+	return GetCurrentThreadId();
+}
+
+
 } // namespace Poco


### PR DESCRIPTION
With the support for C++11 the Thred::currentTid() now returns std::thread::native_handle_type that uniquely identifies a thread. Unfortunately this type is not very useful for tracing logs since its printed as a human unfriendly 14 digit number. This pull request ads a new static function that returns the OS specific thread ID for the calling thread even if the Thread class was not instantiated.