### PR TITLE
Add an option to force the use of PollingDirectoryWatcherStrategy

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -107,7 +107,7 @@
 //#define POCO_NO_INOTIFY
 
 // Define to force the use of PollingDirectoryWatcher 
-#define POCO_DW_FORCE_POLLING
+// #define POCO_DW_FORCE_POLLING
 
 
 // Following are options to remove certain features

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -104,7 +104,7 @@
 
 // Define to disable compilation of DirectoryWatcher
 // on platforms with no inotify.
-//#define POCO_NO_INOTIFY
+// #define POCO_NO_INOTIFY
 
 // Define to force the use of PollingDirectoryWatcher 
 // #define POCO_DW_FORCE_POLLING

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -104,7 +104,10 @@
 
 // Define to disable compilation of DirectoryWatcher
 // on platforms with no inotify.
-// #define POCO_NO_INOTIFY
+//#define POCO_NO_INOTIFY
+
+// Define to force the use of PollingDirectoryWatcher 
+#define POCO_DW_FORCE_POLLING
 
 
 // Following are options to remove certain features

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -252,7 +252,7 @@ private:
 };
 
 
-#elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
+#elif (POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID) && !defined(POCO_DW_FORCE_POLLING)
 
 
 class LinuxDirectoryWatcherStrategy: public DirectoryWatcherStrategy
@@ -572,7 +572,7 @@ void DirectoryWatcher::init()
 
 #if POCO_OS == POCO_OS_WINDOWS_NT
 	_pStrategy = new WindowsDirectoryWatcherStrategy(*this);
-#elif POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
+#elif (POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID) && !defined(POCO_DW_FORCE_POLLING)
 	_pStrategy = new LinuxDirectoryWatcherStrategy(*this);
 #elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
 	_pStrategy = new BSDDirectoryWatcherStrategy(*this);

--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -150,7 +150,7 @@ private:
 };
 
 
-#if POCO_OS == POCO_OS_WINDOWS_NT
+#if (POCO_OS == POCO_OS_WINDOWS_NT) && !defined(POCO_DW_FORCE_POLLING)
 
 
 class WindowsDirectoryWatcherStrategy: public DirectoryWatcherStrategy
@@ -380,7 +380,7 @@ private:
 };
 
 
-#elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
+#elif (POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD)  && !defined(POCO_DW_FORCE_POLLING)
 
 
 class BSDDirectoryWatcherStrategy: public DirectoryWatcherStrategy
@@ -570,11 +570,11 @@ void DirectoryWatcher::init()
 	if (!_directory.isDirectory())
 		throw Poco::InvalidArgumentException("not a directory", _directory.path());
 
-#if POCO_OS == POCO_OS_WINDOWS_NT
+#if (POCO_OS == POCO_OS_WINDOWS_NT) && !defined(POCO_DW_FORCE_POLLING)
 	_pStrategy = new WindowsDirectoryWatcherStrategy(*this);
 #elif (POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID) && !defined(POCO_DW_FORCE_POLLING)
 	_pStrategy = new LinuxDirectoryWatcherStrategy(*this);
-#elif POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD
+#elif (POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FREE_BSD) && !defined(POCO_DW_FORCE_POLLING)
 	_pStrategy = new BSDDirectoryWatcherStrategy(*this);
 #else
 	_pStrategy = new PollingDirectoryWatcherStrategy(*this);


### PR DESCRIPTION
On Linux, inotfy does not work for network mounted volumes (such as NFS). See https://stackoverflow.com/questions/4231243/inotify-with-nfs

By adding flag POCO_DW_FORCE_POLLING in Foundation/Config.h, the use of PollingDirectoryWatcherStrategy is forced on Linux. This is not the same behavior as flag POCO_NO_INOTIFY which disables compilation of DirectoryWatcher.