### PR TITLE
Fix epollfd validity checks when compiling with wepoll

### DIFF
--- a/Net/src/PollSet.cpp
+++ b/Net/src/PollSet.cpp
@@ -88,10 +88,11 @@ public:
 	{
 #ifdef WEPOLL_H_
 		if (_eventfd >= 0) eventfd(_port, _eventfd);
+		if (_epollfd) close(_epollfd);
 #else
 		if (_eventfd > 0) close(_eventfd.exchange(0));
-#endif
 		if (_epollfd >= 0) close(_epollfd);
+#endif
 	}
 
 	void add(const Socket& socket, int mode)
@@ -146,7 +147,11 @@ public:
 			close(_epollfd);
 			_socketMap.clear();
 			_epollfd = epoll_create(1);
+#ifdef WEPOLL_H_
+			if (!_epollfd) SocketImpl::error();
+#else
 			if (_epollfd < 0) SocketImpl::error();
+#endif
 		}
 #ifdef WEPOLL_H_
 		eventfd(_port, _eventfd);

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -646,7 +646,12 @@ bool SocketImpl::poll(const Poco::Timespan& timeout, int mode)
 #else
 	int epollfd = epoll_create(1);
 #endif
+
+#ifdef WEPOLL_H_
+	if (!epollfd)
+#else
 	if (epollfd < 0)
+#endif
 	{
 		error("Can't create epoll queue");
 	}


### PR DESCRIPTION
When compiled with wepoll eventfd is `HANDLE` (which is synonym for `void*`), not `int`, and errors in `epoll_create(int)` are signalled by `NULL`, not `-1`. Code that checks the eventfd validity should account for this difference.