### PR TITLE
fix build issue '#error This file requires compiler and library suppo…

### DIFF
--- a/build/config/Linux
+++ b/build/config/Linux
@@ -39,7 +39,7 @@ SHAREDLIBLINKEXT = .so
 CFLAGS          = -std=c99
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = -Wall -Wno-sign-compare
+CXXFLAGS        = -std=c++11 -Wall -Wno-sign-compare
 CXXFLAGS32      =
 CXXFLAGS64      =
 LINKFLAGS       =


### PR DESCRIPTION
fix build issue '#error This file requires compiler and library support for the ISO C++ 2011 standard.' make version 4.1, g++ 5.4, ubuntu 16.04