### PR TITLE
Fix sockaddr stack aligment

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -104,8 +104,8 @@ SocketImpl* SocketImpl::acceptConnection(SocketAddress& clientAddr)
 {
 	if (_sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
 
-	char buffer[SocketAddress::MAX_ADDRESS_LENGTH];
-	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(buffer);
+	sockaddr_storage buffer;
+	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(&buffer);
 	poco_socklen_t saLen = sizeof(buffer);
 	poco_socket_t sd;
 	do
@@ -502,8 +502,8 @@ int SocketImpl::sendTo(const SocketBufVec& buffers, const SocketAddress& address
 
 int SocketImpl::receiveFrom(void* buffer, int length, SocketAddress& address, int flags)
 {
-	char abuffer[SocketAddress::MAX_ADDRESS_LENGTH];
-	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(abuffer);
+	sockaddr_storage abuffer;
+	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(&abuffer);
 	poco_socklen_t saLen = sizeof(abuffer);
 	poco_socklen_t* pSALen = &saLen;
 	int rc = receiveFrom(buffer, length, &pSA, &pSALen, flags);
@@ -541,8 +541,8 @@ int SocketImpl::receiveFrom(void* buffer, int length, struct sockaddr** ppSA, po
 
 int SocketImpl::receiveFrom(SocketBufVec& buffers, SocketAddress& address, int flags)
 {
-	char abuffer[SocketAddress::MAX_ADDRESS_LENGTH];
-	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(abuffer);
+	sockaddr_storage abuffer;
+	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(&abuffer);
 	poco_socklen_t saLen = sizeof(abuffer);
 	poco_socklen_t* pSALen = &saLen;
 	int rc = receiveFrom(buffers, &pSA, &pSALen, flags);
@@ -846,8 +846,8 @@ SocketAddress SocketImpl::address()
 {
 	if (_sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
 	
-	char buffer[SocketAddress::MAX_ADDRESS_LENGTH];
-	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(buffer);
+	sockaddr_storage buffer;
+	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(&buffer);
 	poco_socklen_t saLen = sizeof(buffer);
 	int rc = ::getsockname(_sockfd, pSA, &saLen);
 	if (rc == 0)
@@ -862,8 +862,8 @@ SocketAddress SocketImpl::peerAddress()
 {
 	if (_sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
 	
-	char buffer[SocketAddress::MAX_ADDRESS_LENGTH];
-	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(buffer);
+	sockaddr_storage buffer;
+	struct sockaddr* pSA = reinterpret_cast<struct sockaddr*>(&buffer);
 	poco_socklen_t saLen = sizeof(buffer);
 	int rc = ::getpeername(_sockfd, pSA, &saLen);
 	if (rc == 0)


### PR DESCRIPTION
This pull request will fix issue #2492 

Use `sockaddr_storage` for proper stack aligment.

From the POSIX standard:
> The sockaddr_storage structure solves the problem of declaring storage for automatic variables which is both large enough and aligned enough for storing the socket address data structure of any family.

See also http://pubs.opengroup.org/onlinepubs/009696699/basedefs/sys/socket.h.html
