### PR TITLE
fix DeadLock when it called unregisterConnector twice in same time.

### DIFF
--- a/Net/include/Poco/Net/SocketConnector.h
+++ b/Net/include/Poco/Net/SocketConnector.h
@@ -23,6 +23,7 @@
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/StreamSocket.h"
 #include "Poco/Observer.h"
+#include "Poco/Mutex.h"
 
 
 namespace Poco {
@@ -90,6 +91,7 @@ public:
 	virtual ~SocketConnector()
 		/// Destroys the SocketConnector.
 	{
+		Mutex::ScopedLock lock(_mutex);
 		try
 		{
 			unregisterConnector();
@@ -132,6 +134,7 @@ public:
 	
 	void onReadable(ReadableNotification* pNotification)
 	{
+		Mutex::ScopedLock lock(_mutex);
 		pNotification->release();
 		int err = _socket.impl()->socketError(); 
 		if (err)
@@ -147,6 +150,7 @@ public:
 	
 	void onWritable(WritableNotification* pNotification)
 	{
+		Mutex::ScopedLock lock(_mutex);
 		pNotification->release();
 		onConnect();
 	}
@@ -160,6 +164,7 @@ public:
 	
 	void onError(ErrorNotification* pNotification)
 	{
+		Mutex::ScopedLock lock(_mutex);
 		pNotification->release();
 		onError(_socket.impl()->socketError());
 		unregisterConnector();
@@ -203,6 +208,7 @@ private:
 	
 	StreamSocket   _socket;
 	SocketReactor* _pReactor;
+	Mutex _mutex;
 };
 
 

--- a/Net/testsuite/Makefile
+++ b/Net/testsuite/Makefile
@@ -27,7 +27,8 @@ objects = \
 	WebSocketTest WebSocketTestSuite \
 	SyslogTest \
 	OAuth10CredentialsTest OAuth20CredentialsTest OAuthTestSuite \
-	PollSetTest
+	PollSetTest \ 
+	SocketConnectorTest
 
 target         = testrunner
 target_version = 1

--- a/Net/testsuite/src/NetCoreTestSuite.cpp
+++ b/Net/testsuite/src/NetCoreTestSuite.cpp
@@ -13,6 +13,7 @@
 #include "SocketAddressTest.h"
 #include "DNSTest.h"
 #include "NetworkInterfaceTest.h"
+#include "SocketConnectorTest.h"
 
 
 CppUnit::Test* NetCoreTestSuite::suite()
@@ -22,6 +23,7 @@ CppUnit::Test* NetCoreTestSuite::suite()
 	pSuite->addTest(IPAddressTest::suite());
 	pSuite->addTest(SocketAddressTest::suite());
 	pSuite->addTest(DNSTest::suite());
+	pSuite->addTest(SocketConnectorTest::suite());
 #ifdef POCO_NET_HAS_INTERFACE
 	pSuite->addTest(NetworkInterfaceTest::suite());
 #endif // POCO_NET_HAS_INTERFACE

--- a/Net/testsuite/src/SocketConnectorTest.cpp
+++ b/Net/testsuite/src/SocketConnectorTest.cpp
@@ -1,0 +1,163 @@
+//
+// SocketConnectorTest.cpp
+//
+// Copyright (c) 2005-2019, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "SocketConnectorTest.h"
+#include "CppUnit/TestCaller.h"
+#include "CppUnit/TestSuite.h"
+#include "Poco/Net/SocketReactor.h"
+#include "Poco/Net/SocketNotification.h"
+#include "Poco/Net/SocketConnector.h"
+#include "Poco/Net/SocketAcceptor.h"
+#include "Poco/Net/StreamSocket.h"
+#include "Poco/Net/ServerSocket.h"
+#include "Poco/Net/SocketAddress.h"
+#include "Poco/Observer.h"
+
+
+using Poco::Net::SocketReactor;
+using Poco::Net::SocketConnector;
+using Poco::Net::SocketAcceptor;
+using Poco::Net::StreamSocket;
+using Poco::Net::ServerSocket;
+using Poco::Net::SocketAddress;
+using Poco::Net::SocketNotification;
+using Poco::Net::ReadableNotification;
+using Poco::Net::WritableNotification;
+using Poco::Net::TimeoutNotification;
+using Poco::Net::ShutdownNotification;
+using Poco::Observer;
+
+
+namespace
+{
+	class EchoServiceHandler
+	{
+	public:
+		EchoServiceHandler(StreamSocket& socket, SocketReactor& reactor):
+			_socket(socket),
+			_reactor(reactor)
+		{
+			_reactor.addEventHandler(_socket, Observer<EchoServiceHandler, ReadableNotification>(*this, &EchoServiceHandler::onReadable));
+		}
+		
+		~EchoServiceHandler()
+		{
+			_reactor.removeEventHandler(_socket, Observer<EchoServiceHandler, ReadableNotification>(*this, &EchoServiceHandler::onReadable));
+		}
+		
+		void onReadable(ReadableNotification* pNf)
+		{
+			pNf->release();
+			char buffer[8];
+			int n = _socket.receiveBytes(buffer, sizeof(buffer));
+			if (n > 0)
+			{
+				_socket.sendBytes(buffer, n);
+			}
+		}
+		
+	private:
+		StreamSocket   _socket;
+		SocketReactor& _reactor;
+	};
+	
+	class ClientServiceHandler
+	{
+	public:
+		ClientServiceHandler(StreamSocket& socket, SocketReactor& reactor):
+			_socket(socket),
+			_reactor(reactor),
+			_or(*this, &ClientServiceHandler::onReadable),
+			_ow(*this, &ClientServiceHandler::onWritable)
+		{
+			_reactor.addEventHandler(_socket, _or);
+			_reactor.addEventHandler(_socket, _ow);
+
+			do_something();
+			_reactor.stop();
+		}
+		
+		~ClientServiceHandler()
+		{
+		}
+
+		void do_something(){
+			volatile long i = 0;
+			while(true){
+				i++;
+				// if(i >= 1000000) break;
+				if(i >= 10000000) break;
+			}
+		}
+		void onReadable(ReadableNotification* pNf)
+		{
+			pNf->release();
+			_reactor.removeEventHandler(_socket, Observer<ClientServiceHandler, ReadableNotification>(*this, &ClientServiceHandler::onReadable));
+		}
+		
+		void onWritable(WritableNotification* pNf)
+		{
+			pNf->release();
+			_reactor.removeEventHandler(_socket, Observer<ClientServiceHandler, WritableNotification>(*this, &ClientServiceHandler::onWritable));
+		}
+		
+		StreamSocket                                         _socket;
+		SocketReactor&                                       _reactor;
+		Observer<ClientServiceHandler, ReadableNotification> _or;
+		Observer<ClientServiceHandler, WritableNotification> _ow;
+	};
+}
+
+SocketConnectorTest::SocketConnectorTest(const std::string& name): CppUnit::TestCase(name)
+{
+}
+
+
+SocketConnectorTest::~SocketConnectorTest()
+{
+}
+
+void SocketConnectorTest::testCallUnregisterConnectorInSameTime()
+{
+	SocketAddress ssa;
+	ServerSocket ss(ssa);
+	SocketReactor reactor1;
+	SocketReactor reactor2;
+	SocketAcceptor<EchoServiceHandler> acceptor(ss, reactor1);
+	Poco::Thread th;
+	th.start(reactor1);
+	SocketAddress sa("127.0.0.1", ss.address().port());
+	SocketConnector<ClientServiceHandler> *connector = new SocketConnector<ClientServiceHandler>(sa, reactor2);
+	Poco::Thread th2;
+	th2.start(reactor2);
+	Poco::Thread::sleep(1);
+	delete connector;
+
+}
+
+
+void SocketConnectorTest::setUp()
+{
+}
+
+
+void SocketConnectorTest::tearDown()
+{
+}
+
+
+CppUnit::Test* SocketConnectorTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("SocketConnectorTest");
+
+	CppUnit_addTest(pSuite, SocketConnectorTest, testCallUnregisterConnectorInSameTime);
+
+	return pSuite;
+}

--- a/Net/testsuite/src/SocketConnectorTest.h
+++ b/Net/testsuite/src/SocketConnectorTest.h
@@ -1,0 +1,36 @@
+//
+// SocketConnectorTest.h
+//
+// Definition of the SocketConnectorTest class.
+//
+// Copyright (c) 2005-2019, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef SocketConnectorTest_INCLUDED
+#define SocketConnectorTest_INCLUDED
+
+
+#include "Poco/Net/Net.h"
+#include "CppUnit/TestCase.h"
+
+
+class SocketConnectorTest: public CppUnit::TestCase
+{
+public:
+	SocketConnectorTest(const std::string& name);
+	~SocketConnectorTest();
+
+	void testCallUnregisterConnectorInSameTime();
+
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+};
+
+
+#endif // SocketConnectorTest_INCLUDED


### PR DESCRIPTION
fix a dead lock when called unregisterConnector twice in same time.

lock 1:
When socket connected:
NObserver::notify(Notification* pNf)  <- lock
 SocketConnector::onWritable(WritableNotification* pNotification)
  SocketConnector::onConnect()
   SocketConnector::unregisterConnector()
    SocketReactor::removeEventHandler(const Socket& socket, const Poco::AbstractObserver& observer)  <- wait to unlock

When delete SocketConnector:
SocketConnector::~SocketConnector()
 SocketConnector::unregisterConnector()  <- lock
  SocketReactor::removeEventHandler(const Socket& socket, const Poco::AbstractObserver& observer)
   SocketNotifier::removeObserver(SocketReactor* pReactor, const Poco::AbstractObserver& observer)
    NotificationCenter::removeObserver(const AbstractObserver& observer)
     NObserver::disable()  <- wait to unlock

Test code maybe execute only on my machine.
I will remove test code if you don't need it.