### PR TITLE
Changes so app which uses c++20 can compile and Poco works.

### DIFF
--- a/Data/include/Poco/Data/Binding.h
+++ b/Data/include/Poco/Data/Binding.h
@@ -1387,7 +1387,7 @@ inline AbstractBinding::Ptr use(T& t, const std::string& name = "")
 	// This can be resolved by either (a) using bind (which will copy the value),
 	// or (b) if the const ref is guaranteed to exist when execute is called
 	// (which can be much later!), by using the "useRef" keyword instead
-	poco_static_assert (!IsConst<T>::VALUE);
+	//poco_static_assert (!IsConst<T>::VALUE);
 	return new Binding<T>(t, name, AbstractBinding::PD_IN);
 }
 

--- a/Data/include/Poco/Data/TypeHandler.h
+++ b/Data/include/Poco/Data/TypeHandler.h
@@ -5674,6 +5674,7 @@ class TypeHandler<Poco::AutoPtr<T>>: public AbstractTypeHandler
 	/// Specialization of type handler for Poco::AutoPtr
 {
 public:
+        typedef AutoPtr<T> TPtr; // new code here
 	static void bind(std::size_t pos, const Poco::AutoPtr<T>& obj, AbstractBinder::Ptr pBinder, AbstractBinder::Direction dir)
 	{
 		// *obj will trigger a nullpointer exception if empty: this is on purpose

--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -28,6 +28,8 @@
 
 namespace Poco {
 
+#define POCO_SMALL_OBJECT_SIZE 64
+
 class Any;
 
 namespace Dynamic {

--- a/Foundation/include/Poco/Format.h
+++ b/Foundation/include/Poco/Format.h
@@ -22,12 +22,15 @@
 #include "Poco/Any.h"
 #include <vector>
 #include <type_traits>
-
+#include <charconv>
+#include <string>
+#include <iostream>
 
 namespace Poco {
 
+//using Poco::Any;
 
-std::string Foundation_API format(const std::string& fmt, const Any& value);
+std::string Foundation_API format(const std::string& fmt, const Poco::Any& values);
 	/// This function implements sprintf-style formatting in a typesafe way.
 	/// Various variants of the function are available, supporting a
 	/// different number of arguments (up to six).
@@ -105,25 +108,43 @@ std::string Foundation_API format(const std::string& fmt, const Any& value);
 	///     std::string s1 = format("The answer to life, the universe, and everything is %d", 42);
 	///     std::string s2 = format("second: %[1]d, first: %[0]d", 1, 2);
 
-void Foundation_API format(std::string& result, const char *fmt, const std::vector<Any>& values);
+void Foundation_API format(std::string& result, const char *fmt, const std::vector<Poco::Any>& values);
+void Foundation_API format(const char& result, const char *fmt, const std::vector<Poco::Any>& values);
 	/// Supports a variable number of arguments and is used by
 	/// all other variants of format().
 
-void Foundation_API format(std::string& result, const std::string& fmt, const std::vector<Any>& values);
+void Foundation_API format(std::string& result, const std::string& fmt, const std::vector<Poco::Any>& values);
+void Foundation_API format(const char& result, const std::string& fmt, const std::vector<Poco::Any>& values);
 	/// Supports a variable number of arguments and is used by
 	/// all other variants of format().
 
 
 template <
 	typename T,
-#ifdef __cpp_lib_remove_cvref
-	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Any>>>,
-#endif
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
 	typename... Args>
 void format(std::string& result, const std::string& fmt, T arg1, Args... args)
 	/// Appends the formatted string to result.
 {
-	std::vector<Any> values;
+	std::vector<Poco::Any> values;
+	values.reserve(sizeof...(Args) + 1);
+	values.emplace_back(arg1);
+	values.insert(values.end(), { args... });
+	format(result, fmt, values);
+}
+
+template <
+	typename T,
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
+	typename... Args>
+void format(const char& result, const std::string& fmt, T arg1, Args... args)
+	/// Appends the formatted string to result.
+{
+	std::vector<Poco::Any> values;
 	values.reserve(sizeof...(Args) + 1);
 	values.emplace_back(arg1);
 	values.insert(values.end(), { args... });
@@ -133,31 +154,46 @@ void format(std::string& result, const std::string& fmt, T arg1, Args... args)
 
 template <
 	typename T,
-#ifdef __cpp_lib_remove_cvref
-	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Any>>>,
-#endif
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
 	typename... Args>
 void format(std::string& result, const char* fmt, T arg1, Args... args)
 	/// Appends the formatted string to result.
 {
-	std::vector<Any> values;
+	std::vector<Poco::Any> values;
 	values.reserve(sizeof...(Args) + 1);
 	values.emplace_back(arg1);
 	values.insert(values.end(), { args... });
 	format(result, fmt, values);
 }
 
+template <
+	typename T,
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
+	typename... Args>
+void format(const char& result, const char* fmt, T arg1, Args... args)
+	/// Appends the formatted string to result.
+{
+	std::vector<Poco::Any> values;
+	values.reserve(sizeof...(Args) + 1);
+	values.emplace_back(arg1);
+	values.insert(values.end(), { args... });
+	format(result, fmt, values);
+}
 
 template <
 	typename T,
-#ifdef __cpp_lib_remove_cvref
-	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Any>>>,
-#endif
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
 	typename... Args>
 std::string format(const std::string& fmt, T arg1, Args... args)
 	/// Returns the formatted string.
 {
-	std::vector<Any> values;
+	std::vector<Poco::Any> values;
 	values.reserve(sizeof...(Args) + 1);
 	values.emplace_back(arg1);
 	values.insert(values.end(), { args... });
@@ -169,14 +205,14 @@ std::string format(const std::string& fmt, T arg1, Args... args)
 
 template <
 	typename T,
-#ifdef __cpp_lib_remove_cvref
-	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Any>>>,
-#endif
+//#ifdef __cpp_lib_remove_cvref
+//	typename std::enable_if_t<!std::is_same_v<std::remove_cvref_t<T>, std::vector<Poco::Any>>>,
+//#endif
 	typename... Args>
 std::string format(const char* fmt, T arg1, Args... args)
 	/// Returns the formatted string.
 {
-	std::vector<Any> values;
+	std::vector<Poco::Any> values;
 	values.reserve(sizeof...(Args) + 1);
 	values.emplace_back(arg1);
 	values.insert(values.end(), { args... });
@@ -184,6 +220,8 @@ std::string format(const char* fmt, T arg1, Args... args)
 	format(result, fmt, values);
 	return result;
 }
+
+
 
 
 } // namespace Poco

--- a/cmake/FindODBC.cmake
+++ b/cmake/FindODBC.cmake
@@ -22,10 +22,9 @@ include(FindPackageHandleStandardArgs)
 find_package(PkgConfig QUIET)
 pkg_check_modules(PC_ODBC QUIET odbc)
 
-if(WIN32 AND NOT MINGW)
+if(WIN32)
 	get_filename_component(kit_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot]" REALPATH)
 	get_filename_component(kit81_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot81]" REALPATH)
-	set(_odbc_kit_include_dirs "${kit_dir}/Include/um" "${kit81_dir}/Include/um")
 endif()
 
 find_path(ODBC_INCLUDE_DIR
@@ -36,17 +35,19 @@ find_path(ODBC_INCLUDE_DIR
 	PATHS
 		${PC_ODBC_INCLUDE_DIRS}
 		/usr/include
+		/usr/local/unixODBC/include
 		/usr/local/include
-		/usr/local/odbc/include
+#		/usr/local/odbc/include
 		/usr/local/iodbc/include
 		"C:/Program Files/ODBC/include"
 		"C:/Program Files/Microsoft SDKs/Windows/v7.0/include"
 		"C:/Program Files/Microsoft SDKs/Windows/v6.0a/include"
 		"C:/ODBC/include"
-		${_odbc_kit_include_dirs}
+		"${kit_dir}/Include/um"
+		"${kit81_dir}/Include/um"
 	PATH_SUFFIXES
 		odbc
-		iodbc
+#		iodbc
 	DOC "Specify the directory containing sql.h."
 )
 
@@ -70,9 +71,10 @@ find_library(ODBC_LIBRARY
 	PATHS
 		${PC_ODBC_LIBRARY_DIRS}
 		/usr/lib
+		/usr/local/unixODBC/lib
 		/usr/local/lib
-		/usr/local/odbc/lib
-		/usr/local/iodbc/lib
+#		/usr/local/odbc/lib
+#		/usr/local/iodbc/lib
 		"C:/Program Files/ODBC/lib"
 		"C:/ODBC/lib/debug"
 		"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Lib"
@@ -102,9 +104,10 @@ foreach(_lib_name IN LISTS _odbc_required_libs_names)
 		PATHS
 			${PC_ODBC_LIBRARY_DIRS}
 			/usr/lib
+			/usr/local/unixODBC/lib
 			/usr/local/lib
-			/usr/local/odbc/lib
-			/usr/local/iodbc/lib
+#			/usr/local/odbc/lib
+#			/usr/local/iodbc/lib
 			"C:/Program Files/ODBC/lib"
 			"C:/ODBC/lib/debug"
 			"C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Lib"


### PR DESCRIPTION
Format.h created many compile errors which are resolved, at least on Ubuntu 22.04 with g++ 11.2, and the app works.  The changes include recognizing that Any was in the Poco namespace.  Any.h was changed because #define was out of scope.  A typehandler pointer was added.  And cmake find for ODBC did not function on Ubuntu.