### PR TITLE
Replace depraceted width and remove Js comment lines

### DIFF
--- a/SQL/samples/WebNotifier/WebNotifier.html
+++ b/SQL/samples/WebNotifier/WebNotifier.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>WebSocketServer</title>
@@ -91,12 +92,8 @@
   </head>
   <body onload="WebSocketOpen()">
     <h1>Web Notifier Example</h1>
-    <!--
-    <p><a href="javascript:WebSocketOpen()">Open WebSocket</a></p>
-    <p><a href="javascript:WebSocketClose()">Close WebSocket</a></p>
-    <p><a href="javascript:WebSocketSend('hello')">Send Echo</a></p>
-    -->
-    <table id="dataTable" width="350px" border="1">
+    
+    <table id="dataTable" style="width:350px" border="1">
       <tr>  <th>ID</th> <th>Name</th>  <th>Address</th>  <th>Age</th></tr>
     </table>
     <div id="output"></div>


### PR DESCRIPTION
Include DOCTYPE declaration  and replace the deprecated "width" in HTML5 by using  "CSS" definition. 