### PR TITLE
fix(openssl-initializer): check legacy provider existence for legacy exception

### DIFF
--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -137,7 +137,7 @@ void OpenSSLInitializer::initialize()
 		if (!_legacyProvider)
 		{
 			_legacyProvider  = OSSL_PROVIDER_load(NULL, "legacy");
-			if (!_defaultProvider) throw CryptoException("Failed to load OpenSSL legacy provider");
+			if (!_legacyProvider) throw CryptoException("Failed to load OpenSSL legacy provider");
 		}
 #endif
 	}


### PR DESCRIPTION
This fixes copy+paste error in openssl3 implementation.
This condition could never be true because default provider failure would throw couple lines above this code.

Note that this fix implies that the library is installed.
I'd suggest to include legacy provider optionally in future version of poco.