### PR TITLE
MongoDB::Array interface improvements (on top of 1.11.2)

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Array.h
+++ b/MongoDB/include/Poco/MongoDB/Array.h
@@ -39,8 +39,31 @@ public:
 	virtual ~Array();
 		/// Destroys the Array.
 
+	// Document template functions available for backward compatibility
+	using Document::add;
+	using Document::get;
+
 	template<typename T>
-	T get(int pos) const
+	Document& add(T value)
+		/// Creates an element with the name from the current pos and value and
+		/// adds it to the array document.
+		///
+		/// The active document is returned to allow chaining of the add methods.
+	{
+		return Document::add<T>(Poco::NumberFormatter::format(size()), value);
+	}
+
+	Document& add(const char* value)
+		/// Creates an element with a name from the current pos and value and
+		/// adds it to the array document.
+		///
+		/// The active document is returned to allow chaining of the add methods.
+	{
+		return Document::add(Poco::NumberFormatter::format(size()), value);
+	}
+
+	template<typename T>
+	T get(std::size_t pos) const
 		/// Returns the element at the given index and tries to convert
 		/// it to the template type. If the element is not found, a
 		/// Poco::NotFoundException will be thrown. If the element cannot be
@@ -50,7 +73,7 @@ public:
 	}
 
 	template<typename T>
-	T get(int pos, const T& deflt) const
+	T get(std::size_t pos, const T& deflt) const
 		/// Returns the element at the given index and tries to convert
 		/// it to the template type. If the element is not found, or
 		/// has the wrong type, the deflt argument will be returned.
@@ -58,12 +81,12 @@ public:
 		return Document::get<T>(Poco::NumberFormatter::format(pos), deflt);
 	}
 
-	Element::Ptr get(int pos) const;
+	Element::Ptr get(std::size_t pos) const;
 		/// Returns the element at the given index.
 		/// An empty element will be returned if the element is not found.
 
 	template<typename T>
-	bool isType(int pos) const
+	bool isType(std::size_t pos) const
 		/// Returns true if the type of the element equals the TypeId of ElementTrait,
 		/// otherwise false.
 	{
@@ -72,6 +95,9 @@ public:
 
 	std::string toString(int indent = 0) const;
 		/// Returns a string representation of the Array.
+
+private:
+	friend void BSONReader::read<Array::Ptr>(Array::Ptr& to);
 };
 
 

--- a/MongoDB/src/Array.cpp
+++ b/MongoDB/src/Array.cpp
@@ -31,7 +31,7 @@ Array::~Array()
 }
 
 
-Element::Ptr Array::get(int pos) const
+Element::Ptr Array::get(std::size_t pos) const
 {
 	std::string name = Poco::NumberFormatter::format(pos);
 	return Document::get(name);

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -10,6 +10,7 @@
 
 #include "Poco/DateTime.h"
 #include "Poco/ObjectPool.h"
+#include "Poco/MongoDB/Array.h"
 #include "Poco/MongoDB/InsertRequest.h"
 #include "Poco/MongoDB/QueryRequest.h"
 #include "Poco/MongoDB/DeleteRequest.h"
@@ -75,6 +76,41 @@ void MongoDBTest::testInsertRequest()
 	Poco::MongoDB::InsertRequest request("team.players");
 	request.documents().push_back(player);
 	_mongo->sendRequest(request);
+}
+
+void MongoDBTest::testArray()
+{
+	Poco::MongoDB::Array::Ptr arr = new Poco::MongoDB::Array();
+
+	arr->add(std::string("First"));
+
+	Poco::DateTime birthdate;
+	birthdate.assign(1969, 3, 9);
+	arr->add(birthdate.timestamp());
+
+	arr->add(static_cast<Poco::Int32>(1993));
+	arr->add(false);
+
+	// Document-style interface
+	arr->add("4", "12.4");
+
+	assertEqual(arr->size(), 5);
+	assertTrue(arr->exists("0"));
+	assertTrue(arr->exists("1"));
+	assertTrue(arr->exists("2"));
+	assertTrue(arr->exists("3"));
+	assertFalse(arr->exists("4"));
+
+	assertEqual(arr->get<std::string>(0), "First");
+	assertEqual(arr->get<Poco::Timestamp>(1).raw(), birthdate.timestamp().raw());
+	assertEqual(arr->get<Poco::Int32>(2), 1993);
+	assertEqual(arr->get<bool>(3), false);
+	assertEqual(arr->get<std::string>(4), "12.4");
+
+	// Document-style interface
+	assertEqual(arr->get<Poco::Int32>("2"), 1993);
+	assertEqual(arr->get<std::string>("4"), "12.4");
+
 }
 
 
@@ -472,6 +508,7 @@ CppUnit::Test* MongoDBTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("MongoDBTest");
 	CppUnit_addTest(pSuite, MongoDBTest, testBuildInfo);
 	CppUnit_addTest(pSuite, MongoDBTest, testInsertRequest);
+	CppUnit_addTest(pSuite, MongoDBTest, testArray);
 	CppUnit_addTest(pSuite, MongoDBTest, testQueryRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testDBQueryRequest);
 	CppUnit_addTest(pSuite, MongoDBTest, testCountCommand);

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -27,6 +27,7 @@ public:
 	virtual ~MongoDBTest();
 
 	void testInsertRequest();
+	void testArray();
 	void testQueryRequest();
 	void testDBQueryRequest();
 	void testCountCommand();


### PR DESCRIPTION
Two improvements:

* Use std::size_t instead of int in get function to be consistent with type returned from size()
* Array-specific add functions that automatically set stringified sequence number for element name to simplify adding members to array
* added test function for MongoDB array