### PR TITLE
ECDSADigestEngine: include missing header

### DIFF
--- a/Crypto/src/ECDSADigestEngine.cpp
+++ b/Crypto/src/ECDSADigestEngine.cpp
@@ -15,6 +15,7 @@
 
 #include "Poco/Crypto/ECDSADigestEngine.h"
 #include "Poco/Crypto/CryptoException.h"
+#include <openssl/bn.h>
 #include <openssl/ecdsa.h>
 
 


### PR DESCRIPTION
BN_ functions are used here.