### PR TITLE
Fix warnings with release 1.9.0 and gcc 9:

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -433,7 +433,7 @@ private:
 			// 'from' is greater than 'T' max value
 			else if (!std::numeric_limits<F>::is_signed &&
 					  std::numeric_limits<T>::is_signed &&
-					  static_cast<Poco::UInt64>(from) > std::numeric_limits<T>::max())
+					  static_cast<Poco::UInt64>(from) > static_cast<Poco::UInt64>(std::numeric_limits<T>::max()))
 			{
 				throw RangeException("Value too large.");
 			}


### PR DESCRIPTION
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-2/include/Poco/Dynamic/VarHolder.h: In instantiation of ‘void Poco::Dynamic::VarHolder::checkUpperLimit(const F&) const [with F = short int; T = signed char]’:
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-2/include/Poco/Dynamic/VarHolder.h:327:4:   required from ‘void Poco::Dynamic::VarHolder::convertToSmaller(const F&, T&) const [with F = short int; T = signed char]’
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-2/include/Poco/Dynamic/VarHolder.h:913:29:   required from here
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-2/include/Poco/Dynamic/VarHolder.h:435:39: error: comparison of integer expressions of different signedness: ‘Poco::UInt64’ {aka ‘long unsigned int’} and ‘signed char’ [-Werror=sign-compare]
  435 |       static_cast<Poco::UInt64>(from) > std::numeric_limits<T>::max())
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~