### PR TITLE
Explicitly create output directories

### DIFF
--- a/build/rules/compile
+++ b/build/rules/compile
@@ -38,34 +38,42 @@ $(OBJPATH_RELEASE_STATIC) $(OBJPATH_DEBUG_STATIC) $(OBJPATH_RELEASE_SHARED) $(OB
 #
 $(OBJPATH_DEBUG_STATIC)/%.o: $(SRCDIR)/%.cpp $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(debug, static)"
+	$(MKDIR) $(OBJPATH_DEBUG_STATIC)
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $(DEBUGOPT_CXX) $(STATICOPT_CXX) -c $< -o $@
 
 $(OBJPATH_RELEASE_STATIC)/%.o: $(SRCDIR)/%.cpp $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(release, static)"
+	$(MKDIR) $(OBJPATH_RELEASE_STATIC)
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $(RELEASEOPT_CXX) $(STATICOPT_CXX) -c $< -o $@
 
 $(OBJPATH_DEBUG_STATIC)/%.o: $(SRCDIR)/%.c $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(debug, static)"
+	$(MKDIR)  $(OBJPATH_DEBUG_STATIC)
 	$(CC) $(INCLUDE) $(CFLAGS) $(DEBUGOPT_CC) $(STATICOPT_CC) -c $< -o $@
 
 $(OBJPATH_RELEASE_STATIC)/%.o: $(SRCDIR)/%.c $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(release, static)"
+	$(MKDIR)  $(OBJPATH_RELEASE_STATIC)
 	$(CC) $(INCLUDE) $(CFLAGS) $(RELEASEOPT_CC) $(STATICOPT_CC) -c $< -o $@
 
 $(OBJPATH_DEBUG_SHARED)/%.o: $(SRCDIR)/%.cpp $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(debug, shared)"
+	$(MKDIR)  $(OBJPATH_DEBUG_SHARED)
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $(DEBUGOPT_CXX) $(SHAREDOPT_CXX) -c $< -o $@
 
 $(OBJPATH_RELEASE_SHARED)/%.o: $(SRCDIR)/%.cpp $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(release, shared)"
+	$(MKDIR)  $(OBJPATH_RELEASE_SHARED)
 	$(CXX) $(INCLUDE) $(CXXFLAGS) $(RELEASEOPT_CXX) $(SHAREDOPT_CXX) -c $< -o $@
 
 $(OBJPATH_DEBUG_SHARED)/%.o: $(SRCDIR)/%.c $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(debug, shared)"
+	$(MKDIR)  $(OBJPATH_DEBUG_SHARED)
 	$(CC) $(INCLUDE) $(CFLAGS) $(DEBUGOPT_CC) $(SHAREDOPT_CC) -c $< -o $@
 
 $(OBJPATH_RELEASE_SHARED)/%.o: $(SRCDIR)/%.c $(DEPPATH)/%.d $(POCO_BASE)/build/config/$(POCO_CONFIG)
 	@echo "** Compiling" $< "(release, shared)"
+	$(MKDIR)  $(OBJPATH_RELEASE_SHARED)
 	$(CC) $(INCLUDE) $(CFLAGS) $(RELEASEOPT_CC) $(SHAREDOPT_CC) -c $< -o $@
 
 #


### PR DESCRIPTION
I have noticed spurious "no such file or directory" failures when
packaging poco using `make j6 all` and I assume that the creation of
these directories is not always guaranteed in such a case. It should
not harm to explicitly create them on the fly.

Signed-off-by: Christoph Höger <christoph.hoeger@celeraone.com>