### PR TITLE
fix std::localtime not thread safe

### DIFF
--- a/Foundation/src/LocalDateTime.cpp
+++ b/Foundation/src/LocalDateTime.cpp
@@ -20,6 +20,8 @@
 #include <ctime>
 #if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
 #include "wce_time.h"
+#elif defined(_WIN32)
+#include <time.h>
 #endif
 
 
@@ -264,7 +266,11 @@ void LocalDateTime::determineTzd(bool adjust)
 #if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
 		std::tm* broken = wceex_localtime(&epochTime);
 #else
-		std::tm* broken = std::localtime(&epochTime);
+		std::tm bufDest;
+		std::tm* broken = &bufDest;
+		errno_t err = localtime_s(broken, &epochTime);
+		if (err)
+			broken = nullptr;
 #endif
 		if (!broken) throw Poco::SystemException("cannot get local time");
 		_tzd = (Timezone::utcOffset() + ((broken->tm_isdst == 1) ? 3600 : 0));

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -304,6 +304,9 @@ public:
 
 	const std::string& welcomeMessage();
 		/// Returns the welcome message.
+	
+	void setActiveDataPort(Poco::UInt16 port);
+		/// Set port to use for active connections
 
 protected:
 	virtual void receiveServerReadyReply();
@@ -358,6 +361,7 @@ private:
 	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
 	std::string _welcomeMessage;
 	Poco::FastMutex _wmMutex;
+	Poco::UInt16   _activeDataPort = 0;
 };
 
 

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -121,6 +121,10 @@ void FTPClientSession::setPassive(bool flag, bool useRFC1738)
 	_supports1738 = useRFC1738;
 }
 
+void FTPClientSession::setActiveDataPort(Poco::UInt16 port)
+{
+	_activeDataPort = port;
+}
 
 bool FTPClientSession::getPassive() const
 {
@@ -452,7 +456,7 @@ StreamSocket FTPClientSession::activeDataConnection(const std::string& command, 
 	if (!isOpen())
 		throw FTPException("Connection is closed.");
 
-	ServerSocket server(SocketAddress(_pControlSocket->address().host(), 0));
+	ServerSocket server(SocketAddress(_pControlSocket->address().host(), _activeDataPort));
 	sendPortCommand(server.address());
 	std::string response;
 	int status = sendCommand(command, arg, response);


### PR DESCRIPTION
std::localtime is not thread safe and can return NULL breaking the determineTzd function. localtime_s is safe, unfortunatly on windows the function is not the same as std