### PR TITLE
Fixed MinGW linking errors

### DIFF
--- a/Util/include/Poco/Util/Application.h
+++ b/Util/include/Poco/Util/Application.h
@@ -480,7 +480,7 @@ inline Poco::Timespan Application::uptime() const
 //
 // Macro to implement main()
 //
-#if defined(_WIN32) && defined(POCO_WIN32_UTF8) && !defined(POCO_NO_WSTRING)
+#if defined(_WIN32) && defined(POCO_WIN32_UTF8) && !defined(POCO_NO_WSTRING) && !defined(__MINGW__) && !defined(__MINGW32__)
 	#define POCO_APP_MAIN(App) \
 	int wmain(int argc, wchar_t** argv)		\
 	{										\

--- a/Util/include/Poco/Util/ServerApplication.h
+++ b/Util/include/Poco/Util/ServerApplication.h
@@ -225,7 +225,7 @@ private:
 //
 // Macro to implement main()
 //
-#if defined(_WIN32) && defined(POCO_WIN32_UTF8)
+#if defined(_WIN32) && defined(POCO_WIN32_UTF8) && !defined(__MINGW__) && !defined(__MINGW32__)
 	#define POCO_SERVER_MAIN(App) \
 	int wmain(int argc, wchar_t** argv)	\
 	{									\


### PR DESCRIPTION
MinGW does not support wmain.
This commit fixes this by using main instead of wmain if using MinGW.