### PR TITLE
Fix CLOB type support in StatementImpl and RecordSet

### DIFF
--- a/Data/src/RecordSet.cpp
+++ b/Data/src/RecordSet.cpp
@@ -164,6 +164,7 @@ Poco::Dynamic::Var RecordSet::value(const std::string& name, std::size_t row, bo
 	case MetaColumn::FDT_STRING:    return value<std::string>(name, row, useFilter);
 	case MetaColumn::FDT_WSTRING:   return value<UTF16String>(name, row, useFilter);
 	case MetaColumn::FDT_BLOB:      return value<BLOB>(name, row, useFilter);
+	case MetaColumn::FDT_CLOB:      return value<CLOB>(name, row, useFilter);
 	case MetaColumn::FDT_DATE:      return value<Date>(name, row, useFilter);
 	case MetaColumn::FDT_TIME:      return value<Time>(name, row, useFilter);
 	case MetaColumn::FDT_TIMESTAMP: return value<DateTime>(name, row, useFilter);

--- a/Data/src/StatementImpl.cpp
+++ b/Data/src/StatementImpl.cpp
@@ -343,6 +343,8 @@ void StatementImpl::makeExtractors(std::size_t count)
 				addInternalExtract<Poco::UTF16String>(mc); break;
 			case MetaColumn::FDT_BLOB:   
 				addInternalExtract<BLOB>(mc); break;
+			case MetaColumn::FDT_CLOB:   
+				addInternalExtract<CLOB>(mc); break;
 			case MetaColumn::FDT_DATE:
 				addInternalExtract<Date>(mc); break;
 			case MetaColumn::FDT_TIME:


### PR DESCRIPTION
As written in [this](https://github.com/pocoproject/poco/issues/2566#issue-390609008) this commit fixes issue with CLOB datatypes (i.e. text datatype in PostgreSQL)