### PR TITLE
#2755: Fix MySQL's LONGBLOB/LONGTEXT not allocating enough space

### DIFF
--- a/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
@@ -320,6 +320,8 @@ public:
 private:
 	bool realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, bool isUnsigned = false);
 
+	bool extractLongLOB(std::size_t pos);
+
 	// Prevent VC8 warning "operator= could not be generated"
 	Extractor& operator=(const Extractor&);
 

--- a/Data/MySQL/include/Poco/Data/MySQL/ResultMetadata.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/ResultMetadata.h
@@ -40,6 +40,9 @@ class ResultMetadata
 	/// MySQL result metadata
 {
 public:
+	~ResultMetadata();
+		/// Destroys the ResultMetadata.
+
 	void reset();
 		/// Resets the metadata.
 
@@ -64,10 +67,13 @@ public:
 	bool isNull(std::size_t pos) const;
 		/// Returns true if value at pos is null.
 
+	void adjustColumnSizeToFit(std::size_t pos);
+		/// Expands the size allocated for column to fit the length of the data.
+
 private:
 	std::vector<MetaColumn>    _columns;
 	std::vector<MYSQL_BIND>    _row;
-	std::vector<char>          _buffer;
+	std::vector<char*>         _buffer;
 	std::vector<unsigned long> _lengths;
 	std::vector<my_boolv>      _isNull; // using char instead of bool to avoid std::vector<bool> disaster
 };

--- a/Data/MySQL/src/Extractor.cpp
+++ b/Data/MySQL/src/Extractor.cpp
@@ -147,6 +147,9 @@ bool Extractor::extract(std::size_t pos, Poco::Data::BLOB& val)
 	if (_metadata.metaColumn(static_cast<Poco::UInt32>(pos)).type() != Poco::Data::MetaColumn::FDT_BLOB)
 		throw MySQLException("Extractor: not a blob");
 
+	if (_metadata.metaColumn(static_cast<Poco::UInt32>(pos)).length() == 0 && !extractLongLOB(pos))
+		return false;
+
 	val.assignRaw(_metadata.rawData(pos), _metadata.length(pos));
 	return true;
 }
@@ -162,6 +165,9 @@ bool Extractor::extract(std::size_t pos, Poco::Data::CLOB& val)
 
 	if (_metadata.metaColumn(static_cast<Poco::UInt32>(pos)).type() != Poco::Data::MetaColumn::FDT_BLOB)
 		throw MySQLException("Extractor: not a blob");
+
+	if (_metadata.metaColumn(static_cast<Poco::UInt32>(pos)).length() == 0 && !extractLongLOB(pos))
+		return false;
 
 	val.assignRaw(reinterpret_cast<const char*>(_metadata.rawData(pos)), _metadata.length(pos));
 	return true;
@@ -249,6 +255,22 @@ bool Extractor::realExtractFixed(std::size_t pos, enum_field_types type, void* b
 		return false;
 
 	return isNull == 0;
+}
+
+bool Extractor::extractLongLOB(std::size_t pos)
+{
+	// Large LOBs (LONGBLOB and LONGTEXT) are fetched
+	// with a zero-length buffer to avoid allocating
+	// huge amounts of memory. Therefore, when extracting
+	// the buffers need to be adjusted.
+	
+	_metadata.adjustColumnSizeToFit(pos);
+	
+	MYSQL_BIND* row = _metadata.row();
+	if (!_stmt.fetchColumn(pos, &row[pos]))
+		return false;
+	
+	return true;
 }
 
 

--- a/Data/MySQL/src/ResultMetadata.cpp
+++ b/Data/MySQL/src/ResultMetadata.cpp
@@ -140,6 +140,13 @@ namespace Data {
 namespace MySQL {
 
 
+ResultMetadata::~ResultMetadata()
+{
+	for (std::vector<char*>::iterator it = _buffer.begin(); it != _buffer.end(); ++it)
+		std::free(*it);
+}
+
+
 void ResultMetadata::reset()
 {
 	_columns.resize(0);
@@ -165,12 +172,12 @@ void ResultMetadata::init(MYSQL_STMT* stmt)
 	std::size_t count = mysql_num_fields(h);
 	MYSQL_FIELD* fields = mysql_fetch_fields(h);
 
-	std::size_t commonSize = 0;
 	_columns.reserve(count);
 
 	for (std::size_t i = 0; i < count; i++)
 	{
 		std::size_t size = fieldSize(fields[i]);
+		if (size == 0xFFFFFFFF) size = 0;
 
 		_columns.push_back(MetaColumn(
 			i,                               // position
@@ -180,29 +187,24 @@ void ResultMetadata::init(MYSQL_STMT* stmt)
 			0,                               // TODO: precision
 			!IS_NOT_NULL(fields[i].flags)    // nullable
 			));
-
-		commonSize += _columns[i].length();
 	}
 
-	_buffer.resize(commonSize);
+	_buffer.resize(count);
 	_row.resize(count);
 	_lengths.resize(count);
 	_isNull.resize(count);
-
-	std::size_t offset = 0;
 
 	for (std::size_t i = 0; i < count; i++)
 	{
 		std::memset(&_row[i], 0, sizeof(MYSQL_BIND));
 		unsigned int len = static_cast<unsigned int>(_columns[i].length());
+		_buffer[i] = (char*) std::calloc(len, sizeof(char));
 		_row[i].buffer_type   = fields[i].type;
 		_row[i].buffer_length = len;
-		_row[i].buffer        = (len > 0) ? (&_buffer[0] + offset) : 0;
+		_row[i].buffer        = _buffer[i];
 		_row[i].length        = &_lengths[i];
 		_row[i].is_null       = reinterpret_cast<my_bool*>(&_isNull[i]); // workaround to make it work with both MySQL 8 and earlier
 		_row[i].is_unsigned   = (fields[i].flags & UNSIGNED_FLAG) > 0;
-		
-		offset += _row[i].buffer_length;
 	}
 }
 
@@ -240,6 +242,15 @@ const unsigned char* ResultMetadata::rawData(std::size_t pos) const
 bool ResultMetadata::isNull(std::size_t pos) const 
 {
 	return (_isNull[pos] != 0);
+}
+
+
+void ResultMetadata::adjustColumnSizeToFit(std::size_t pos)
+{
+	std::free(_buffer[pos]);
+	_buffer[pos] = (char*) std::calloc(_lengths[pos], sizeof(char));
+	_row[pos].buffer = _buffer[pos];
+	_row[pos].buffer_length = _lengths[pos];
 }
 
 

--- a/Data/MySQL/src/ResultMetadata.cpp
+++ b/Data/MySQL/src/ResultMetadata.cpp
@@ -171,7 +171,6 @@ void ResultMetadata::init(MYSQL_STMT* stmt)
 	for (std::size_t i = 0; i < count; i++)
 	{
 		std::size_t size = fieldSize(fields[i]);
-		if (size == 0xFFFFFFFF) size = 0;
 
 		_columns.push_back(MetaColumn(
 			i,                               // position

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -467,6 +467,15 @@ void MySQLTest::testBLOBStmt()
 }
 
 
+void MySQLTest::testLongText()
+{
+	if (!_pSession) fail ("Test not available.");
+
+	recreatePersonLongTextTable();
+	_pExecutor->longText();
+}
+
+
 void MySQLTest::testUnsignedInts()
 {
 	if (!_pSession) fail ("Test not available.");
@@ -741,6 +750,15 @@ void MySQLTest::recreatePersonTimeTable()
 }
 
 
+void MySQLTest::recreatePersonLongTextTable()
+{
+	dropTable("Person");
+	try { *_pSession << "CREATE TABLE Person (LastName VARCHAR(30), FirstName VARCHAR(30), Address VARCHAR(30), Biography LONGTEXT)", now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail ("recreatePersonLongTextTable()"); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail ("recreatePersonLongTextTable()"); }
+}
+
+
 void MySQLTest::recreateIntsTable()
 {
 	dropTable("Strings");
@@ -899,6 +917,7 @@ CppUnit::Test* MySQLTest::suite()
 	CppUnit_addTest(pSuite, MySQLTest, testDateTime);
 	//CppUnit_addTest(pSuite, MySQLTest, testBLOB);
 	CppUnit_addTest(pSuite, MySQLTest, testBLOBStmt);
+	CppUnit_addTest(pSuite, MySQLTest, testLongText);
 	CppUnit_addTest(pSuite, MySQLTest, testUnsignedInts);
 	CppUnit_addTest(pSuite, MySQLTest, testFloat);
 	CppUnit_addTest(pSuite, MySQLTest, testDouble);

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -467,12 +467,12 @@ void MySQLTest::testBLOBStmt()
 }
 
 
-void MySQLTest::testLongText()
+void MySQLTest::testLongBLOB()
 {
 	if (!_pSession) fail ("Test not available.");
 
-	recreatePersonLongTextTable();
-	_pExecutor->longText();
+	recreatePersonLongBLOBTable();
+	_pExecutor->longBlob();
 }
 
 
@@ -750,12 +750,12 @@ void MySQLTest::recreatePersonTimeTable()
 }
 
 
-void MySQLTest::recreatePersonLongTextTable()
+void MySQLTest::recreatePersonLongBLOBTable()
 {
 	dropTable("Person");
 	try { *_pSession << "CREATE TABLE Person (LastName VARCHAR(30), FirstName VARCHAR(30), Address VARCHAR(30), Biography LONGTEXT)", now; }
-	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail ("recreatePersonLongTextTable()"); }
-	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail ("recreatePersonLongTextTable()"); }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail ("recreatePersonLongBLOBTable()"); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail ("recreatePersonLongBLOBTable()"); }
 }
 
 
@@ -917,7 +917,7 @@ CppUnit::Test* MySQLTest::suite()
 	CppUnit_addTest(pSuite, MySQLTest, testDateTime);
 	//CppUnit_addTest(pSuite, MySQLTest, testBLOB);
 	CppUnit_addTest(pSuite, MySQLTest, testBLOBStmt);
-	CppUnit_addTest(pSuite, MySQLTest, testLongText);
+	CppUnit_addTest(pSuite, MySQLTest, testLongBLOB);
 	CppUnit_addTest(pSuite, MySQLTest, testUnsignedInts);
 	CppUnit_addTest(pSuite, MySQLTest, testFloat);
 	CppUnit_addTest(pSuite, MySQLTest, testDouble);

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -79,6 +79,7 @@ public:
 	void testDateTime();
 	void testBLOB();
 	void testBLOBStmt();
+	void testLongText();
 
 	void testUnsignedInts();
 	void testFloat();
@@ -115,6 +116,7 @@ private:
 	void recreatePersonDateTimeTable();
 	void recreatePersonDateTable();
 	void recreatePersonTimeTable();
+	void recreatePersonLongTextTable();
 	void recreateStringsTable();
 	void recreateIntsTable();
 	void recreateUnsignedIntsTable();

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -79,7 +79,7 @@ public:
 	void testDateTime();
 	void testBLOB();
 	void testBLOBStmt();
-	void testLongText();
+	void testLongBLOB();
 
 	void testUnsignedInts();
 	void testFloat();
@@ -116,7 +116,7 @@ private:
 	void recreatePersonDateTimeTable();
 	void recreatePersonDateTable();
 	void recreatePersonTimeTable();
-	void recreatePersonLongTextTable();
+	void recreatePersonLongBLOBTable();
 	void recreateStringsTable();
 	void recreateIntsTable();
 	void recreateUnsignedIntsTable();

--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -1412,6 +1412,36 @@ void SQLExecutor::blobStmt()
 }
 
 
+void SQLExecutor::longText()
+{
+	std::string funct = "longText()";
+	std::string lastName("lastname");
+	std::string firstName("firstname");
+	std::string address("Address");
+	std::string biography(
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+		"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+		"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+
+	int count = 0;
+	Statement ins = (*_pSession << "INSERT INTO Person VALUES (?,?,?,?)", use(lastName), use(firstName), use(address), use(biography));
+	ins.execute();
+	try { *_pSession << "SELECT COUNT(*) FROM Person", into(count), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	assertTrue (count == 1);
+
+	std::string res;
+	poco_assert (res.size() == 0);
+	Statement stmt = (*_pSession << "SELECT Biography FROM Person", into(res));
+	try { stmt.execute(); }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	poco_assert (res == biography);
+}
+
+
 void SQLExecutor::tuples()
 {
 	typedef Tuple<int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int> TupleType;

--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -1412,17 +1412,13 @@ void SQLExecutor::blobStmt()
 }
 
 
-void SQLExecutor::longText()
+void SQLExecutor::longBlob()
 {
-	std::string funct = "longText()";
+	std::string funct = "longBlob()";
 	std::string lastName("lastname");
 	std::string firstName("firstname");
 	std::string address("Address");
-	std::string biography(
-		"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
-		"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
-		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
-		"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+	Poco::Data::CLOB biography("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 123);
 
 	int count = 0;
 	Statement ins = (*_pSession << "INSERT INTO Person VALUES (?,?,?,?)", use(lastName), use(firstName), use(address), use(biography));
@@ -1432,7 +1428,7 @@ void SQLExecutor::longText()
 	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
 	assertTrue (count == 1);
 
-	std::string res;
+	Poco::Data::CLOB res;
 	poco_assert (res.size() == 0);
 	Statement stmt = (*_pSession << "SELECT Biography FROM Person", into(res));
 	try { stmt.execute(); }

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -83,7 +83,7 @@ public:
 	void dateTime();
 	void date();
 	void time();
-	void longText();
+	void longBlob();
 	void unsignedInts();
 	void floats();
 	void doubles();

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -83,6 +83,7 @@ public:
 	void dateTime();
 	void date();
 	void time();
+	void longText();
 	void unsignedInts();
 	void floats();
 	void doubles();


### PR DESCRIPTION
Hi,

This is my take on a fix for bug #2755. I found that for LONGBLOB and LONGTEXT columns the size of the buffer was being set to zero. This was due to a fix for a memory leak reported on #174, where 4GB of space were being allocated for this buffers. At first I thought of just removing the condition that set the buffer size to zero. However, after reading the [MySQL doc's recommendations for fetching large values](https://dev.mysql.com/doc/c-api/8.0/en/mysql-stmt-fetch.html), I decided to implement a way to adjust the buffer sizes to fit the length of the data. At extraction time I would check if the size allocated for that column is zero. If it is then I will adjust the buffer size and fetch that column again. Hope this helps. Let me know if there is something I can improve or if there is a better solution.