### PR TITLE
Set correct build type for Visual Studio builds with cmake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -414,7 +414,6 @@ build_script:
         $defs = "-H."
         $defs+=" -Bbuild-cmake"
         $defs+=" -G" + $generator;
-        $defs+=" -DCMAKE_BUILD_TYPE=Debug";
         $defs+=" -DPOCO_ENABLE_PDF=OFF";
         $defs+=" -DPOCO_ENABLE_NETSSL=ON";
         $defs+=" -DPOCO_ENABLE_NETSSL_WIN=ON";
@@ -427,8 +426,8 @@ build_script:
         gc cout; gc cerr;
         try {
           $ErrorActionPreference = 'Continue';
-          Write-Host -ForegroundColor Yellow cmake `-`-build build-cmake
-          cmake `-`-build build-cmake
+          Write-Host -ForegroundColor Yellow cmake `-`-build build-cmake --config Debug
+          cmake `-`-build build-cmake --config Debug
         } catch {
           Write-Warning "Oops: $_"
         }
@@ -566,7 +565,7 @@ test_script:
         {
           pushd build-cmake;
           Write-Host -ForegroundColor Yellow $line;
-          ctest --config RelWithDebInfo -N
+          ctest --config Debug -N
           Write-Host -ForegroundColor Yellow $line;
 
           $cmd='ctest -C Debug --output-on-failure -E SQL*';


### PR DESCRIPTION
Set correct build type for Visual Studio builds with cmake on AppVeyor. 
See also the explanation of[`CMAKE_BUILD_TYPE` and `--config` on stackoverflow](https://stackoverflow.com/questions/24460486/cmake-build-type-not-being-used-in-cmakelists-txt)