### PR TITLE
std::forward for Poco::Optional ctor with rvalue

### DIFF
--- a/Foundation/include/Poco/Optional.h
+++ b/Foundation/include/Poco/Optional.h
@@ -69,7 +69,7 @@ public:
 
 	Optional(C&& value):
 		/// Creates a Optional by moving the given value.
-		_value(value),
+		_value(std::forward<C>(value)),
 		_isSpecified(true)
 	{
 	}


### PR DESCRIPTION
Poco::Optional has a ctor

```cpp
Optional(C&& value):
		/// Creates a Optional by moving the given value.
		_value(value),
		_isSpecified(true)
	{
	}
```

And if we'll try to use an object without copy-constructor we'll have a compilation error about trying using deleted copy constructor

example

```cpp
class OnlyMoveable {
  std::unique_ptr<int> _i;

public:
  OnlyMoveable() = default;
  explicit OnlyMoveable(int i) : _i(new int(i)) {}
  OnlyMoveable(const OnlyMoveable&) = delete; // <--- ATTENTION! deleted copy-constructor
  OnlyMoveable(OnlyMoveable &&) = default;
  ~OnlyMoveable() = default;
};

Optional<OnlyMoveable> om(OnlyMoveable(42)); // <--- problem is here
```

And if we change ctor to 
```cpp
Optional(C&& value):
		/// Creates a Optional by moving the given value.
		_value(std::forward<C>(value)), // <--- here
		_isSpecified(true)
	{
	}
```
All be ok