### PR TITLE
add buffersize property to the AsyncChannel

### DIFF
--- a/Foundation/include/Poco/AsyncChannel.h
+++ b/Foundation/include/Poco/AsyncChannel.h
@@ -50,14 +50,14 @@ public:
 	void setChannel(Channel::Ptr pChannel);
 		/// Connects the AsyncChannel to the given target channel.
 		/// All messages will be forwarded to this channel.
-		
+
 	Channel::Ptr getChannel() const;
 		/// Returns the target channel.
 
 	void open();
 		/// Opens the channel and creates the
 		/// background logging thread.
-		
+
 	void close();
 		/// Closes the channel and stops the background
 		/// logging thread.
@@ -65,6 +65,9 @@ public:
 	void log(const Message& msg);
 		/// Queues the message for processing by the
 		/// background thread.
+
+	void setBufferSize(const std::string& sizeStr);
+		/// Set maximum number of Notifications in the buffer
 
 	void setProperty(const std::string& name, const std::string& value);
 		/// Sets or changes a configuration property.
@@ -87,13 +90,16 @@ protected:
 	~AsyncChannel();
 	void run();
 	void setPriority(const std::string& value);
-		
+
 private:
 	Channel::Ptr      _pChannel;
 	Thread            _thread;
 	FastMutex         _threadMutex;
 	FastMutex         _channelMutex;
 	NotificationQueue _queue;
+	UInt32            _bufferSize;
+	UInt32            _dropCount;
+	static const UInt32 BUFFER_SIZE_NONE;
 };
 
 


### PR DESCRIPTION
GOAL : adding a bufferSize property to AsyncChannel

RATIONALE:
AsyncChannel is a channel that decouples the log() call from the actual writing. That works with a queue of messages to be written. In the original Poco AsyncChannel, there is no limit to the size of that buffer such that it could grow infinitely if the writing thread is not able to consume the messages as fast as the callers of log(). In our case, one of the callers is a high priority real-time thread. So there is a risk of being flooded.

This pull request introduces a property, bufferSize, on the AsyncChannel. If there are more than that many messages in the buffer, the buffer stops queuing and counts the messages that have been discarded. The next message which can be written will be preceded by the number of messages that have been discarded (sent in the same logging facility and with that logging level).

