### PR TITLE
Avoid clang 10 -Wimplicit-int-float-conversion warning/error when con…

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -429,15 +429,33 @@ private:
 	template <typename F, typename T>
 	void checkUpperLimitFloat(const F& from) const
 	{
-		if (from > std::numeric_limits<T>::max())
-			throw RangeException("Value too large.");
+		if (std::is_floating_point<T>::value)
+		{
+			if (from > std::numeric_limits<T>::max())
+				throw RangeException("Value too large.");
+		}
+		else
+		{
+			// Avoid clang -Wimplicit-int-float-conversion warning with an explicit cast.
+			if (from > static_cast<F>(std::numeric_limits<T>::max()))
+				throw RangeException("Value too large.");
+		}
 	}
 
 	template <typename F, typename T>
 	void checkLowerLimitFloat(const F& from) const
 	{
-		if (from < -std::numeric_limits<T>::max())
-			throw RangeException("Value too small.");
+		if (std::is_floating_point<T>::value)
+		{
+			if (from < -std::numeric_limits<T>::max())
+				throw RangeException("Value too small.");
+		}
+		else
+		{
+			// Avoid clang -Wimplicit-int-float-conversion warning with an explicit cast.
+			if (from < static_cast<F>(std::numeric_limits<T>::min()))
+				throw RangeException("Value too small.");
+		}
 	}
 
 	template <typename F, typename T>


### PR DESCRIPTION
…verting int into float

Example of warning (error when using -Werror) we get with clang 10:

/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-6/include/Poco/Dynamic/VarHolder.h:444:14: error: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Werror,-Wimplicit-int-float-conversion]
                if (from > std::numeric_limits<T>::max())
                         ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-6/include/Poco/Dynamic/VarHolder.h:332:4: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::checkUpperLimitFloat<float, int>' requested here
                        checkUpperLimitFloat<F,T>(from);
                        ^
/remote/intdeliv/components/osp/Poco/Foundation/19-0-0-6/include/Poco/Dynamic/VarHolder.h:2175:3: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::convertToSmaller<float, int>' requested here
                convertToSmaller(_val, val);
                ^