### PR TITLE
[docs] Add how to install using Conan section on README

### DIFF
--- a/README
+++ b/README
@@ -167,6 +167,25 @@ If the version is out of date, please create an issue or pull request(https://gi
 on the vcpkg repository.
 
 
+BUILDING - USING CONAN
+======================
+
+You can download and install poco using the Conan(https://github.com/conan-io/conan)
+package manager. It needed to be installed first(https://conan.io/downloads.html):
+
+You can install Poco libraries from Conan Center(https://conan.io/center.html):
+
+$ conan install -r conancenter poco/1.12.0@
+
+Or, you can download Poco recipe and build locally:
+
+$ conan install -r conancenter poco/1.12.0@ --build=poco
+
+The Poco recipe and packages in Conan Center are kept up to date by Conan team members and community contributors.
+If the version is out of date, or you detect any wrong behavior, please create an issue or pull request(https://github.com/conan-io/conan-center-index)
+on the Conan Center Index repository.
+
+
 BUILDING ON WINDOWS
 ===================
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ The poco port in vcpkg is kept up to date by Microsoft team members and communit
 If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg)
 on the vcpkg repository.
 
+#### Building and Installing - Using Conan
+
+You can download and install poco using the Conan(https://github.com/conan-io/conan)
+package manager. It needed to be installed first(https://conan.io/downloads.html):
+
+You can install Poco libraries from Conan Center(https://conan.io/center.html):
+
+    $ conan install -r conancenter poco/1.12.0@
+
+Or, you can download Poco recipe and build locally:
+
+    $ conan install -r conancenter poco/1.12.0@ --build=poco
+
+The Poco recipe and packages in Conan Center are kept up to date by Conan team members and community contributors.
+If the version is out of date, or you detect any wrong behavior, please create an issue or pull request(https://github.com/conan-io/conan-center-index)
+on the Conan Center Index repository.
+
 
 ### Building Without CMake
 


### PR DESCRIPTION
- Add new section to README and README.md (they are equal), explaining how to install and build Poco using Conan package manager.
- All related issues are pointed to be solved by Conan Center Index.