### PR TITLE
PKCS12Container: fix memory leaks on exceptions (devel)

### DIFF
--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -155,6 +155,7 @@ void PKCS12Container::load(PKCS12* pPKCS12, const std::string& password)
 			{
 				_pX509Cert.reset(new X509Certificate(pCert, true));
 				_pkcsFriendlyName = extractFriendlyName(pCert);
+				X509_free(pCert);
 			}
 			else _pX509Cert.reset();
 
@@ -171,17 +172,22 @@ void PKCS12Container::load(PKCS12* pPKCS12, const std::string& password)
 						_caCertList.push_back(X509Certificate(pX509, true));
 						_caCertNames.push_back(extractFriendlyName(pX509));
 					}
-					else throw OpenSSLException("PKCS12Container::load()");
+					else
+					{
+						sk_X509_pop_free(pCA, X509_free);
+						PKCS12_free(pPKCS12);
+						throw OpenSSLException("PKCS12Container::load()");
+					}
 				}
+				sk_X509_pop_free(pCA, X509_free);
 			}
 		}
 		else
 		{
+			PKCS12_free(pPKCS12);
 			throw OpenSSLException();
 		}
 		PKCS12_free(pPKCS12);
-		sk_X509_pop_free(pCA, X509_free);
-		if (pCert) X509_free(pCert);
 		poco_assert_dbg (_caCertList.size() == _caCertNames.size());
 	}
 	else


### PR DESCRIPTION
PKCS12Container::load forgets to free pPKCS12 in case of bad container password. There are some more potential memory leaks related to exceptions. I have fixed them all.

Re-targeted to devel branch (see also #3025).