### PR TITLE
Fix HTTPChunkedStreamBuf trying to read after eof

### DIFF
--- a/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -53,6 +53,7 @@ private:
 	openmode        _mode;
 	std::streamsize _chunk;
 	std::string     _chunkBuffer;
+	bool            _finished;
 };
 
 

--- a/Net/testsuite/src/HTTPServerTest.h
+++ b/Net/testsuite/src/HTTPServerTest.h
@@ -30,6 +30,7 @@ public:
 	void testClosedRequest();
 	void testIdentityRequestKeepAlive();
 	void testChunkedRequestKeepAlive();
+	void testChunkedRequestFreeze();
 	void testClosedRequestKeepAlive();
 	void testMaxKeepAlive();
 	void testKeepAliveTimeout();


### PR DESCRIPTION
Before this commit reading from HTTPChunkedStreamBuf could freeze if
HTTPChunkedStreamBuf::readFromDevice was called once more after
receiving EOF. This can happens if reading from HTTPChunkedStreamBuf is
performed using streambuf::sgetn method available through
istream::rdbuf.