### PR TITLE
Add fuzzer

### DIFF
--- a/JSON/testsuite/fuzz/json_parse_fuzzer.cc
+++ b/JSON/testsuite/fuzz/json_parse_fuzzer.cc
@@ -1,0 +1,19 @@
+#include "../src/JSONTest.h"
+
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+        std::string json(reinterpret_cast<const char*>(data), size);
+        Poco::JSON::Parser parser;
+
+        Poco::Dynamic::Var result;
+        try
+        {
+                result = parser.parse(json);
+        }
+        catch(const std::exception& e)
+        {
+                return 0;
+        }
+        return 0;
+}


### PR DESCRIPTION
I have been working on setting up continuous fuzzing of Poco by way of OSS-fuzz.
Fuzzing is a way of testing applications, whereby pseudo-random data is passed to the target - in this case the json parser - with the goal of finding bugs and vulnerabilities.

This PR adds a fuzzer implemented by way of LibFuzzer. I have also integrated this fuzzer into OSS-fuzz's infrastructure, and I will be happy to integrate Poco into the OSS-fuzz project. This will allow Google to run this fuzzer and all future fuzzers in the Poco project and notify maintainers with detailed reports in case bugs are found. It is a service that is offered free of charge to open source projects with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Poco are put to good use.

To finalize the integration into OSS-fuzz, at least one maintainer email address is needed. This can be shared here, via email to me or on the OSS-fuzz side of things when I submit Poco. All maintainer email addresses will be added to a public list that can be changed at any time.

OSS-fuzz has a 90 day public disclosure policy.