### PR TITLE
Correct Var::parse null value

### DIFF
--- a/Foundation/src/Var.cpp
+++ b/Foundation/src/Var.cpp
@@ -436,6 +436,9 @@ Var Var::parse(const std::string& val, std::string::size_type& pos)
 				if (str == "true")
 					return true;
 
+				if (str == "null")
+					return Var();
+
 				bool isNumber = false;
 				bool isSigned = false;
 				int separators = 0;

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -2623,9 +2623,9 @@ void VarTest::testJSONDeserializeString()
 	a = Var::parse(tst);
 	assertTrue (a.toString() == "{ \"a\" : \"1\", \"b\" : \"2\" }");
 
-	tst = "{ \"message\" : \"escape\\b\\f\\n\\r\\t\", \"path\" : \"\\/dev\\/null\" }";
+	tst = "{ \"message\" : \"escape\\b\\f\\n\\r\\t\", \"path\" : \"\\/dev\\/null\", \"zero\" : null }";
 	a = Var::parse(tst);
-	assertTrue(a.toString() == "{ \"message\" : \"escape\\b\\f\\n\\r\\t\", \"path\" : \"\\/dev\\/null\" }");
+	assertTrue(a.toString() == "{ \"message\" : \"escape\\b\\f\\n\\r\\t\", \"path\" : \"\\/dev\\/null\", \"zero\" : null }");
 }
 
 


### PR DESCRIPTION
The parser parses a null value into a string "null", which is incorrect.