### PR TITLE
Fixed MySQL session reset

### DIFF
--- a/Data/MySQL/src/SessionHandle.cpp
+++ b/Data/MySQL/src/SessionHandle.cpp
@@ -178,11 +178,21 @@ void SessionHandle::rollback()
 
 void SessionHandle::reset()
 {
-#if ((defined (MYSQL_VERSION_ID)) && (MYSQL_VERSION_ID >= 50700)) || ((defined (MARIADB_PACKAGE_VERSION_ID)) && (MARIADB_PACKAGE_VERSION_ID >= 30000))
-	if (mysql_reset_connection(_pHandle) != 0)
-#else
-	if (mysql_refresh(_pHandle, REFRESH_TABLES | REFRESH_STATUS | REFRESH_THREADS | REFRESH_READ_LOCK) != 0)
-#endif
+/*
+  We have to somehow reset sessions before getting session from session pool, because sometimes
+  used session has some remains from previous usage. 
+
+  First, we tried call mysql_refresh() (now obsolete) and then mysql_reset_connection(). Both of
+  these functions caused unintended reseting of variables holding charset/encoding (internal variables
+  like "session.collation_connection" etc., was reseted to default value which is "latin1_swedish_ci").
+
+  Executing query FLUSH seems that it resets session and does not harm encoding.
+  I have tried few flush options (PRIVILEGES, USER_RESOURCES, QUERY CACHE, STATUS) and every of
+  these worked. Only option which did not work was FLUSH TABLES - it caused deadlocks. So I decided
+  call only FLUSH STATUS.
+*/
+
+if (mysql_query(_pHandle, "FLUSH STATUS;") != 0)
 		throw TransactionException("Reset connection failed.", _pHandle);
 }
 

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -23,6 +23,7 @@
 #include "Poco/Data/MySQL/MySQLException.h"
 #include "Poco/Nullable.h"
 #include "Poco/Data/DataException.h"
+#include "Poco/Data/SessionPool.h"
 #include <iostream>
 
 using namespace Poco::Data;
@@ -420,6 +421,15 @@ void MySQLTest::testDateTime()
 	_pExecutor->date();
 	recreatePersonTimeTable();
 	_pExecutor->time();
+}
+
+
+void MySQLTest::testSessionPoolAndUnicode()
+{
+	if (!_pSession) fail ("Test not available.");
+
+	recreateStringsTable();
+	_pExecutor->sessionPoolAndUnicode(_dbConnString);
 }
 
 
@@ -897,6 +907,7 @@ CppUnit::Test* MySQLTest::suite()
 	CppUnit_addTest(pSuite, MySQLTest, testSingleSelect);
 	CppUnit_addTest(pSuite, MySQLTest, testEmptyDB);
 	CppUnit_addTest(pSuite, MySQLTest, testDateTime);
+	CppUnit_addTest(pSuite, MySQLTest, testSessionPoolAndUnicode);
 	//CppUnit_addTest(pSuite, MySQLTest, testBLOB);
 	CppUnit_addTest(pSuite, MySQLTest, testBLOBStmt);
 	CppUnit_addTest(pSuite, MySQLTest, testUnsignedInts);

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -77,6 +77,7 @@ public:
 	void testSingleSelect();
 	void testEmptyDB();
 	void testDateTime();
+	void testSessionPoolAndUnicode();
 	void testBLOB();
 	void testBLOBStmt();
 

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -89,6 +89,8 @@ public:
 	void tuples();
 	void tupleVector();
 
+	void sessionPoolAndUnicode(const std::string& connString);
+
 	void internalExtraction();
 	void doNull();
 


### PR DESCRIPTION
* In Data/MySQL/src/SessionHandle.cpp changed calling of mysql_reset_connection() to query FLUSH
* previously used mysql_reset_connection() caused issues with encoding
* see comment in Data/MySQL/src/SessionHandle.cpp:181 SessionHandle::reset() for more info

# Related issues
https://github.com/pocoproject/poco/issues/2546
https://github.com/pocoproject/poco/issues/2800