### PR TITLE
Feature/win service start improvments

### DIFF
--- a/Util/include/Poco/Util/WinService.h
+++ b/Util/include/Poco/Util/WinService.h
@@ -119,15 +119,32 @@ public:
 	bool isStopped() const;
 		/// Returns true if the service is currently stopped.
 
+
+	void startWithoutWait();
+		/// Starts the service.
+		/// Does nothing if the service is already running
+		///
+		/// Throws a NotFoundException if the service has not been registered.
+		/// Did not wait until the Service is started.
+
 	void start(int timeout = START_STOP_TIMEOUT);
 		/// Starts the service.
 		/// Does nothing if the service is already running.
+		/// Waits until the Service was started successfully or the timeout is passed.
 		///
 		/// Throws a NotFoundException if the service has not been registered.
+
+	void stopWithoutWait();
+		/// Starts the service.
+		/// Does nothing if the service is already running
+		///
+		/// Throws a NotFoundException if the service has not been registered.
+		/// Did not wait until the Service is stopped.
 
 	void stop(int timeout = START_STOP_TIMEOUT);
 		/// Stops the service.
 		/// Does nothing if the service is not running.
+		/// Waits until the Service was stopped successfully or the timeout is passed.
 		///
 		/// Throws a NotFoundException if the service has not been registered.
 

--- a/Util/include/Poco/Util/WinService.h
+++ b/Util/include/Poco/Util/WinService.h
@@ -118,14 +118,14 @@ public:
 
 	bool isStopped() const;
 		/// Returns true if the service is currently stopped.
-		
-	void start();
+
+	void start(int timeout = START_STOP_TIMEOUT);
 		/// Starts the service.
 		/// Does nothing if the service is already running.
 		///
 		/// Throws a NotFoundException if the service has not been registered.
 
-	void stop();
+	void stop(int timeout = START_STOP_TIMEOUT);
 		/// Stops the service.
 		/// Does nothing if the service is not running.
 		///
@@ -151,7 +151,7 @@ public:
 	std::string getDescription() const;
 		/// Returns the service description from the registry.
 
-	static const int STARTUP_TIMEOUT;
+	static const int START_STOP_TIMEOUT;
 
 protected:
 	static const std::string REGISTRY_KEY;

--- a/Util/src/WinService.cpp
+++ b/Util/src/WinService.cpp
@@ -173,6 +173,13 @@ bool WinService::isStopped() const
 	return ss.dwCurrentState == SERVICE_STOPPED;
 }
 
+void WinService::startWithoutWait() 
+{
+	open();
+	if (!StartService(_svcHandle, 0, NULL))
+		throw SystemException("cannot start service", _name);
+}
+
 void WinService::start(int timeout)
 {
 	open();
@@ -193,6 +200,14 @@ void WinService::start(int timeout)
 	else if (svcStatus.dwCurrentState != SERVICE_RUNNING)
 		throw SystemException("service failed to start within a reasonable time", _name);
  }
+
+void WinService::stopWithoutWait() 
+{
+	open();
+	SERVICE_STATUS svcStatus;
+	if (!ControlService(_svcHandle, SERVICE_CONTROL_STOP, &svcStatus))
+		throw SystemException("cannot stop service", _name);
+}
 
 
 void WinService::stop(int timeout)


### PR DESCRIPTION
As an answer to my question #2858 i changed the `start` and `stop` Method to accept a timeout or use the default one. 
I also added two new Methods `startWithoutWait` and `stopWithoutWait` to start/stop a Windows Service without waiting for the Result.