### PR TITLE
Modify mysql testsuite solution to be compatible with mysql8.0:

### DIFF
--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -551,7 +551,7 @@ void SQLExecutor::uuids()
 	Poco::UUID data("da8b9c4d-faa0-44e1-b834-ece1e7d31cd5");
 	Poco::UUID ret;
 
-	try { *_pSession << "INSERT INTO Strings VALUES (?)", use(data), now; }
+	try { *_pSession << "INSERT INTO Strings VALUES (?)", use(data.toString()), now; }
 	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
 	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
 


### PR DESCRIPTION
1、transaction_isolation was added in MySQL 5.7.20 as an alias for tx_isolation, which is now deprecated and is removed in MySQL 8.0;
2、mysql8.0 Default character set is utf8mb4;