### PR TITLE
Update Any.h

### DIFF
--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -522,10 +522,10 @@ ValueType AnyCast(Any& operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._pHolder)
+		if (operand._valueHolder.content())
 		{
 			s.append(1, '(');
-			s.append(operand._pHolder->type().name());
+			s.append(operand._valueHolder.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');
@@ -564,10 +564,10 @@ const ValueType& RefAnyCast(const Any & operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._pHolder)
+		if (operand._valueHolder.content())
 		{
 			s.append(1, '(');
-			s.append(operand._pHolder->type().name());
+			s.append(operand._valueHolder.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');
@@ -589,10 +589,10 @@ ValueType& RefAnyCast(Any& operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._pHolder)
+		if (operand._valueHolder.content())
 		{
 			s.append(1, '(');
-			s.append(operand._pHolder->type().name());
+			s.append(operand._valueHolder.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');

--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -522,10 +522,10 @@ ValueType AnyCast(Any& operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._valueHolder.content())
+		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand._valueHolder.content()->type().name());
+			s.append(operand.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');
@@ -564,10 +564,11 @@ const ValueType& RefAnyCast(const Any & operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._valueHolder.content())
+
+		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand._valueHolder.content()->type().name());
+			s.append(operand.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');
@@ -589,10 +590,10 @@ ValueType& RefAnyCast(Any& operand)
 	if (!result)
 	{
 		std::string s = "RefAnyCast: Failed to convert between Any types ";
-		if (operand._valueHolder.content())
+		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand._valueHolder.content()->type().name());
+			s.append(operand.content()->type().name());
 			s.append(" => ");
 			s.append(typeid(ValueType).name());
 			s.append(1, ')');


### PR DESCRIPTION
Fixes #3297 

The Poco Any/DynamicAny::Var SOO now compiles properly if POCO_ENABLE_SOO is defined.

I left SOO off by default still. I know Poco supports min of C++14 now. You guys can change it if you like. I didn't know the proper way to go about it in the code base.
