### PR TITLE
Windows embedded OpenSSL: Fixed bogus warning during compilation

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -191,7 +191,7 @@
 //   empty or other value:
 //     Do not link any OpenSSL libraries automatically. You will have to edit the
 //     Visual C++ project files for Crypto and NetSSL_OpenSSL.
-#ifndef POCO_EXTERNAL_OPENSSL
+#if !defined(POCO_EXTERNAL_OPENSSL) && defined(POCO_EXTERNAL_OPENSSL_SLPRO)
 	#define POCO_EXTERNAL_OPENSSL POCO_EXTERNAL_OPENSSL_SLPRO
 #endif
 


### PR DESCRIPTION
When compiling Poco with Embeded OpenSLL, a warning is printed in `Crypto.h`:

`
External OpenSSL defined but internal headers used - possible mismatch!
`

The warning is bogus because `POCO_EXTERNAL_OPENSSL` gets defined to undefined `POCO_EXTERNAL_OPENSSL_SLPRO` in `Config.h`.

This change fixes that.