### PR TITLE
Only support extracting JSON fields when the SDK supports it

### DIFF
--- a/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/Extractor.h
@@ -324,9 +324,9 @@ private:
 	bool realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, bool isUnsigned = false);
 
 	bool extractLongLOB(std::size_t pos);
-
+#ifdef POCO_MYSQL_JSON
 	bool extractJSON(std::size_t pos);
-
+#endif
 	// Prevent VC8 warning "operator= could not be generated"
 	Extractor& operator=(const Extractor&);
 

--- a/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
@@ -62,5 +62,17 @@
 	#endif
 #endif
 
+//
+// Detect support for JSON data type
+//
+#if defined(MARIADB_VERSION_ID)
+	#if MARIADB_VERSION_ID > 100207
+		#define POCO_MYSQL_JSON
+	#endif
+#else
+	#if MYSQL_VERSION_ID > 50708
+		#define POCO_MYSQL_JSON
+	#endif
+#endif
 
 #endif // MySQL_MySQL_INCLUDED

--- a/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
@@ -66,11 +66,11 @@
 // Detect support for JSON data type
 //
 #if defined(MARIADB_VERSION_ID)
-	#if MARIADB_VERSION_ID > 100207
+	#if MARIADB_VERSION_ID >= 100207
 		#define POCO_MYSQL_JSON
 	#endif
 #else
-	#if MYSQL_VERSION_ID > 50708
+	#if MYSQL_VERSION_ID >= 50708
 		#define POCO_MYSQL_JSON
 	#endif
 #endif

--- a/Data/MySQL/src/Extractor.cpp
+++ b/Data/MySQL/src/Extractor.cpp
@@ -128,12 +128,16 @@ bool Extractor::extract(std::size_t pos, std::string& val)
 
 	//mysql reports TEXT types as FDT_BLOB when being extracted
 	MetaColumn::ColumnDataType columnType = _metadata.metaColumn(static_cast<Poco::UInt32>(pos)).type();
+#ifdef POCO_MYSQL_JSON
 	if (columnType != Poco::Data::MetaColumn::FDT_STRING && columnType != Poco::Data::MetaColumn::FDT_BLOB && columnType != Poco::Data::MetaColumn::FDT_JSON)
+#else
+	if (columnType != Poco::Data::MetaColumn::FDT_STRING && columnType != Poco::Data::MetaColumn::FDT_BLOB)
+#endif
 		throw MySQLException("Extractor: not a string");
-
+#ifdef POCO_MYSQL_JSON
 	if (columnType == Poco::Data::MetaColumn::FDT_JSON && !extractJSON(pos))
 		return false;
-
+#endif
 	if (columnType == Poco::Data::MetaColumn::FDT_BLOB && !extractLongLOB(pos))
 		return false;
 
@@ -291,6 +295,7 @@ bool Extractor::extractLongLOB(std::size_t pos)
 	return true;
 }
 
+#ifdef POCO_MYSQL_JSON
 bool Extractor::extractJSON(std::size_t pos)
 {
 	// JSON columns are fetched with a zero-length
@@ -306,6 +311,7 @@ bool Extractor::extractJSON(std::size_t pos)
 
 	return true;
 }
+#endif
 
 //////////////
 // Not implemented

--- a/Data/MySQL/src/ResultMetadata.cpp
+++ b/Data/MySQL/src/ResultMetadata.cpp
@@ -72,7 +72,9 @@ namespace
 		case MYSQL_TYPE_MEDIUM_BLOB:
 		case MYSQL_TYPE_LONG_BLOB:
 		case MYSQL_TYPE_BLOB:
+#ifdef POCO_MYSQL_JSON
 		case MYSQL_TYPE_JSON:
+#endif		
 			return field.length;
 
 		default:

--- a/Data/MySQL/testsuite/src/MySQLTest.cpp
+++ b/Data/MySQL/testsuite/src/MySQLTest.cpp
@@ -487,6 +487,7 @@ void MySQLTest::testLongTEXT()
 	_pExecutor->longText();
 }
 
+#ifdef POCO_MYSQL_JSON
 void MySQLTest::testJSON()
 {
 	if (!_pSession) fail("Test not available.");
@@ -494,7 +495,7 @@ void MySQLTest::testJSON()
 	recreatePersonJSONTable();
 	_pExecutor->json();
 }
-
+#endif
 
 void MySQLTest::testUnsignedInts()
 {
@@ -796,7 +797,7 @@ void MySQLTest::recreatePersonLongBLOBTable()
 	catch(StatementException& se){ std::cout << se.displayText() << std::endl; fail ("recreatePersonLongBLOBTable()"); }
 }
 
-
+#ifdef POCO_MYSQL_JSON
 void MySQLTest::recreatePersonJSONTable()
 {
 	dropTable("Person");
@@ -804,7 +805,7 @@ void MySQLTest::recreatePersonJSONTable()
 	catch (ConnectionException& ce) { std::cout << ce.displayText() << std::endl; fail("recreatePersonJSONTable()"); }
 	catch (StatementException& se) { std::cout << se.displayText() << std::endl; fail("recreatePersonJSONTable()"); }
 }
-
+#endif
 
 void MySQLTest::recreateIntsTable()
 {

--- a/Data/MySQL/testsuite/src/MySQLTest.h
+++ b/Data/MySQL/testsuite/src/MySQLTest.h
@@ -81,7 +81,9 @@ public:
 	void testBLOBStmt();
 	void testLongBLOB();
 	void testLongTEXT();
+#ifdef POCO_MYSQL_JSON
 	void testJSON();
+#endif
 
 	void testUnsignedInts();
 	void testFloat();
@@ -122,7 +124,9 @@ private:
 	void recreatePersonTimeTable();
 	void recreatePersonTimestampTable();
 	void recreatePersonLongBLOBTable();
+#ifdef POCO_MYSQL_JSON
 	void recreatePersonJSONTable();
+#endif
 	void recreateStringsTable();
 	void recreateIntsTable();
 	void recreateUnsignedIntsTable();

--- a/Data/MySQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/MySQL/testsuite/src/SQLExecutor.cpp
@@ -1513,6 +1513,7 @@ void SQLExecutor::longText()
 	poco_assert (longTextRes == biography);
 }
 
+#ifdef POCO_MYSQL_JSON
 void SQLExecutor::json()
 {
 	std::string funct = "json()";
@@ -1537,7 +1538,7 @@ void SQLExecutor::json()
 	catch (StatementException& se) { std::cout << se.displayText() << std::endl; fail(funct); }
 	poco_assert(res == biography);
 }
-
+#endif
 
 void SQLExecutor::tuples()
 {

--- a/Data/MySQL/testsuite/src/SQLExecutor.h
+++ b/Data/MySQL/testsuite/src/SQLExecutor.h
@@ -86,7 +86,9 @@ public:
 	void timestamp();
 	void longBlob();
 	void longText();
+#ifdef POCO_MYSQL_JSON
 	void json();
+#endif	
 	void unsignedInts();
 	void floats();
 	void doubles();


### PR DESCRIPTION
Fixes #3689

Minimum supported versions taken from
MariaDB: https://mariadb.com/kb/en/json-data-type
MySQL: https://dev.mysql.com/doc/refman/5.7/en/json.html