### PR TITLE
Settings to verify OCSP stapling response (if received any) for client connections

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -155,7 +155,11 @@ public:
 		bool loadDefaultCAs;
 			/// Specifies whether the builtin CA certificates from OpenSSL are used.
 			/// Defaults to false.
-	
+
+		bool ocspStaplingVerification;
+			/// Specifies whether Client should verify OCSP Response
+			/// Defaults to false.
+
 		std::string cipherList;
 			/// Specifies the supported ciphers in OpenSSL notation.
 			/// Defaults to "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH".
@@ -371,7 +375,11 @@ public:
 		/// When choosing a cipher, use the server's preferences instead of the client
 		/// preferences. When not called, the SSL server will always follow the clients
 		/// preferences. When called, the SSL/TLS server will choose following its own
-		/// preferences.
+		/// preferences.	
+		
+	bool ocspStaplingResponseVerificationEnabled() const;
+		/// Returns true if automatic OCSP response
+		/// reception and verification is enabled for client connections
 
 private:
 	void init(const Params& params);
@@ -391,6 +399,7 @@ private:
 	VerificationMode _mode;
 	SSL_CTX* _pSSLContext;
 	bool _extendedCertificateVerification;
+	bool _ocspStaplingResponseVerification;
 };
 
 
@@ -429,6 +438,10 @@ inline bool Context::extendedCertificateVerificationEnabled() const
 	return _extendedCertificateVerification;
 }
 
+inline bool Context::ocspStaplingResponseVerificationEnabled() const
+{
+	return _ocspStaplingResponseVerification;
+}
 
 } } // namespace Poco::Net
 

--- a/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -278,6 +278,11 @@ protected:
 		/// Throws a InvalidStateException if not application instance
 		/// is available.
 
+	static int verifyOCSPResponse(SSL *s, void *arg);
+		/// The return value of this method defines how errors in
+		/// verification are handled. Return 0 to terminate the handshake,
+		/// or 1 to continue .
+
 private:
 	SSLManager();
 		/// Creates the SSLManager.

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -163,6 +163,9 @@ void SecureSocketImpl::connectSSL(bool performHandshake)
 		SSL_set_tlsext_host_name(_pSSL, _peerHostName.c_str());
 	}
 #endif
+	
+	if(_pContext->ocspStaplingResponseVerificationEnabled())
+		SSL_set_tlsext_status_type(_pSSL, TLSEXT_STATUSTYPE_ocsp);
 
 	if (_pSession)
 	{


### PR DESCRIPTION
Hello @obiltschnig This pull request has the modifications for configuring OCSP stapling response verification for client connections for review. By default it is set to false.
Have followed the guide lines in below openssl wiki link for configuring openssl call back functions.
https://wiki.nikhef.nl/grid/How_to_handle_OpenSSL_and_not_get_hurt_and_what_does_that_library_call_really_do%3F#Enabling_OCSP_stapling_client_side_support

This is my first commit on this poco repo and also on github. 
Please let me know if I am missing any guide lines.

Thanks