### PR TITLE
AIX: fixed st_timespec handling

### DIFF
--- a/Foundation/src/File_UNIX.cpp
+++ b/Foundation/src/File_UNIX.cpp
@@ -47,6 +47,14 @@ namespace{
 Poco::Timestamp::TimeVal timespec2Microsecs(const struct timespec &ts) {
 	return ts.tv_sec * 1000000L + ts.tv_nsec / 1000L;
 }
+
+#if defined(_AIX) && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
+// on AIX struct timespec is not the same as struct st_timespec
+Poco::Timestamp::TimeVal timespec2Microsecs(const struct st_timespec &ts) {
+	return ts.tv_sec * 1000000L + ts.tv_nsec / 1000;
+}
+#endif // defined(_AIX) && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700
+
 } // namespace
 
 namespace Poco {


### PR DESCRIPTION
On AIX struct timespec is not the same as struct st_timespec, so using members *st_ctim* and *st_mtim* to get file times requires a special handler.