### PR TITLE
 Add variable to check if ssl data connection use a reused control connection session

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -64,6 +64,9 @@ public:
 	bool isSecure() const;
 		/// Returns true if the session is FTPS.
 
+	void forceSessionReuse(bool enable);
+		/// Enable disable FTPS check reuse session (enabled by default)
+		
 protected:
 	virtual StreamSocket establishDataConnection(const std::string& command, const std::string& arg);
 		/// Create secure data connection
@@ -78,6 +81,7 @@ private:
 	void afterCreateControlSocket();
 		///Send commands to make SSL negotiating of control channel
 
+	bool _forceSessionReuse = true;
 	bool _enableFTPS = true;
 	bool _secureDataConnection = false;
 	Context::Ptr _pContext;

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -127,6 +127,18 @@ StreamSocket FTPSClientSession::establishDataConnection(const std::string& comma
 		{
 			Poco::Net::SecureStreamSocket sss(Poco::Net::SecureStreamSocket::attach(ss, pSecure->context(), pSecure->currentSession()));
 			ss = sss;
+			if (_forceSessionReuse) 
+			{
+				sss.setLazyHandshake(false);
+				if (sss.completeHandshake() != 1) 
+				{
+					throw Poco::Net::FTPException("SSL Session HANSHAKE error");
+				}
+				if (!sss.sessionWasReused()) 
+				{
+					throw Poco::Net::FTPException("SSL Session for data connection was not reused");
+				}
+			}
 		}
 	}
 	return ss;

--- a/NetSSL_OpenSSL/src/FTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/FTPSClientSession.cpp
@@ -60,7 +60,11 @@ void FTPSClientSession::enableFTPS(bool enable)
 	_enableFTPS = enable;
 }
 
-
+void FTPSClientSession::forceSessionReuse(bool enable) 
+{
+	_forceSessionReuse = enable;
+}
+	
 void FTPSClientSession::beforeCreateDataSocket()
 {
 	if (_secureDataConnection) return;


### PR DESCRIPTION
To improve security data connection should always reuse the SSL session created in the control connections