### PR TITLE
Fix crash due to X.509 certificates with Subject Alternative Name other than DNS Host

### DIFF
--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -275,11 +275,11 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 
 	schannelCred.grbitEnabledProtocols = proto();
 
-    // Windows NT and Windows Me/98/95: revocation checking not supported via flags
-    if (_options & Context::OPT_PERFORM_REVOCATION_CHECK)
-        schannelCred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
-    else
-        schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+	// Windows NT and Windows Me/98/95: revocation checking not supported via flags
+	if (_options & Context::OPT_PERFORM_REVOCATION_CHECK)
+		schannelCred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
+	else
+		schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
 	if (isForServerUse())
 	{

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -275,9 +275,11 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 
 	schannelCred.grbitEnabledProtocols = proto();
 
-    // Always use soft server revocation checks to enable MITM proxies
-    // https://github.com/curl/curl/issues/3727
-    schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+    // Windows NT and Windows Me/98/95: revocation checking not supported via flags
+    if (_options & Context::OPT_PERFORM_REVOCATION_CHECK)
+        schannelCred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
+    else
+        schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
 	if (isForServerUse())
 	{

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -275,11 +275,10 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 
 	schannelCred.grbitEnabledProtocols = proto();
 
-	// Windows NT and Windows Me/98/95: revocation checking not supported via flags
-	if (_options & Context::OPT_PERFORM_REVOCATION_CHECK)
-		schannelCred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
-	else
-		schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+    // Always use soft server revocation checks to enable MITM proxies
+    // https://github.com/curl/curl/issues/3727
+    // https://github.com/adobe/chromium/blob/master/net/socket/ssl_client_socket_win.cc
+    schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
 	if (isForServerUse())
 	{

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -277,7 +277,6 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 
     // Always use soft server revocation checks to enable MITM proxies
     // https://github.com/curl/curl/issues/3727
-    // https://github.com/adobe/chromium/blob/master/net/socket/ssl_client_socket_win.cc
     schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
 	if (isForServerUse())

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -1317,7 +1317,7 @@ void SecureSocketImpl::verifyCertificateChainClient(PCCERT_CONTEXT pServerCert)
 
 			// Revocation check of the root certificate may fail due to missing CRL points, etc.
 			// We ignore all errors checking the root certificate except CRYPT_E_REVOKED.
-			if (!ok && (revStat.dwIndex < certs.size() - 1 || revStat.dwError == CRYPT_E_REVOKED))
+            if (!ok && revStat.dwIndex < certs.size() - 1 && revStat.dwError == CRYPT_E_REVOKED)
 			{
 				VerificationErrorArgs args(cert, revStat.dwIndex, revStat.dwReason, Utility::formatError(revStat.dwError));
 				SSLManager::instance().ClientVerificationError(this, args);

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -1317,7 +1317,7 @@ void SecureSocketImpl::verifyCertificateChainClient(PCCERT_CONTEXT pServerCert)
 
 			// Revocation check of the root certificate may fail due to missing CRL points, etc.
 			// We ignore all errors checking the root certificate except CRYPT_E_REVOKED.
-            if (!ok && revStat.dwIndex < certs.size() - 1 && revStat.dwError == CRYPT_E_REVOKED)
+			if (!ok && revStat.dwIndex < certs.size() - 1 && revStat.dwError == CRYPT_E_REVOKED)
 			{
 				VerificationErrorArgs args(cert, revStat.dwIndex, revStat.dwReason, Utility::formatError(revStat.dwError));
 				SSLManager::instance().ClientVerificationError(this, args);
@@ -1421,7 +1421,10 @@ void SecureSocketImpl::serverVerifyCertificate()
 						CERT_VERIFY_REV_CHAIN_FLAG,
 						NULL,
 						&revStat);
-		if (!ok && (revStat.dwIndex < certs.size() - 1 || revStat.dwError == CRYPT_E_REVOKED))
+		
+		// Revocation check of the root certificate may fail due to missing CRL points, etc.
+		// We ignore all errors checking the root certificate except CRYPT_E_REVOKED.
+		if (!ok && revStat.dwIndex < certs.size() - 1 && revStat.dwError == CRYPT_E_REVOKED)
 		{
 			VerificationErrorArgs args(cert, revStat.dwIndex, revStat.dwReason, Utility::formatError(revStat.dwReason));
 			SSLManager::instance().ServerVerificationError(this, args);

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -279,14 +279,12 @@ void X509Certificate::extractNames(std::string& cmnName, std::set<std::string>& 
 				for (int i = 0; i < pNameInfo->cAltEntry; i++)
 				{
                     // Some certificates have Subject Alternative Name entries that are not DNS Name. Skip them.
-                    if (pNameInfo->rgAltEntry[i].pwszDNSName == NULL) {
-                        continue;
+                    if (pNameInfo->rgAltEntry[i].pwszDNSName != NULL) {
+                        std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
+                        std::string altName;
+                        Poco::UnicodeConverter::toUTF8(waltName, altName);
+                        domainNames.insert(altName);
                     }
-                    
-					std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
-					std::string altName;
-					Poco::UnicodeConverter::toUTF8(waltName, altName);
-					domainNames.insert(altName);
 				}
 			}
 		}

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -278,8 +278,7 @@ void X509Certificate::extractNames(std::string& cmnName, std::set<std::string>& 
 				PCERT_ALT_NAME_INFO pNameInfo = reinterpret_cast<PCERT_ALT_NAME_INFO>(buffer.begin());
 				for (int i = 0; i < pNameInfo->cAltEntry; i++)
 				{
-                    // Some certificates have an empty value here.
-                    // Check if this indicates an invalid cert. If so, consider an exception.
+                    // Some certificates have Subject Alternative Name entries that are not DNS Name. Skip them.
                     if (pNameInfo->rgAltEntry[i].pwszDNSName == NULL) {
                         continue;
                     }

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -278,13 +278,14 @@ void X509Certificate::extractNames(std::string& cmnName, std::set<std::string>& 
 				PCERT_ALT_NAME_INFO pNameInfo = reinterpret_cast<PCERT_ALT_NAME_INFO>(buffer.begin());
 				for (int i = 0; i < pNameInfo->cAltEntry; i++)
 				{
-                    // Some certificates have Subject Alternative Name entries that are not DNS Name. Skip them.
-                    if (pNameInfo->rgAltEntry[i].dwAltNameChoice == CERT_ALT_NAME_DNS_NAME) {
-                        std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
-                        std::string altName;
-                        Poco::UnicodeConverter::toUTF8(waltName, altName);
-                        domainNames.insert(altName);
-                    }
+					// Some certificates have Subject Alternative Name entries that are not DNS Name. Skip them.
+					if (pNameInfo->rgAltEntry[i].dwAltNameChoice == CERT_ALT_NAME_DNS_NAME)
+					{
+						std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
+						std::string altName;
+						Poco::UnicodeConverter::toUTF8(waltName, altName);
+						domainNames.insert(altName);
+					}
 				}
 			}
 		}

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -278,6 +278,12 @@ void X509Certificate::extractNames(std::string& cmnName, std::set<std::string>& 
 				PCERT_ALT_NAME_INFO pNameInfo = reinterpret_cast<PCERT_ALT_NAME_INFO>(buffer.begin());
 				for (int i = 0; i < pNameInfo->cAltEntry; i++)
 				{
+                    // Some certificates have an empty value here.
+                    // Check if this indicates an invalid cert. If so, consider an exception.
+                    if (pNameInfo->rgAltEntry[i].pwszDNSName == NULL) {
+                        continue;
+                    }
+                    
 					std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
 					std::string altName;
 					Poco::UnicodeConverter::toUTF8(waltName, altName);

--- a/NetSSL_Win/src/X509Certificate.cpp
+++ b/NetSSL_Win/src/X509Certificate.cpp
@@ -279,7 +279,7 @@ void X509Certificate::extractNames(std::string& cmnName, std::set<std::string>& 
 				for (int i = 0; i < pNameInfo->cAltEntry; i++)
 				{
                     // Some certificates have Subject Alternative Name entries that are not DNS Name. Skip them.
-                    if (pNameInfo->rgAltEntry[i].pwszDNSName != NULL) {
+                    if (pNameInfo->rgAltEntry[i].dwAltNameChoice == CERT_ALT_NAME_DNS_NAME) {
                         std::wstring waltName(pNameInfo->rgAltEntry[i].pwszDNSName);
                         std::string altName;
                         Poco::UnicodeConverter::toUTF8(waltName, altName);


### PR DESCRIPTION
This PR fixes https://github.com/pocoproject/poco/issues/3221. 

Modified `X509Certificate.cpp` to skip Subject Alternative Name entries other than DNS Host. This fixes a crash.

Modified `SecureSocketImpl.cpp` to fix an error check issue. The comment indicates the code should have ignored errors other than CRYPT_E_REVOKED, however `revStat.dwIndex < certs.size() - 1` is true when you have any error.

