### PR TITLE
Fix the issue with incorrect type of store name parameter in CertOpenStore API call into NetSSL_Win

### DIFF
--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -167,7 +167,7 @@ void Context::loadCertificate()
 	if (!_hCertStore)
 	{
 		if (_options & OPT_USE_MACHINE_STORE)
-			_hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE, _certStoreName.c_str());
+			_hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE, wcertStore.c_str());
 		else
 			_hCertStore = CertOpenSystemStoreW(0, wcertStore.c_str());
 	}

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -366,7 +366,7 @@ void X509Certificate::loadCertificate(const std::string& certName, const std::st
 	Poco::UnicodeConverter::convert(certStoreName, wcertStore);
 	HCERTSTORE hCertStore;
 	if (useMachineStore)
-		hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE, certStoreName.c_str());
+		hCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE, wcertStore.c_str());
 	else
 		hCertStore = CertOpenSystemStoreW(0, wcertStore.c_str());
 


### PR DESCRIPTION
We were unable to load SSL certificates from the Windows certificate store with the OPT_USE_MACHINE_STORE option enabled.
During debugging, we found that the problem was in calling the Windows CertOpenStore API function.
According to the documentation, if you use the CERT_STORE_PROV_SYSTEM parameter, the pvPara parameter must point to a Unicode string that contains the name of the system storage. But in fact, the pvPara parameter pointed to the Ansi string.
Therefore, we changed the std::string certStoreName parameter to std::wstring wcertStore.
We checked this solution. Currently, we can load SSL certificates from the Windows certificate store with the OPT_USE_MACHINE_STORE option enabled.