### PR TITLE
added facility to SyslogChannel

### DIFF
--- a/Foundation/src/SyslogChannel.cpp
+++ b/Foundation/src/SyslogChannel.cpp
@@ -69,7 +69,8 @@ void SyslogChannel::close()
 void SyslogChannel::log(const Message& msg)
 {
 	if (!_open) open();
-	syslog(getPrio(msg), "%s", msg.getText().c_str());
+	const int pri = getPrio(msg) + _facility;
+	syslog(pri, "%s", msg.getText().c_str());
 }
 
 


### PR DESCRIPTION
RFC-5424 transmits the Severity and Facility of a message. But facility is discarded in SyslogChannel::log(const Message &).
Therefore, this pull_request adds the Facility information to the syslog command.