### PR TITLE
Fix unbundled PCRE2 dependency

### DIFF
--- a/Foundation/cmake/PocoFoundationConfig.cmake
+++ b/Foundation/cmake/PocoFoundationConfig.cmake
@@ -2,7 +2,7 @@ if(@POCO_UNBUNDLED@)
 	include(CMakeFindDependencyMacro)
 	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 	find_dependency(ZLIB REQUIRED)
-	find_dependency(PCRE REQUIRED)
+	find_dependency(PCRE2 REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/PocoFoundationTargets.cmake")


### PR DESCRIPTION
After switch to PCRE2, builds with unbundled dependencies fail with

|   By not providing "FindPCRE.cmake" in CMAKE_MODULE_PATH this project has
|   asked CMake to find a package configuration file provided by "PCRE", but
|   CMake did not find one.

Signed-off-by: Peter Marko <peter.marko@siemens.com>
Signed-off-by: Andrej Valek <andrej.valek@siemens.com>