### PR TITLE
Handle unexpected EOF when reading HTTP streams

### DIFF
--- a/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -48,6 +48,9 @@ protected:
 	int readFromDevice(char* buffer, std::streamsize length);
 	int writeToDevice(const char* buffer, std::streamsize length);
 
+	unsigned int parseChunkLen();
+	void skipCRLF();
+
 private:
 	HTTPSession&    _session;
 	openmode        _mode;

--- a/Net/src/HTTPFixedLengthStream.cpp
+++ b/Net/src/HTTPFixedLengthStream.cpp
@@ -14,6 +14,7 @@
 
 #include "Poco/Net/HTTPFixedLengthStream.h"
 #include "Poco/Net/HTTPSession.h"
+#include "Poco/Net/NetException.h"
 
 
 using Poco::BufferedStreamBuf;
@@ -50,7 +51,10 @@ int HTTPFixedLengthStreamBuf::readFromDevice(char* buffer, std::streamsize lengt
 		if (_count + length > _length)
 			length = static_cast<std::streamsize>(_length - _count);
 		n = _session.read(buffer, length);
-		if (n > 0) _count += n;
+		if (n > 0)
+			_count += n;
+		else
+			throw MessageException("Unexpected EOF");
 	}
 	return n;
 }


### PR DESCRIPTION
Throw an exception on EOF before stream is complete.
Stream is complete if:
Chunked-Encoding: zero-length chunk received
Content-Length:  N bytes received