### PR TITLE
Changed EventHandlerMap key

### DIFF
--- a/Net/include/Poco/Net/SocketReactor.h
+++ b/Net/include/Poco/Net/SocketReactor.h
@@ -209,7 +209,7 @@ protected:
 private:
 	typedef Poco::AutoPtr<SocketNotifier>     NotifierPtr;
 	typedef Poco::AutoPtr<SocketNotification> NotificationPtr;
-	typedef std::map<Socket, NotifierPtr>     EventHandlerMap;
+	typedef std::map<poco_socket_t, NotifierPtr>     EventHandlerMap;
 	typedef Poco::FastMutex                   MutexType;
 	typedef MutexType::ScopedLock             ScopedLock;
 

--- a/Net/src/SocketReactor.cpp
+++ b/Net/src/SocketReactor.cpp
@@ -179,11 +179,12 @@ bool SocketReactor::hasEventHandler(const Socket& socket, const Poco::AbstractOb
 
 SocketReactor::NotifierPtr SocketReactor::getNotifier(const Socket& socket, bool makeNew)
 {
+	if (socket.impl() == nullptr) return 0;
 	ScopedLock lock(_mutex);
 
-	EventHandlerMap::iterator it = _handlers.find(socket);
+	EventHandlerMap::iterator it = _handlers.find(socket.impl()->sockfd());
 	if (it != _handlers.end()) return it->second;
-	else if (makeNew) return (_handlers[socket] = new SocketNotifier(socket));
+	else if (makeNew) return (_handlers[socket.impl()->sockfd()] = new SocketNotifier(socket));
 
 	return 0;
 }
@@ -191,6 +192,7 @@ SocketReactor::NotifierPtr SocketReactor::getNotifier(const Socket& socket, bool
 
 void SocketReactor::removeEventHandler(const Socket& socket, const Poco::AbstractObserver& observer)
 {
+	if (socket.impl() == nullptr) return;
 	NotifierPtr pNotifier = getNotifier(socket);
 	if (pNotifier && pNotifier->hasObserver(observer))
 	{
@@ -198,7 +200,7 @@ void SocketReactor::removeEventHandler(const Socket& socket, const Poco::Abstrac
 		{
 			{
 				ScopedLock lock(_mutex);
-				_handlers.erase(socket);
+				_handlers.erase(socket.impl()->sockfd());
 			}
 			_pollSet.remove(socket);
 		}


### PR DESCRIPTION
Changed EventHandlerMap key from Socket to poco_socket_t to avoid errors in removing/access EventHandlerMap when for example we make an SSL handshake. This way we have the same behavior PollSet has