### PR TITLE
Added JSON Array::empty() method

### DIFF
--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -124,6 +124,9 @@ public:
 	std::size_t size() const;
 		/// Returns the size of the array.
 
+	bool empty() const;
+		/// Returns true if the array is empty, false otherwise.
+
 	bool isArray(unsigned int index) const;
 		/// Returns true when the element is an array.
 
@@ -238,6 +241,12 @@ inline Array::ValueVec::const_iterator Array::end() const
 inline std::size_t Array::size() const
 {
 	return static_cast<std::size_t>(_values.size());
+}
+
+
+inline bool Array::empty() const
+{
+	return _values.empty();
 }
 
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -791,9 +791,11 @@ void JSONTest::testEmptyArray()
 
 	Poco::JSON::Array::Ptr array = result.extract<Poco::JSON::Array::Ptr>();
 	assertTrue (array->size() == 0);
+	assertTrue (array->empty());
 
 	Poco::Dynamic::Array da = *array;
 	assertTrue (da.size() == 0);
+	assertTrue (da.empty());
 }
 
 
@@ -817,9 +819,11 @@ void JSONTest::testNestedArray()
 
 	Poco::JSON::Array::Ptr array = result.extract<Poco::JSON::Array::Ptr>();
 	assertTrue (array->size() == 1);
+	assertTrue (!array->empty());
 
 	Poco::Dynamic::Array da = *array;
 	assertTrue (da.size() == 1);
+	assertTrue (!da.empty());
 	assertTrue (da[0].size() == 1);
 	assertTrue (da[0][0].size() == 1);
 	assertTrue (da[0][0][0].size() == 0);


### PR DESCRIPTION
To be in sync with the underlying std::vector and to allow more concise code being written I added an empty() method to Poco::JSON::Array.