### PR TITLE
HTTPServer Applications Slow to Terminate #3796

### DIFF
--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -173,7 +173,10 @@ void TCPServerDispatcher::stop()
 	FastMutex::ScopedLock lock(_mutex);
 	_stopped = true;
 	_queue.clear();
-	_queue.enqueueNotification(new StopNotification);
+	for (int i = 0; i < _threadPool.allocated(); i++)
+	{
+		_queue.enqueueNotification(new StopNotification);
+	}
 }
 
 


### PR DESCRIPTION
 - Queue a StopNotification for each thread in the TCPServerDispatcher thread pool. Otherwise, only one thread in the thread pool is terminated.

Signed-off-by: Stephen Balousek <sbalousek@wickedloop.com>