### PR TITLE
Write only Filename to the Log Output

### DIFF
--- a/Foundation/include/Poco/PatternFormatter.h
+++ b/Foundation/include/Poco/PatternFormatter.h
@@ -45,6 +45,7 @@ class Foundation_API PatternFormatter: public Formatter
 	///   * %I - message thread identifier (numeric)
 	///   * %N - node or host name
 	///   * %U - message source file path (empty string if not set)
+	///	  * %O - message source file filename (empty string if not set)
 	///   * %u - message source line number (0 if not set)
 	///   * %w - message date/time abbreviated weekday (Mon, Tue, ...)
 	///   * %W - message date/time full weekday (Monday, Tuesday, ...)

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -23,7 +23,7 @@
 #include "Poco/Environment.h"
 #include "Poco/NumberParser.h"
 #include "Poco/StringTokenizer.h"
-
+#include "Poco/Path.h"
 
 namespace Poco {
 
@@ -79,6 +79,7 @@ void PatternFormatter::format(const Message& msg, std::string& text)
 		case 'I': NumberFormatter::append(text, msg.getTid()); break;
 		case 'N': text.append(Environment::nodeName()); break;
 		case 'U': text.append(msg.getSourceFile() ? msg.getSourceFile() : ""); break;
+		case 'O': text.append(msg.getSourceFile() ? Path{ msg.getSourceFile() }.getFileName() : ""); break;
 		case 'u': NumberFormatter::append(text, msg.getSourceLine()); break;
 		case 'w': text.append(DateTimeFormat::WEEKDAY_NAMES[dateTime.dayOfWeek()], 0, 3); break;
 		case 'W': text.append(DateTimeFormat::WEEKDAY_NAMES[dateTime.dayOfWeek()]); break;

--- a/Foundation/testsuite/src/PatternFormatterTest.cpp
+++ b/Foundation/testsuite/src/PatternFormatterTest.cpp
@@ -42,6 +42,7 @@ void PatternFormatterTest::testPatternFormatter()
 	msg.setThread("TestThread");
 	msg.setPriority(Message::PRIO_ERROR);
 	msg.setTime(DateTime(2005, 1, 1, 14, 30, 15, 500).timestamp());
+	msg.setSourceFile(__FILE__);
 	msg["testParam"] = "Test Parameter";
 	
 	std::string result;
@@ -91,6 +92,11 @@ void PatternFormatterTest::testPatternFormatter()
 	fmt.setProperty("pattern", "start %v[8] end");
 	fmt.format(msg, result);
 	assertTrue (result == "start stSource end");
+
+	result.clear();
+	fmt.setProperty("pattern", "%O");
+	fmt.format(msg, result);
+	assertTrue (result == "PatternFormatterTest.cpp");
 }
 
 


### PR DESCRIPTION
Added a new Pattern for the PatternFormatter `%O`.
With the `%O` only the Filename is written to the Log Output instead of the Full Source File Path.