### PR TITLE
improve performance for toLower/toUpper

### DIFF
--- a/Foundation/include/Poco/Ascii.h
+++ b/Foundation/include/Poco/Ascii.h
@@ -208,7 +208,7 @@ inline bool Ascii::isPrintable(int ch)
 inline int Ascii::toLower(int ch)
 {
 	if (isUpper(ch))
-		return ch + 32;
+		return ch | 0x20;
 	else
 		return ch;
 }
@@ -217,7 +217,7 @@ inline int Ascii::toLower(int ch)
 inline int Ascii::toUpper(int ch)
 {
 	if (isLower(ch))
-		return ch - 32;
+		return ch & ~0x20;
 	else
 		return ch;
 }

--- a/Foundation/include/Poco/String.h
+++ b/Foundation/include/Poco/String.h
@@ -126,7 +126,8 @@ S toUpper(const S& str)
 #elif defined( _MSC_VER )
 #pragma loop( hint_parallel( 0 ) )
 #endif
-	while (it != end) {
+	while (it != end)
+	{
 		int ch = static_cast<unsigned char>(*it);
 		*it = static_cast<typename S::value_type>(Ascii::toUpper(ch));
 		++it;
@@ -147,7 +148,8 @@ S& toUpperInPlace(S& str)
 #elif defined( _MSC_VER )
 #pragma loop( hint_parallel( 0 ) )
 #endif
-	while (it != end) {
+	while (it != end)
+	{
 		int ch = static_cast<unsigned char>(*it);
 		*it = static_cast<typename S::value_type>(Ascii::toUpper(ch));
 		++it;

--- a/Foundation/include/Poco/String.h
+++ b/Foundation/include/Poco/String.h
@@ -116,12 +116,21 @@ template <class S>
 S toUpper(const S& str)
 	/// Returns a copy of str containing all upper-case characters.
 {
-	typename S::const_iterator it  = str.begin();
-	typename S::const_iterator end = str.end();
-
-	S result;
-	result.reserve(str.size());
-	while (it != end) result += static_cast<typename S::value_type>(Ascii::toUpper(*it++));
+	S result(str);
+	
+	typename S::iterator it  = result.begin();
+	typename S::iterator end = result.end();
+	
+#ifdef __clang__
+#pragma unroll
+#elif defined( _MSC_VER )
+#pragma loop( hint_parallel( 0 ) )
+#endif
+	while (it != end) {
+		int ch = static_cast<unsigned char>(*it);
+		*it = static_cast<typename S::value_type>(Ascii::toUpper(ch));
+		++it;
+	} 
 	return result;
 }
 
@@ -132,8 +141,17 @@ S& toUpperInPlace(S& str)
 {
 	typename S::iterator it  = str.begin();
 	typename S::iterator end = str.end();
-
-	while (it != end) { *it = static_cast<typename S::value_type>(Ascii::toUpper(*it)); ++it; }
+	
+#ifdef __clang__
+#pragma unroll
+#elif defined( _MSC_VER )
+#pragma loop( hint_parallel( 0 ) )
+#endif
+	while (it != end) {
+		int ch = static_cast<unsigned char>(*it);
+		*it = static_cast<typename S::value_type>(Ascii::toUpper(ch));
+		++it;
+	} 
 	return str;
 }
 
@@ -142,12 +160,21 @@ template <class S>
 S toLower(const S& str)
 	/// Returns a copy of str containing all lower-case characters.
 {
-	typename S::const_iterator it  = str.begin();
-	typename S::const_iterator end = str.end();
+	S result(str);
+	
+	typename S::iterator it  = result.begin();
+	typename S::iterator end = result.end();
 
-	S result;
-	result.reserve(str.size());
-	while (it != end) result += static_cast<typename S::value_type>(Ascii::toLower(*it++));
+#ifdef __clang__
+#pragma unroll
+#elif defined( _MSC_VER )
+#pragma loop( hint_parallel( 0 ) )
+#endif
+	while (it != end) {
+		int ch = static_cast<unsigned char>(*it);
+		*it = static_cast<typename S::value_type>(Ascii::toLower(ch));
+		++it;
+	} 
 	return result;
 }
 
@@ -159,7 +186,16 @@ S& toLowerInPlace(S& str)
 	typename S::iterator it  = str.begin();
 	typename S::iterator end = str.end();
 
-	while (it != end) { *it = static_cast<typename S::value_type>(Ascii::toLower(*it)); ++it; }
+#ifdef __clang__
+#pragma unroll
+#elif defined( _MSC_VER )
+#pragma loop( hint_parallel( 0 ) )
+#endif
+	while (it != end) {
+		int ch = static_cast<unsigned char>(*it);
+		*it = static_cast<typename S::value_type>(Ascii::toLower(ch));
+		++it;
+	} 
 	return str;
 }
 


### PR DESCRIPTION
applied loop unrolling for clang and MS compilers. Use new Ascii::toLower and Ascii::toUpper implementations with bitwise operations. Also, S::reserve and S::operator+ replaced to copy ctor (tested many times, and copy ctor works faster on average).