### PR TITLE
switching iPhoneSimulator arch to 64 bit

### DIFF
--- a/build/config/iPhoneSimulator
+++ b/build/config/iPhoneSimulator
@@ -5,7 +5,7 @@
 # 
 
 IPHONE_SDK         = iPhoneSimulator
-POCO_TARGET_OSARCH = i686
+POCO_TARGET_OSARCH = x86_64
 OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone

--- a/build/config/iPhoneSimulator-clang
+++ b/build/config/iPhoneSimulator-clang
@@ -5,7 +5,7 @@
 # 
 
 IPHONE_SDK         = iPhoneSimulator
-POCO_TARGET_OSARCH = i686
+POCO_TARGET_OSARCH = x86_64
 OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone-clang

--- a/build/config/iPhoneSimulator-clang-libc++
+++ b/build/config/iPhoneSimulator-clang-libc++
@@ -5,7 +5,7 @@
 # 
 
 IPHONE_SDK         = iPhoneSimulator
-POCO_TARGET_OSARCH = i686
+POCO_TARGET_OSARCH = x86_64
 OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone-clang-libc++


### PR DESCRIPTION
starting from iOS 11 only 64 bit builds are supported