### PR TITLE
MinGW also defines __GNUC__.

### DIFF
--- a/Foundation/include/Poco/Platform.h
+++ b/Foundation/include/Poco/Platform.h
@@ -237,6 +237,9 @@
 	#define POCO_COMPILER_MSVC
 #elif defined (__GNUC__)
 	#define POCO_COMPILER_GCC
+	#if defined (__MINGW32__) || defined (__MINGW64__)
+		#define POCO_COMPILER_MINGW
+	#endif
 #elif defined (__MINGW32__) || defined (__MINGW64__)
 	#define POCO_COMPILER_MINGW
 #elif defined (__INTEL_COMPILER) || defined(__ICC) || defined(__ECC) || defined(__ICL)


### PR DESCRIPTION
`POCO_COMPILER_MINGW` is never defined because MinGW also defines `__GNUC__`. The solution is to either check for `__MINGW32__`/`__MINGW64__` before GCC but then `POCO_COMPILER_GCC` is not defined. Or duplicate the MinGW branch inside the GCC branch since they would be interchangeable.