### PR TITLE
Revert Application::uninitialize to old behavior.

### DIFF
--- a/Util/src/Application.cpp
+++ b/Util/src/Application.cpp
@@ -191,10 +191,10 @@ void Application::uninitialize()
 {
 	if (_initialized)
 	{
-		for (auto& pSub: _subsystems)
+		for (auto it = _subsystems.rbegin(); it != _subsystems.rend(); ++it)
 		{
-			_pLogger->debug(std::string("Uninitializing subsystem: ") + pSub->name());
-			pSub->uninitialize();
+			_pLogger->debug(std::string("Uninitializing subsystem: ") + (*it)->name());
+			(*it)->uninitialize();
 		}
 		_initialized = false;
 	}


### PR DESCRIPTION
Fix for issue:  https://github.com/pocoproject/poco/issues/3012

****

I note that the behavior of Application::uninitialize was changed in commit 1bf40a0

Documentation states:

    Uninitializes the application and all registered subsystems. Subsystems are always uninitialized in reverse order in which they have been initialized.

    Overriding implementations must call the base class implementation.

However, this is no longer the case. Subsystems are now uninitialized in the order of which they were registered.