### PR TITLE
ObjectPool wait on borrow condition fix

### DIFF
--- a/Foundation/testsuite/src/ObjectPoolTest.h
+++ b/Foundation/testsuite/src/ObjectPoolTest.h
@@ -25,6 +25,7 @@ public:
 	~ObjectPoolTest();
 
 	void testObjectPool();
+	void testObjectPoolWaitOnBorrowObject();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Fixed bug when object is returned into pool when other thread is waiting on conditional variable during object borrow.
@obiltschnig  https://github.com/pocoproject/poco/issues/2986