### PR TITLE
Fixed internal OpenSSL Windows build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,20 +61,6 @@ endif()
 # Include some common macros to simpilfy the Poco CMake files
 include(PocoMacros)
 
-if(POCO_ENABLE_NETSSL OR POCO_ENABLE_CRYPTO OR (POCO_ENABLE_SQL_MYSQL AND MINGW))
-	find_package(OpenSSL REQUIRED)
-else()
-	find_package(OpenSSL)
-endif()
-
-if(OPENSSL_FOUND)
-	option(POCO_ENABLE_NETSSL "Enable NetSSL" ON)
-	option(POCO_ENABLE_CRYPTO "Enable Crypto" ON)
-else()
-	option(POCO_ENABLE_NETSSL "Enable NetSSL" OFF)
-	option(POCO_ENABLE_CRYPTO "Enable Crypto" OFF)
-endif()
-
 if(POCO_ENABLE_APACHECONNECTOR)
     find_package(APR REQUIRED)
     find_package(Apache2 REQUIRED)
@@ -193,6 +179,20 @@ if(MSVC AND (EXISTS "${PROJECT_SOURCE_DIR}/openssl/build/") AND NOT POCO_DISABLE
 	endforeach()
 	list(APPEND OPENSSL_ROOT_DIR ${INTERNAL_OPENSSL_LIBRARIES})
 endif(MSVC AND (EXISTS "${PROJECT_SOURCE_DIR}/openssl/build/") AND NOT POCO_DISABLE_INTERNAL_OPENSSL)
+
+if(POCO_ENABLE_NETSSL OR POCO_ENABLE_CRYPTO OR (POCO_ENABLE_SQL_MYSQL AND MINGW))
+	find_package(OpenSSL REQUIRED)
+else()
+	find_package(OpenSSL)
+endif()
+
+if(OPENSSL_FOUND)
+	option(POCO_ENABLE_NETSSL "Enable NetSSL" ON)
+	option(POCO_ENABLE_CRYPTO "Enable Crypto" ON)
+else()
+	option(POCO_ENABLE_NETSSL "Enable NetSSL" OFF)
+	option(POCO_ENABLE_CRYPTO "Enable Crypto" OFF)
+endif()
 
 if(WIN32)
     option(POCO_ENABLE_NETSSL_WIN "NetSSL Windows" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,19 @@ option(POCO_ENABLE_FPENVIRONMENT "Enable floating-point support" ON)
 option(POCO_ENABLE_CPPUNIT "Enable CppUnit" ON)
 
 # allow disabling of internally built OpenSSL# (see below for details)
+if(POCO_STATIC)
+    message(DEPRECATION "POCO_STATIC is deprecated and will be removed! Use BUILD_SHARED_LIBS instead")
+    if(POCO_VERBOSE_MESSAGES)
+	message(STATUS "Building static libraries")
+    endif()
+    option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+else()
+    if(POCO_VERBOSE_MESSAGES)
+	message(STATUS "Building dynamic libraries")
+    endif()
+    option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+endif()
+
 # if POCO pre-built OpenSSL directory is found, and POCO_DISABLE_INTERNAL_OPENSSL=OFF,
 # the internal OpenSSL build will be used
 option(POCO_DISABLE_INTERNAL_OPENSSL "Disable internal OpensSSL binaries use" OFF)
@@ -192,18 +205,6 @@ option(POCO_ENABLE_TESTS
 
 option(POCO_ENABLE_SAMPLES
   "Set to OFF|ON (default is OFF) to control build of POCO samples" OFF)
-if(POCO_STATIC)
-    message(DEPRECATION "POCO_STATIC is deprecated and will be removed! Use BUILD_SHARED_LIBS instead")
-    if(POCO_VERBOSE_MESSAGES)
-	message(STATUS "Building static libraries")
-    endif()
-    option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-else()
-    if(POCO_VERBOSE_MESSAGES)
-	message(STATUS "Building dynamic libraries")
-    endif()
-    option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-endif()
 
 option(POCO_UNBUNDLED
   "Set to OFF|ON (default is OFF) to control linking dependencies as external" OFF)


### PR DESCRIPTION
Using internal OpenSSL needs BUILD_SHARED_LIBS defined (default ON) so I moved it up as it was before last merge from 1.9.1 branch (a4a0052cc1b2faee285b9ffc9888e3b0ee58a88f).