### PR TITLE
Change EventHandlerMap key from Socket to poco_socket_t

### DIFF
--- a/Net/include/Poco/Net/SocketReactor.h
+++ b/Net/include/Poco/Net/SocketReactor.h
@@ -209,7 +209,7 @@ protected:
 private:
 	typedef Poco::AutoPtr<SocketNotifier>     NotifierPtr;
 	typedef Poco::AutoPtr<SocketNotification> NotificationPtr;
-	typedef std::map<Socket, NotifierPtr>     EventHandlerMap;
+	typedef std::map<poco_socket_t, NotifierPtr>     EventHandlerMap;
 	typedef Poco::FastMutex                   MutexType;
 	typedef MutexType::ScopedLock             ScopedLock;
 


### PR DESCRIPTION
the EventHandlerMap key now is Socket: that could end up in some coding problem if you for example have to accept a socket and than make it ssl handshake. That way we make the same key used in PollSet