### PR TITLE
Fix error in `find_package` example

### DIFF
--- a/doc/00200-GettingStarted.page
+++ b/doc/00200-GettingStarted.page
@@ -457,7 +457,7 @@ or
 
 To use POCO C++ Libraries in your cmake project, add following line in your project for example to use crypto:
 
-    find_package(Poco REQUIRED PocoCrypto)
+    find_package(Poco REQUIRED Crypto)
     ....
     target_link_libraries(yourTargetName ... Poco::Crypto)
 


### PR DESCRIPTION
I'm using `cmake 3.16.3` on Ubuntu and find that `find_package(Poco REQUIRED PocoCrypto)` yields an error. The correct "require" is `Crypto` without the `Poco` prefix.