### PR TITLE
Add getRawPort() method in URI

### DIFF
--- a/Foundation/include/Poco/URI.h
+++ b/Foundation/include/Poco/URI.h
@@ -145,6 +145,12 @@ public:
 		/// the given scheme is returned if it is known.
 		/// Otherwise, 0 is returned.
 		
+	unsigned short getRawPort() const;
+		/// Returns the parsed port number part of the URI.
+		///
+		/// If no port number (0) has been specified,
+		/// 0 is returned.
+
 	void setPort(unsigned short port);
 		/// Sets the port number part of the URI.
 		
@@ -375,6 +381,10 @@ inline const std::string& URI::getHost() const
 	return _host;
 }
 
+inline unsigned short URI::getRawPort() const
+{
+	return _port;
+}
 	
 inline const std::string& URI::getPath() const
 {

--- a/Foundation/src/URI.cpp
+++ b/Foundation/src/URI.cpp
@@ -55,7 +55,6 @@ URI::URI(const std::string& scheme, const std::string& pathEtc):
 	_port(0)
 {
 	toLowerInPlace(_scheme);
-	_port = getWellKnownPort();
 	std::string::const_iterator beg = pathEtc.begin();
 	std::string::const_iterator end = pathEtc.end();
 	parsePathEtc(beg, end);
@@ -242,8 +241,6 @@ void URI::setScheme(const std::string& scheme)
 {
 	_scheme = scheme;
 	toLowerInPlace(_scheme);
-	if (_port == 0)
-		_port = getWellKnownPort();
 }
 
 	
@@ -817,9 +814,9 @@ void URI::parseHostAndPort(std::string::const_iterator& it, const std::string::c
 			else
 				throw URISyntaxException("bad or invalid port number", port);
 		}
-		else _port = getWellKnownPort();
+		else _port = 0;
 	}
-	else _port = getWellKnownPort();
+	else _port = 0;
 	_host = host;
 	toLowerInPlace(_host);
 }


### PR DESCRIPTION
HTTP is often used for inner communication between servers in projects and the standard port in this case may differ from 80. Now there's no way of knowing whether the port 80 was set explicitly or it was set because of it is WellKnownPort.