### PR TITLE
Fixed suspend/resumeEvents pair in DirectoryWatcher

### DIFF
--- a/Foundation/src/DirectoryWatcher.cpp
+++ b/Foundation/src/DirectoryWatcher.cpp
@@ -544,7 +544,7 @@ DirectoryWatcher::~DirectoryWatcher()
 }
 
 	
-void DirectoryWatcher::suspendEvents()
+void DirectoryWatcher::resumeEvents()
 {
 	poco_assert (_eventsSuspended > 0);
 	
@@ -552,7 +552,7 @@ void DirectoryWatcher::suspendEvents()
 }
 
 
-void DirectoryWatcher::resumeEvents()
+void DirectoryWatcher::suspendEvents()
 {
 	_eventsSuspended++;
 }

--- a/Foundation/testsuite/src/DirectoryWatcherTest.cpp
+++ b/Foundation/testsuite/src/DirectoryWatcherTest.cpp
@@ -188,6 +188,139 @@ void DirectoryWatcherTest::testMoved()
 }
 
 
+void DirectoryWatcherTest::testSuspend()
+{
+	Poco::Path p(path());
+	p.setFileName("test.txt");
+	Poco::FileOutputStream fos(p.toString());
+	fos << "Hello, world!";
+	fos.close();
+
+	DirectoryWatcher dw(path().toString(), DirectoryWatcher::DW_FILTER_ENABLE_ALL, 2);
+	
+	dw.itemAdded += Poco::delegate(this, &DirectoryWatcherTest::onItemAdded);
+	dw.itemRemoved += Poco::delegate(this, &DirectoryWatcherTest::onItemRemoved);
+	dw.itemModified += Poco::delegate(this, &DirectoryWatcherTest::onItemModified);
+	dw.itemMovedFrom += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedFrom);
+	dw.itemMovedTo += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedTo);
+	
+	Poco::Thread::sleep(1000);
+	
+	dw.suspendEvents();
+
+	Poco::FileOutputStream fos2(p.toString(), std::ios::app);
+	fos2 << "Again!";
+	fos2.close();
+	
+	Poco::Thread::sleep(2000*dw.scanInterval());
+	
+	assertTrue (_events.size() == 0);
+	assertTrue (!_error);
+}
+
+
+void DirectoryWatcherTest::testResume()
+{
+	Poco::Path p(path());
+	p.setFileName("test.txt");
+	Poco::FileOutputStream fos(p.toString());
+	fos << "Hello, world!";
+	fos.close();
+
+	DirectoryWatcher dw(path().toString(), DirectoryWatcher::DW_FILTER_ENABLE_ALL, 2);
+	
+	dw.itemAdded += Poco::delegate(this, &DirectoryWatcherTest::onItemAdded);
+	dw.itemRemoved += Poco::delegate(this, &DirectoryWatcherTest::onItemRemoved);
+	dw.itemModified += Poco::delegate(this, &DirectoryWatcherTest::onItemModified);
+	dw.itemMovedFrom += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedFrom);
+	dw.itemMovedTo += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedTo);
+	
+	Poco::Thread::sleep(1000);
+	
+	dw.suspendEvents();
+
+	Poco::FileOutputStream fos2(p.toString(), std::ios::app);
+	fos2 << "Again!";
+	fos2.close();
+	
+	assertTrue (_events.size() == 0);
+	assertTrue (!_error);
+	
+	dw.resumeEvents();
+	
+	Poco::FileOutputStream fos3(p.toString(), std::ios::app);
+	fos3 << "Now it works!";
+	fos3.close();
+	
+	Poco::Thread::sleep(2000*dw.scanInterval());
+	
+	assertTrue (_events.size() >= 1);
+	assertTrue (_events[0].callback == "onItemModified");
+	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
+	assertTrue (_events[0].type == DirectoryWatcher::DW_ITEM_MODIFIED);
+	assertTrue (!_error);
+}
+
+
+void DirectoryWatcherTest::testSuspendMultipleTimes()
+{
+	Poco::Path p(path());
+	p.setFileName("test.txt");
+	Poco::FileOutputStream fos(p.toString());
+	fos << "Hello, world!";
+	fos.close();
+
+	DirectoryWatcher dw(path().toString(), DirectoryWatcher::DW_FILTER_ENABLE_ALL, 2);
+	
+	dw.itemAdded += Poco::delegate(this, &DirectoryWatcherTest::onItemAdded);
+	dw.itemRemoved += Poco::delegate(this, &DirectoryWatcherTest::onItemRemoved);
+	dw.itemModified += Poco::delegate(this, &DirectoryWatcherTest::onItemModified);
+	dw.itemMovedFrom += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedFrom);
+	dw.itemMovedTo += Poco::delegate(this, &DirectoryWatcherTest::onItemMovedTo);
+	
+	Poco::Thread::sleep(1000);
+	
+	dw.suspendEvents();
+	dw.suspendEvents();
+	dw.suspendEvents();
+
+	Poco::FileOutputStream fos2(p.toString(), std::ios::app);
+	fos2 << "Not notified!";
+	fos2.close();
+	
+	Poco::Thread::sleep(2000*dw.scanInterval());
+	
+	assertTrue (_events.size() == 0);
+	assertTrue (!_error);
+
+	dw.resumeEvents();
+
+	Poco::FileOutputStream fos3(p.toString(), std::ios::app);
+	fos3 << "Still not notified!";
+	fos3.close();
+	
+	Poco::Thread::sleep(2000*dw.scanInterval());
+	
+	assertTrue (_events.size() == 0);
+	assertTrue (!_error);
+	
+	dw.resumeEvents();
+	dw.resumeEvents();
+	
+	Poco::FileOutputStream fos4(p.toString(), std::ios::app);
+	fos4 << "Now it works!";
+	fos4.close();
+	
+	Poco::Thread::sleep(2000*dw.scanInterval());
+	
+	assertTrue (_events.size() >= 1);
+	assertTrue (_events[0].callback == "onItemModified");
+	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
+	assertTrue (_events[0].type == DirectoryWatcher::DW_ITEM_MODIFIED);
+	assertTrue (!_error);
+}
+
+
 void DirectoryWatcherTest::setUp()
 {
 	_error = false;
@@ -292,6 +425,9 @@ CppUnit::Test* DirectoryWatcherTest::suite()
 	CppUnit_addTest(pSuite, DirectoryWatcherTest, testRemoved);
 	CppUnit_addTest(pSuite, DirectoryWatcherTest, testModified);
 	CppUnit_addTest(pSuite, DirectoryWatcherTest, testMoved);
+	CppUnit_addTest(pSuite, DirectoryWatcherTest, testSuspend);
+	CppUnit_addTest(pSuite, DirectoryWatcherTest, testResume);
+	CppUnit_addTest(pSuite, DirectoryWatcherTest, testSuspendMultipleTimes);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/DirectoryWatcherTest.h
+++ b/Foundation/testsuite/src/DirectoryWatcherTest.h
@@ -35,6 +35,9 @@ public:
 	void testRemoved();
 	void testModified();
 	void testMoved();
+	void testSuspend();
+	void testResume();
+	void testSuspendMultipleTimes();
 	
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
I'm taking the opportunity of Hacktoberfest to submit this. I noticed the suspendEvents and resumeEvents were inverted in the logic of the DirectoryWatcher events.

I added simple tests to the testsuite. These fail with the current implementation and pass with this fix.