### PR TITLE
Fix invalid request parsing.

### DIFF
--- a/Net/include/Poco/Net/HTTPHeaderStream.h
+++ b/Net/include/Poco/Net/HTTPHeaderStream.h
@@ -50,7 +50,7 @@ protected:
 private:
 	HTTPSession& _session;
 	bool         _end;
-	bool         _line_ended;
+	bool         _lineEnd;
 };
 
 

--- a/Net/include/Poco/Net/HTTPHeaderStream.h
+++ b/Net/include/Poco/Net/HTTPHeaderStream.h
@@ -50,6 +50,7 @@ protected:
 private:
 	HTTPSession& _session;
 	bool         _end;
+	bool         _line_ended;
 };
 
 

--- a/Net/src/HTTPHeaderStream.cpp
+++ b/Net/src/HTTPHeaderStream.cpp
@@ -29,7 +29,7 @@ HTTPHeaderStreamBuf::HTTPHeaderStreamBuf(HTTPSession& session, openmode mode):
 	HTTPBasicStreamBuf(HTTPBufferAllocator::BUFFER_SIZE, mode),
 	_session(session),
 	_end(false),
-	_line_ended(true)
+	_lineEnd(true)
 {
 }
 
@@ -56,9 +56,9 @@ int HTTPHeaderStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 	if (ch != eof)
 	{
 		*buffer++ = (char) ch; ++n;
-		if (n == 2) _end = _line_ended;
+		if (n == 2) _end = _lineEnd;
 	}
-	_line_ended = (ch == '\n');
+	_lineEnd = (ch == '\n');
 	return n;
 }
 

--- a/Net/src/HTTPHeaderStream.cpp
+++ b/Net/src/HTTPHeaderStream.cpp
@@ -28,7 +28,8 @@ namespace Net {
 HTTPHeaderStreamBuf::HTTPHeaderStreamBuf(HTTPSession& session, openmode mode):
 	HTTPBasicStreamBuf(HTTPBufferAllocator::BUFFER_SIZE, mode),
 	_session(session),
-	_end(false)
+	_end(false),
+	_line_ended(true)
 {
 }
 
@@ -55,8 +56,9 @@ int HTTPHeaderStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 	if (ch != eof)
 	{
 		*buffer++ = (char) ch; ++n;
-		if (n == 2) _end = true;
+		if (n == 2) _end = _line_ended;
 	}
+	_line_ended = (ch == '\n');
 	return n;
 }
 


### PR DESCRIPTION
Problem is in case, when buffer stops reading in the last symbol of the
line. Next time it will read '\r\n' sequence and interpret it as an
empty line and set _end to true.