### PR TITLE
Add missing relational operators to VarIterator

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarIterator.h
+++ b/Foundation/include/Poco/Dynamic/VarIterator.h
@@ -69,6 +69,18 @@ public:
 	bool operator != (const VarIterator& other) const;
 		/// Inequality operator.
 
+	bool operator < (const VarIterator& other) const;
+		/// Less than operator.
+
+	bool operator > (const VarIterator& other) const;
+		/// Greater than operator.
+
+	bool operator <= (const VarIterator& other) const;
+		/// Less than or equal to operator.
+
+	bool operator >= (const VarIterator& other) const;
+		/// Greater than or equal to operator.
+
 	Var& operator * () const;
 		/// Returns value at the current position.
 
@@ -79,11 +91,11 @@ public:
 		/// Advances by one position and returns current position.
 
 	VarIterator operator ++ (int) const;
-		/// Advances by one position and returns copy of the iterator with 
+		/// Advances by one position and returns copy of the iterator with
 		/// previous current position.
 
 	const VarIterator& operator -- () const;
-		/// Goes back by one position and returns copy of the iterator with 
+		/// Goes back by one position and returns copy of the iterator with
 		/// previous current position.
 
 	VarIterator operator -- (int) const;
@@ -103,15 +115,15 @@ private:
 	VarIterator();
 
 	void increment() const;
-		/// Increments the iterator position by one. 
+		/// Increments the iterator position by one.
 		/// Throws RangeException if position is out of range.
 
 	void decrement() const;
-		/// Decrements the iterator position by one. 
+		/// Decrements the iterator position by one.
 		/// Throws RangeException if position is out of range.
 
 	void setPosition(std::size_t pos) const;
-		/// Sets the iterator position. 
+		/// Sets the iterator position.
 		/// Throws RangeException if position is out of range.
 
 	Var*                _pVar;
@@ -135,6 +147,30 @@ inline bool VarIterator::operator == (const VarIterator& other) const
 inline bool VarIterator::operator != (const VarIterator& other) const
 {
 	return _pVar != other._pVar || _position != other._position;
+}
+
+
+inline bool VarIterator::operator < (const VarIterator& other) const
+{
+	return _position < other._position;
+}
+
+
+inline bool VarIterator::operator > (const VarIterator& other) const
+{
+	return _position > other._position;
+}
+
+
+inline bool VarIterator::operator <= (const VarIterator& other) const
+{
+	return _position <= other._position;
+}
+
+
+inline bool VarIterator::operator >= (const VarIterator& other) const
+{
+	return _position >= other._position;
 }
 
 

--- a/Foundation/src/VarIterator.cpp
+++ b/Foundation/src/VarIterator.cpp
@@ -27,7 +27,7 @@ namespace Dynamic {
 const std::size_t VarIterator::POSITION_END = std::numeric_limits<std::size_t>::max();
 
 
-VarIterator::VarIterator(Var* pVar, bool positionEnd): 
+VarIterator::VarIterator(Var* pVar, bool positionEnd):
 	_pVar(pVar),
 	_position(positionEnd ? POSITION_END : 0)
 {
@@ -72,7 +72,7 @@ VarIterator& VarIterator::operator = (VarIterator&& other) noexcept
 void VarIterator::swap(VarIterator& other)
 {
 	using std::swap;
-	
+
 	swap(_pVar, other._pVar);
 	swap(_position, other._position);
 }
@@ -82,8 +82,7 @@ void VarIterator::increment() const
 {
 	if (POSITION_END == _position)
 		throw RangeException("End of iterator reached.");
-
-	if (_position < _pVar->size() - 1)
+	else if (_position < _pVar->size() - 1)
 		++_position;
 	else
 		_position = POSITION_END;


### PR DESCRIPTION
Was not sure if implementation should be put in .cpp or in .h with inline. So I did the same thing as the two operators that was already there.