### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README
+++ b/README
@@ -149,6 +149,18 @@ $ make -s -j (or build the generated Visual Studio solution on Windows)
 If you cannot or do not want to build with CMake, there are other options,
 described in the following.
 
+BUILDING - USING VCPKG
+===================
+
+You can download and install poco using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+$ git clone https://github.com/Microsoft/vcpkg.git
+$ cd vcpkg
+$ ./bootstrap-vcpkg.sh
+$ ./vcpkg integrate install
+$ vcpkg install poco
+
+The poco port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 BUILDING ON WINDOWS
 ===================

--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ The default install location is `/usr/local/` on Linux and macOS and
 `C:\Program Files (x64)\` on Windows and can be overridden by setting
 the `CMAKE_INSTALL_PREFIX` CMake variable.
 
+#### Building and Installing - Using vcpkg
+
+You can download and install poco using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```
+$ git clone https://github.com/Microsoft/vcpkg.git
+$ cd vcpkg
+$ ./bootstrap-vcpkg.sh
+$ ./vcpkg integrate install
+$ vcpkg install poco
+```
+The poco port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 
 ### Building Without CMake
 


### PR DESCRIPTION
`Poco `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `poco `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `poco`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/poco/portfile.cmake). We try to keep the library maintained as close as possible to the original library.