### PR TITLE
Add FTP active data port configuration

### DIFF
--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -306,7 +306,10 @@ public:
 		/// Returns true if the session is FTPS.
 		
 	const std::string& welcomeMessage();
-	/// Returns welcome message.
+		/// Returns welcome message.
+	
+	void setActiveDataPort(Poco::UInt16 port);
+		/// Set port to use for active connections
 	
 protected:
 	virtual void receiveServerReadyReply();
@@ -352,6 +355,7 @@ private:
 	
 	std::string    _host;
 	Poco::UInt16   _port = 0;
+	Poco::UInt16   _activeDataPort = 0;
 	bool	   _passiveMode = true;
 	FileType       _fileType = TYPE_BINARY;
 	bool	   _supports1738 = true;

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -31,7 +31,8 @@ namespace Net {
 FTPClientSession::FTPClientSession():
 	_pControlSocket(0),
 	_pDataStream(0),
-	_port(0),		
+	_port(0),
+	_activeDataPort(0),
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),
@@ -47,6 +48,7 @@ FTPClientSession::FTPClientSession(const StreamSocket& socket, bool readWelcomeM
 	_pDataStream(0),
 	_host(socket.address().host().toString()),
 	_port(socket.address().port()),
+	_activeDataPort(0),
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),
@@ -73,7 +75,8 @@ FTPClientSession::FTPClientSession(const std::string& host,
 	_pControlSocket(new DialogSocket(SocketAddress(host, port))),
 	_pDataStream(0),
 	_host(host),
-	_port(port),		
+	_port(port),
+	_activeDataPort(0),
 	_passiveMode(true),
 	_fileType(TYPE_BINARY),
 	_supports1738(true),
@@ -120,6 +123,10 @@ void FTPClientSession::setPassive(bool flag, bool useRFC1738)
 	_supports1738 = useRFC1738;
 }
 
+void FTPClientSession::setActiveDataPort(Poco::UInt16 port)
+{
+	_activeDataPort = port;
+}
 	
 bool FTPClientSession::getPassive() const
 {
@@ -440,7 +447,7 @@ StreamSocket FTPClientSession::activeDataConnection(const std::string& command, 
 	if (!isOpen())
 		throw FTPException("Connection is closed.");
 
-	ServerSocket server(SocketAddress(_pControlSocket->address().host(), 0));
+	ServerSocket server(SocketAddress(_pControlSocket->address().host(), _activeDataPort));
 	sendPortCommand(server.address());
 	std::string response;
 	int status = sendCommand(command, arg, response);


### PR DESCRIPTION
Add active data port configuration so an ftp client behind a NAT/Firewall, that must connect in active mode, can choose one port to use for natting: that way communication is still possible