### PR TITLE
Fix PostgresSQL BLOB extractor

### DIFF
--- a/Data/PostgreSQL/src/Extractor.cpp
+++ b/Data/PostgreSQL/src/Extractor.cpp
@@ -317,6 +317,7 @@ bool Extractor::extract(std::size_t pos, Poco::Data::BLOB& val)
 
 	const char * pBLOB = reinterpret_cast<const char*>(outputParameter.pData());
 	std::size_t BLOBSize  = outputParameter.size();
+	val = Poco::Data::BLOB(); // don't share contents with _default
 
 	if	(	'\\' == pBLOB[0]
 		 && 'x'  == pBLOB[1]	// preamble to BYTEA data format in text form is \x


### PR DESCRIPTION
Closes https://github.com/pocoproject/poco/issues/3045

The problem begins in https://github.com/pocoproject/poco/blob/3fc3e5f5b8462f7666952b43381383a79b8b5d92/Data/include/Poco/Data/Extraction.h#L191-L192

For non-LOB types `_default` value is copied into `_rResult` container, but `BLOB` is a reference-counted type and they share the same contents. Then we do https://github.com/pocoproject/poco/blob/3fc3e5f5b8462f7666952b43381383a79b8b5d92/Data/PostgreSQL/src/Extractor.cpp#L335 it affects `_default` and all other `BLOB` results as well, effectively corrupting them.

I fixed it the least intrusive way, but maybe `_rResult`-updating logic should be changed instead?

Also, some unit tests might be needed, but I haven't figured out yet how to add them.
 