### PR TITLE
Add back NIOS2 double conversion detection to fix compile errors

### DIFF
--- a/Foundation/src/utils.h
+++ b/Foundation/src/utils.h
@@ -102,7 +102,8 @@ int main(int argc, char** argv) {
     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
     defined(__riscv) || \
     defined(__or1k__) || defined(__arc__) || \
-    defined(__EMSCRIPTEN__)
+    defined(__EMSCRIPTEN__) || \
+    defined(nios2) || defined(__nios2) || defined(__nios2__)
 #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
 #elif defined(__mc68000__) || \
     defined(__pnacl__) || defined(__native_client__)


### PR DESCRIPTION
The commit
https://github.com/pocoproject/poco/commit/558324f672d824300498060aff63356bc6bb8097

removed the nios2 support, which was originally added in
https://github.com/pocoproject/poco/commit/e7b91e8125d6910b53f94de5be4bb53f38dc77c1

This commit add it back.

Signed-off-by: Julien Olivain <ju.o@free.fr>

Note 1: the devel branch still include the nios2 support.
Note 2: this patch was tested against poco v1.11.1 in Buildroot, in https://git.buildroot.org/buildroot/commit/?id=5086d75cc8613a9730150662ca83dfa4592dfef0