### PR TITLE
Use POCO_IOS_INIT_HACK for Linux in combination with libc++

### DIFF
--- a/Foundation/include/Poco/StreamUtil.h
+++ b/Foundation/include/Poco/StreamUtil.h
@@ -78,6 +78,9 @@
     // QNX with Dinkumware but not GNU C++ Library
 #	elif defined(__QNX__) && !defined(__GLIBCPP__)
 #		define POCO_IOS_INIT_HACK 1
+    // Linux with libc++
+#	elif defined(__linux) && defined(_LIBCPP_VERSION)
+#		define POCO_IOS_INIT_HACK 1
 #	endif
 #endif
 


### PR DESCRIPTION
In POCO StreamUtil.h exists a workaround for an ios_base memory leak using the POCO_IOS_INIT_HACK macro.
This workaround is also needed for the combination of Linux and libc++ (the LLVM C++ Standard library).

Here you can find the corresponding libc++ code: https://github.com/llvm-mirror/libcxx/blob/master/src/ios.cpp


```
void
ios_base::init(void* sb)
{
    __rdbuf_ = sb;
    __rdstate_ = __rdbuf_ ? goodbit : badbit;
    __exceptions_ = goodbit;
    __fmtflags_ = skipws | dec;
    __width_ = 0;
    __precision_ = 6;
    __fn_ = 0;
    __index_ = 0;
    __event_size_ = 0;
    __event_cap_ = 0;
    __iarray_ = 0;
    __iarray_size_ = 0;
    __iarray_cap_ = 0;
    __parray_ = 0;
    __parray_size_ = 0;
    __parray_cap_ = 0;
    ::new(&__loc_) locale;
}

```

One can see that multiple calls to ios_base::init() for the same instance overwrite the `__loc_` pointer and therefore leak memory. Internally we have seen this issue with UTF-8 locales generated by Boost.Locale (in combination with ICU).
Valgrind then reports the memory leak.
