### PR TITLE
Fixed null character issue when parsing a JSON

### DIFF
--- a/JSON/src/ParserImpl.cpp
+++ b/JSON/src/ParserImpl.cpp
@@ -204,8 +204,15 @@ void ParserImpl::handle()
 			break;
 		}
 		case JSON_STRING:
-			if (_pHandler) _pHandler->value(std::string(json_get_string(_pJSON, NULL)));
+		{
+			if (_pHandler) 
+			{
+				std::size_t length = 0;
+				const char* val = json_get_string(_pJSON, &length);
+				_pHandler->value(std::string(val, length == 0 ? 0 : --length)); // Decrease the length by 1 because it also contains the terminating null character
+			}
 			break;
+		}
 		case JSON_OBJECT:
 			if (_pHandler) _pHandler->startObject();
 			handleObject();

--- a/JSON/src/ParserImpl.cpp
+++ b/JSON/src/ParserImpl.cpp
@@ -209,7 +209,7 @@ void ParserImpl::handle()
 			{
 				std::size_t length = 0;
 				const char* val = json_get_string(_pJSON, &length);
-				_pHandler->value(std::string(val, length == 0 ? 0 : --length)); // Decrease the length by 1 because it also contains the terminating null character
+				_pHandler->value(std::string(val, length == 0 ? 0 : length-1)); // Decrease the length by 1 because it also contains the terminating null character
 			}
 			break;
 		}

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -1936,6 +1936,15 @@ void JSONTest::testEscape0()
 	json->stringify(ss);
 
 	assertTrue (ss.str().compare("{\"name\":\"B\\u0000b\"}") == 0);
+
+	// parse the JSON containing the escaped string
+	Poco::JSON::Parser parser(new Poco::JSON::ParseHandler());
+	Var result = parser.parse(ss.str());
+
+	assert(result.type() == typeid(Object::Ptr));
+
+	Object::Ptr object = result.extract<Object::Ptr>();
+	assert(object->get("name").extract<std::string>() == nullString);
 }
 
 


### PR DESCRIPTION
Consider the length of string values to ensure that strings, containing a null character, get not truncated at the null character. 