### PR TITLE
setPadding does nothing when OpenSSL 1.1.x is used

### DIFF
--- a/Crypto/src/CipherImpl.cpp
+++ b/Crypto/src/CipherImpl.cpp
@@ -151,7 +151,7 @@ namespace
 	int CryptoTransformImpl::setPadding(int padding)
 	{
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-		return EVP_CIPHER_CTX_block_size(_pContext);
+		return EVP_CIPHER_CTX_set_padding(_pContext, padding);
 #else
 		return EVP_CIPHER_CTX_set_padding(&_context, padding);
 #endif


### PR DESCRIPTION
EVP_CIPHER_CTX_block_size was used in CryptoTransformImpl::setPadding. This looks like an copy paste from previous function. New implementation uses EVP_CIPHER_CTX_set_padding.