### PR TITLE
Close Service Handle after DeleteService Function call

### DIFF
--- a/Util/src/WinService.cpp
+++ b/Util/src/WinService.cpp
@@ -125,6 +125,7 @@ void WinService::unregisterService()
 	open();
 	if (!DeleteService(_svcHandle))
 		throw SystemException("cannot unregister service", _name);
+	close();
 }
 
 


### PR DESCRIPTION
As in the [Windows API Documentation ](https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-deleteservice#remarks) mentioned, the Service will be deleted if all Handles to that service are closed.
With the call to `close` this will be the case. 