### PR TITLE
Log stream buf pre allocation

### DIFF
--- a/Foundation/include/Poco/AsyncChannel.h
+++ b/Foundation/include/Poco/AsyncChannel.h
@@ -50,14 +50,14 @@ public:
 	void setChannel(Channel::Ptr pChannel);
 		/// Connects the AsyncChannel to the given target channel.
 		/// All messages will be forwarded to this channel.
-		
+
 	Channel::Ptr getChannel() const;
 		/// Returns the target channel.
 
 	void open();
 		/// Opens the channel and creates the
 		/// background logging thread.
-		
+
 	void close();
 		/// Closes the channel and stops the background
 		/// logging thread.
@@ -65,6 +65,9 @@ public:
 	void log(const Message& msg);
 		/// Queues the message for processing by the
 		/// background thread.
+
+	void setBufferSize(const std::string& sizeStr);
+		/// Set maximum number of Notifications in the buffer
 
 	void setProperty(const std::string& name, const std::string& value);
 		/// Sets or changes a configuration property.
@@ -87,13 +90,16 @@ protected:
 	~AsyncChannel();
 	void run();
 	void setPriority(const std::string& value);
-		
+
 private:
 	Channel::Ptr      _pChannel;
 	Thread            _thread;
 	FastMutex         _threadMutex;
 	FastMutex         _channelMutex;
 	NotificationQueue _queue;
+	UInt32            _bufferSize;
+	UInt32            _dropCount;
+	static const UInt32 BUFFER_SIZE_NONE;
 };
 
 

--- a/Foundation/include/Poco/LogStream.h
+++ b/Foundation/include/Poco/LogStream.h
@@ -37,7 +37,7 @@ class Foundation_API LogStreamBuf: public UnbufferedStreamBuf
 	/// priority.
 {
 public:
-	LogStreamBuf(Logger& logger, Message::Priority priority);
+	LogStreamBuf(Logger& logger, Message::Priority priority, std::size_t initSize);
 		/// Creates the LogStream.
 
 	~LogStreamBuf();
@@ -51,6 +51,8 @@ public:
 
 	Logger& logger() const;
 		/// Returns a reference to the Logger.
+
+	void reserve(std::size_t n);
 
 private:
 	int writeToDevice(char c);
@@ -69,7 +71,7 @@ class Foundation_API LogIOS: public virtual std::ios
 	/// order of the stream buffer and base classes.
 {
 public:
-	LogIOS(Logger& logger, Message::Priority priority);
+	LogIOS(Logger& logger, Message::Priority priority, std::size_t initBufSize);
 	~LogIOS();
 	LogStreamBuf* rdbuf();
 
@@ -93,10 +95,12 @@ class Foundation_API LogStream: public LogIOS, public std::ostream
 	///     ls.error() << "Some error message" << std::endl;
 {
 public:
-	LogStream(Logger& logger, Message::Priority priority = Message::PRIO_INFORMATION);
+	static const std::size_t DEFAULT_INIT_BUF_SIZE = 200;
+
+	LogStream(Logger& logger, Message::Priority priority = Message::PRIO_INFORMATION, std::size_t initBufSize = DEFAULT_INIT_BUF_SIZE);
 		/// Creates the LogStream, using the given logger and priority.
 
-	LogStream(const std::string& loggerName, Message::Priority priority = Message::PRIO_INFORMATION);
+	LogStream(const std::string& loggerName, Message::Priority priority = Message::PRIO_INFORMATION, std::size_t initBufSize = DEFAULT_INIT_BUF_SIZE);
 		/// Creates the LogStream, using the logger identified
 		/// by loggerName, and sets the priority.
 		

--- a/Foundation/src/LogStream.cpp
+++ b/Foundation/src/LogStream.cpp
@@ -23,10 +23,12 @@ namespace Poco {
 //
 
 
-LogStreamBuf::LogStreamBuf(Logger& rLogger, Message::Priority priority):
-	_logger(rLogger),
-	_priority(priority)
+LogStreamBuf::LogStreamBuf(Logger& logger, Message::Priority priority, std::size_t initSize):
+	_logger(logger),
+	_priority(priority),
+	_message()
 {
+	reserve(initSize);
 }
 
 
@@ -56,14 +58,18 @@ int LogStreamBuf::writeToDevice(char c)
 	return c;
 }
 
+void LogStreamBuf::reserve(std::size_t n)
+{
+	_message.reserve(n);
+}
 
 //
 // LogIOS
 //
 
 
-LogIOS::LogIOS(Logger& logger, Message::Priority priority):
-	_buf(logger, priority)
+LogIOS::LogIOS(Logger& logger, Message::Priority priority, std::size_t initBufSize):
+	_buf(logger, priority, initBufSize)
 {
 	poco_ios_init(&_buf);
 }
@@ -84,16 +90,17 @@ LogStreamBuf* LogIOS::rdbuf()
 // LogStream
 //
 
-
-LogStream::LogStream(Logger& logger, Message::Priority messagePriority):
-	LogIOS(logger, messagePriority),
+const std::size_t LogStream::DEFAULT_INIT_BUF_SIZE;
+ 
+LogStream::LogStream(Logger& logger, Message::Priority priority, std::size_t initBufSize):
+	LogIOS(logger, priority, initBufSize),
 	std::ostream(&_buf)
 {
 }
 
 
-LogStream::LogStream(const std::string& loggerName, Message::Priority messagePriority):
-	LogIOS(Logger::get(loggerName), messagePriority),
+LogStream::LogStream(const std::string& loggerName, Message::Priority priority, std::size_t initBufSize):
+	LogIOS(Logger::get(loggerName), priority, initBufSize),
 	std::ostream(&_buf)
 {
 }
@@ -208,9 +215,9 @@ LogStream& LogStream::trace(const std::string& message)
 }
 
 
-LogStream& LogStream::priority(Message::Priority messagePriority)
+LogStream& LogStream::priority(Message::Priority priority)
 {
-	_buf.setPriority(messagePriority);
+	_buf.setPriority(priority);
 	return *this;
 }
 


### PR DESCRIPTION
GOAL : allowing pre-allocation of the buffer in LogStreamBuf

RATIONALE:
Like any iostream buffer, LogStreamBuf comes with an unknown buffer space pre-allocated. When the logging messages are long, it can induce a number of realloc. Pre-allocating the buffer allows to avoid those expensive reallocations. This is important when the logging happens often (inside a loop that is repeated a lot).

