### PR TITLE
Remove incorrect upper size limits for SSL certificates in NetSSL_Win

### DIFF
--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -193,7 +193,6 @@ void Context::importCertificate()
 	Poco::File certFile(_certNameOrPath);
 	if (!certFile.exists()) throw Poco::FileNotFoundException(_certNameOrPath);
 	Poco::File::FileSize size = certFile.getSize();
-	if (size > 4096) throw Poco::DataFormatException("PKCS #12 certificate file too large", _certNameOrPath);
 	Poco::Buffer<char> buffer(static_cast<std::size_t>(size));
 	Poco::FileInputStream istr(_certNameOrPath);
 	istr.read(buffer.begin(), buffer.size());

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -397,7 +397,6 @@ void X509Certificate::importCertificate(const std::string& certPath)
 	Poco::File certFile(certPath);
 	if (!certFile.exists()) throw Poco::FileNotFoundException(certPath);
 	Poco::File::FileSize size = certFile.getSize();
-	if (size > 4096) throw Poco::DataFormatException("certificate file too large", certPath);
 	if (size < 32) throw Poco::DataFormatException("certificate file too small", certPath);
 	Poco::Buffer<char> buffer(static_cast<std::size_t>(size));
 	Poco::FileInputStream istr(certPath);


### PR DESCRIPTION
In our experience, many valid certificates which we used were larger than the limits set in code (4096 bytes) and thus couldn't be used with our app at all. I believe this restriction (4096) comes from confusing max key size in bits with the file size. In any case I think that calls to the underlying WinAPI should return an error in case the certificate file is defective in some way.

We've been using this "fix" for several months in production, no problems whatsoever. Don't know about the lower size in X509Certificate.cpp (size < 32) though - following the same logic maybe it should be removed too. Anyways we haven't seen a certificate as small as that.

The linux NetSSL seems to work regardless of certificate sizes, so I suppose there is no such confusion there. We haven't experienced any issues with our linux builds and larger certs.