### PR TITLE
Do not initialize value with undefined behavior

### DIFF
--- a/Data/ODBC/include/Poco/Data/ODBC/Extractor.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/Extractor.h
@@ -462,7 +462,7 @@ private:
 	bool extractManualImpl(std::size_t pos, T& val, SQLSMALLINT cType)
 	{
 		SQLRETURN rc = 0;
-		T value = (T) 0;
+		T value;
 
 		resizeLengths(pos);
 


### PR DESCRIPTION
When this template is instantiated with BLOB / CLOB, such construction would trigger [undefined behavior](https://en.cppreference.com/w/cpp/string/basic_string/basic_string):

_The behavior is undefined if [s, s + Traits::length(s)) is not a valid range (for example, if s is a null pointer)._