### PR TITLE
Fix wrong buffer size in client handshake when re-using a SecureSocket

### DIFF
--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -970,6 +970,9 @@ void SecureSocketImpl::performClientHandshakeLoopCondReceive()
 	performClientHandshakeLoopInit();
 	if (_needData)
 	{
+		if (_recvBuffer.capacity() != IO_BUFFER_SIZE)
+			_recvBuffer.setCapacity(IO_BUFFER_SIZE);
+
 		performClientHandshakeLoopReceive();
 	}
 	else _needData = true;


### PR DESCRIPTION
In NetSSL_Win SecureSocket impl, receive buffer can be resized after initialization. Therefore when re-using a socket (`reconnect()`), receive buffer shall be reset during client handshake.