### PR TITLE
better socket reactor wake up

### DIFF
--- a/Net/src/SocketReactor.cpp
+++ b/Net/src/SocketReactor.cpp
@@ -137,7 +137,6 @@ void SocketReactor::stop()
 
 
 void SocketReactor::wakeUp()
-	/// Wake up reactor, if invoker running in event loop thread there is no need to wake up.
 {
 	if (_pThread && _pThread != Thread::current())
 	{

--- a/Net/src/SocketReactor.cpp
+++ b/Net/src/SocketReactor.cpp
@@ -137,8 +137,13 @@ void SocketReactor::stop()
 
 
 void SocketReactor::wakeUp()
+	/// Wake up reactor, if invoker running in event loop thread there is no need to wake up.
 {
-	if (_pThread) _pThread->wakeUp();
+	if (_pThread && _pThread != Thread::current())
+	{
+		_pThread->wakeUp();
+		_pollSet.wakeUp();
+	}
 }
 
 


### PR DESCRIPTION
1.  If invoker running in event loop thread there is no need to wake it up.
2. add `_pollSet.wakeUp()`