### PR TITLE
Added tryWait() into Process and ProcessHandle. Handle kill()-ed UNIX process exit codes.

### DIFF
--- a/Foundation/include/Poco/Process.h
+++ b/Foundation/include/Poco/Process.h
@@ -68,6 +68,11 @@ public:
 		/// Waits for the process to terminate
 		/// and returns the exit code of the process.
 
+	int tryWait() const;
+		/// Checks that process is terminated
+		/// and returns the exit code of the process.
+		/// If the process ai still running, returns -1.
+
 protected:
 	ProcessHandle(ProcessHandleImpl* pImpl);
 
@@ -212,6 +217,10 @@ public:
 	static int wait(const ProcessHandle& handle);
 		/// Waits for the process specified by handle to terminate
 		/// and returns the exit code of the process.
+
+	static int tryWait(const ProcessHandle& handle);
+		/// Checks that process is finished and returns the exit code of the
+		/// process. If the process is still running, returns -1.
 
 	static bool isRunning(const ProcessHandle& handle);
 		/// check if the process specified by handle is running or not

--- a/Foundation/include/Poco/Process.h
+++ b/Foundation/include/Poco/Process.h
@@ -71,7 +71,7 @@ public:
 	int tryWait() const;
 		/// Checks that process is terminated
 		/// and returns the exit code of the process.
-		/// If the process ai still running, returns -1.
+		/// If the process is still running, returns -1.
 
 protected:
 	ProcessHandle(ProcessHandleImpl* pImpl);

--- a/Foundation/include/Poco/Process_UNIX.h
+++ b/Foundation/include/Poco/Process_UNIX.h
@@ -39,6 +39,7 @@ public:
 	
 	pid_t id() const;
 	int wait() const;
+	int tryWait() const;
 	
 private:
 	pid_t _pid;

--- a/Foundation/include/Poco/Process_VX.h
+++ b/Foundation/include/Poco/Process_VX.h
@@ -41,6 +41,7 @@ public:
 	
 	int id() const;
 	int wait() const;
+	int tryWait() const;
 	
 private:
 	int _pid;

--- a/Foundation/include/Poco/Process_WIN32.h
+++ b/Foundation/include/Poco/Process_WIN32.h
@@ -40,6 +40,7 @@ public:
 	UInt32 id() const;
 	HANDLE process() const;
 	int wait() const;
+	int tryWait() const;
 	void closeHandle();
 
 private:

--- a/Foundation/include/Poco/Process_WIN32U.h
+++ b/Foundation/include/Poco/Process_WIN32U.h
@@ -40,6 +40,7 @@ public:
 	UInt32 id() const;
 	HANDLE process() const;
 	int wait() const;
+	int tryWait() const;
 	void closeHandle();
 
 private:

--- a/Foundation/include/Poco/Process_WINCE.h
+++ b/Foundation/include/Poco/Process_WINCE.h
@@ -40,6 +40,7 @@ public:
 	UInt32 id() const;
 	HANDLE process() const;
 	int wait() const;
+	int tryWait() const;
 	void closeHandle();
 
 private:

--- a/Foundation/src/Process.cpp
+++ b/Foundation/src/Process.cpp
@@ -111,6 +111,10 @@ int ProcessHandle::wait() const
 	return _pImpl->wait();
 }
 
+int ProcessHandle::tryWait() const
+{
+	return _pImpl->tryWait();
+}
 
 //
 // Process
@@ -167,6 +171,10 @@ int Process::wait(const ProcessHandle& handle)
 	return handle.wait();
 }
 
+int Process::tryWait(const ProcessHandle& handle)
+{
+	return handle.tryWait();
+}
 
 void Process::kill(ProcessHandle& handle)
 {
@@ -183,6 +191,7 @@ bool Process::isRunning(const ProcessHandle& handle)
 {
 	return isRunningImpl(*handle._pImpl);
 }
+
 bool Process::isRunning(PID pid)
 {
 	return isRunningImpl(pid);

--- a/Foundation/src/Process_UNIX.cpp
+++ b/Foundation/src/Process_UNIX.cpp
@@ -78,7 +78,7 @@ int ProcessHandleImpl::tryWait() const
 	int rc;
 	do
 	{
-		rc = waitpid(_pid, &status, 0);
+		rc = waitpid(_pid, &status, WNOHANG);
 	}
 	while (rc < 0 && errno == EINTR);
 	if (rc == 0)

--- a/Foundation/src/Process_VX.cpp
+++ b/Foundation/src/Process_VX.cpp
@@ -44,6 +44,10 @@ int ProcessHandleImpl::wait() const
 	throw Poco::NotImplementedException("Process::wait()");
 }
 
+int ProcessHandleImpl::tryWait() const
+{
+	throw Poco::NotImplementedException("Process::tryWait()");
+}
 
 //
 // ProcessImpl

--- a/Foundation/src/Process_WIN32.cpp
+++ b/Foundation/src/Process_WIN32.cpp
@@ -78,10 +78,10 @@ int ProcessHandleImpl::tryWait() const
 	DWORD exitCode;
 	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
 		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
-    if (exitCode == STILL_ACTIVE)
-        return -1;
-    else
-        return exitCode;
+	if (exitCode == STILL_ACTIVE)
+		return -1;
+	else
+		return exitCode;
 }
 
 //

--- a/Foundation/src/Process_WIN32.cpp
+++ b/Foundation/src/Process_WIN32.cpp
@@ -73,6 +73,16 @@ int ProcessHandleImpl::wait() const
 	return exitCode;
 }
 
+int ProcessHandleImpl::tryWait() const
+{
+	DWORD exitCode;
+	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
+		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
+    if (exitCode == STILL_ACTIVE)
+        return -1;
+    else
+        return exitCode;
+}
 
 //
 // ProcessImpl

--- a/Foundation/src/Process_WIN32U.cpp
+++ b/Foundation/src/Process_WIN32U.cpp
@@ -82,10 +82,10 @@ int ProcessHandleImpl::tryWait() const
 	DWORD exitCode;
 	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
 		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
-    if (exitCode == STILL_ACTIVE)
-        return -1;
-    else
-        return exitCode;
+	if (exitCode == STILL_ACTIVE)
+		return -1;
+	else
+		return exitCode;
 }
 
 //

--- a/Foundation/src/Process_WIN32U.cpp
+++ b/Foundation/src/Process_WIN32U.cpp
@@ -77,6 +77,16 @@ int ProcessHandleImpl::wait() const
 	return exitCode;
 }
 
+int ProcessHandleImpl::tryWait() const
+{
+	DWORD exitCode;
+	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
+		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
+    if (exitCode == STILL_ACTIVE)
+        return -1;
+    else
+        return exitCode;
+}
 
 //
 // ProcessImpl

--- a/Foundation/src/Process_WINCE.cpp
+++ b/Foundation/src/Process_WINCE.cpp
@@ -72,6 +72,16 @@ int ProcessHandleImpl::wait() const
 	return exitCode;
 }
 
+int ProcessHandleImpl::tryWait() const
+{
+	DWORD exitCode;
+	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
+		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
+    if (exitCode == STILL_ACTIVE)
+        return -1;
+    else
+        return exitCode;
+}
 
 //
 // ProcessImpl

--- a/Foundation/src/Process_WINCE.cpp
+++ b/Foundation/src/Process_WINCE.cpp
@@ -77,10 +77,10 @@ int ProcessHandleImpl::tryWait() const
 	DWORD exitCode;
 	if (GetExitCodeProcess(_hProcess, &exitCode) == 0)
 		throw SystemException("Cannot get exit code for process", NumberFormatter::format(_pid));
-    if (exitCode == STILL_ACTIVE)
-        return -1;
-    else
-        return exitCode;
+	if (exitCode == STILL_ACTIVE)
+		return -1;
+	else
+		return exitCode;
 }
 
 //


### PR DESCRIPTION
Unfortunately, `kill(pid, 0)` treats zombie processes as running. So it is impossible to implement periodical watchdog for a child processes.

I propose new method `tryWait()` in Poco::Process and Poco::ProcessHandle. It checks process status and returns immediately with value indicating running process or it's exit code.

Also I have added distinction between exited and killed process return codes in `wait` and `tryWait`.