### PR TITLE
Syslog: Include Facility to Syslog Message

### DIFF
--- a/Net/include/Poco/Net/RemoteSyslogChannel.h
+++ b/Net/include/Poco/Net/RemoteSyslogChannel.h
@@ -132,6 +132,9 @@ public:
 	static void registerChannel();
 		/// Registers the channel with the global LoggingFactory.
 
+	static const char* facilityToString(Facility facility);
+		/// Returns the string describing the SyslogFacility
+
 	static const std::string PROP_NAME;
 	static const std::string PROP_FACILITY;
 	static const std::string PROP_FORMAT;

--- a/Net/include/Poco/Net/RemoteSyslogListener.h
+++ b/Net/include/Poco/Net/RemoteSyslogListener.h
@@ -100,6 +100,7 @@ public:
 	static const std::string PROP_THREADS;
 	static const std::string PROP_BUFFER;
 
+	static const std::string LOG_PROP_FACILITY;
 	static const std::string LOG_PROP_APP;
 	static const std::string LOG_PROP_HOST;
 	static const std::string LOG_PROP_STRUCTURED_DATA;

--- a/Net/include/Poco/Net/RemoteSyslogListener.h
+++ b/Net/include/Poco/Net/RemoteSyslogListener.h
@@ -100,8 +100,8 @@ public:
 	static const std::string PROP_THREADS;
 	static const std::string PROP_BUFFER;
 
-    static const std::string LOG_PROP_APP;
-    static const std::string LOG_PROP_HOST;
+	static const std::string LOG_PROP_APP;
+	static const std::string LOG_PROP_HOST;
 	static const std::string LOG_PROP_STRUCTURED_DATA;
 
 protected:

--- a/Net/src/RemoteSyslogChannel.cpp
+++ b/Net/src/RemoteSyslogChannel.cpp
@@ -362,6 +362,63 @@ int RemoteSyslogChannel::getPrio(const Message& msg)
 	}
 }
 
+const char* RemoteSyslogChannel::facilityToString(const Facility facility)
+{
+	switch(facility)
+	{
+	case RemoteSyslogChannel::SYSLOG_KERN:
+		return "KERN";
+	case RemoteSyslogChannel::SYSLOG_USER:
+		return "USER";
+	case RemoteSyslogChannel::SYSLOG_MAIL:
+		return "MAIL";
+	case RemoteSyslogChannel::SYSLOG_DAEMON:
+		return "DAEMON";
+	case RemoteSyslogChannel::SYSLOG_AUTH:
+		return "AUTH";
+	case RemoteSyslogChannel::SYSLOG_SYSLOG:
+		return "SYSLOG";
+	case RemoteSyslogChannel::SYSLOG_LPR:
+		return "LPR";
+	case RemoteSyslogChannel::SYSLOG_NEWS:
+		return "NEWS";
+	case RemoteSyslogChannel::SYSLOG_UUCP:
+		return "UUCP";
+	case RemoteSyslogChannel::SYSLOG_CRON:
+		return "CRON";
+	case RemoteSyslogChannel::SYSLOG_AUTHPRIV:
+		return "AUTHPRIV";
+	case RemoteSyslogChannel::SYSLOG_FTP:
+		return "FTP";
+	case RemoteSyslogChannel::SYSLOG_NTP:
+		return "NTP";
+	case RemoteSyslogChannel::SYSLOG_LOGAUDIT:
+		return "LOGAUDIT";
+	case RemoteSyslogChannel::SYSLOG_LOGALERT:
+		return "LOGALERT";
+	case RemoteSyslogChannel::SYSLOG_CLOCK:
+		return "CLOCK";
+	case RemoteSyslogChannel::SYSLOG_LOCAL0:
+		return "LOCAL0";
+	case RemoteSyslogChannel::SYSLOG_LOCAL1:
+		return "LOCAL1";
+	case RemoteSyslogChannel::SYSLOG_LOCAL2:
+		return "LOCAL2";
+	case RemoteSyslogChannel::SYSLOG_LOCAL3:
+		return "LOCAL3";
+	case RemoteSyslogChannel::SYSLOG_LOCAL4:
+		return "LOCAL4";
+	case RemoteSyslogChannel::SYSLOG_LOCAL5:
+		return "LOCAL5";
+	case RemoteSyslogChannel::SYSLOG_LOCAL6:
+		return "LOCAL6";
+	case RemoteSyslogChannel::SYSLOG_LOCAL7:
+		return "LOCAL7";
+	default:
+		return "";
+	}
+}
+
 
 void RemoteSyslogChannel::registerChannel()
 {

--- a/Net/src/RemoteSyslogListener.cpp
+++ b/Net/src/RemoteSyslogListener.cpp
@@ -312,6 +312,7 @@ void SyslogParser::parseNew(const std::string& line, RemoteSyslogChannel::Severi
 	int tzd = 0;
 	bool hasDate = Poco::DateTimeParser::tryParse(RemoteSyslogChannel::SYSLOG_TIMEFORMAT, timeStr, date, tzd);
 	Poco::Message logEntry(msgId, messageText, prio);
+	logEntry[RemoteSyslogListener::LOG_PROP_FACILITY] = RemoteSyslogChannel::facilityToString(fac);
 	logEntry[RemoteSyslogListener::LOG_PROP_HOST] = hostName;
 	logEntry[RemoteSyslogListener::LOG_PROP_APP] = appName;
 	logEntry[RemoteSyslogListener::LOG_PROP_STRUCTURED_DATA] = sd;
@@ -390,6 +391,7 @@ void SyslogParser::parseBSD(const std::string& line, RemoteSyslogChannel::Severi
 	pos = line.size();
 	Poco::Message logEntry(hostName, messageText, prio);
 	logEntry.setTime(date.timestamp());
+	logEntry[RemoteSyslogListener::LOG_PROP_FACILITY] = RemoteSyslogChannel::facilityToString(fac);
 	message.swap(logEntry);
 }
 
@@ -500,6 +502,7 @@ const std::string RemoteSyslogListener::PROP_PORT("port");
 const std::string RemoteSyslogListener::PROP_THREADS("threads");
 const std::string RemoteSyslogListener::PROP_BUFFER("buffer");
 
+const std::string RemoteSyslogListener::LOG_PROP_FACILITY("facility");
 const std::string RemoteSyslogListener::LOG_PROP_APP("app");
 const std::string RemoteSyslogListener::LOG_PROP_HOST("host");
 const std::string RemoteSyslogListener::LOG_PROP_STRUCTURED_DATA("structured-data");

--- a/Net/testsuite/src/SyslogTest.cpp
+++ b/Net/testsuite/src/SyslogTest.cpp
@@ -144,6 +144,44 @@ void SyslogTest::testListener()
 	assertTrue (msgs[0].getPriority() == Poco::Message::PRIO_CRITICAL);
 }
 
+void SyslogTest::testChannelFacility()
+{
+	Poco::AutoPtr<RemoteSyslogChannel> channel = new RemoteSyslogChannel();
+	channel->setProperty("loghost", "127.0.0.1:51400");
+	channel->setProperty("facility", "KERN");
+	channel->open();
+	Poco::AutoPtr<RemoteSyslogListener> listener = new RemoteSyslogListener(51400);
+	listener->open();
+	auto pCL = Poco::makeAuto<CachingChannel>();
+	listener->addChannel(pCL);
+	assertTrue (pCL->getCurrentSize() == 0);
+	Poco::Message msg("asource", "amessage", Poco::Message::PRIO_CRITICAL);
+	channel->log(msg);
+	channel->setProperty("facility", "USER");
+	msg.setText("asecondmessage");
+	channel->log(msg);
+	assertFalse (msg.has("facility"));
+	Poco::Thread::sleep(1000);
+	listener->close();
+	channel->close();
+	assertTrue (pCL->getCurrentSize() == 2);
+	std::vector<Poco::Message> msgs;
+	pCL->getMessages(msgs, 0, 10);
+
+	assertTrue (msgs.size() == 2);
+
+	assertTrue (msgs[1].getSource() == "asource");
+	assertTrue (msgs[1].getText() == "amessage");
+	assertTrue (msgs[1].getPriority() == Poco::Message::PRIO_CRITICAL);
+	assertTrue (msgs[1].has("facility"));
+	assertTrue (msgs[1].get("facility") == "KERN");
+
+	assertTrue (msgs[0].getSource() == "asource");
+	assertTrue (msgs[0].getText() == "asecondmessage");
+	assertTrue (msgs[0].getPriority() == Poco::Message::PRIO_CRITICAL);
+	assertTrue (msgs[0].has("facility"));
+	assertTrue (msgs[0].get("facility") == "USER");
+}
 
 void SyslogTest::testChannelOpenClose()
 {
@@ -262,6 +300,7 @@ CppUnit::Test* SyslogTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("SyslogTest");
 
 	CppUnit_addTest(pSuite, SyslogTest, testListener);
+	CppUnit_addTest(pSuite, SyslogTest, testChannelFacility);
 	CppUnit_addTest(pSuite, SyslogTest, testChannelOpenClose);
 	CppUnit_addTest(pSuite, SyslogTest, testOldBSD);
 	CppUnit_addTest(pSuite, SyslogTest, testStructuredData);

--- a/Net/testsuite/src/SyslogTest.h
+++ b/Net/testsuite/src/SyslogTest.h
@@ -25,6 +25,7 @@ public:
 	~SyslogTest();
 
 	void testListener();
+	void testChannelFacility();
 	void testChannelOpenClose();
 	void testOldBSD();
 	void testStructuredData();


### PR DESCRIPTION
RFC-5424 transmits the Severity and Facility of a message. Severity is available in the message-data-structure of the Syslog implementation, but facility is ignored from the parser inside RemoteSyslogListener. 
Therefore, this pull_request adds the Facility information to the messages StringMap, to make it available as LogProperty.