### PR TITLE
testDynamicStructEmptyString always failed

### DIFF
--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -2291,7 +2291,7 @@ void VarTest::testDynamicStructEmptyString()
 	DynamicStruct aStruct;
 	aStruct["Empty"] = "";
 	aStruct["Space"] = " ";
-	assertEqual(aStruct.toString(false), "{ \"Empty\": \"\", \"Space\": \" \" }");
+	assertEqual(aStruct.toString(true), "{ \"Empty\": \"\", \"Space\": \" \" }");
 }
 
 


### PR DESCRIPTION
There was 1 failure:
 1: N7CppUnit10TestCallerI7VarTestEE.testDynamicStructEmptyString
    "expected: "{ "Empty": "", "Space":   }" but was: "{ "Empty": "", "Space": " " }""
    in "src/VarTest.cpp", line 2294

It's happen because in test we call aStruct.toString(false). It's mean that we don't expect wrapping, but expected result was written with wrapping