### PR TITLE
PatternFormatter priorityNames fix

### DIFF
--- a/Foundation/include/Poco/PatternFormatter.h
+++ b/Foundation/include/Poco/PatternFormatter.h
@@ -144,6 +144,8 @@ private:
 
 	void parsePriorityNames();
 
+	static const std::string DEFAULT_PRIORITY_NAMES;
+
 	std::vector<PatternAction> _patternActions;
 	bool _localTime;
 	std::string _pattern;

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -31,10 +31,11 @@ namespace Poco {
 const std::string PatternFormatter::PROP_PATTERN = "pattern";
 const std::string PatternFormatter::PROP_TIMES   = "times";
 const std::string PatternFormatter::PROP_PRIORITY_NAMES = "priorityNames";
-
+const std::string PatternFormatter::DEFAULT_PRIORITY_NAMES = "Fatal,Critical,Error,Warning,Notice,Information,Debug,Trace";
 
 PatternFormatter::PatternFormatter():
-	_localTime(false)
+	_localTime(false),
+	_priorityNames(DEFAULT_PRIORITY_NAMES)
 {
 	parsePriorityNames();
 }
@@ -42,7 +43,8 @@ PatternFormatter::PatternFormatter():
 
 PatternFormatter::PatternFormatter(const std::string& format):
 	_localTime(false),
-	_pattern(format)
+	_pattern(format),
+	_priorityNames(DEFAULT_PRIORITY_NAMES)
 {
 	parsePriorityNames();
 	parsePattern();
@@ -230,49 +232,23 @@ std::string PatternFormatter::getProperty(const std::string& name) const
 		return Formatter::getProperty(name);
 }
 
-
-namespace
-{
-	static std::string priorities[] = 
-	{
-		"",
-		"Fatal",
-		"Critical",
-		"Error",
-		"Warning",
-		"Notice",
-		"Information",
-		"Debug",
-		"Trace"
-	};
-}
-
-
 void PatternFormatter::parsePriorityNames()
 {
-	for (int i = 0; i <= 8; i++)
+	StringTokenizer st(_priorityNames, ",;", StringTokenizer::TOK_TRIM);
+	if (st.count() == 8)
 	{
-		_priorities[i] = priorities[i];
-	}
-	if (!_priorityNames.empty())
-	{
-		StringTokenizer st(_priorityNames, ",;", StringTokenizer::TOK_TRIM);
-		if (st.count() == 8)
+		for (int i = 1; i <= 8; i++)
 		{
-			for (int i = 1; i <= 8; i++)
-			{
-				_priorities[i] = st[i - 1];
-			}
+			_priorities[i] = st[i - 1];
 		}
-		else throw Poco::SyntaxException("priorityNames property must specify a comma-separated list of 8 property names");
 	}
+	else throw Poco::SyntaxException("priorityNames property must specify a comma-separated list of 8 property names");
 }
-
 
 const std::string& PatternFormatter::getPriorityName(int prio)
 {
 	poco_assert (1 <= prio && prio <= 8);	
-	return priorities[prio];
+	return _priorities[prio];
 }
 
 

--- a/Foundation/testsuite/src/PatternFormatterTest.cpp
+++ b/Foundation/testsuite/src/PatternFormatterTest.cpp
@@ -97,6 +97,12 @@ void PatternFormatterTest::testPatternFormatter()
 	fmt.setProperty("pattern", "%O");
 	fmt.format(msg, result);
 	assertTrue (result == "PatternFormatterTest.cpp");
+
+	result.clear();
+	fmt.setProperty("priorityNames", "FATAL,CRITICAL,SPECIAL_ERROR_NAME,WARN,NOTICE,INFO,DEBUG,TRACE");
+	fmt.setProperty("pattern", "%p");
+	fmt.format(msg, result);
+	assertTrue (result == "SPECIAL_ERROR_NAME");
 }
 
 


### PR DESCRIPTION
PatternFormatter fixed bug where setting custom priority names does not have change format output.

@obiltschnig  https://github.com/pocoproject/poco/issues/2989
