### PR TITLE
return actual number of sent bytes in sendBytes()

### DIFF
--- a/Net/src/WebSocketImpl.cpp
+++ b/Net/src/WebSocketImpl.cpp
@@ -104,8 +104,7 @@ int WebSocketImpl::sendBytes(const void* buffer, int length, int flags)
 	{
 		std::memcpy(frame.begin() + ostr.charsWritten(), buffer, length);
 	}
-	_pStreamSocketImpl->sendBytes(frame.begin(), length + static_cast<int>(ostr.charsWritten()));
-	return length;
+	return _pStreamSocketImpl->sendBytes(frame.begin(), length + static_cast<int>(ostr.charsWritten()));
 }
 
 


### PR DESCRIPTION
According to https://pocoproject.org/docs/Poco.Net.StreamSocket.html#25805 `sendBytes()` should return the number of actual sent bytes. Without this patch `sendBytes()` does always return the number of bytes passed by the caller.