### PR TITLE
Fix an undeclared side effect in poco/SevenZip/src/CpuArch.c

### DIFF
--- a/SevenZip/src/CpuArch.c
+++ b/SevenZip/src/CpuArch.c
@@ -39,7 +39,7 @@ static UInt32 CheckFlag(UInt32 flag)
     "push %%EDX\n\t"
     "popf\n\t"
     "andl %%EAX, %0\n\t":
-    "=c" (flag) : "c" (flag));
+    "=c" (flag) : "c" (flag) : "eax", "edx");
   #endif
   return flag;
 }


### PR DESCRIPTION
I noticed that in function of CheckFlag at
poco/SevenZip/src/CpuArch.c:13, an inline assembly statement is used
but didn't declare the side effect, this may corrupt the normal data
flow under some context. I produce the bug case below:

```
int __attribute__((noinline)) set_val(int v) { return v; }

int main() {
  int a = set_val(0);
  int b = set_val(1);
  int c = set_val(2);
  a = a + b; b = b + c; c = c + a;
  int d = CheckFlag(0);
  printf("%d, %d, %d, %d\n", a, b, c, d);
  return 0;
}
```
Assume CheckFlag return 0, the above code should produce output 1, 3, 3,
0, replace the invocation of CheckFlag by 0 will indeed output these four
numbers. But if the above code is unchanged and compiled with -O2 flag, the output
will be wrong. In my PC (gcc-8 -O2), the above code will output 514, 1, 514, 0.
The root cause of the wrong output is that inline assembly needs user to
declare extra side effect, as mentioned in GNU specification
https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Clobbers-and-Scratch-Registers,
"In order to inform the compiler of these changes, list them in the
clobber list."