### PR TITLE
fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/Crypto/src/Envelope.cpp
+++ b/Crypto/src/Envelope.cpp
@@ -14,6 +14,9 @@
 
 #include "Poco/Crypto/Envelope.h"
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define EVP_CIPHER_CTX_init(a) 1
+#endif
 
 namespace Poco {
 namespace Crypto {

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -23,6 +23,8 @@
 #include "Poco/Format.h"
 #include "Poco/Error.h"
 #include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
Missing headers and function.

Signed-off-by: Rosen Penev <rosenp@gmail.com>