### PR TITLE
Avoid access to already freed memory in JSON code

### DIFF
--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -443,7 +443,6 @@ inline std::size_t Object::size() const
 
 inline void Object::remove(const std::string& key)
 {
-	_values.erase(key);
 	if (_preserveInsOrder)
 	{
 		KeyList::iterator it = _keys.begin();
@@ -457,6 +456,7 @@ inline void Object::remove(const std::string& key)
 			}
 		}
 	}
+	_values.erase(key);
 	_modified = true;
 }
 


### PR DESCRIPTION
First doing
`_values.erase(key);`
invalidates the iterator of the element and so conflicts with
`if (key == (*it)->first)`

The patch ensures that first the entry in _keys is erased and then the one in _values.