### PR TITLE
Fixed typo in overridden

### DIFF
--- a/Data/include/Poco/Data/SQLChannel.h
+++ b/Data/include/Poco/Data/SQLChannel.h
@@ -55,7 +55,7 @@ class Data_API SQLChannel: public Poco::Channel
 	/// To provide as non-intrusive operation as possbile, the log entries are cached and
 	/// inserted into the target database asynchronously by default. The blocking, however, will occur
 	/// before the next entry insertion with default timeout of 1 second. The default settings can be
-	/// overriden (see async, timeout and throw properties for details).
+	/// overridden (see async, timeout and throw properties for details).
 	/// If throw property is false, insertion timeouts are ignored, otherwise a TimeoutException is thrown.
 	/// To force insertion of every entry, set timeout to 0. This setting, however, introduces
 	/// a risk of long blocking periods in case of remote server communication delays.

--- a/Data/include/Poco/Data/StatementImpl.h
+++ b/Data/include/Poco/Data/StatementImpl.h
@@ -279,7 +279,7 @@ protected:
 		/// usually the case when stored procedures are called). In such cases
 		/// no storage is needed because output parameters serve as storage.
 		/// At the Data framework level, this function always returns false.
-		/// When connector-specific behavior is desired, it should be overriden 
+		/// When connector-specific behavior is desired, it should be overridden 
 		/// by the statement implementation.
 
 	std::size_t currentDataSet() const;

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -135,47 +135,47 @@ public:
 		/// (typeid) for the stored content.
 
 	virtual void convert(Int8& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(Int16& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(Int32& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(Int64& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(UInt8& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(UInt16& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(UInt32& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(UInt64& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(DateTime& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(LocalDateTime& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(Timestamp& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 #ifndef POCO_INT64_IS_LONG
@@ -189,96 +189,96 @@ public:
 #else
 
 	virtual void convert(long long& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to suport the conversion.
 
 	virtual void convert(unsigned long long & val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to suport the conversion.
 
 #endif
 
 	virtual void convert(bool& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(float& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(double& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(char& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(std::string& val) const;
-		/// Throws BadCastException. Must be overriden in a type
+		/// Throws BadCastException. Must be overridden in a type
 		/// specialization in order to support the conversion.
 
 	virtual void convert(Poco::UTF16String& val) const;
-	/// Throws BadCastException. Must be overriden in a type
+	/// Throws BadCastException. Must be overridden in a type
 	/// specialization in order to support the conversion.
 
 	virtual bool isArray() const;
 		/// Returns true.
 
 	virtual bool isVector() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isList() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isDeque() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isStruct() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isOrdered() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isInteger() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isSigned() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isNumeric() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isBoolean() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isString() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isDate() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isTime() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual bool isDateTime() const;
-		/// Returns false. Must be properly overriden in a type
+		/// Returns false. Must be properly overridden in a type
 		/// specialization in order to support the diagnostic.
 
 	virtual std::size_t size() const;
-		/// Returns 1 iff Var is not empty or this function overriden.
+		/// Returns 1 iff Var is not empty or this function overridden.
 
 protected:
 	VarHolder();

--- a/Foundation/include/Poco/MemoryPool.h
+++ b/Foundation/include/Poco/MemoryPool.h
@@ -94,7 +94,7 @@ private:
 //
 
 // Macro defining the default initial size of any
-// FastMemoryPool; can be overriden by specifying
+// FastMemoryPool; can be overridden by specifying
 // FastMemoryPool pre-alloc at runtime.
 #define POCO_FAST_MEMORY_POOL_PREALLOC 1000
 

--- a/Net/include/Poco/Net/ICMPPacketImpl.h
+++ b/Net/include/Poco/Net/ICMPPacketImpl.h
@@ -43,7 +43,7 @@ public:
 
 	virtual int packetSize() const = 0;
 		/// Returns the total size of packet (ICMP header + data) in number of octets.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	virtual int maxPacketSize() const;
 		/// Returns the maximum permitted size of packet in number of octets.
@@ -62,14 +62,14 @@ public:
 		/// Otherwise, it extracts the time value from the supplied buffer.
 		/// 
 		/// Supplied buffer includes IP header, ICMP header and data.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	virtual bool validReplyID(unsigned char* buffer, int length) const = 0;
 		/// Returns true if the extracted id is recognized 
 		/// (i.e. equals the process id).
 		///	
 		/// Supplied buffer includes IP header, ICMP header and data.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	virtual std::string errorDescription(Poco::UInt8* buffer, int length, int& type, int& code) = 0;
 		/// Returns error description string.
@@ -79,11 +79,11 @@ public:
 		/// assigned to the type and code respectively.
 		///
 		/// Supplied buffer includes IP header, ICMP header and data.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	virtual std::string typeDescription(int typeId) = 0;
 		/// Returns the description of the packet type.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	static const Poco::UInt16 MAX_PACKET_SIZE;
 	static const Poco::UInt16 MAX_PAYLOAD_SIZE;
@@ -98,7 +98,7 @@ protected:
 
 	virtual void initPacket() = 0;
 		/// (Re)assembles the packet.
-		/// Must be overriden.
+		/// Must be overridden.
 
 	Poco::UInt16 checksum(Poco::UInt16 *addr, Poco::Int32 len);
 		/// Calculates the checksum for supplied buffer.

--- a/Net/include/Poco/Net/UDPClient.h
+++ b/Net/include/Poco/Net/UDPClient.h
@@ -65,7 +65,7 @@ public:
 
 	virtual int handleResponse(char* buffer, int length);
 		/// Handles responses from UDP server. For non-POCO UDP servers,
-		/// this function should be overriden in inheriting class.
+		/// this function should be overridden in inheriting class.
 
 	void setOption(int opt, int val);
 		/// Sets socket option.

--- a/Net/include/Poco/Net/UDPHandler.h
+++ b/Net/include/Poco/Net/UDPHandler.h
@@ -313,7 +313,7 @@ public:
 	virtual void processData(char*)
 		/// Caled when data is received by reader.
 		///
-		/// No-op here, must be overriden by inheriting
+		/// No-op here, must be overridden by inheriting
 		/// class in order to do useful work.
 	{
 	};
@@ -322,7 +322,7 @@ public:
 		/// Caled when error is detected by reader.
 		///
 		/// Only functional if stream pointer is provided
-		/// to the handler, otherwise it must be overriden
+		/// to the handler, otherwise it must be overridden
 		/// by inheriting class in order to do useful work.
 	{
 		if (_pErr) *_pErr << error(buf) << std::endl;


### PR DESCRIPTION
The term "overridden" was missing one of the "d" characters a few times.