### PR TITLE
FifoBuffer.advance method not throw exception when length==0

### DIFF
--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -334,7 +334,7 @@ public:
 		/// Should be called AFTER the data 
 		/// was copied into the buffer.
 	{
-        if (0 == length) return;
+		if (0 == length) return;
 		Mutex::ScopedLock lock(_mutex);
 
 		if (length > available())

--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -334,6 +334,7 @@ public:
 		/// Should be called AFTER the data 
 		/// was copied into the buffer.
 	{
+        if (0 == length) return;
 		Mutex::ScopedLock lock(_mutex);
 
 		if (length > available())


### PR DESCRIPTION
FifoBuffer.advance method not throw exception when length==0 and buffer is full.