### PR TITLE
TLS mode/version when FIPS is enabled

### DIFF
--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -393,7 +393,7 @@ void Context::preferServerCiphers()
 
 void Context::createSSLContext()
 {
-	if (SSLManager::isFIPSEnabled())
+	if (_usage == (CLIENT_USE || SERVER_USE) && SSLManager::isFIPSEnabled())
 	{
 		_pSSLContext = SSL_CTX_new(TLSv1_method());
 	}


### PR DESCRIPTION
It should be possible to set TLS version independently from enable FIPS mode. FIPS (Federal Information Processing Standard) does not prohibit the use of any TLS mode/version.
