### PR TITLE
Bugcheck: indicate compiler that functions will never return

### DIFF
--- a/Foundation/include/Poco/Bugcheck.h
+++ b/Foundation/include/Poco/Bugcheck.h
@@ -39,19 +39,19 @@ class Foundation_API Bugcheck
 	/// automatically provide useful context information.
 {
 public:
-	static void assertion(const char* cond, const char* file, int line, const char* text = 0);
+	[[noreturn]] static void assertion(const char* cond, const char* file, int line, const char* text = 0);
 		/// An assertion failed. Break into the debugger, if
 		/// possible, then throw an AssertionViolationException.
 
-	static void nullPointer(const char* ptr, const char* file, int line);
+	[[noreturn]] static void nullPointer(const char* ptr, const char* file, int line);
 		/// An null pointer was encountered. Break into the debugger, if
 		/// possible, then throw an NullPointerException.
 
-	static void bugcheck(const char* file, int line);
+	[[noreturn]] static void bugcheck(const char* file, int line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 
-	static void bugcheck(const char* msg, const char* file, int line);
+	[[noreturn]] static void bugcheck(const char* msg, const char* file, int line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 


### PR DESCRIPTION
There are four functions in the Poco::Bugcheck class that always exit by throwing an exception. The C++11 standard provides the [`noreturn` attribute](https://en.cppreference.com/w/cpp/language/attributes/noreturn) that hints the compiler about this and allows some optimizations.

It also prevents the compiler from issuing some warnings, e.g.:
```
int processPositiveInteger(int i) {
  if (i > 0) {
    return i*2;
  }
  poco_bugcheck();
}
```
Many compilers will warn that the end of the function above will be reached without a return statement. But the end of the function is never reached because `poco_bugcheck()` will always throw. The `noreturn` attribute helps the compiler in such cases.