### PR TITLE
Add convertation to string in Redis Command#set

### DIFF
--- a/Redis/src/Command.cpp
+++ b/Redis/src/Command.cpp
@@ -479,7 +479,7 @@ Command Command::set(const std::string& key, const std::string& value, bool over
 	cmd << key << value;
 	if (! overwrite) cmd << "NX";
 	if (! create) cmd << "XX";
-	if (expireTime.totalMicroseconds() > 0) cmd << "PX" << expireTime.totalMilliseconds();
+	if (expireTime.totalMicroseconds() > 0) cmd << "PX" << NumberFormatter::format(expireTime.totalMilliseconds());
 
 	return cmd;
 }


### PR DESCRIPTION
There is a problem in `Poco::Redis::Command::set(...)`

If I want to set expire time for the value, I can't just write:
```cpp
Poco::Redis::Command::set(key, value, true, Poco::Timespan(60, 0));
```
That doesn't work because of incorrect implementation of the `set` function: when `expireTime` is added to `cmd` it's not converted from `Int64` to `std::string`.

This PR fixes the issue.