### PR TITLE
Rename pcre internal symbols used by Poco to avoid symbol collision

### DIFF
--- a/Foundation/src/pcre_internal.h
+++ b/Foundation/src/pcre_internal.h
@@ -2652,6 +2652,18 @@ typedef struct {
   pcre_uint16 value;
 } ucp_type_table;
 
+#define _pcre_utf8_table1      _poco__pcre_utf8_table1
+#define _pcre_utf8_table1_size _poco__pcre_utf8_table1_size
+#define _pcre_utf8_table2      _poco__pcre_utf8_table2
+#define _pcre_utf8_table3      _poco__pcre_utf8_table3
+#define _pcre_utf8_table4      _poco__pcre_utf8_table4
+#define _pcre_utt              _poco__pcre_utt
+#define _pcre_utt_size         _poco__pcre_utt_size
+#define _pcre_utt_names        _poco__pcre_utt_names
+#define _pcre_OP_lengths       _poco__pcre_OP_lengths
+#define _pcre_ucp_gbtable      _poco__pcre_ucp_gbtable
+#define _pcre_vspace_list      _poco__pcre_vspace_list
+#define _pcre_hspace_list      _poco__pcre_hspace_list
 
 /* Internal shared data tables. These are tables that are used by more than one
 of the exported public functions. They have to be "external" in the C sense,
@@ -2765,6 +2777,14 @@ typedef struct {
   pcre_uint8 caseset;    /* offset to multichar other cases or zero */
   pcre_int32 other_case; /* offset to other case, or zero if none */
 } ucd_record;
+
+
+/* renamed to avoid clashes with system pcre */
+#define _pcre_ucd_records _poco__pcre_ucd_records
+#define _pcre_ucd_stage1 _poco__pcre_ucd_stage1
+#define _pcre_ucd_stage2 _poco__pcre_ucd_stage2
+#define _pcre_ucp_gentype _poco__pcre_ucp_gentype
+#define _pcre_ucd_caseless_sets _poco__pcre_ucd_caseless_sets
 
 extern const pcre_uint32 PRIV(ucd_caseless_sets)[];
 extern const ucd_record  PRIV(ucd_records)[];


### PR DESCRIPTION
https://github.com/pocoproject/poco/issues/2916
This patch was backported from https://github.com/pld-linux/poco/blob/master/pcre.patch