### PR TITLE
Poco::Data::PostgreSQL::SessionImpl::connectorName() returns empty string

### DIFF
--- a/Data/PostgreSQL/src/SessionImpl.cpp
+++ b/Data/PostgreSQL/src/SessionImpl.cpp
@@ -21,7 +21,6 @@
 #include "Poco/String.h"
 #include <map>
 
-
 namespace
 {
 	std::string copyStripped(std::string::const_iterator aFromStringCItr, std::string::const_iterator aToStringCItr)

--- a/Data/PostgreSQL/src/SessionImpl.cpp
+++ b/Data/PostgreSQL/src/SessionImpl.cpp
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier:	BSL-1.0
 //
 
-
+#include "Poco/Data/PostgreSQL/Connector.h"
 #include "Poco/Data/PostgreSQL/SessionImpl.h"
 #include "Poco/Data/PostgreSQL/PostgreSQLException.h"
 #include "Poco/Data/PostgreSQL/PostgreSQLStatementImpl.h"
@@ -56,7 +56,8 @@ namespace PostgreSQL {
 
 
 SessionImpl::SessionImpl(const std::string& aConnectionString, std::size_t aLoginTimeout):
-	Poco::Data::AbstractSessionImpl<SessionImpl>(aConnectionString, aLoginTimeout)
+	Poco::Data::AbstractSessionImpl<SessionImpl>(aConnectionString, aLoginTimeout),
+	_connectorName(Connector::KEY)
 {
 	setProperty("handle", static_cast<SessionHandle*>(&_sessionHandle));
 	setConnectionTimeout(CONNECTION_TIMEOUT_DEFAULT);


### PR DESCRIPTION
fix bug #3057