### PR TITLE
FileChannel: make it possible to override ArchiveStrategy and RotateStrategy

### DIFF
--- a/Foundation/include/Poco/ArchiveStrategy.h
+++ b/Foundation/include/Poco/ArchiveStrategy.h
@@ -42,6 +42,7 @@ public:
 	ArchiveStrategy();
 	virtual ~ArchiveStrategy();
 
+	virtual LogFile* open(LogFile* pFile) = 0;
 	virtual LogFile* archive(LogFile* pFile) = 0;
 		/// Renames the given log file for archiving
 		/// and creates and returns a new log file.
@@ -71,6 +72,8 @@ class Foundation_API ArchiveByNumberStrategy: public ArchiveStrategy
 public:
 	ArchiveByNumberStrategy();
 	~ArchiveByNumberStrategy();
+
+	LogFile* open(LogFile* pFile);
 	LogFile* archive(LogFile* pFile);
 };
 
@@ -87,6 +90,11 @@ public:
 	
 	~ArchiveByTimestampStrategy()
 	{
+	}
+
+	LogFile* open(LogFile* pFile)
+	{
+		return pFile;
 	}
 	
 	LogFile* archive(LogFile* pFile)

--- a/Foundation/include/Poco/FileChannel.h
+++ b/Foundation/include/Poco/FileChannel.h
@@ -232,6 +232,11 @@ public:
 
 protected:
 	~FileChannel();
+
+	void setRotationStrategy(RotateStrategy* strategy);
+	void setArchiveStrategy(ArchiveStrategy* strategy);
+	void setPurgeStrategy(PurgeStrategy* strategy);
+
 	void setRotation(const std::string& rotation);
 	void setArchive(const std::string& archive);
 	void setCompress(const std::string& compress);
@@ -241,11 +246,15 @@ protected:
 	void setRotateOnOpen(const std::string& rotateOnOpen);
 	void purge();
 
+
 private:
 	bool setNoPurge(const std::string& value);
 	int extractDigit(const std::string& value, std::string::const_iterator* nextToDigit = NULL) const;
-	void setPurgeStrategy(PurgeStrategy* strategy);
 	Timespan::TimeDiff extractFactor(const std::string& value, std::string::const_iterator start) const;
+
+
+	virtual RotateStrategy* createRotation(const std::string& rotation, const std::string& times);
+	virtual ArchiveStrategy* createArchive(const std::string& archive, const std::string& times);
 
 	std::string      _path;
 	std::string      _times;

--- a/Foundation/src/ArchiveStrategy.cpp
+++ b/Foundation/src/ArchiveStrategy.cpp
@@ -161,6 +161,12 @@ ArchiveByNumberStrategy::~ArchiveByNumberStrategy()
 }
 
 
+LogFile* ArchiveByNumberStrategy::open(LogFile* pFile)
+{
+	return pFile;
+}
+
+
 LogFile* ArchiveByNumberStrategy::archive(LogFile* pFile)
 {
 	std::string basePath = pFile->path();


### PR DESCRIPTION
Currently, the `FileChannel` offer limited variants of `ArchiveStrategy` and `RotateStrategy`, based on the properties of the channel.

However, it might be useful for the user to provide its own `ArchiveStrategy` or `RotateStrategy`.
Such a use case would be, for example, to add a header every-time a new log file is created (or rotated).

Without access to the `ArchiveStrategy`, this is currently not possible.

This Pull Request just makes it possible for the user to inherit from `FileChannel` and override `createArchiveStrategy` or `createRotationStrategy` virtual functions.

Note that this PR also adds a new `open()` function to the `ArchiveStrategy` interface so that the user can know from the strategy that a log file has been opened by the `FileChannel` and implement custom behavior from there (such as writing a header to the file).
