### PR TITLE
Fix GlobTest testcase.

### DIFF
--- a/Foundation/testsuite/src/GlobTest.cpp
+++ b/Foundation/testsuite/src/GlobTest.cpp
@@ -459,7 +459,7 @@ void GlobTest::testGlob()
 #if !defined(_WIN32_WCE)
 	// won't work if current directory is root dir
 	files.clear();
-	Glob::glob("globtest/../*/testsuite/*/", files);
+	Glob::glob("globtest/../g*/testsuite/*/", files);
 	translatePaths(files);
 	assertTrue (files.size() == 1);
 #endif


### PR DESCRIPTION
The current CMake code causes directories like "Crypto/testsuite/..." to appear, which gets picked up by "globtest/../*/" glob.