### PR TITLE
Fix cmake config modul location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ install(
 		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake
 		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake
 	DESTINATION
-		"lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}"
+		"${PocoConfigPackageLocation}"
 	COMPONENT
 		Devel
 )


### PR DESCRIPTION
Fix following error on Windows:
```
lib/cmake/Poco/PocoConfig.cmake:29 (find_package):
  Could not find a package configuration file provided by "PocoFoundation"
  with any of the following names:
    PocoFoundationConfig.cmake
    pocofoundation-config.cmake
  Add the installation prefix of "PocoFoundation" to CMAKE_PREFIX_PATH or set
  "PocoFoundation_DIR" to a directory containing one of the above files.  If
  "PocoFoundation" provides a separate development package or SDK, be sure it
  has been installed.
```
as I [comment on)(https://github.com/pocoproject/poco/issues/2894#issuecomment-583516967) on #2894