### PR TITLE
Publicly expose Poco::Message parameters

### DIFF
--- a/Foundation/include/Poco/Message.h
+++ b/Foundation/include/Poco/Message.h
@@ -43,7 +43,9 @@ class Foundation_API Message
 	/// caused the message.
 {
 public:
-	enum Priority
+    typedef std::map<std::string, std::string> StringMap;
+    
+    enum Priority
 	{
 		PRIO_FATAL = 1,   /// A fatal error. The application will most likely terminate. This is the highest priority.
 		PRIO_CRITICAL,    /// A critical error. The application might not be able to continue running successfully.
@@ -175,7 +177,10 @@ public:
 		/// with the given name. If the parameter with the given name
 		/// does not exist, then defaultValue is returned.
 
-	void set(const std::string& param, const std::string& value);
+    const StringMap& getAll() const;
+    /// Returns a const reference to all the values
+    
+    void set(const std::string& param, const std::string& value);
 		/// Sets the value for a parameter. If the parameter does
 		/// not exist, then it is created.
 
@@ -192,7 +197,6 @@ public:
 
 protected:
 	void init();
-	typedef std::map<std::string, std::string> StringMap;
 
 private:
 	std::string _source;

--- a/Foundation/src/Message.cpp
+++ b/Foundation/src/Message.cpp
@@ -266,6 +266,15 @@ const std::string& Message::get(const std::string& param, const std::string& def
 	return defaultValue;
 }
 
+const Message::StringMap& Message::getAll() const
+{
+    static StringMap empty;
+
+    if (_pMap)
+        return *_pMap;
+
+    return empty;
+}
 
 void Message::set(const std::string& param, const std::string& value)
 {


### PR DESCRIPTION
It is now possible to retrieve all the parameters from a `Poco::Message`.