### PR TITLE
Invalid read of memory in Poco::Environment::set which may cause crashes.

### DIFF
--- a/Foundation/src/Environment_UNIX.cpp
+++ b/Foundation/src/Environment_UNIX.cpp
@@ -61,7 +61,7 @@ void EnvironmentImpl::setImpl(const std::string& name, const std::string& value)
 	std::string var = name;
 	var.append("=");
 	var.append(value);
-	_map[name] = var;
+	std::swap(_map[name],var);
 	if (putenv((char*) _map[name].c_str()))
 	{
 		std::string msg = "cannot set environment variable: ";

--- a/Foundation/src/Environment_VX.cpp
+++ b/Foundation/src/Environment_VX.cpp
@@ -70,7 +70,7 @@ void EnvironmentImpl::setImpl(const std::string& name, const std::string& value)
 	std::string var = name;
 	var.append("=");
 	var.append(value);
-	_map[name] = var;
+	std::swap(_map[name],var);
 	if (putenv((char*) _map[name].c_str()))
 	{
 		std::string msg = "cannot set environment variable: ";


### PR DESCRIPTION

[SampleProgram.txt](https://github.com/pocoproject/poco/files/3207667/SampleProgram.txt)
[ValgrindOutput.txt](https://github.com/pocoproject/poco/files/3207685/ValgrindOutput.txt)

Issue description - 
When the same name is passed to Poco::Environment::set such as -
Poco::Environment::set("ABC", "XYZ");
Poco::Environment::set("ABC", "xyz");
there is invalid memory read. This can be seen in attached ValgrindOutput.txt.

With the first call Poco::Environment::set internally calls putenv with the address of _map[value], this address is stored in __environ global variable of libc. 
putenv do not expect variables whose addresses are stored in __environ to be deleted. As it iterates through it in __add_to_environ call for checking if the same name already exists in __environ

On the second call of Poco::Environment::set internal variable _map deletes the previous string held by _map[value] and assign it a new string value.
This happens at Poco::Environment::set -
_map[name] = var 

This follows by call to putenv -> __add_to_environ which iterates through __environ and tries to access the already deleted variable.

We should not delete the previous variable whose address is still stored in __environ. We may delete it once it is out of __environ.

std::swap(_map[name],var); 
This will keep the address of the previous string of _map[name] in var. 
Address in __environ will be changed with the address of the given new value. 
putenv can now access the previous value which is stored in var after swap.
Now the memory stored in var can be safely deleted which will be done automatically at function exit.
