### PR TITLE
Add POCO_PGSQL_{INCLUDE,LIB} variables

### DIFF
--- a/Data/PostgreSQL/Makefile
+++ b/Data/PostgreSQL/Makefile
@@ -6,6 +6,7 @@
 
 include $(POCO_BASE)/build/rules/global
 
+ifndef POCO_PGSQL_INCLUDE
 ifeq (0, $(shell test -e /usr/include/postgresql; echo $$?))
 INCLUDE += -I/usr/include/postgresql
 endif
@@ -21,7 +22,9 @@ endif
 ifeq (0, $(shell test -e /usr/local/opt/libpq/include; echo $$?))
 INCLUDE += -I/usr/local/opt/libpq/include
 endif
+endif
 
+ifndef POCO_PGSQL_LIB
 ifeq (0, $(shell test -e /usr/lib$(LIB64SUFFIX)/postgresql; echo $$?))
 SYSLIBS += -L/usr/lib$(LIB64SUFFIX)/postgresql
 endif
@@ -40,7 +43,15 @@ endif
 ifeq (0, $(shell test -e /usr/local/opt/libpq/lib; echo $$?))
 SYSLIBS += -L/usr/local/opt/libpq/lib$(LIB64SUFFIX)
 endif
+endif
 SYSLIBS += -lpq
+
+ifdef POCO_PGSQL_INCLUDE
+INCLUDE += -I$(POCO_PGSQL_INCLUDE)
+endif
+ifdef POCO_PGSQL_LIB
+SYSLIBS += -L$(POCO_PGSQL_LIB)
+endif
 
 objects = Extractor Binder SessionImpl Connector \
 	PostgreSQLStatementImpl PostgreSQLException \

--- a/configure
+++ b/configure
@@ -108,6 +108,12 @@ Options:
   --mysql-include=<path>
     Specify the directory where MySQL header files are located.
 
+  --pgsql-lib=<path>
+    Specify the directory where PostGreSQL library is located.
+
+  --pgsql-include=<path>
+    Specify the directory where PostGreSQL header files are located.
+
   --cflags=<flags>
     Pass additional flags to compiler.
     Example: --cflags=-wall
@@ -189,6 +195,12 @@ while [ $# -ge 1 ]; do
 
 	--mysql-include=*)
 		mysqlinclude="`echo ${1} | awk '{print substr($0,17)}'`" ;;
+
+	--pgsql-lib=*)
+		pgsqllib="`echo ${1} | awk '{print substr($0,13)}'`" ;;
+
+	--pgsql-include=*)
+		pgsqlinclude="`echo ${1} | awk '{print substr($0,17)}'`" ;;
 
 	--cflags=*)
 		flags="$flags `echo ${1} | awk '{print substr($0,10)}'`" ;;
@@ -333,6 +345,13 @@ fi
 if [ -n "$mysqlinclude" ] ; then
         echo "POCO_MYSQL_INCLUDE = $mysqlinclude" >>$build/config.make
 fi
+if [ -n "$pgsqllib" ] ; then
+        echo "POCO_PGSQL_LIB = $pgsqllib" >>$build/config.make
+fi
+if [ -n "$pgsqlinclude" ] ; then
+        echo "POCO_PGSQL_INCLUDE = $pgsqlinclude" >>$build/config.make
+fi
+
 if [ -n "$unbundled" ] ; then
 	echo "POCO_UNBUNDLED = 1" >>$build/config.make
 fi


### PR DESCRIPTION
Add `POCO_PGSQL_{INCLUDE,LIB}` variables to avoid the following build failure when cross-compiling with buildroot:

`arm-linux-g++: ERROR: unsafe header/library path used in cross-compilation: '-L/usr/lib/postgresql'`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>