### PR TITLE
Handle MariaDB JSON columns since they are stored as `longtext`

### DIFF
--- a/Data/MySQL/src/Extractor.cpp
+++ b/Data/MySQL/src/Extractor.cpp
@@ -134,6 +134,9 @@ bool Extractor::extract(std::size_t pos, std::string& val)
 	if (columnType == Poco::Data::MetaColumn::FDT_JSON && !extractJSON(pos))
 		return false;
 
+	if (columnType == Poco::Data::MetaColumn::FDT_BLOB && !extractLongLOB(pos))
+		return false;
+
 	val.assign(reinterpret_cast<const char*>(_metadata.rawData(pos)), _metadata.length(pos));
 	return true;
 }

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -479,6 +479,14 @@ void MySQLTest::testLongBLOB()
 	_pExecutor->longBlob();
 }
 
+void MySQLTest::testLongTEXT()
+{
+	if (!_pSession) fail ("Test not available.");
+
+	recreatePersonLongBLOBTable();
+	_pExecutor->longText();
+}
+
 void MySQLTest::testJSON()
 {
 	if (!_pSession) fail("Test not available.");
@@ -966,6 +974,7 @@ CppUnit::Test* MySQLTest::suite()
 	//CppUnit_addTest(pSuite, MySQLTest, testBLOB);
 	CppUnit_addTest(pSuite, MySQLTest, testBLOBStmt);
 	CppUnit_addTest(pSuite, MySQLTest, testLongBLOB);
+	CppUnit_addTest(pSuite, MySQLTest, testLongTEXT);
 	CppUnit_addTest(pSuite, MySQLTest, testJSON);
 	CppUnit_addTest(pSuite, MySQLTest, testUnsignedInts);
 	CppUnit_addTest(pSuite, MySQLTest, testFloat);

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -793,8 +793,8 @@ void MySQLTest::recreatePersonJSONTable()
 {
 	dropTable("Person");
 	try { *_pSession << "CREATE TABLE Person (LastName VARCHAR(30), FirstName VARCHAR(30), Address VARCHAR(30), Biography JSON)", now; }
-	catch (ConnectionException& ce) { std::cout << ce.displayText() << std::endl; fail("recreatePersonLongBLOBTable()"); }
-	catch (StatementException& se) { std::cout << se.displayText() << std::endl; fail("recreatePersonLongBLOBTable()"); }
+	catch (ConnectionException& ce) { std::cout << ce.displayText() << std::endl; fail("recreatePersonJSONTable()"); }
+	catch (StatementException& se) { std::cout << se.displayText() << std::endl; fail("recreatePersonJSONTable()"); }
 }
 
 

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -80,6 +80,7 @@ public:
 	void testBLOB();
 	void testBLOBStmt();
 	void testLongBLOB();
+	void testLongTEXT();
 	void testJSON();
 
 	void testUnsignedInts();

--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -1488,6 +1488,31 @@ void SQLExecutor::longBlob()
 	poco_assert (res == biography);
 }
 
+void SQLExecutor::longText()
+{
+	std::string funct = "longText()";
+	std::string lastName("lastname");
+	std::string firstName("firstname");
+	std::string address("Address");
+	std::string biography("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", 123);
+
+	int count = 0;
+	Statement ins = (*_pSession << "INSERT INTO Person VALUES (?,?,?,?)", use(lastName), use(firstName), use(address), use(biography));
+	ins.execute();
+	try { *_pSession << "SELECT COUNT(*) FROM Person", into(count), now; }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	assertTrue (count == 1);
+
+	std::string longTextRes;
+	poco_assert (longTextRes.size() == 0);
+	Statement stmt = (*_pSession << "SELECT Biography FROM Person", into(longTextRes));
+	try { stmt.execute(); }
+	catch(ConnectionException& ce){ std::cout << ce.displayText() << std::endl; fail (funct); }
+	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail (funct); }
+	poco_assert (longTextRes == biography);
+}
+
 void SQLExecutor::json()
 {
 	std::string funct = "json()";

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -85,6 +85,7 @@ public:
 	void time();
 	void timestamp();
 	void longBlob();
+	void longText();
 	void json();
 	void unsignedInts();
 	void floats();


### PR DESCRIPTION
Fixes #3618 