### PR TITLE
Fixed converting/correcting pre-gregorian dates (#3723).

### DIFF
--- a/Foundation/src/DateTime.cpp
+++ b/Foundation/src/DateTime.cpp
@@ -420,7 +420,14 @@ void DateTime::computeGregorian(double julianDay)
 
 void DateTime::computeDaytime()
 {
-	Timespan span(_utcTime/10);
+	Timestamp::UtcTimeVal ut(_utcTime);
+	if (ut < 0) {
+		// GH3723: UtcTimeVal is negative for pre-gregorian dates
+		// move it 1600 years to the future
+		// keeping hour, minute, second,... for corrections
+		ut += Int64(86400)*1000*1000*10*1600*365;
+	}
+	Timespan span(ut/10);
 	int hour = span.hours();
 	// Due to double rounding issues, the previous call to computeGregorian()
 	// may have crossed into the next or previous day. We need to correct that.

--- a/Foundation/testsuite/src/DateTimeFormatterTest.cpp
+++ b/Foundation/testsuite/src/DateTimeFormatterTest.cpp
@@ -14,10 +14,11 @@
 #include "Poco/DateTimeFormatter.h"
 #include "Poco/DateTimeFormat.h"
 #include "Poco/DateTime.h"
+#include "Poco/Timestamp.h"
 #include "Poco/Timespan.h"
 
-
 using Poco::DateTime;
+using Poco::Timestamp;
 using Poco::Timespan;
 using Poco::DateTimeFormat;
 using Poco::DateTimeFormatter;
@@ -65,6 +66,22 @@ void DateTimeFormatterTest::testISO8601Frac()
 
 	str = DateTimeFormatter::format(dt, DateTimeFormat::ISO8601_FRAC_FORMAT, -3600);
 	assertTrue (str == "2005-01-08T12:30:00.012034-01:00");
+}
+
+
+void DateTimeFormatterTest::testISO8601Timestamp()
+{
+	DateTime dt(1582, 10, 15, 1, 2, 34, 56, 78);
+	Timestamp ts = dt.timestamp();
+
+	std::string str = DateTimeFormatter::format(ts, DateTimeFormat::ISO8601_FRAC_FORMAT);
+	assertTrue (str == "1582-10-15T01:02:34.056078Z");
+
+	DateTime preGregorian(1580, 1, 1, 1, 2, 34, 56, 78);
+	ts = preGregorian.timestamp();
+
+	str = DateTimeFormatter::format(ts, DateTimeFormat::ISO8601_FRAC_FORMAT);
+	assertTrue (str == "1580-01-01T01:02:34.056078Z");
 }
 
 
@@ -214,6 +231,7 @@ CppUnit::Test* DateTimeFormatterTest::suite()
 
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testISO8601);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testISO8601Frac);
+	CppUnit_addTest(pSuite, DateTimeFormatterTest, testISO8601Timestamp);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testRFC822);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testRFC1123);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testHTTP);

--- a/Foundation/testsuite/src/DateTimeFormatterTest.h
+++ b/Foundation/testsuite/src/DateTimeFormatterTest.h
@@ -26,6 +26,7 @@ public:
 
 	void testISO8601();
 	void testISO8601Frac();
+	void testISO8601Timestamp();
 	void testRFC822();
 	void testRFC1123();
 	void testHTTP();


### PR DESCRIPTION
The fix is to move negative **_utcTime** in future so that it becomes positive and keeping hour, minute, second... values used for correcting double rounding issues in **DateTime::computeDaytime()**.