### PR TITLE
fix(JSON::Object): crash when a key is removed from object with JSON_PRESERVE_KEY_ORDER

### DIFF
--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -443,7 +443,6 @@ inline std::size_t Object::size() const
 
 inline void Object::remove(const std::string& key)
 {
-	_values.erase(key);
 	if (_preserveInsOrder)
 	{
 		KeyList::iterator it = _keys.begin();
@@ -457,6 +456,7 @@ inline void Object::remove(const std::string& key)
 			}
 		}
 	}
+	_values.erase(key);
 	_modified = true;
 }
 

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -2163,6 +2163,47 @@ void JSONTest::testMove()
 	assertTrue (nl[2] == "baz");
 }
 
+void JSONTest::testRemove()
+{
+	Object obj1;
+	obj1.set("foo", 0);
+	obj1.set("bar", 0);
+	obj1.set("baz", 0);
+
+	Object::NameList nl = obj1.getNames();
+
+	assertTrue(nl.size() == 3);
+	assertTrue(nl[0] == "bar");
+	assertTrue(nl[1] == "baz");
+	assertTrue(nl[2] == "foo");
+
+	obj1.remove("baz");
+
+	nl = obj1.getNames();
+	assertTrue(nl.size() == 2);
+	assertTrue(nl[0] == "bar");
+	assertTrue(nl[1] == "foo");
+
+	Object obj2(Poco::JSON_PRESERVE_KEY_ORDER);
+	obj2.set("foo", 0);
+	obj2.set("bar", 0);
+	obj2.set("baz", 0);
+
+	nl = obj2.getNames();
+	assertTrue(nl.size() == 3);
+	assertTrue(nl[0] == "foo");
+	assertTrue(nl[1] == "bar");
+	assertTrue(nl[2] == "baz");
+
+	obj2.remove("bar");
+	nl = obj2.getNames();
+
+	assertTrue(nl.size() == 2);
+	assertTrue(nl[0] == "foo");
+	assertTrue(nl[1] == "baz");
+
+}
+
 
 CppUnit::Test* JSONTest::suite()
 {
@@ -2214,6 +2255,7 @@ CppUnit::Test* JSONTest::suite()
 	CppUnit_addTest(pSuite, JSONTest, testEscapeUnicode);
 	CppUnit_addTest(pSuite, JSONTest, testCopy);
 	CppUnit_addTest(pSuite, JSONTest, testMove);
+	CppUnit_addTest(pSuite, JSONTest, testRemove);
 
 	return pSuite;
 }

--- a/JSON/testsuite/src/JSONTest.h
+++ b/JSON/testsuite/src/JSONTest.h
@@ -81,6 +81,7 @@ public:
 
 	void testCopy();
 	void testMove();
+	void testRemove();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
If you remove a key from the JSON object with option JSON_PRESERVE_KEY_ORDER, it will cause a crash.