### PR TITLE
Handle OpenSSL bidirectional shutdown

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -193,6 +193,8 @@ public:
 			///   and other TLSv1.3 ephemeral key negotiation, based
 			///   on the group names defined by OpenSSL. Defaults to
 			///   "X448:X25519:ffdhe4096:ffdhe3072:ffdhe2048:ffdhe6144:ffdhe8192:P-521:P-384:P-256"
+			
+		int securityLevel;
 	};
 
 	using InvalidCertificateHandlerPtr = Poco::SharedPtr<InvalidCertificateHandler>;
@@ -211,7 +213,8 @@ public:
 		VerificationMode verificationMode = VERIFY_RELAXED,
 		int verificationDepth = 9,
 		bool loadDefaultCAs = false,
-		const std::string& cipherList = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+		const std::string& cipherList = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
+		int securityLevel = -1);
 		/// Creates a Context.
 		///
 		///   * usage specifies whether the context is used by a client or server.
@@ -239,7 +242,8 @@ public:
 		VerificationMode verificationMode = VERIFY_RELAXED,
 		int verificationDepth = 9,
 		bool loadDefaultCAs = false,
-		const std::string& cipherList = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+		const std::string& cipherList = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
+		int securityLevel = -1);
 		/// Creates a Context.
 		///
 		///   * usage specifies whether the context is used by a client or server.

--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -385,6 +385,7 @@ public:
 		/// session resumption.
 		///
 		/// The feature can be disabled by calling this method.
+		
 
 	void disableProtocols(int protocols);
 		/// Disables the given protocols.
@@ -393,7 +394,13 @@ public:
 		/// values from the Protocols enumeration, e.g.:
 		///
 		///   context.disableProtocols(PROTO_SSLV2 | PROTO_SSLV3);
-
+		
+	void setSecurityLevel(int level);
+		/// Set Openssl security level
+		///
+		/// use SSL_CTX_set_security_level to set compatibility
+		/// with old https server/client
+		
 	void requireMinimumProtocol(Protocols protocol);
 		/// Disables all protocol version lower than the given one.
 		/// To require at least TLS 1.2 or later:

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -281,6 +281,7 @@ private:
 	bool _needHandshake;
 	std::string _peerHostName;
 	Session::Ptr _pSession;
+	bool _bidirectionalShutdown;
 
 	friend class SecureStreamSocketImpl;
 };

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -85,7 +85,8 @@ Context::Context(
 	VerificationMode verificationMode,
 	int verificationDepth,
 	bool loadDefaultCAs,
-	const std::string& cipherList):
+	const std::string& cipherList,
+	int securityLevel):
 	_usage(usage),
 	_mode(verificationMode),
 	_pSSLContext(0),
@@ -98,6 +99,7 @@ Context::Context(
 	params.verificationDepth = verificationDepth;
 	params.loadDefaultCAs = loadDefaultCAs;
 	params.cipherList = cipherList;
+	params.securityLevel = securityLevel;
 	init(params);
 }
 
@@ -121,6 +123,8 @@ void Context::init(const Params& params)
 	Poco::Crypto::OpenSSLInitializer::initialize();
 
 	createSSLContext();
+	
+	setSecurityLevel(params.securityLevel);
 
 	try
 	{
@@ -362,7 +366,15 @@ void Context::disableStatelessSessionResumption()
 #endif
 }
 
-
+void Context::setSecurityLevel(int level)
+{
+	if (level < 0)
+		return;
+#if OPENSSL_VERSION_NUMBER >= 0x030000000L
+	SSL_CTX_set_security_level(_pSSLContext, level);
+#endif
+}
+	
 void Context::disableProtocols(int protocols)
 {
 	if (protocols & PROTO_SSLV2)

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -36,7 +36,8 @@ Context::Params::Params():
 	loadDefaultCAs(false),
 	ocspStaplingVerification(false),
 	cipherList("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"),
-	dhUse2048Bits(false)
+	dhUse2048Bits(false),
+	securityLevel(-1)
 {
 }
 
@@ -60,7 +61,8 @@ Context::Context(
 	VerificationMode verificationMode,
 	int verificationDepth,
 	bool loadDefaultCAs,
-	const std::string& cipherList):
+	const std::string& cipherList,
+	int securityLevel):
 	_usage(usage),
 	_mode(verificationMode),
 	_pSSLContext(0),
@@ -75,6 +77,7 @@ Context::Context(
 	params.verificationDepth = verificationDepth;
 	params.loadDefaultCAs = loadDefaultCAs;
 	params.cipherList = cipherList;
+	params.securityLevel = securityLevel;
 	init(params);
 }
 


### PR DESCRIPTION
Handle bidirectional SSL shutdown when a FTPS data like client that never read from socket has to close connection. If it shutdown properly you can end up with data truncation problem server side