### PR TITLE
Fix the FAQ documentation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -7,7 +7,7 @@
 
 **A:** It depends on what exactly [xyz] is. POCO community is more than happy to help newcomers and experienced C++ programmers alike. There are, however, certain limitations as to how far we are willing to go as well as expectations we have for people asking questions:
 
-  - First and foremost, read the relevant [documentation](http://pocoproject.org/documentation/index.html)
+  - First and foremost, read the relevant [documentation](http://pocoproject.org/documentation.html)
 
   - Please be patient and respectful; we answer questions free of charge and our time is at least as valuable as yours.
 


### PR DESCRIPTION
Fix the link to the documentation in the FAQ by removing the `index` from the URL.