### PR TITLE
A collection of fixes originally contributed to branch "develop-experimental"

### DIFF
--- a/Foundation/include/Poco/Message.h
+++ b/Foundation/include/Poco/Message.h
@@ -132,6 +132,9 @@ public:
 	long getTid() const;
 		/// Returns the numeric thread identifier for the message.
 
+	long getOsTid() const;
+		/// Returns the numeric thread identifier for the message.
+
 	void setPid(long pid);
 		/// Sets the process identifier for the message.
 
@@ -200,6 +203,7 @@ private:
 	Priority    _prio;
 	Timestamp   _time;
 	long        _tid;
+	long        _ostid;
 	std::string _thread;
 	long        _pid;
 	const char* _file;
@@ -246,6 +250,10 @@ inline long Message::getTid() const
 	return _tid;
 }
 
+inline long Message::getOsTid() const
+{
+	return _ostid;
+}
 
 inline long Message::getPid() const
 {

--- a/Foundation/include/Poco/PatternFormatter.h
+++ b/Foundation/include/Poco/PatternFormatter.h
@@ -43,6 +43,7 @@ class Foundation_API PatternFormatter: public Formatter
 	///   * %P - message process identifier
 	///   * %T - message thread name
 	///   * %I - message thread identifier (numeric)
+	///   * %O - message thread OS identifier (numeric)
 	///   * %N - node or host name
 	///   * %U - message source file path (empty string if not set)
 	///   * %u - message source line number (0 if not set)

--- a/Foundation/include/Poco/Thread.h
+++ b/Foundation/include/Poco/Thread.h
@@ -224,8 +224,11 @@ public:
 		/// Returns the Thread object for the currently active thread.
 		/// If the current thread is the main thread, 0 is returned.
 
- 	static TID currentTid();
- 		/// Returns the native thread ID for the current thread.
+	static TID currentTid();
+		/// Returns the native thread ID for the current thread.
+
+	static long currentOsTid();
+		/// Returns the operating system specific thread ID for the current thread.
 
 protected:
 	ThreadLocalStorage& tls();
@@ -378,6 +381,10 @@ inline Thread::TID Thread::currentTid()
 	return currentTidImpl();
 }
 
+inline long Thread::currentOsTid()
+{
+	return currentOsTidImpl();
+}
 
 } // namespace Poco
 

--- a/Foundation/include/Poco/Thread_POSIX.h
+++ b/Foundation/include/Poco/Thread_POSIX.h
@@ -80,6 +80,7 @@ public:
 	static void yieldImpl();
 	static ThreadImpl* currentImpl();
 	static TIDImpl currentTidImpl();
+	static long currentOsTidImpl();
 
 protected:
 	static void* runnableEntry(void* pThread);

--- a/Foundation/include/Poco/Thread_VX.h
+++ b/Foundation/include/Poco/Thread_VX.h
@@ -88,6 +88,7 @@ public:
 	static void yieldImpl();
 	static ThreadImpl* currentImpl();
 	static TIDImpl currentTidImpl();
+	static long currentOsTidImpl();
 
 protected:
 	static void runnableEntry(void* pThread, int, int, int, int, int, int, int, int, int);

--- a/Foundation/include/Poco/Thread_WIN32.h
+++ b/Foundation/include/Poco/Thread_WIN32.h
@@ -73,7 +73,8 @@ public:
 	static void yieldImpl();
 	static ThreadImpl* currentImpl();
 	static TIDImpl currentTidImpl();
-    
+	static long currentOsTidImpl();
+
 protected:
 #if defined(_DLL)
 	static DWORD WINAPI runnableEntry(LPVOID pThread);

--- a/Foundation/include/Poco/Thread_WINCE.h
+++ b/Foundation/include/Poco/Thread_WINCE.h
@@ -73,6 +73,7 @@ public:
 	static void yieldImpl();
 	static ThreadImpl* currentImpl();
 	static TIDImpl currentTidImpl();
+	static long currentOsTidImpl();
 
 protected:
 	static DWORD WINAPI runnableEntry(LPVOID pThread);

--- a/Foundation/samples/Logger/src/Logger.cpp
+++ b/Foundation/samples/Logger/src/Logger.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
 {
 	// set up two channel chains - one to the
 	// console and the other one to a log file.
-	FormattingChannel* pFCConsole = new FormattingChannel(new PatternFormatter("%s: %p: %t"));
+	FormattingChannel* pFCConsole = new FormattingChannel(new PatternFormatter("[%O] %s: %p: %t"));
 	pFCConsole->setChannel(new ConsoleChannel);
 	pFCConsole->open();
 	

--- a/Foundation/src/Message.cpp
+++ b/Foundation/src/Message.cpp
@@ -27,6 +27,7 @@ namespace Poco {
 Message::Message():
 	_prio(PRIO_FATAL),
 	_tid(0),
+	_ostid(0),
 	_pid(0),
 	_file(0),
 	_line(0),
@@ -41,6 +42,7 @@ Message::Message(const std::string& source, const std::string& text, Priority pr
 	_text(text),
 	_prio(prio),
 	_tid(0),
+	_ostid(0),
 	_pid(0),
 	_file(0),
 	_line(0),
@@ -55,6 +57,7 @@ Message::Message(const std::string& source, const std::string& text, Priority pr
 	_text(text),
 	_prio(prio),
 	_tid(0),
+	_ostid(0),
 	_pid(0),
 	_file(file),
 	_line(line),
@@ -70,6 +73,7 @@ Message::Message(const Message& msg):
 	_prio(msg._prio),
 	_time(msg._time),
 	_tid(msg._tid),
+	_ostid(msg._ostid),
 	_thread(msg._thread),
 	_pid(msg._pid),
 	_file(msg._file),
@@ -88,6 +92,7 @@ Message::Message(Message&& msg) noexcept:
 	_prio(std::move(msg._prio)),
 	_time(std::move(msg._time)),
 	_tid(std::move(msg._tid)),
+	_ostid(std::move(msg._ostid)),
 	_thread(std::move(msg._thread)),
 	_pid(std::move(msg._pid)),
 	_file(std::move(msg._file)),
@@ -104,6 +109,7 @@ Message::Message(const Message& msg, const std::string& text):
 	_prio(msg._prio),
 	_time(msg._time),
 	_tid(msg._tid),
+	_ostid(msg._ostid),
 	_thread(msg._thread),
 	_pid(msg._pid),
 	_file(msg._file),
@@ -127,6 +133,7 @@ void Message::init()
 #if !defined(POCO_VXWORKS)
 	_pid = Process::id();
 #endif
+	_ostid = (IntPtr)Thread::currentOsTid();
 	Thread* pThread = Thread::current();
 	if (pThread)
 	{
@@ -154,6 +161,7 @@ Message& Message::operator = (Message&& msg) noexcept
 	_prio = std::move(msg._prio);
 	_time = std::move(msg._time);
 	_tid = std::move(msg._tid);
+	_ostid = std::move(msg._ostid);
 	_thread = std::move(msg._thread);
 	_pid = std::move(msg._pid);
 	_file = std::move(msg._file);
@@ -173,6 +181,7 @@ void Message::swap(Message& msg)
 	swap(_prio, msg._prio);
 	swap(_time, msg._time);
 	swap(_tid, msg._tid);
+	swap(_ostid, msg._ostid);
 	swap(_thread, msg._thread);
 	swap(_pid, msg._pid);
 	swap(_file, msg._file);

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -77,6 +77,7 @@ void PatternFormatter::format(const Message& msg, std::string& text)
 		case 'P': NumberFormatter::append(text, msg.getPid()); break;
 		case 'T': text.append(msg.getThread()); break;
 		case 'I': NumberFormatter::append(text, msg.getTid()); break;
+		case 'O': NumberFormatter::append(text, msg.getOsTid()); break;
 		case 'N': text.append(Environment::nodeName()); break;
 		case 'U': text.append(msg.getSourceFile() ? msg.getSourceFile() : ""); break;
 		case 'u': NumberFormatter::append(text, msg.getSourceLine()); break;

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -28,6 +28,12 @@
 #	include <time.h>
 #endif
 
+#if POCO_OS == POCO_OS_LINUX
+	#define _GNU_SOURCE         /* See feature_test_macros(7) */
+	#include <unistd.h>
+	#include <sys/syscall.h>   /* For SYS_xxx definitions */
+#endif
+
 //
 // Block SIGPIPE in main thread.
 //
@@ -265,6 +271,16 @@ ThreadImpl::TIDImpl ThreadImpl::currentTidImpl()
 	return pthread_self();
 }
 
+long ThreadImpl::currentOsTidImpl()
+{
+#if POCO_OS == POCO_OS_LINUX
+    return ::syscall(SYS_gettid);
+#elif POCO_OS == POCO_OS_MAC_OS_X
+    return ::pthread_mach_thread_np(::pthread_self());
+#else
+    return ::pthread_self();
+#endif
+}
 
 void ThreadImpl::sleepImpl(long milliseconds)
 {

--- a/Foundation/src/Thread_VX.cpp
+++ b/Foundation/src/Thread_VX.cpp
@@ -144,6 +144,10 @@ ThreadImpl::TIDImpl ThreadImpl::currentTidImpl()
     return taskIdSelf();
 }
 
+long ThreadImpl::currentOsTidImpl()
+{
+	return taskIdSelf();
+}
 
 void ThreadImpl::sleepImpl(long milliseconds)
 {

--- a/Foundation/src/Thread_WIN32.cpp
+++ b/Foundation/src/Thread_WIN32.cpp
@@ -189,6 +189,10 @@ ThreadImpl::TIDImpl ThreadImpl::currentTidImpl()
 	return GetCurrentThreadId();
 }
 
+long ThreadImpl::currentOsTidImpl()
+{
+	return GetCurrentThreadId();
+}
 
 #if defined(_DLL)
 DWORD WINAPI ThreadImpl::runnableEntry(LPVOID pThread)

--- a/Foundation/src/Thread_WINCE.cpp
+++ b/Foundation/src/Thread_WINCE.cpp
@@ -139,9 +139,13 @@ ThreadImpl* ThreadImpl::currentImpl()
 
 ThreadImpl::TIDImpl ThreadImpl::currentTidImpl()
 {
-    return GetCurrentThreadId();
+	return GetCurrentThreadId();
 }
 
+long ThreadImpl::currentOsTidImpl()
+{
+	return GetCurrentThreadId();
+}
 
 DWORD WINAPI ThreadImpl::runnableEntry(LPVOID pThread)
 {

--- a/MongoDB/include/Poco/MongoDB/Cursor.h
+++ b/MongoDB/include/Poco/MongoDB/Cursor.h
@@ -23,7 +23,6 @@
 #include "Poco/MongoDB/QueryRequest.h"
 #include "Poco/MongoDB/ResponseMessage.h"
 
-
 namespace Poco {
 namespace MongoDB {
 
@@ -37,6 +36,9 @@ public:
 
 	Cursor(const std::string& fullCollectionName, QueryRequest::Flags flags = QueryRequest::QUERY_DEFAULT);
 		/// Creates a Cursor for the given database and collection ("database.collection"), using the specified flags.
+
+    Cursor(const Document& aggregationResponse);
+        /// Creates a Cursor for the given agregation query response.
 
 	virtual ~Cursor();
 		/// Destroys the Cursor.

--- a/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
+++ b/MongoDB/include/Poco/MongoDB/PoolableConnectionFactory.h
@@ -116,7 +116,24 @@ public:
 		return _connection;
 	}
 
+#if defined(POCO_ENABLE_CPP11)
+	// Disable copy to prevent unwanted release of resources: C++11 way
+    PooledConnection(const PooledConnection&) = delete;
+    PooledConnection& operator=(const PooledConnection&) = delete;
+
+    // Enable move semantics
+    PooledConnection(PooledConnection&& other) = default;
+    PooledConnection& operator=(PooledConnection&&) = default;
+#endif
+
 private:
+
+#if ! defined(POCO_ENABLE_CPP11)
+	// Disable copy to prevent unwanted release of resources: pre C++11 way
+    PooledConnection(const PooledConnection&);
+    PooledConnection& operator=(const PooledConnection&);
+#endif
+
 	Poco::ObjectPool<Connection, Connection::Ptr>& _pool;
 	Connection::Ptr _connection;
 };

--- a/MongoDB/include/Poco/MongoDB/ResponseMessage.h
+++ b/MongoDB/include/Poco/MongoDB/ResponseMessage.h
@@ -36,6 +36,9 @@ public:
 	ResponseMessage();
 		/// Creates an empty ResponseMessage.
 
+    ResponseMessage(const Int64& cursorID);
+        /// Creates an ResponseMessage for existing cursor ID.
+
 	virtual ~ResponseMessage();
 		/// Destroys the ResponseMessage.
 

--- a/MongoDB/src/Cursor.cpp
+++ b/MongoDB/src/Cursor.cpp
@@ -33,6 +33,12 @@ Cursor::Cursor(const std::string& fullCollectionName, QueryRequest::Flags flags)
 }
 
 
+Cursor::Cursor(const Document& aggregationResponse) :
+    _query(aggregationResponse.get<Poco::MongoDB::Document::Ptr>("cursor")->get<std::string>("ns")),
+    _response(aggregationResponse.get<Poco::MongoDB::Document::Ptr>("cursor")->get<Int64>("id"))
+{
+}
+
 Cursor::~Cursor()
 {
 	try

--- a/MongoDB/src/ResponseMessage.cpp
+++ b/MongoDB/src/ResponseMessage.cpp
@@ -30,6 +30,16 @@ ResponseMessage::ResponseMessage():
 }
 
 
+ResponseMessage::ResponseMessage(const Int64& cursorID):
+	Message(MessageHeader::OP_REPLY),
+	_responseFlags(0),
+	_cursorID(cursorID),
+	_startingFrom(0),
+	_numberReturned(0)
+{
+}
+
+
 ResponseMessage::~ResponseMessage()
 {
 }


### PR DESCRIPTION
This pull request contains a few fixes and improvements that were originally merged to develop but then did not make it to releases. Changes are cherry picks or reimplementations of the following:

* #2470 (Can't use Poco::MongDB::Cursor on aggregation curcor), PR #2471
* #860 (Poco::MongoDB connection pool and multithreading), PR #1146

The improvement to get numeric thread ID and have the possibility to use it in Logger could not be cherry picked anymore, so I re-implemented it on master. Changes are based on:

* #2465 (Operating system specific thread ID is not available any more in Logger/Formatter), PR #2466
* PR #846 (Posix OS thread ID, added %O (thread ID) to logger)
