### PR TITLE
Ignore Chunked-Body trailer

### DIFF
--- a/Net/src/HTTPChunkedStream.cpp
+++ b/Net/src/HTTPChunkedStream.cpp
@@ -84,6 +84,11 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 	else 
 	{
 		int ch = _session.get();
+		while (!Poco::Ascii::isSpace(ch)) // ignore trailer
+		{
+			while (ch != eof && ch != '\n') ch = _session.get();
+			ch = _session.get();
+		}
 		while (ch != eof && ch != '\n') ch = _session.get();
 		return 0;
 	}

--- a/Net/testsuite/src/HTTPServerTest.h
+++ b/Net/testsuite/src/HTTPServerTest.h
@@ -30,6 +30,7 @@ public:
 	void testClosedRequest();
 	void testIdentityRequestKeepAlive();
 	void testChunkedRequestKeepAlive();
+	void testChunkedRequestKeepAliveTrailers();
 	void testClosedRequestKeepAlive();
 	void testMaxKeepAlive();
 	void testKeepAliveTimeout();


### PR DESCRIPTION
Correct processing of trailer that may exist in Chunked-Body (see 3.6.1
RFC 2616) was added.