### PR TITLE
lowercase winsock2 and iphlpapi to allow cross compile

### DIFF
--- a/Foundation/include/Poco/UnWindows.h
+++ b/Foundation/include/Poco/UnWindows.h
@@ -29,8 +29,8 @@
 #if !defined(POCO_NO_WINDOWS_H)
     #include <windows.h>
     #ifdef __MINGW32__
-        #include <Winsock2.h>
-        #include <Iphlpapi.h>
+        #include <winsock2.h>
+        #include <iphlpapi.h>
         #include <ws2tcpip.h>
     #endif // __MINGW32__
 #endif


### PR DESCRIPTION
File paths are case sensitive on linux. Currently this results in a "No such file or directory" error when compiling with w64-mingw32 on Ubuntu