### PR TITLE
Allow using `Poco::FileStream` to wrap arbitrary file handles/descriptors as C++ streams

### DIFF
--- a/Foundation/include/Poco/FileStream.h
+++ b/Foundation/include/Poco/FileStream.h
@@ -66,7 +66,7 @@ public:
 		/// does not exist or is not accessible for other reasons and
 		/// a new file cannot be created.
 
-	void open_handle(NativeHandle handle, std::ios::openmode mode);
+	void openHandle(NativeHandle handle, std::ios::openmode mode);
 		/// Takes ownership of the handle.
 
 	void close();

--- a/Foundation/include/Poco/FileStream_POSIX.h
+++ b/Foundation/include/Poco/FileStream_POSIX.h
@@ -40,7 +40,7 @@ public:
 	void open(const std::string& path, std::ios::openmode mode);
 		/// Opens the given file in the given mode.
 
-	void open_handle(int fd, std::ios::openmode mode);
+	void openHandle(int fd, std::ios::openmode mode);
 		/// Take ownership of the given file descriptor.
 
 	bool close();

--- a/Foundation/include/Poco/FileStream_WIN32.h
+++ b/Foundation/include/Poco/FileStream_WIN32.h
@@ -39,7 +39,7 @@ public:
 	void open(const std::string& path, std::ios::openmode mode);
 		/// Opens the given file in the given mode.
 
-	void open_handle(HANDLE handle, std::ios::openmode mode);
+	void openHandle(HANDLE handle, std::ios::openmode mode);
 		/// Take ownership of the given HANDLE.
 
 	bool close();

--- a/Foundation/src/FileStream.cpp
+++ b/Foundation/src/FileStream.cpp
@@ -43,10 +43,10 @@ void FileIOS::open(const std::string& path, std::ios::openmode mode)
 }
 
 
-void FileIOS::open_handle(NativeHandle handle, std::ios::openmode mode)
+void FileIOS::openHandle(NativeHandle handle, std::ios::openmode mode)
 {
 	clear();
-	_buf.open_handle(handle, mode | _defaultMode);
+	_buf.openHandle(handle, mode | _defaultMode);
 }
 
 

--- a/Foundation/src/FileStream_POSIX.cpp
+++ b/Foundation/src/FileStream_POSIX.cpp
@@ -70,7 +70,7 @@ void FileStreamBuf::open(const std::string& path, std::ios::openmode mode)
 }
 
 
-void FileStreamBuf::open_handle(int fd, std::ios::openmode mode)
+void FileStreamBuf::openHandle(int fd, std::ios::openmode mode)
 {
 	poco_assert(_fd == -1);
 	poco_assert(fd != -1);

--- a/Foundation/src/FileStream_WIN32.cpp
+++ b/Foundation/src/FileStream_WIN32.cpp
@@ -74,7 +74,7 @@ void FileStreamBuf::open(const std::string& path, std::ios::openmode mode)
 }
 
 
-void FileStreamBuf::open_handle(HANDLE handle, std::ios::openmode mode)
+void FileStreamBuf::openHandle(HANDLE handle, std::ios::openmode mode)
 {
 	poco_assert(_handle == INVALID_HANDLE_VALUE);
 	poco_assert(handle != INVALID_HANDLE_VALUE);


### PR DESCRIPTION
In our application we open files in Python code, pass the file handle/descriptor to C++ code, and then use `FileStream` to access the file from C++. It's also possible for Python to pass a duplicate of the stdin handle to C++, so we need to handle the `ERROR_BROKEN_PIPE` special case.