### PR TITLE
CipherImpl: Fix small error with OpenSSL 1.1

### DIFF
--- a/Crypto/src/CipherImpl.cpp
+++ b/Crypto/src/CipherImpl.cpp
@@ -130,7 +130,7 @@ namespace
 	CryptoTransformImpl::~CryptoTransformImpl()
 	{
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-		EVP_CIPHER_CTX_cleanup(_pContext);
+		EVP_CIPHER_CTX_reset(_pContext);
 		EVP_CIPHER_CTX_free(_pContext);
 #else
 		EVP_CIPHER_CTX_cleanup(&_context);


### PR DESCRIPTION
EVP_CIPHER_CTX_cleanup is deprecated in 1.1. Replaced by _reset.

Signed-off-by: Rosen Penev <rosenp@gmail.com>