### PR TITLE
Fix issue in NetSSL_Win. Windows Server 2016 reboots while trying to …

### DIFF
--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -308,7 +308,7 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 		schannelCred.dwFlags |= SCH_USE_STRONG_CRYPTO;
 #endif
 
-	 schannelCred.hRootStore = isForServerUse() ? _hCollectionCertStore : NULL;
+	schannelCred.hRootStore = isForServerUse() ? _hCollectionCertStore : NULL;
 
 	TimeStamp tsExpiry;
 	tsExpiry.LowPart = tsExpiry.HighPart = 0;

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -308,7 +308,7 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 		schannelCred.dwFlags |= SCH_USE_STRONG_CRYPTO;
 #endif
 
-	schannelCred.hRootStore = _hCollectionCertStore;
+	 schannelCred.hRootStore = isForServerUse() ? _hCollectionCertStore : NULL;
 
 	TimeStamp tsExpiry;
 	tsExpiry.LowPart = tsExpiry.HighPart = 0;


### PR DESCRIPTION
…establish an SSL connection.

We faced the next issue with Windows Server 2016:
When we attempted to make an SSL connection we had error "Failed to acquire Schannel credentials: The Local Security Authority cannot be contacted". After this exception Windows crashes and restart.

We found discussion about similar issue: https://github.com/pocoproject/poco/issues/1423
We applied fix which was described by the link.

We successfully tested the fix and now we are using it in production.
