### PR TITLE
Foundation/CMakeLists.txt: Use '-l' prefix for linking to android log…

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -219,7 +219,7 @@ if(ANDROID)
 			POCO_NO_WSTRING
 			POCO_NO_SHAREDMEMORY
 	)
-	target_link_libraries(Foundation PUBLIC log)
+	target_link_libraries(Foundation PUBLIC -llog)
 endif()
 
 POCO_INSTALL(Foundation)


### PR DESCRIPTION
Fix for https://github.com/pocoproject/poco/issues/3652