### PR TITLE
Fix configuration error while cross compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,9 @@ add_custom_target(uninstall
 #############################################################
 # Enable packaging
 
-include(InstallRequiredSystemLibraries)
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  include(InstallRequiredSystemLibraries)
+endif()
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Poco Libraries")
 set(CPACK_PACKAGE_VENDOR "Applied Informatics Software Engineering GmbH")


### PR DESCRIPTION
During the configuration phase in a cross compilation scenario (at least with wine + msvc),
`include(InstallRequiredSystemLibraries)` fails even if
`MSVC_REDIST_DIR` is provided with the error message 
`cmake_host_system_information does not recognize <key> VS_15_DIR`.

This should not be an hard error, in case someone wants to
compile/use the library, and not package it.

As explained on https://reviews.llvm.org/D41220, the most sensible fix
is to include `InstallRequiredSystemLibraries` only on a Windows host.