### PR TITLE
allow to handle hot-journal (fixes #3135)

### DIFF
--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -248,7 +248,7 @@ bool Utility::fileToMemory(sqlite3* pInMemory, const std::string& fileName)
 	sqlite3* pFile;
 	sqlite3_backup* pBackup;
 
-	rc = sqlite3_open_v2(fileName.c_str(), &pFile, SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, NULL);
+	rc = sqlite3_open_v2(fileName.c_str(), &pFile, SQLITE_OPEN_READWRITE | SQLITE_OPEN_URI, NULL);
 	if(rc == SQLITE_OK )
 	{
 		pBackup = sqlite3_backup_init(pInMemory, "main", pFile, "main");


### PR DESCRIPTION
Before, when executing the Poco::Data::SQLite::Utility::fileToMemory method
for a SQLite database with an existing hot journal, the method returns successfully,
but the resulting in-memory database is corrupted.

This is because if a hot journal exists, this can not processed
correctly if only read only access to the database is available.