### PR TITLE
Remove unnecessary dup. of std::string in NumberParser::tryParseFloat

### DIFF
--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -188,7 +188,7 @@ double NumberParser::parseFloat(const std::string& s, char decSep, char thSep)
 
 bool NumberParser::tryParseFloat(const std::string& s, double& value, char decSep, char thSep)
 {
-	return strToDouble(s.c_str(), value, decSep, thSep);
+	return strToDouble(s, value, decSep, thSep);
 }
 
 


### PR DESCRIPTION
NumberParser::tryParseFloat is calling this overload:
`bool strToDouble(const std::string& str, double& result, char decSep, char thSep, const char* inf, const char* nan)`

Since it accepts a const std::string& str,, calling with s.c_str() will create a temporary std::string to call strToDouble


-------------------
Maybe a possible patch for strToDouble would be change the strToDouble to receive a string by value without const ref and remove the std::string tmp from the code, thisway can avoid some possible multiple duplications when calling with a char* or similar.
```
bool strToDouble(std::string str, double& result, char decSep, char thSep, const char* inf, const char* nan)
{
	if (str.empty()) return false;

	using namespace double_conversion;

	trimInPlace(str);
	removeInPlace(str, thSep);
	replaceInPlace(str, decSep, '.');
	removeInPlace(str, 'f');
	result = strToDouble(str.c_str(), inf, nan);
	return !FPEnvironment::isInfinite(result) &&
		!FPEnvironment::isNaN(result);
}
```
