### PR TITLE
Set timeouts for FTP passive connections

### DIFF
--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -441,6 +441,8 @@ StreamSocket FTPClientSession::passiveDataConnection(const std::string& command,
 	SocketAddress sa(sendPassiveCommand());
 	StreamSocket sock;
 	sock.connect(sa, _timeout);
+	sock.setReceiveTimeout(_timeout);
+	sock.setSendTimeout(_timeout);
 	std::string response;
 	int status = sendCommand(command, arg, response);
 	if (!isPositivePreliminary(status)) 


### PR DESCRIPTION
Came across the issue of FTP transfers hanging when the connection was dropped in 1.9.2.

Looks like it was fixed in develop with #2234 but has never been merged into a stable release or master.