### PR TITLE
Fix error C2664: 'int EVP_PKEY_size(EVP_PKEY *)' : impossible de conv…

### DIFF
--- a/Crypto/src/EVPCipherImpl.cpp
+++ b/Crypto/src/EVPCipherImpl.cpp
@@ -84,7 +84,7 @@ namespace
 			if (EVP_PKEY_encrypt_init(_pCtx) <= 0)
         		throwError(Poco::format(fmt, std::string("EVP_PKEY_encrypt_init")));
 
-			_blockSize = EVP_PKEY_size(_pEVP);
+			_blockSize = EVP_PKEY_size(const_cast<EVP_PKEY*>(_pEVP));
 			if (!_blockSize)
 				throwError(Poco::format(fmt, std::string("EVP_PKEY_size")));
 			_pBuf = new unsigned char[_blockSize];
@@ -197,7 +197,7 @@ namespace
 			if (EVP_PKEY_decrypt_init(_pCtx) <= 0)
         		throwError(Poco::format(fmt, std::string("EVP_PKEY_decrypt_init")));
 
-			_blockSize = EVP_PKEY_size(_pEVP);
+			_blockSize = EVP_PKEY_size(const_cast<EVP_PKEY*>(_pEVP));
 			if (!_blockSize)
 				throwError(Poco::format(fmt, std::string("EVP_PKEY_size")));
 			_pBuf = new unsigned char[_blockSize];


### PR DESCRIPTION
Hi

This PR fixes the VS2019 error on line 81 of  `poco\crypto\src\EVPCipherImpl.cpp`
```
		std::memset(holder, 0, sizeof(Placeholder));
```
```
Error C2664: unable to convert the argument 1 from 'const EVP_PKEY *' to 'EVP_PKEY *'
```
Signed-off-by: Francis ANDRE <francis.andre.kampbell@orange.fr>