### PR TITLE
Disable TLS1.3 session resumption

### DIFF
--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -95,6 +95,19 @@ void SecureSocketImpl::acceptSSL()
 		BIO_free(pBIO);
 		throw SSLException("Cannot create SSL object");
 	}
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+	/* TLS 1.3 server sends session tickets after a handhake as part of
+	* the SSL_accept(). If a client finishes all its job before server
+	* sends the tickets, SSL_accept() fails with EPIPE errno. Since we
+	* are not interested in a session resumption, we can not to send the
+	* tickets. */
+	if (1 != SSL_set_num_tickets(_pSSL, 0)) 
+	{
+		BIO_free(pBIO);
+		throw SSLException("Cannot create SSL object");
+	}
+	//Otherwise we can perform two-way shutdown. Client must call SSL_read() before the final SSL_shutdown().
+#endif
 	SSL_set_bio(_pSSL, pBIO, pBIO);
 	SSL_set_accept_state(_pSSL);
 	_needHandshake = true;


### PR DESCRIPTION
In TLS 1.3 session resumption is enabled by default: we can disable to keep shutdown working as is, otherwise we should change the way shutdown close connection.
related issue: [#2776](https://github.com/pocoproject/poco/issues/2776)