### PR TITLE
Add support for QNX

### DIFF
--- a/Crypto/samples/genrsakey/Makefile
+++ b/Crypto/samples/genrsakey/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 objects = genrsakey
 

--- a/Crypto/testsuite/Makefile
+++ b/Crypto/testsuite/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = CryptoTestSuite Driver \

--- a/Foundation/src/File_UNIX.cpp
+++ b/Foundation/src/File_UNIX.cpp
@@ -23,7 +23,7 @@
 #if defined(POCO_OS_FAMILY_BSD)
 #include <sys/param.h>
 #include <sys/mount.h>
-#elif (POCO_OS == POCO_OS_SOLARIS)
+#elif ((POCO_OS == POCO_OS_SOLARIS) || (POCO_OS == POCO_OS_QNX))
 #include <sys/statvfs.h>
 #else
 #include <sys/statfs.h>
@@ -35,7 +35,7 @@
 #include <utime.h>
 #include <cstring>
 
-#if (POCO_OS == POCO_OS_SOLARIS)
+#if ((POCO_OS == POCO_OS_SOLARIS) || (POCO_OS == POCO_OS_QNX))
 #define STATFSFN statvfs
 #define STATFSSTRUCT statvfs
 #else

--- a/NetSSL_OpenSSL/samples/HTTPSTimeServer/Makefile
+++ b/NetSSL_OpenSSL/samples/HTTPSTimeServer/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = HTTPSTimeServer

--- a/NetSSL_OpenSSL/samples/Mail/Makefile
+++ b/NetSSL_OpenSSL/samples/Mail/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = Mail

--- a/NetSSL_OpenSSL/samples/TwitterClient/Makefile
+++ b/NetSSL_OpenSSL/samples/TwitterClient/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = Twitter TweetApp

--- a/NetSSL_OpenSSL/samples/download/Makefile
+++ b/NetSSL_OpenSSL/samples/download/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = download

--- a/NetSSL_OpenSSL/testsuite/Makefile
+++ b/NetSSL_OpenSSL/testsuite/Makefile
@@ -10,7 +10,11 @@ include $(POCO_BASE)/build/rules/global
 ifeq ($(POCO_CONFIG),FreeBSD)
 SYSLIBS += -lssl -lcrypto -lz
 else
+ifeq ($(POCO_CONFIG),QNX)
+SYSLIBS += -lssl -lcrypto -lz
+else
 SYSLIBS += -lssl -lcrypto -lz -ldl
+endif
 endif
 
 objects = NetSSLTestSuite Driver \


### PR DESCRIPTION
a. Fix Makefiles so as not to use "dl" library because it's included in C library in QNX SDP7.0
b. Fix File_UNIX.cpp so as it include sys/statvfs.h instead of sys/statfs.h