### PR TITLE
Deleting Registry Keys on the WOW6432Node is not possible on 64Bit Applications

### DIFF
--- a/Util/src/WinRegistryKey.cpp
+++ b/Util/src/WinRegistryKey.cpp
@@ -352,7 +352,7 @@ void WinRegistryKey::deleteKey()
 		std::string subKey(_subKey);
 		subKey += "\\";
 		subKey += *it;
-		WinRegistryKey subRegKey(_hRootKey, subKey);
+		WinRegistryKey subRegKey(_hRootKey, subKey, _readOnly, _extraSam);
 		subRegKey.deleteKey();
 	}
 


### PR DESCRIPTION
On 64 Bit Applications, its not possible to delete an Registry Key located inside the WOW6432Node.
The problem is the constructor call in the deleteKey function. If the Attributes _readOnly and _extraSam are passed to the constructor call the Function works as expected.
Should Resolve #2010

----

Now Targeting poco-1.10.0 branch