### PR TITLE
Fixed stack corruption in select method

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -708,7 +708,8 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 	return rc > 0;
 
 #else
-
+	if (sockfd >= FD_SETSIZE) throw InvalidSocketException();
+	
 	fd_set fdRead;
 	fd_set fdWrite;
 	fd_set fdExcept;

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -708,6 +708,8 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 	return rc > 0;
 
 #else
+	//select() can monitor only file descriptors numbers that are less than FD_SETSIZE
+	//otherwise it can cause stack corruption (known issue)
 	if (sockfd >= FD_SETSIZE) throw InvalidSocketException();
 	
 	fd_set fdRead;


### PR DESCRIPTION
select() can monitor only file descriptors numbers that are less than FD_SETSIZE, otherwise ic can cause stack corruption (known issue)