### PR TITLE
Do not incur insane stack limit in Foundation-ThreadPool test.

### DIFF
--- a/Foundation/testsuite/src/ThreadPoolTest.cpp
+++ b/Foundation/testsuite/src/ThreadPoolTest.cpp
@@ -35,7 +35,6 @@ ThreadPoolTest::~ThreadPoolTest()
 void ThreadPoolTest::testThreadPool()
 {
 	ThreadPool pool(2, 3, 3);
-	pool.setStackSize(1);
 
 	assertTrue (pool.allocated() == 2);
 	assertTrue (pool.used() == 0);


### PR DESCRIPTION
This fixes the test on FreeBSD.