### PR TITLE
Fix Visual Studio warnings at level /Wall

### DIFF
--- a/Foundation/src/WindowsConsoleChannel.cpp
+++ b/Foundation/src/WindowsConsoleChannel.cpp
@@ -23,8 +23,8 @@ namespace Poco {
 
 
 WindowsConsoleChannel::WindowsConsoleChannel():
-	_isFile(false),
-	_hConsole(INVALID_HANDLE_VALUE)
+	_hConsole(INVALID_HANDLE_VALUE),
+	_isFile(false)
 {
 	_hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 	// check whether the console has been redirected
@@ -60,8 +60,8 @@ void WindowsConsoleChannel::log(const Message& msg)
 
 WindowsColorConsoleChannel::WindowsColorConsoleChannel():
 	_enableColors(true),
-	_isFile(false),
-	_hConsole(INVALID_HANDLE_VALUE)
+	_hConsole(INVALID_HANDLE_VALUE),
+	_isFile(false)
 {
 	_hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 	// check whether the console has been redirected


### PR DESCRIPTION
poco\foundation\src\windowsconsolechannel.cpp(28): warning C5038: data member 'Poco::WindowsConsoleChannel::_isFile' will be initialized after data member 'Poco::WindowsConsoleChannel::_hConsole'
poco\foundation\src\windowsconsolechannel.cpp(70): warning C5038: data member 'Poco::WindowsColorConsoleChannel::_isFile' will be initialized after data member 'Poco::WindowsColorConsoleChannel::_hConsole'