### PR TITLE
riscv: Enable double operations when using double float abi

### DIFF
--- a/Foundation/include/Poco/Platform.h
+++ b/Foundation/include/Poco/Platform.h
@@ -135,6 +135,7 @@
 #define POCO_ARCH_AARCH64 0x0f
 #define POCO_ARCH_ARM64   0x0f // same as POCO_ARCH_AARCH64
 #define POCO_ARCH_RISCV64 0x10
+#define POCO_ARCH_RISCV32 0x11
 
 
 #if defined(__ALPHA) || defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA)
@@ -225,11 +226,15 @@
 #elif defined(__AARCH64EB__)
 	#define POCO_ARCH POCO_ARCH_AARCH64
 	#define POCO_ARCH_BIG_ENDIAN 1
-#elif defined(__riscv) && (__riscv_xlen == 64)
-	#define POCO_ARCH POCO_ARCH_RISCV64
-	#define POCO_ARCH_LITTLE_ENDIAN 1
+#elif defined(__riscv)
+	#if (__riscv_xlen == 64)
+		#define POCO_ARCH POCO_ARCH_RISCV64
+		#define POCO_ARCH_LITTLE_ENDIAN 1
+	#elif(__riscv_xlen == 32)
+		#define POCO_ARCH POCO_ARCH_RISCV32
+		#define POCO_ARCH_LITTLE_ENDIAN 1
+	#endif
 #endif
-
 
 #if defined(__clang__)
 	#define POCO_COMPILER_CLANG

--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -62,7 +62,7 @@
     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
     defined(__SH4__) || defined(__alpha__) || \
     defined(_MIPS_ARCH_MIPS32R2) || \
-    defined(__riscv) || \
+    (defined(__riscv) && defined(__riscv_float_abi_double)) || \
 	defined(__AARCH64EL__) || \
     defined(nios2) || defined(__nios2) || defined(__nios2__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>