### PR TITLE
Add && !defined(POCO_VXWORKS_RTP) to POCO_APP_MAIN

### DIFF
--- a/Util/include/Poco/Util/Application.h
+++ b/Util/include/Poco/Util/Application.h
@@ -520,7 +520,7 @@ inline Poco::Timespan Application::uptime() const
 		}									\
 		return pApp->run();					\
 	}
-#elif defined(POCO_VXWORKS)
+#elif defined(POCO_VXWORKS) && !defined(POCO_VXWORKS_RTP)
 	#define POCO_APP_MAIN(App) \
 	int pocoAppMain(const char* appName, ...) \
 	{ \


### PR DESCRIPTION
This change allows a Poco::Util::Application to be compiled for VxWorks RTP context.