### PR TITLE
Restore pre-1.8.0 behaviour of Poco::Net::ServerSocket::bind.

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -205,7 +205,7 @@ void SocketImpl::connectNB(const SocketAddress& address)
 
 void SocketImpl::bind(const SocketAddress& address, bool reuseAddress)
 {
-	bind(address, reuseAddress, true);
+	bind(address, reuseAddress, reuseAddress);
 }
 
 


### PR DESCRIPTION
Use `reuseAddress` as the value of `reusePort` for backwards compatibility with older Poco versions. Fixes #2615 