### PR TITLE
Remove SSL23 support from Poco/Crypto

### DIFF
--- a/Crypto/include/Poco/Crypto/Crypto.h
+++ b/Crypto/include/Poco/Crypto/Crypto.h
@@ -49,10 +49,6 @@ enum RSAPaddingMode
 		/// EME-OAEP as defined in PKCS #1 v2.0 with SHA-1, MGF1 and an empty 
 		/// encoding parameter. This mode is recommended for all new applications.
 		
-	RSA_PADDING_SSLV23,
-		/// PKCS #1 v1.5 padding with an SSL-specific modification that denotes 
-		/// that the server is SSL3 capable. 
-		
 	RSA_PADDING_NONE
 		/// Raw RSA encryption. This mode should only be used to implement cryptographically 
 		/// sound padding modes in the application code. Encrypting user data directly with RSA 

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -50,8 +50,6 @@ namespace
 			return RSA_PKCS1_PADDING;
 		case RSA_PADDING_PKCS1_OAEP:
 			return RSA_PKCS1_OAEP_PADDING;
-		case RSA_PADDING_SSLV23:
-			return RSA_SSLV23_PADDING;
 		case RSA_PADDING_NONE:
 			return RSA_NO_PADDING;
 		default:
@@ -116,7 +114,6 @@ namespace
 		switch (_paddingMode)
 		{
 		case RSA_PADDING_PKCS1:
-		case RSA_PADDING_SSLV23:
 			size -= 11;
 			break;
 		case RSA_PADDING_PKCS1_OAEP:


### PR DESCRIPTION
As per OpenSSL 3 (since alpha 13), the support of SSL23 has been removed
(https://github.com/openssl/openssl/pull/14248).

Reference: #3223