### PR TITLE
Support environments without hardware floating point

### DIFF
--- a/Foundation/include/Poco/FPEnvironment_C99.h
+++ b/Foundation/include/Poco/FPEnvironment_C99.h
@@ -31,18 +31,54 @@ class FPEnvironmentImpl
 protected:
 	enum RoundingModeImpl
 	{
+#ifdef FE_DOWNWARD
 		FP_ROUND_DOWNWARD_IMPL   = FE_DOWNWARD,
+#else
+		FP_ROUND_DOWNWARD_IMPL   = 0,
+#endif
+#ifdef FE_UPWARD
 		FP_ROUND_UPWARD_IMPL     = FE_UPWARD,
+#else
+		FP_ROUND_UPWARD_IMPL     = 0,
+#endif
+#ifdef FE_TONEAREST
 		FP_ROUND_TONEAREST_IMPL  = FE_TONEAREST,
+#else
+		FP_ROUND_TONEAREST_IMPL  = 0,
+#endif
+#ifdef FE_TOWARDZERO
 		FP_ROUND_TOWARDZERO_IMPL = FE_TOWARDZERO
+#else
+		FP_ROUND_TOWARDZERO_IMPL = 0
+#endif
 	};
 	enum FlagImpl
 	{
+#ifdef FE_DIVBYZERO
 		FP_DIVIDE_BY_ZERO_IMPL = FE_DIVBYZERO,
+#else
+		FP_DIVIDE_BY_ZERO_IMPL = 0,
+#endif
+#ifdef FE_INEXACT
 		FP_INEXACT_IMPL        = FE_INEXACT,
+#else
+		FP_INEXACT_IMPL        = 0,
+#endif
+#ifdef FE_OVERFLOW
 		FP_OVERFLOW_IMPL       = FE_OVERFLOW,
+#else
+		FP_OVERFLOW_IMPL       = 0,
+#endif
+#ifdef FE_UNDERFLOW
 		FP_UNDERFLOW_IMPL      = FE_UNDERFLOW,
+#else
+		FP_UNDERFLOW_IMPL      = 0,
+#endif
+#ifdef FE_INVALID
 		FP_INVALID_IMPL        = FE_INVALID
+#else
+		FP_INVALID_IMPL        = 0
+#endif
 	};
 	FPEnvironmentImpl();
 	FPEnvironmentImpl(const FPEnvironmentImpl& env);


### PR DESCRIPTION
Based on:
https://sources.debian.org/patches/poco/1.9.0-5/0006-fp-support-environments-without-hardware-floating-po.patch/

Fix issue:
https://github.com/pocoproject/poco/issues/2904