### PR TITLE
fix(Crypto) Update method to extract friendlyName from certificate

### DIFF
--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -125,18 +125,18 @@ PKCS12Container::~PKCS12Container()
 
 std::string PKCS12Container::extractFriendlyName(X509* pCert)
 {
-    std::string friendlyName;
-    if(pCert)
-    {
-        int len = 0;
-        char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &len));
-        if (pBuffer) {
-            friendlyName.append(pBuffer, len);
-        }
-    }
-    else throw NullPointerException("PKCS12Container::extractFriendlyName()");
+	std::string friendlyName;
+	if(pCert)
+	{
+		int len = 0;
+		char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &len));
+		if (pBuffer) {
+			friendlyName.append(pBuffer, len);
+		}
+	}
+	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
 
-    return friendlyName;
+	return friendlyName;
 }
 
 

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -125,26 +125,18 @@ PKCS12Container::~PKCS12Container()
 
 std::string PKCS12Container::extractFriendlyName(X509* pCert)
 {
-	std::string friendlyName;
-	if(pCert)
-	{
-		STACK_OF(PKCS12_SAFEBAG)*pBags = 0;
-		PKCS12_SAFEBAG*pBag = PKCS12_add_cert(&pBags, pCert);
-		if(pBag)
-		{
-			char* pBuffer = PKCS12_get_friendlyname(pBag);
-			if(pBuffer)
-			{
-				friendlyName = pBuffer;
-				OPENSSL_free(pBuffer);
-			}
-			if(pBags) sk_PKCS12_SAFEBAG_pop_free(pBags, PKCS12_SAFEBAG_free);
-		}
-		else throw OpenSSLException("PKCS12Container::extractFriendlyName()");
-	}
-	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
+    std::string friendlyName;
+    if(pCert)
+    {
+        int len = 0;
+        char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &len));
+        if (pBuffer) {
+            friendlyName.append(pBuffer, len);
+        }
+    }
+    else throw NullPointerException("PKCS12Container::extractFriendlyName()");
 
-	return friendlyName;
+    return friendlyName;
 }
 
 

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -125,18 +125,18 @@ PKCS12Container::~PKCS12Container()
 
 std::string PKCS12Container::extractFriendlyName(X509* pCert)
 {
- 	std::string friendlyName;
- 	if(pCert)
- 	{
- 		int length = 0;
- 		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
- 		if (pBuffer) {
- 			friendlyName.append(pBuffer, length);
- 		}
- 	}
- 	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
- 
- 	return friendlyName;
+	std::string friendlyName;
+	if(pCert)
+	{
+		int length = 0;
+		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
+		if (pBuffer) {
+			friendlyName.append(pBuffer, length);
+		}
+	}
+	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
+
+	return friendlyName;
 }
 
 

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -125,18 +125,18 @@ PKCS12Container::~PKCS12Container()
 
 std::string PKCS12Container::extractFriendlyName(X509* pCert)
 {
-	std::string friendlyName;
-	if(pCert)
-	{
-		int length = 0;
-		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
-		if (pBuffer) {
-			friendlyName.append(pBuffer, length);
-		}
-	}
-	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
-
-	return friendlyName;
+ 	std::string friendlyName;
+ 	if(pCert)
+ 	{
+ 		int length = 0;
+ 		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
+ 		if (pBuffer) {
+ 			friendlyName.append(pBuffer, length);
+ 		}
+ 	}
+ 	else throw NullPointerException("PKCS12Container::extractFriendlyName()");
+ 
+ 	return friendlyName;
 }
 
 

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -128,10 +128,10 @@ std::string PKCS12Container::extractFriendlyName(X509* pCert)
 	std::string friendlyName;
 	if(pCert)
 	{
-		int len = 0;
-		char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &len));
+		int length = 0;
+		char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &length));
 		if (pBuffer) {
-			friendlyName.append(pBuffer, len);
+			friendlyName.append(pBuffer, length);
 		}
 	}
 	else throw NullPointerException("PKCS12Container::extractFriendlyName()");

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -130,7 +130,8 @@ std::string PKCS12Container::extractFriendlyName(X509* pCert)
 	{
 		int length = 0;
 		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
-		if (pBuffer) {
+		if (pBuffer)
+		{
 			friendlyName.append(pBuffer, length);
 		}
 	}

--- a/Crypto/src/PKCS12Container.cpp
+++ b/Crypto/src/PKCS12Container.cpp
@@ -129,7 +129,7 @@ std::string PKCS12Container::extractFriendlyName(X509* pCert)
 	if(pCert)
 	{
 		int length = 0;
-		char* pBuffer = reinterpret_cast<char *>(X509_alias_get0(pCert, &length));
+		char* pBuffer = reinterpret_cast<char*>(X509_alias_get0(pCert, &length));
 		if (pBuffer) {
 			friendlyName.append(pBuffer, length);
 		}


### PR DESCRIPTION
Hey,
in single codebase I need to use webrtc with BoringSSL and Poco.
I ran into a few problems compiling poco with BoringSSL, I'll try to suggest some changes to make it easier for others.

First things first: the current `extractFriendlyName` method doesn't compile with BoringSSL, I asked the BoringSSL team for advice and I have a tip on that:
https://bugs.chromium.org/p/boringssl/issues/detail?id=515

The discussion shows that this is a compatible change with a positive effect on the current code.

I run the Crypto test suite and it returned:
```
...
OK (44 tests)
```

BTW: These changes are not `BoringSSL` specific.