### PR TITLE
Avoid clang tidy warning

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -416,7 +416,7 @@ private:
 			throw RangeException("Value too large.");
 		}
 		else
-		if (from > std::numeric_limits<T>::max())
+		if (from > static_cast<F>(std::numeric_limits<T>::max()))
 		{
 			throw RangeException("Value too large.");
 		}
@@ -457,7 +457,7 @@ private:
 	template <typename F, typename T>
 	void checkLowerLimit(const F& from) const
 	{
-		if (from < std::numeric_limits<T>::min())
+		if (from < static_cast<F>(std::numeric_limits<T>::min()))
 			throw RangeException("Value too small.");
 	}
 };


### PR DESCRIPTION
Avoid clang tidy warning in `VarHolder`

```
[  2%] Building CXX object Foundation/CMakeFiles/Foundation.dir/src/VarIterator.cpp.o
In file included from /Users/wujianchao5/project/github/poco/Foundation/src/VarHolder.cpp:15:
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:419:14: warning: implicit conversion from 'std::numeric_limits<int>::type' (aka 'int') to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
                if (from > std::numeric_limits<T>::max())
                         ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:326:4: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::checkUpperLimit<float, int>' requested here
                        checkUpperLimit<F,T>(from);
                        ^
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:2202:3: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::convertToSmaller<float, int>' requested here
                convertToSmaller(_val, val);
                ^
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:419:14: warning: implicit conversion from 'std::numeric_limits<long long>::type' (aka 'long long') to 'float' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
                if (from > std::numeric_limits<T>::max())
                         ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:326:4: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::checkUpperLimit<float, long long>' requested here
                        checkUpperLimit<F,T>(from);
                        ^
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:2207:3: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::convertToSmaller<float, long long>' requested here
                convertToSmaller(_val, val);
                ^
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:419:14: warning: implicit conversion from 'std::numeric_limits<long long>::type' (aka 'long long') to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
                if (from > std::numeric_limits<T>::max())
                         ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:326:4: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::checkUpperLimit<double, long long>' requested here
                        checkUpperLimit<F,T>(from);
                        ^
/Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/VarHolder.h:2360:3: note: in instantiation of function template specialization 'Poco::Dynamic::VarHolder::convertToSmaller<double, long long>' requested here
                convertToSmaller(_val, val);
                ^
In file included from /Users/wujianchao5/project/github/poco/Foundation/src/VarIterator.cpp:16:
In file included from /Users/wujianchao5/project/github/poco/Foundation/include/Poco/Dynamic/Var.h:26:
```