### PR TITLE
Added missing Crypto Header to ProGen source

### DIFF
--- a/Crypto/Crypto_VS90.vcproj
+++ b/Crypto/Crypto_VS90.vcproj
@@ -654,6 +654,10 @@
 					>
 				</File>
 				<File
+					RelativePath=".\include\Poco\Crypto\EVPCipherImpl.h"
+					>
+				</File>
+				<File
 					RelativePath=".\include\Poco\Crypto\EVPPKey.h"
 					>
 				</File>
@@ -675,6 +679,10 @@
 				>
 				<File
 					RelativePath=".\src\CryptoException.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\src\EVPCipherImpl.cpp"
 					>
 				</File>
 				<File
@@ -733,6 +741,10 @@
 					RelativePath=".\include\Poco\Crypto\ECKeyImpl.h"
 					>
 				</File>
+				<File
+					RelativePath=".\include\Poco\Crypto\Envelope.h"
+					>
+				</File>
 			</Filter>
 			<Filter
 				Name="Source Files"
@@ -747,6 +759,10 @@
 				</File>
 				<File
 					RelativePath=".\src\ECKeyImpl.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\src\Envelope.cpp"
 					>
 				</File>
 			</Filter>

--- a/Crypto/testsuite/TestSuite_VS90.vcproj
+++ b/Crypto/testsuite/TestSuite_VS90.vcproj
@@ -583,6 +583,10 @@
 					>
 				</File>
 				<File
+					RelativePath=".\src\EnvelopeTest.h"
+					>
+				</File>
+				<File
 					RelativePath=".\src\RSATest.h"
 					>
 				</File>
@@ -608,6 +612,10 @@
 				</File>
 				<File
 					RelativePath=".\src\PKCS12ContainerTest.cpp"
+					>
+				</File>
+				<File
+					RelativePath=".\src\EnvelopeTest.cpp"
 					>
 				</File>
 				<File


### PR DESCRIPTION
Fix 3721
https://github.com/pocoproject/poco/issues/3721

I modified the V90 project file to make Progen work 
After that, I couldn't convert to V140-170 using Progen because I didn't know how.

Accept this "PR" and then use ProGen to convert a project and someone commits it
or
Ignore this "PR" and perform the ProGen conversion.