### PR TITLE
Add ODBC DirectExec public API

### DIFF
--- a/Data/ODBC/include/Poco/Data/ODBC/ODBCStatementImpl.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBCStatementImpl.h
@@ -88,7 +88,8 @@ protected:
 	AbstractBinding::BinderPtr binder();
 		/// Returns the concrete binder used by the statement.
 
-    void execDirectImpl(std::string query);
+	void execDirectImpl(const std::string& query);
+		/// Execute query directly impl
 
 	std::string nativeSQL();
 		/// Returns the SQL string as modified by the driver.

--- a/Data/ODBC/include/Poco/Data/ODBC/ODBCStatementImpl.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBCStatementImpl.h
@@ -88,6 +88,8 @@ protected:
 	AbstractBinding::BinderPtr binder();
 		/// Returns the concrete binder used by the statement.
 
+    void execDirectImpl(std::string query);
+
 	std::string nativeSQL();
 		/// Returns the SQL string as modified by the driver.
 

--- a/Data/ODBC/src/ODBCStatementImpl.cpp
+++ b/Data/ODBC/src/ODBCStatementImpl.cpp
@@ -228,6 +228,16 @@ void ODBCStatementImpl::bindImpl()
 	_pBinder->synchronize();
 }
 
+void ODBCStatementImpl::execDirectImpl(std::string query)
+{
+    auto data=&query.at(0);
+    SQLCHAR * statementText=reinterpret_cast<unsigned char*>(data);
+    SQLINTEGER textLength=query.size();
+    SQLRETURN rc = SQLExecDirect(_stmt,statementText,textLength);
+
+    checkError(rc, "SQLExecute()");
+}
+
 
 void ODBCStatementImpl::putData()
 {

--- a/Data/ODBC/src/ODBCStatementImpl.cpp
+++ b/Data/ODBC/src/ODBCStatementImpl.cpp
@@ -230,9 +230,8 @@ void ODBCStatementImpl::bindImpl()
 
 void ODBCStatementImpl::execDirectImpl(const std::string& query)
 {
-	auto data = query;
-	SQLCHAR * statementText=reinterpret_cast<unsigned char*>(&data.at(0));
-	SQLINTEGER textLength=query.size();
+	SQLCHAR * statementText = (SQLCHAR*) query.c_str();
+	SQLINTEGER textLength = query.size();
 	SQLRETURN rc = SQLExecDirect(_stmt,statementText,textLength);
 
 	checkError(rc, "SQLExecute()");

--- a/Data/ODBC/src/ODBCStatementImpl.cpp
+++ b/Data/ODBC/src/ODBCStatementImpl.cpp
@@ -228,14 +228,14 @@ void ODBCStatementImpl::bindImpl()
 	_pBinder->synchronize();
 }
 
-void ODBCStatementImpl::execDirectImpl(std::string query)
+void ODBCStatementImpl::execDirectImpl(const std::string& query)
 {
-    auto data=&query.at(0);
-    SQLCHAR * statementText=reinterpret_cast<unsigned char*>(data);
-    SQLINTEGER textLength=query.size();
-    SQLRETURN rc = SQLExecDirect(_stmt,statementText,textLength);
+	auto data = query;
+	SQLCHAR * statementText=reinterpret_cast<unsigned char*>(&data.at(0));
+	SQLINTEGER textLength=query.size();
+	SQLRETURN rc = SQLExecDirect(_stmt,statementText,textLength);
 
-    checkError(rc, "SQLExecute()");
+	checkError(rc, "SQLExecute()");
 }
 
 

--- a/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
+++ b/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
@@ -148,6 +148,21 @@ void ODBCSQLServerTest::testBareboneODBC()
 	executor().bareboneODBCMultiResultTest(dbConnString(), tableCreateString, SQLExecutor::PB_AT_EXEC, SQLExecutor::DE_BOUND);
 }
 
+void ODBCSQLServerTest::testTempTable()
+{
+	session() << "IF(OBJECT_ID('tempdb..#test') is not null) drop table #test;", now;
+
+	std::string query("create table #test (s1 int,s2 int ,s3 int);");
+	Statement stmt(session());
+	stmt.executeDirect(query);
+	session() << "insert into #test select 1,2,3;", now;
+
+	typedef Poco::Tuple<int, int, int> testParam;
+	std::vector<testParam> testParams;
+	session() << ("select * from #test;"), into(testParams), now;
+
+	assertEquals(1, testParams.size());
+}
 
 void ODBCSQLServerTest::testBLOB()
 {

--- a/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
+++ b/Data/ODBC/testsuite/src/ODBCSQLServerTest.cpp
@@ -162,6 +162,10 @@ void ODBCSQLServerTest::testTempTable()
 	session() << ("select * from #test;"), into(testParams), now;
 
 	assertEquals(1, testParams.size());
+
+	assertEquals(1, testParams.front().get<0>());
+	assertEquals(2, testParams.front().get<1>());
+	assertEquals(3, testParams.front().get<2>());
 }
 
 void ODBCSQLServerTest::testBLOB()

--- a/Data/ODBC/testsuite/src/ODBCSQLServerTest.h
+++ b/Data/ODBC/testsuite/src/ODBCSQLServerTest.h
@@ -40,6 +40,8 @@ public:
 
 	void testBareboneODBC();
 
+	void testTempTable();
+
 	void testBLOB();
 	void testNull();
 	void testBulk();

--- a/Data/ODBC/testsuite/src/ODBCTest.h
+++ b/Data/ODBC/testsuite/src/ODBCTest.h
@@ -101,6 +101,7 @@ public:
 	virtual void testIllegalRange();
 	virtual void testSingleSelect();
 	virtual void testEmptyDB();
+	virtual void testTempTable();
 
 	virtual void testBLOB();
 	virtual void testBLOBContainer();
@@ -221,8 +222,13 @@ private:
 // inlines
 //
 
-inline void ODBCTest::testStoredProcedure()
+inline void ODBCTest::testTempTable()
 {
+	throw Poco::NotImplementedException("ODBCTest::testTempTable()");
+}
+
+inline void ODBCTest::testStoredProcedure() 
+{ 
 	throw Poco::NotImplementedException("ODBCTest::testStoredProcedure()");
 }
 

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -304,7 +304,7 @@ public:
 		/// The result of execution (i.e. number of returned or affected rows) can be
 		/// obtained by calling wait() on the statement at a later point in time.
 
-    void executeDirect(const std::string&query);
+    void executeDirect(const std::string& query);
         /// Executes the statement synchronously and directly.
         /// If isAsync() returns  true, the statement is also executed synchronously
 

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -305,6 +305,8 @@ public:
 		/// obtained by calling wait() on the statement at a later point in time.
 
     void executeDirect(const std::string&query);
+        /// Executes the statement synchronously and directly.
+        /// If isAsync() returns  true, the statement is also executed synchronously
 
 	const Result& executeAsync(bool reset = true);
 		/// Executes the statement asynchronously.

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -304,9 +304,9 @@ public:
 		/// The result of execution (i.e. number of returned or affected rows) can be
 		/// obtained by calling wait() on the statement at a later point in time.
 
-    void executeDirect(const std::string& query);
-        /// Executes the statement synchronously and directly.
-        /// If isAsync() returns  true, the statement is also executed synchronously
+	void executeDirect(const std::string& query);
+		/// Executes the query synchronously and directly.
+		/// If isAsync() returns true, the statement is also executed synchronously.
 
 	const Result& executeAsync(bool reset = true);
 		/// Executes the statement asynchronously.

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -304,6 +304,8 @@ public:
 		/// The result of execution (i.e. number of returned or affected rows) can be
 		/// obtained by calling wait() on the statement at a later point in time.
 
+    void executeDirect(const std::string&query);
+
 	const Result& executeAsync(bool reset = true);
 		/// Executes the statement asynchronously.
 		/// Stops when either a limit is hit or the whole statement was executed.

--- a/Data/include/Poco/Data/StatementImpl.h
+++ b/Data/include/Poco/Data/StatementImpl.h
@@ -133,7 +133,8 @@ public:
 		/// this execution step. When reset is false, data is appended to the
 		/// bound containers during multiple execute calls.
 
-    void executeDirect(const std::string &query);
+	void executeDirect(const std::string& query);
+		/// Execute query directly.
 
 	void reset();
 		/// Resets the statement, so that we can reuse all bindings and re-execute again.
@@ -201,7 +202,8 @@ protected:
 	virtual void bindImpl() = 0;
 		/// Binds parameters.
 
-    virtual void execDirectImpl(std::string query);
+	virtual void execDirectImpl(const std::string& query);
+		/// Execute query directly.
 
 	virtual AbstractExtraction::ExtractorPtr extractor() = 0;
 		/// Returns the concrete extractor used by the statement.

--- a/Data/include/Poco/Data/StatementImpl.h
+++ b/Data/include/Poco/Data/StatementImpl.h
@@ -133,6 +133,8 @@ public:
 		/// this execution step. When reset is false, data is appended to the
 		/// bound containers during multiple execute calls.
 
+    void executeDirect(const std::string &query);
+
 	void reset();
 		/// Resets the statement, so that we can reuse all bindings and re-execute again.
 
@@ -198,6 +200,8 @@ protected:
 
 	virtual void bindImpl() = 0;
 		/// Binds parameters.
+
+    virtual void execDirectImpl(std::string query);
 
 	virtual AbstractExtraction::ExtractorPtr extractor() = 0;
 		/// Returns the concrete extractor used by the statement.

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -136,25 +136,25 @@ std::size_t Statement::execute(bool reset)
 	else throw InvalidAccessException("Statement still executing.");
 }
 
-void Statement::executeDirect(const std::string &query)
+void Statement::executeDirect(const std::string& query)
 {
-    Mutex::ScopedLock lock(_mutex);
-    bool isDone = done();
-    if (initialized() || paused() || isDone)
-    {
+	Mutex::ScopedLock lock(_mutex);
+	bool isDone = done();
+	if (initialized() || paused() || isDone)
+	{
 
-        if (!isAsync())
-        {
-            if (isDone) _pImpl->reset();
-            return _pImpl->executeDirect(query);
-        }
-//        else
-//        {
-//            doAsyncExec();
-//            return;
-//        }
-    }
-    else throw InvalidAccessException("Statement still executing.");
+		if (!isAsync())
+		{
+			if (isDone) _pImpl->reset();
+			return _pImpl->executeDirect(query);
+		}
+//		else
+//		{
+//          doAsyncExec();
+//          return;
+//		}
+	}
+	else throw InvalidAccessException("Statement still executing.");
 }
 
 

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -148,11 +148,7 @@ void Statement::executeDirect(const std::string& query)
 			if (isDone) _pImpl->reset();
 			return _pImpl->executeDirect(query);
 		}
-//		else
-//		{
-//          doAsyncExec();
-//          return;
-//		}
+		else throw InvalidAccessException("Cannot be executed async.");
 	}
 	else throw InvalidAccessException("Statement still executing.");
 }

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -136,6 +136,27 @@ std::size_t Statement::execute(bool reset)
 	else throw InvalidAccessException("Statement still executing.");
 }
 
+void Statement::executeDirect(const std::string &query)
+{
+    Mutex::ScopedLock lock(_mutex);
+    bool isDone = done();
+    if (initialized() || paused() || isDone)
+    {
+
+        if (!isAsync())
+        {
+            if (isDone) _pImpl->reset();
+            return _pImpl->executeDirect(query);
+        }
+//        else
+//        {
+//            doAsyncExec();
+//            return;
+//        }
+    }
+    else throw InvalidAccessException("Statement still executing.");
+}
+
 
 const Statement::Result& Statement::executeAsync(bool reset)
 {

--- a/Data/src/StatementImpl.cpp
+++ b/Data/src/StatementImpl.cpp
@@ -109,12 +109,14 @@ std::size_t StatementImpl::execute(const bool& reset)
 
 void StatementImpl::executeDirect(const std::string &query)
 {
-    if (!_rSession.isConnected())
-    {
-        _state = ST_DONE;
-        throw NotConnectedException(_rSession.connectionString());
-    }
-    execDirectImpl(query);
+	if (!_rSession.isConnected())
+	{
+		_state = ST_DONE;
+		throw NotConnectedException(_rSession.connectionString());
+	}
+	_ostr.str("");
+	_ostr << query;
+	execDirectImpl(_ostr.str());
 }
 
 

--- a/Data/src/StatementImpl.cpp
+++ b/Data/src/StatementImpl.cpp
@@ -107,6 +107,16 @@ std::size_t StatementImpl::execute(const bool& reset)
 	return lim;
 }
 
+void StatementImpl::executeDirect(const std::string &query)
+{
+    if (!_rSession.isConnected())
+    {
+        _state = ST_DONE;
+        throw NotConnectedException(_rSession.connectionString());
+    }
+    execDirectImpl(query);
+}
+
 
 void StatementImpl::assignSubTotal(bool reset)
 {
@@ -378,6 +388,11 @@ const MetaColumn& StatementImpl::metaColumn(const std::string& name) const
 	}
 
 	throw NotFoundException(format("Invalid column name: %s", name));
+}
+
+void StatementImpl::execDirectImpl(std::string query)
+{
+    poco_assert("Not implemented");
 }
 
 

--- a/Data/src/StatementImpl.cpp
+++ b/Data/src/StatementImpl.cpp
@@ -390,9 +390,9 @@ const MetaColumn& StatementImpl::metaColumn(const std::string& name) const
 	throw NotFoundException(format("Invalid column name: %s", name));
 }
 
-void StatementImpl::execDirectImpl(std::string query)
+void StatementImpl::execDirectImpl(const std::string& query)
 {
-    poco_assert("Not implemented");
+	poco_assert("Not implemented");
 }
 
 


### PR DESCRIPTION
It was a very long story how i couldn't determine why temp tables dont work in Poco between statements (https://github.com/pocoproject/poco/issues/3499). After all, I compared how Poco use ODBC api and NanoODBC
For 1 single statement Poco call stack (except attrs and some non-related things):
```
SQLAllocHandle
SQLPrepareW
SQLNumResultCol
SQLExecute
SQLFetch
SQLRowCount
SQLFreeHandle
```
For 1 single statement NanoODBC call stack (except attrs and some non-related things):
```
SQLAllocHandle
SQLExecDirect
SQLNumResultCol
SQLCancel
SQLFreeStmt
SQLFreeHandle
```
Looks like Poco uses only prepared statement while nanodbc calls execute direct every time. I tried to investigate deeper and deeper. If I create temp table with prepared statement, temp table will not be available in the next statement. How it works with sessions but with statements. But if I create temp table with direct execute, it will be available in the statements... 
So I tried to add direct execute to Poco but I dont understand well Poco architecture and it needs to change a lot of classes and maybe architecture too. So I create this PR as proposal or draft.
 If you provide me some help I'll be very thankful.

Closes #3499

MS mention this in docs https://learn.microsoft.com/en-us/sql/relational-databases/native-client-odbc-queries/executing-statements/prepared-execution?view=sql-server-ver16
`Prepared statements cannot be used to create temporary objects on SQL Server.`