### PR TITLE
buildwin.ps1 script error building the x64 version of Poco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,207 +1,207 @@
 name: poco-ci
 on: [push, pull_request]
 jobs:
-  linux-gcc-make:
-    runs-on: ubuntu-20.04
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_USER: pocotest
-          MYSQL_PASSWORD: pocotest
-          MYSQL_DATABASE: pocotest
-        ports:
-          - 3306:3306
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
-      - run: ./configure --everything --omit=PDF && make all -s -j4 && sudo make install
-      - run: >-
-          sudo -s
-          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
-          ./ci/runtests.sh
-
-  linux-gcc-make-cxx20:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
-      - run: ./configure --config=Linux-c++20 --everything --omit=PDF && make all -s -j4 && sudo make install
-      - run: >-
-          sudo -s
-          EXCLUDE_TESTS="Data/ODBC Data/MySQL Data/PostgreSQL MongoDB"
-          ./ci/runtests.sh
-
-  linux-gcc-make-asan:
-    runs-on: ubuntu-20.04
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_USER: pocotest
-          MYSQL_PASSWORD: pocotest
-          MYSQL_DATABASE: pocotest
-        ports:
-          - 3306:3306
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
-      - run: >-
-          sudo -s
-          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
-          ./ci/runtests.sh
-
-  linux-gcc-make-asan-no-soo:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-      - run: ./configure --everything --no-samples --omit=PDF --no-soo && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
-      - run: >-
-          sudo -s
-          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
-          ./ci/runtests.sh
-
-  linux-gcc-make-ubsan:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=undefined && sudo make install
-      - run: >-
-          sudo -s
-          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
-          ./ci/runtests.sh
-
-  linux-gcc-make-tsan:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-      - run: ./configure --everything --no-samples --omit=CppParser,Encodings,Data/MySQL,Data/ODBC,Data/PostgreSQL,MongoDB,PageCompiler,PDF,PocoDoc,ProGen,Redis,SevenZip && make all -s -j4 SANITIZEFLAGS=-fsanitize=thread && sudo make install
-      - run: >-
-          sudo -s
-          ./ci/runtests.sh TSAN
-
-  linux-gcc-cmake:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-      - run: cmake -H. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON && cmake --build cmake-build --target all
-      - run: >-
-          cd cmake-build &&
-          sudo -s
-          PWD=`pwd`
-          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
-
-  linux-gcc-make-cross-armhf:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: >-
-          sudo apt-get -y update &&
-          sudo apt-get -y install crossbuild-essential-armhf
-      - run: >-
-          ./configure --config=ARM-Linux --everything --omit=PDF,Crypto,NetSSL_OpenSSL,JWT,Data/MySQL,Data/ODBC,Data/PostgreSQL,PageCompiler,PageCompiler/File2Page &&
-          make all -s -j4 ARCHFLAGS="-mcpu=cortex-a8 -mfloat-abi=hard -mfpu=neon" TOOL=arm-linux-gnueabihf
-
-  macos-clang-make:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-      - run: brew install openssl@1.1 mysql-client unixodbc libpq
-      - run: ./configure --everything --no-prefix --omit=PDF --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib && make all -s -j4
-      - run: >-
-          sudo -s
-          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-          EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
-          ./ci/runtests.sh
-
-  macos-clang-cmake:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-      - run: brew install openssl@1.1 mysql-client unixodbc libpq
-      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
-      - run: >-
-          cd cmake-build &&
-          sudo -s
-          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-          PWD=`pwd`
-          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
-
-  macos-clang-cmake-openssl3:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-      - run: brew install openssl@3 mysql-client unixodbc libpq
-      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
-      - run: >-
-          cd cmake-build &&
-          sudo -s
-          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-          PWD=`pwd`
-          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
-
-  windows-2019-msvc-cmake:
-    runs-on: windows-2019
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
-      - run: cmake --build cmake-build --config Release
-      - run: >-
-          cd cmake-build;
-          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
-          
-  windows-2019-msvc-buildwin-x64:
-    runs-on: windows-2019
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
-      
-  windows-2019-msvc-buildwin-win32:
-    runs-on: windows-2019
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
-
+#  linux-gcc-make:
+#    runs-on: ubuntu-20.04
+#    services:
+#      mysql:
+#        image: mysql:latest
+#        env:
+#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+#          MYSQL_USER: pocotest
+#          MYSQL_PASSWORD: pocotest
+#          MYSQL_DATABASE: pocotest
+#        ports:
+#          - 3306:3306
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
+#      - run: ./configure --everything --omit=PDF && make all -s -j4 && sudo make install
+#      - run: >-
+#          sudo -s
+#          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
+#          ./ci/runtests.sh
+#
+#  linux-gcc-make-cxx20:
+#    runs-on: ubuntu-22.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
+#      - run: ./configure --config=Linux-c++20 --everything --omit=PDF && make all -s -j4 && sudo make install
+#      - run: >-
+#          sudo -s
+#          EXCLUDE_TESTS="Data/ODBC Data/MySQL Data/PostgreSQL MongoDB"
+#          ./ci/runtests.sh
+#
+#  linux-gcc-make-asan:
+#    runs-on: ubuntu-20.04
+#    services:
+#      mysql:
+#        image: mysql:latest
+#        env:
+#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+#          MYSQL_USER: pocotest
+#          MYSQL_PASSWORD: pocotest
+#          MYSQL_DATABASE: pocotest
+#        ports:
+#          - 3306:3306
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+#      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
+#      - run: >-
+#          sudo -s
+#          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
+#          ./ci/runtests.sh
+#
+#  linux-gcc-make-asan-no-soo:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+#      - run: ./configure --everything --no-samples --omit=PDF --no-soo && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
+#      - run: >-
+#          sudo -s
+#          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
+#          ./ci/runtests.sh
+#
+#  linux-gcc-make-ubsan:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+#      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=undefined && sudo make install
+#      - run: >-
+#          sudo -s
+#          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
+#          ./ci/runtests.sh
+#
+#  linux-gcc-make-tsan:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+#      - run: ./configure --everything --no-samples --omit=CppParser,Encodings,Data/MySQL,Data/ODBC,Data/PostgreSQL,MongoDB,PageCompiler,PDF,PocoDoc,ProGen,Redis,SevenZip && make all -s -j4 SANITIZEFLAGS=-fsanitize=thread && sudo make install
+#      - run: >-
+#          sudo -s
+#          ./ci/runtests.sh TSAN
+#
+#  linux-gcc-cmake:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+#      - run: cmake -H. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON && cmake --build cmake-build --target all
+#      - run: >-
+#          cd cmake-build &&
+#          sudo -s
+#          PWD=`pwd`
+#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
+#
+#  linux-gcc-make-cross-armhf:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: >-
+#          sudo apt-get -y update &&
+#          sudo apt-get -y install crossbuild-essential-armhf
+#      - run: >-
+#          ./configure --config=ARM-Linux --everything --omit=PDF,Crypto,NetSSL_OpenSSL,JWT,Data/MySQL,Data/ODBC,Data/PostgreSQL,PageCompiler,PageCompiler/File2Page &&
+#          make all -s -j4 ARCHFLAGS="-mcpu=cortex-a8 -mfloat-abi=hard -mfpu=neon" TOOL=arm-linux-gnueabihf
+#
+#  macos-clang-make:
+#    runs-on: macos-10.15
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: brew install openssl@1.1 mysql-client unixodbc libpq
+#      - run: ./configure --everything --no-prefix --omit=PDF --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib && make all -s -j4
+#      - run: >-
+#          sudo -s
+#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+#          EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
+#          ./ci/runtests.sh
+#
+#  macos-clang-cmake:
+#    runs-on: macos-10.15
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: brew install openssl@1.1 mysql-client unixodbc libpq
+#      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+#      - run: >-
+#          cd cmake-build &&
+#          sudo -s
+#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+#          PWD=`pwd`
+#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
+#
+#  macos-clang-cmake-openssl3:
+#    runs-on: macos-10.15
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: brew install openssl@3 mysql-client unixodbc libpq
+#      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+#      - run: >-
+#          cd cmake-build &&
+#          sudo -s
+#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+#          PWD=`pwd`
+#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
+#
+#  windows-2019-msvc-cmake:
+#    runs-on: windows-2019
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+#      - run: cmake --build cmake-build --config Release
+#      - run: >-
+#          cd cmake-build;
+#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+#          
+#  windows-2019-msvc-buildwin-x64:
+#    runs-on: windows-2019
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#      
+#  windows-2019-msvc-buildwin-win32:
+#    runs-on: windows-2019
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#
   windows-2022-msvc-buildwin-x64:
-    runs-on: windows-2019
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
-
-  windows-2022-msvc-buildwin-win32:
     runs-on: windows-2022
     env:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
-
-  windows-2022-msvc-cmake-2022:
-    runs-on: windows-2022
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
-      - run: cmake --build cmake-build --config Release
-      - run: >-
-          cd cmake-build;
-          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#
+#  windows-2022-msvc-buildwin-win32:
+#    runs-on: windows-2022
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#
+#  windows-2022-msvc-cmake-2022:
+#    runs-on: windows-2022
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+#      - run: cmake --build cmake-build --config Release
+#      - run: >-
+#          cd cmake-build;
+#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
 
 # missing asan dll path
 #  windows-2022-msvc-cmake-2022-asan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: buildwin.ps1 -poco_base . -vs160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
+      - run: .\buildwin.ps1 -poco_base . -vs160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Encodings,Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
       - run: >-
           cd cmake-build;
           ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+          
+  windows-2019-msvc-buildwin-x64:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: buildwin.ps1 -poco_base . -vs160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,21 +175,21 @@ jobs:
 #      - uses: actions/checkout@v2
 #      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 #
-  windows-2022-msvc-buildwin-x64:
-    runs-on: windows-2022
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
-#
-#  windows-2022-msvc-buildwin-win32:
+#  windows-2022-msvc-buildwin-x64:
 #    runs-on: windows-2022
 #    env:
 #      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
 #    steps:
 #      - uses: actions/checkout@v2
-#      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+
+  windows-2022-msvc-buildwin-win32:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 #
 #  windows-2022-msvc-cmake-2022:
 #    runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'CppUnit;Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT'
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Encodings;Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,13 +183,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
-  windows-2022-msvc-buildwin-win32:
-    runs-on: windows-2022
-    env:
-      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-    steps:
-      - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+#  windows-2022-msvc-buildwin-win32:
+#    runs-on: windows-2022
+#    env:
+#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+#    steps:
+#      - uses: actions/checkout@v2
+#      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+      
+  windows-2019-msvc-buildwin-win32:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT'
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'CppUnit;Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT'
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
       
   windows-2019-msvc-buildwin-win32:
     runs-on: windows-2019
@@ -173,7 +173,23 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
+
+  windows-2022-msvc-buildwin-x64:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
+
+  windows-2022-msvc-buildwin-win32:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'NetSSL_OpenSSL;Crypto;JWT;Data/MySQL;Data/PostgreSQL'
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit 'Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT'
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,187 +1,187 @@
 name: poco-ci
 on: [push, pull_request]
 jobs:
-#  linux-gcc-make:
-#    runs-on: ubuntu-20.04
-#    services:
-#      mysql:
-#        image: mysql:latest
-#        env:
-#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-#          MYSQL_USER: pocotest
-#          MYSQL_PASSWORD: pocotest
-#          MYSQL_DATABASE: pocotest
-#        ports:
-#          - 3306:3306
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
-#      - run: ./configure --everything --omit=PDF && make all -s -j4 && sudo make install
-#      - run: >-
-#          sudo -s
-#          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
-#          ./ci/runtests.sh
-#
-#  linux-gcc-make-cxx20:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
-#      - run: ./configure --config=Linux-c++20 --everything --omit=PDF && make all -s -j4 && sudo make install
-#      - run: >-
-#          sudo -s
-#          EXCLUDE_TESTS="Data/ODBC Data/MySQL Data/PostgreSQL MongoDB"
-#          ./ci/runtests.sh
-#
-#  linux-gcc-make-asan:
-#    runs-on: ubuntu-20.04
-#    services:
-#      mysql:
-#        image: mysql:latest
-#        env:
-#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-#          MYSQL_USER: pocotest
-#          MYSQL_PASSWORD: pocotest
-#          MYSQL_DATABASE: pocotest
-#        ports:
-#          - 3306:3306
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-#      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
-#      - run: >-
-#          sudo -s
-#          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
-#          ./ci/runtests.sh
-#
-#  linux-gcc-make-asan-no-soo:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-#      - run: ./configure --everything --no-samples --omit=PDF --no-soo && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
-#      - run: >-
-#          sudo -s
-#          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
-#          ./ci/runtests.sh
-#
-#  linux-gcc-make-ubsan:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-#      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=undefined && sudo make install
-#      - run: >-
-#          sudo -s
-#          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
-#          ./ci/runtests.sh
-#
-#  linux-gcc-make-tsan:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-#      - run: ./configure --everything --no-samples --omit=CppParser,Encodings,Data/MySQL,Data/ODBC,Data/PostgreSQL,MongoDB,PageCompiler,PDF,PocoDoc,ProGen,Redis,SevenZip && make all -s -j4 SANITIZEFLAGS=-fsanitize=thread && sudo make install
-#      - run: >-
-#          sudo -s
-#          ./ci/runtests.sh TSAN
-#
-#  linux-gcc-cmake:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server
-#      - run: cmake -H. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON && cmake --build cmake-build --target all
-#      - run: >-
-#          cd cmake-build &&
-#          sudo -s
-#          PWD=`pwd`
-#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
-#
-#  linux-gcc-make-cross-armhf:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: >-
-#          sudo apt-get -y update &&
-#          sudo apt-get -y install crossbuild-essential-armhf
-#      - run: >-
-#          ./configure --config=ARM-Linux --everything --omit=PDF,Crypto,NetSSL_OpenSSL,JWT,Data/MySQL,Data/ODBC,Data/PostgreSQL,PageCompiler,PageCompiler/File2Page &&
-#          make all -s -j4 ARCHFLAGS="-mcpu=cortex-a8 -mfloat-abi=hard -mfpu=neon" TOOL=arm-linux-gnueabihf
-#
-#  macos-clang-make:
-#    runs-on: macos-10.15
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: brew install openssl@1.1 mysql-client unixodbc libpq
-#      - run: ./configure --everything --no-prefix --omit=PDF --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib && make all -s -j4
-#      - run: >-
-#          sudo -s
-#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-#          EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
-#          ./ci/runtests.sh
-#
-#  macos-clang-cmake:
-#    runs-on: macos-10.15
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: brew install openssl@1.1 mysql-client unixodbc libpq
-#      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
-#      - run: >-
-#          cd cmake-build &&
-#          sudo -s
-#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-#          PWD=`pwd`
-#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
-#
-#  macos-clang-cmake-openssl3:
-#    runs-on: macos-10.15
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: brew install openssl@3 mysql-client unixodbc libpq
-#      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
-#      - run: >-
-#          cd cmake-build &&
-#          sudo -s
-#          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
-#          PWD=`pwd`
-#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
-#
-#  windows-2019-msvc-cmake:
-#    runs-on: windows-2019
-#    env:
-#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
-#      - run: cmake --build cmake-build --config Release
-#      - run: >-
-#          cd cmake-build;
-#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
-#          
-#  windows-2019-msvc-buildwin-x64:
-#    runs-on: windows-2019
-#    env:
-#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
-#      
-#  windows-2019-msvc-buildwin-win32:
-#    runs-on: windows-2019
-#    env:
-#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
-#
-#  windows-2022-msvc-buildwin-x64:
-#    runs-on: windows-2022
-#    env:
-#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+  linux-gcc-make:
+    runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_USER: pocotest
+          MYSQL_PASSWORD: pocotest
+          MYSQL_DATABASE: pocotest
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
+      - run: ./configure --everything --omit=PDF && make all -s -j4 && sudo make install
+      - run: >-
+          sudo -s
+          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
+          ./ci/runtests.sh
+
+  linux-gcc-make-cxx20:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev redis-server libmysqlclient-dev
+      - run: ./configure --config=Linux-c++20 --everything --omit=PDF && make all -s -j4 && sudo make install
+      - run: >-
+          sudo -s
+          EXCLUDE_TESTS="Data/ODBC Data/MySQL Data/PostgreSQL MongoDB"
+          ./ci/runtests.sh
+
+  linux-gcc-make-asan:
+    runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_USER: pocotest
+          MYSQL_PASSWORD: pocotest
+          MYSQL_DATABASE: pocotest
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
+      - run: >-
+          sudo -s
+          EXCLUDE_TESTS="Data/ODBC Data/PostgreSQL MongoDB"
+          ./ci/runtests.sh
+
+  linux-gcc-make-asan-no-soo:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+      - run: ./configure --everything --no-samples --omit=PDF --no-soo && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
+      - run: >-
+          sudo -s
+          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
+          ./ci/runtests.sh
+
+  linux-gcc-make-ubsan:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+      - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=undefined && sudo make install
+      - run: >-
+          sudo -s
+          EXCLUDE_TESTS="Data/MySQL Data/ODBC Data/PostgreSQL MongoDB"
+          ./ci/runtests.sh
+
+  linux-gcc-make-tsan:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+      - run: ./configure --everything --no-samples --omit=CppParser,Encodings,Data/MySQL,Data/ODBC,Data/PostgreSQL,MongoDB,PageCompiler,PDF,PocoDoc,ProGen,Redis,SevenZip && make all -s -j4 SANITIZEFLAGS=-fsanitize=thread && sudo make install
+      - run: >-
+          sudo -s
+          ./ci/runtests.sh TSAN
+
+  linux-gcc-cmake:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server
+      - run: cmake -H. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON && cmake --build cmake-build --target all
+      - run: >-
+          cd cmake-build &&
+          sudo -s
+          PWD=`pwd`
+          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
+
+  linux-gcc-make-cross-armhf:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: >-
+          sudo apt-get -y update &&
+          sudo apt-get -y install crossbuild-essential-armhf
+      - run: >-
+          ./configure --config=ARM-Linux --everything --omit=PDF,Crypto,NetSSL_OpenSSL,JWT,Data/MySQL,Data/ODBC,Data/PostgreSQL,PageCompiler,PageCompiler/File2Page &&
+          make all -s -j4 ARCHFLAGS="-mcpu=cortex-a8 -mfloat-abi=hard -mfpu=neon" TOOL=arm-linux-gnueabihf
+
+  macos-clang-make:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install openssl@1.1 mysql-client unixodbc libpq
+      - run: ./configure --everything --no-prefix --omit=PDF --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib && make all -s -j4
+      - run: >-
+          sudo -s
+          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+          EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
+          ./ci/runtests.sh
+
+  macos-clang-cmake:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install openssl@1.1 mysql-client unixodbc libpq
+      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+      - run: >-
+          cd cmake-build &&
+          sudo -s
+          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+          PWD=`pwd`
+          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
+
+  macos-clang-cmake-openssl3:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install openssl@3 mysql-client unixodbc libpq
+      - run: cmake -H. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+      - run: >-
+          cd cmake-build &&
+          sudo -s
+          CPPUNIT_IGNORE="N7CppUnit10TestCallerI10ThreadTestEE.testTrySleep,N7CppUnit10TestCallerI13TimestampTestEE.testTimestamp,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI24UniqueExpireLRUCacheTestEE.testExpireN,N7CppUnit10TestCallerI18ExpireLRUCacheTestEE.testAccessExpireN,N7CppUnit10TestCallerI11PollSetTestEE.testPollClosedServer"
+          PWD=`pwd`
+          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
+
+  windows-2019-msvc-cmake:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+      - run: cmake --build cmake-build --config Release
+      - run: >-
+          cd cmake-build;
+          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+          
+  windows-2019-msvc-buildwin-x64:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+      
+  windows-2019-msvc-buildwin-win32:
+    runs-on: windows-2019
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
+
+  windows-2022-msvc-buildwin-x64:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
   windows-2022-msvc-buildwin-win32:
     runs-on: windows-2022
@@ -190,18 +190,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: .\buildwin.ps1 -poco_base . -vs 170 -action build -linkmode all -config release -platform Win32 -samples -tests -omit "Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
-#
-#  windows-2022-msvc-cmake-2022:
-#    runs-on: windows-2022
-#    env:
-#      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
-#      - run: cmake --build cmake-build --config Release
-#      - run: >-
-#          cd cmake-build;
-#          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+
+  windows-2022-msvc-cmake-2022:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+      - run: cmake --build cmake-build --config Release
+      - run: >-
+          cd cmake-build;
+          ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
 
 # missing asan dll path
 #  windows-2022-msvc-cmake-2022-asan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Encodings;Crypto;NetSSL_OpenSSL;Data/MySQL;Data/PostgreSQL;JWT"
+      - run: .\buildwin.ps1 -poco_base . -vs 160 -action build -linkmode all -config release -platform x64 -samples -tests -omit "Encodings,Crypto,NetSSL_OpenSSL,Data/MySQL,Data/PostgreSQL,JWT"
 
   windows-2022-msvc-cmake-2022:
     runs-on: windows-2022

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -409,10 +409,7 @@ function Build-Exec([string] $tool, [string] $vsProject, [switch] $skipStatic)
 
 
 function Build-Components([string] $extension, [string] $type)
-{
-	$dummy = Get-Content "$poco_base\components"
-	Write-Host "$dummy"
-	
+{	
 	Get-Content "$poco_base\components" | Foreach-Object {
 
 		$component = $_
@@ -422,22 +419,10 @@ function Build-Components([string] $extension, [string] $type)
 		$suffix = "_vs$vs"
 
 		$omitArray = @()
-		$omit.Split(',') | ForEach {
+		$omit.Split(';') | ForEach {
 				$omitArray += $_.Trim()
 		}
 		
-		Write-Host "Omit Array: $omitArray"
-		Write-Host "Component: $component"
-		
-		if ($omitArray -NotContains $component) 
-		{
-			Write-Host "Not in Omit Array"
-		} 
-		else 
-		{
-			Write-Host "In Omit Array"
-		}			
-
 		if ($omitArray -NotContains $component)
 		{
 			$vsProject = "$poco_base\$componentDir\$componentName$($suffix).$($extension)"

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -422,7 +422,7 @@ function Build-Components([string] $extension, [string] $type)
 		$suffix = "_vs$vs"
 
 		$omitArray = @()
-		$omit.Split(',;') | ForEach {
+		$omit.Split(',') | ForEach {
 				$omitArray += $_.Trim()
 		}
 		

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -11,7 +11,7 @@
 #              [-platform     Win32 | x64 | WinCE | WEC2013]
 #              [-samples]
 #              [-tests]
-#              [-omit         "Lib1X;LibY;LibZ;..."]
+#              [-omit         "Lib1X,LibY,LibZ,..."]
 #              [-tool         msbuild | devenv]
 #              [-useenv       env | noenv]
 #              [-verbosity    m[inimal] | q[uiet] | n[ormal] | d[etailed] | diag[nostic]]
@@ -216,7 +216,7 @@ function Process-Input
 		Write-Host '						 [-platform		 Win32 | x64 | WinCE | WEC2013]'
 		Write-Host '						 [-samples]'
 		Write-Host '						 [-tests]'
-		Write-Host '						 [-omit				 "Lib1X;LibY;LibZ;..."]'
+		Write-Host '						 [-omit				 "Lib1X,LibY,LibZ,..."]'
 		Write-Host '						 [-tool				 msbuild | devenv]'
 		Write-Host '						 [-useenv			 env | noenv]'
 		Write-Host '						 [-verbosity		minimal | quiet | normal | detailed | diagnostic'
@@ -419,7 +419,7 @@ function Build-Components([string] $extension, [string] $type)
 		$suffix = "_vs$vs"
 
 		$omitArray = @()
-		$omit.Split(';') | ForEach {
+		$omit.Split(',') | ForEach {
 				$omitArray += $_.Trim()
 		}
 		

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -423,6 +423,9 @@ function Build-Components([string] $extension, [string] $type)
 		$omit.Split(',;') | ForEach {
 				$omitArray += $_.Trim()
 		}
+		
+		Write-Host "Omit Array: $omitArray"
+		Write-Host "Component: $component"
 
 		if ($omitArray -NotContains $component)
 		{

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -410,7 +410,9 @@ function Build-Exec([string] $tool, [string] $vsProject, [switch] $skipStatic)
 
 function Build-Components([string] $extension, [string] $type)
 {
-
+	$dummy = Get-Content "$poco_base\components"
+	Write-Host "$dummy"
+	
 	Get-Content "$poco_base\components" | Foreach-Object {
 
 		$component = $_

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -428,6 +428,15 @@ function Build-Components([string] $extension, [string] $type)
 		
 		Write-Host "Omit Array: $omitArray"
 		Write-Host "Component: $component"
+		
+		if ($omitArray -NotContains $component) 
+		{
+			Write-Host "Not in Omit Array"
+		} 
+		else 
+		{
+			Write-Host "Not in Omit Array"
+		}			
 
 		if ($omitArray -NotContains $component)
 		{

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -408,7 +408,7 @@ function Build-Exec([string] $tool, [string] $vsProject, [switch] $skipStatic)
 }
 
 
-function Build-Components([string] $extension, [string] $platformName, [string] $type)
+function Build-Components([string] $extension, [string] $type)
 {
 
 	Get-Content "$poco_base\components" | Foreach-Object {
@@ -426,11 +426,11 @@ function Build-Components([string] $extension, [string] $platformName, [string] 
 
 		if ($omitArray -NotContains $component)
 		{
-			$vsProject = "$poco_base\$componentDir\$componentName$($platformName)$($suffix).$($extension)"
+			$vsProject = "$poco_base\$componentDir\$componentName$($suffix).$($extension)"
 
 			if (!(Test-Path -Path $vsProject)) # when VS project name is not same as directory name
 			{
-				$vsProject = "$poco_base\$componentDir$($platformName)$($suffix).$($extension)"
+				$vsProject = "$poco_base\$componentDir$($suffix).$($extension)"
 				if (!(Test-Path -Path $vsProject)) # not found
 				{
 					Write-Host "+------------------------------------------------------------------"
@@ -450,7 +450,7 @@ function Build-Components([string] $extension, [string] $platformName, [string] 
 			}
 			ElseIf ($tests -and ($type -eq "test"))
 			{
-				$vsTestProject = "$poco_base\$componentDir\testsuite\TestSuite$($platformName)$($suffix).$($extension)"
+				$vsTestProject = "$poco_base\$componentDir\testsuite\TestSuite$($suffix).$($extension)"
 				Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 				Write-Host "| Building $vsTestProject"
 				Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
@@ -458,13 +458,13 @@ function Build-Components([string] $extension, [string] $platformName, [string] 
 
 				if ($component -eq "Foundation") # special case for Foundation, which needs test app and dll
 				{
-					$vsTestProject = "$poco_base\$componentDir\testsuite\TestApp$($platformName)$($suffix).$($extension)"
+					$vsTestProject = "$poco_base\$componentDir\testsuite\TestApp$($suffix).$($extension)"
 					Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 					Write-Host "| Building $vsTestProject"
 					Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 					Build-Exec $tool $vsTestProject
 
-					$vsTestProject = "$poco_base\$componentDir\testsuite\TestLibrary$($platformName)$($suffix).$($extension)"
+					$vsTestProject = "$poco_base\$componentDir\testsuite\TestLibrary$($suffix).$($extension)"
 					Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 					Write-Host "| Building $vsTestProject"
 					Write-Host "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
@@ -476,7 +476,7 @@ function Build-Components([string] $extension, [string] $platformName, [string] 
 				if ($platform -eq 'x64')
 				{
 					Get-Childitem "$poco_base\$($componentDir)" -Recurse |`
-						Where {$_.Extension -Match $extension -And $_.DirectoryName -Like "*samples*" -And $_.BaseName -Like "*$platformName$($suffix)" } `
+						Where {$_.Extension -Match $extension -And $_.DirectoryName -Like "*samples*" -And $_.BaseName -Like "*$($suffix)" } `
 						| Build-samples "$_"
 				}
 				else
@@ -504,11 +504,11 @@ function Build
 	if ($vs -lt 100) { $extension = 'vcproj'	}
 	else										 { $extension = 'vcxproj' }
 
-	$platformName = ''
+	
 
-	Build-Components $extension $platformName "lib"
-	Build-Components $extension $platformName "test"
-	Build-Components $extension $platformName "sample"
+	Build-Components $extension "lib"
+	Build-Components $extension "test"
+	Build-Components $extension "sample"
 }
 
 

--- a/buildwin.ps1
+++ b/buildwin.ps1
@@ -94,7 +94,7 @@ function Add-VSCOMNTOOLS([int] $vsver)
 			$range='[17.0,18.0)'
 		}
 		
-		$installationPath = Get-VSSetupInstance | Select-VSSetupInstance -Version $range -Latest -Require Microsoft.VisualStudio.Component.VC.Tools.x86.x64 | select InstallationPath
+		$installationPath = Get-VSSetupInstance | Select-VSSetupInstance -Version $range -product * -Latest -Require Microsoft.VisualStudio.Component.VC.Tools.x86.x64 | select InstallationPath
 		$vscomntools = $installationPath.psobject.properties.Value;
 		if ($vsver -eq 150)
 		{
@@ -505,8 +505,6 @@ function Build
 	else										 { $extension = 'vcxproj' }
 
 	$platformName = ''
-	if ($platform -eq 'x64')			 { $platformName = '_x64' }
-	elseif ($platform -eq 'WinCE') { $platformName = '_CE' }
 
 	Build-Components $extension $platformName "lib"
 	Build-Components $extension $platformName "test"


### PR DESCRIPTION
If build x64 the scripts looks for the _x64.vcproj Files which no longer exists. By removing this the Build is possible.
If only the Build Tools for Visual Studio are available the script does not run because those are not recognized by the Select-VSSetupInstance Script.
Adding the parameter `-product *` also recognizes the Build Tools.

#3740