### PR TITLE
Always set thread names on POSIX platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,10 @@ cmake-build/
 *.bak
 stage/
 releases/
+
+# vim #
+#######
+*.orig
+*.swp
+*.vim
+tags

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -62,9 +62,6 @@ namespace
 #endif
 
 
-#if defined(POCO_POSIX_DEBUGGER_THREAD_NAMES)
-
-
 namespace {
 void setThreadName(pthread_t thread, const std::string& threadName)
 {
@@ -81,9 +78,6 @@ void setThreadName(pthread_t thread, const std::string& threadName)
 #endif
 }
 }
-
-
-#endif
 
 
 namespace Poco {
@@ -357,9 +351,7 @@ void* ThreadImpl::runnableEntry(void* pThread)
 #endif
 
 	ThreadImpl* pThreadImpl = reinterpret_cast<ThreadImpl*>(pThread);
-#if defined(POCO_POSIX_DEBUGGER_THREAD_NAMES)
 	setThreadName(pThreadImpl->_pData->thread, reinterpret_cast<Thread*>(pThread)->getName());
-#endif
 	AutoPtr<ThreadData> pData = pThreadImpl->_pData;
 	try
 	{


### PR DESCRIPTION
I'm not sure about the original intent to hide it under a DEBUG macro.

Naming the threads in release mode makes it easier to see runtime
application and know which thread pool uses how many threads and what
their names are. Firefox, Chromium and many other apps do this on Linux.