### PR TITLE
Documented ENABLE_JWT option

### DIFF
--- a/doc/00200-GettingStarted.page
+++ b/doc/00200-GettingStarted.page
@@ -362,6 +362,7 @@ type the following command:
 Here an overview of POCO build options:
 
     * ENABLE_XML                       Set to OFF|ON (default is ON) to build XML support library
+    * ENABLE_JWT                       Set to OFF|ON (default is ON, if OpenSSL is present) to build JWT (JSON Web Token) library
     * ENABLE_JSON                      Set to OFF|ON (default is ON) to build JSON support library
     * ENABLE_NET                       Set to OFF|ON (default is ON) to build Net support library
     * ENABLE_NETSSL                    Set to OFF|ON (default is ON) to build NetSSL support library (Need installed openssl libraries)


### PR DESCRIPTION
This option (and probably the library as well) seems to have been introduced with Poco 1.10.0, but apparently it has been
forgotten to document it alongside the other build options.