### PR TITLE
Use `tx_isolation` when connected to MariaDB regardless of version

### DIFF
--- a/Data/MySQL/src/SessionImpl.cpp
+++ b/Data/MySQL/src/SessionImpl.cpp
@@ -255,16 +255,28 @@ void SessionImpl::setTransactionIsolation(Poco::UInt32 ti)
 
 Poco::UInt32 SessionImpl::getTransactionIsolation() const
 {
+	const std::string MARIADB_HOSTINFO_SUFFIX = "MariaDB";
+
 	std::string isolation;
+	std::string serverInfo = Utility::serverInfo(_handle);
 	unsigned long version = Utility::serverVersion(_handle);
-	if (version >= 80000)
-	{
-		getSetting("transaction_isolation", isolation);
-		isolation = isolation.c_str();
-	}
-	else
+
+	if (Poco::endsWith(serverInfo, MARIADB_HOSTINFO_SUFFIX)) //MariaDB
 	{
 		getSetting("tx_isolation", isolation);
+		isolation = isolation.c_str();
+	}
+	else //MySQL
+	{
+		if (version >= 80000)
+		{
+			getSetting("transaction_isolation", isolation);
+			isolation = isolation.c_str();
+		}
+		else
+		{
+			getSetting("tx_isolation", isolation);
+		}
 	}
 	Poco::replaceInPlace(isolation, "-", " ");
 	if (MYSQL_READ_UNCOMMITTED == isolation)


### PR DESCRIPTION
Fixes #3620 