### PR TITLE
Correct documentation of reusePort parameter

### DIFF
--- a/Net/include/Poco/Net/ServerSocket.h
+++ b/Net/include/Poco/Net/ServerSocket.h
@@ -90,7 +90,7 @@ public:
 		/// If reuseAddress is true, sets the SO_REUSEADDR
 		/// socket option.
 		///
-		/// If reuseAddress is true, sets the SO_REUSEPORT
+		/// If reusePort is true, sets the SO_REUSEPORT
 		/// socket option.
 
 	virtual void bind(Poco::UInt16 port, bool reuseAddress = false);


### PR DESCRIPTION
the documentation had a typo, it had to be reusePort and not reuseAddress that is being documented