### PR TITLE
MongoDB replica set uri support

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -89,6 +89,9 @@ public:
 	Poco::Net::SocketAddress address() const;
 		/// Returns the address of the MongoDB server.
 
+    std::string uri() const;
+        /// Returns the uri on which the connection was made.
+
 	void connect(const std::string& hostAndPort);
 		/// Connects to the given MongoDB server.
 		///
@@ -146,6 +149,7 @@ protected:
 private:
 	Poco::Net::SocketAddress _address;
 	Poco::Net::StreamSocket _socket;
+    std::string _uri;
 };
 
 
@@ -156,6 +160,11 @@ inline Net::SocketAddress Connection::address() const
 {
 	return _address;
 }
+inline std::string Connection::uri() const
+{
+    return _uri;
+}
+
 
 
 } } // namespace Poco::MongoDB

--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -89,8 +89,8 @@ public:
 	Poco::Net::SocketAddress address() const;
 		/// Returns the address of the MongoDB server.
 
-    std::string uri() const;
-        /// Returns the uri on which the connection was made.
+	std::string uri() const;
+		/// Returns the uri on which the connection was made.
 
 	void connect(const std::string& hostAndPort);
 		/// Connects to the given MongoDB server.
@@ -162,7 +162,7 @@ inline Net::SocketAddress Connection::address() const
 }
 inline std::string Connection::uri() const
 {
-    return _uri;
+	return _uri;
 }
 
 

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -221,7 +221,7 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
         else if (it->first == "readPreference")
         {
             readPreference= it->second;
-            if (readPreference != "primary" or readPreference != "secondary"){
+            if (readPreference != "primary" and readPreference != "secondary"){
                 throw Poco::InvalidArgumentException("read preference", readPreference);
             }
         }

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -143,72 +143,142 @@ void Connection::connect(const Poco::Net::StreamSocket& socket)
 }
 
 
-void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
-{
-	Poco::URI theURI(uri);
-	if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
+    void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
+    {
+        std::vector<std::string> str_addresses;
+        std::string new_uri;
 
-	std::string userInfo = theURI.getUserInfo();
-	std::string host = theURI.getHost();
-	Poco::UInt16 port = theURI.getPort();
-	if (port == 0) port = 27017;
+        if (uri.find(',') != std::string::npos) {
+            size_t pos;
+            size_t head = 0;
+            if ((pos = uri.find("@")) != std::string::npos){
+                head = pos + 1;
+            } else if ((pos = uri.find("://")) != std::string::npos){
+                head = pos + 3;
+            }
 
-	std::string databaseName = theURI.getPath();
-	if (!databaseName.empty() && databaseName[0] == '/') databaseName.erase(0, 1);
-	if (databaseName.empty()) databaseName = "admin";
+            std::string tempstr;
+            std::string::const_iterator it = uri.begin();
+            it += head;
+            size_t tail = head;
+            for (;it != uri.end() && *it != '?' && *it != '/'; ++it) {
+                tempstr += *it;
+                tail++;
+            }
 
-	bool ssl = false;
-	Poco::Timespan connectTimeout;
-	Poco::Timespan socketTimeout;
-	std::string authMechanism = Database::AUTH_SCRAM_SHA1;
+            it = tempstr.begin();
+            std::string token;
+            for (;it != tempstr.end(); ++it) {
+                if (*it == ','){
+                    new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+                    str_addresses.push_back(new_uri);
+                    token = "";
+                }else {
+                    token += *it;
+                }
+            }
+            new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+            str_addresses.push_back(new_uri);
+        }else{
+            str_addresses.push_back(uri);
+        }
 
-	Poco::URI::QueryParameters params = theURI.getQueryParameters();
-	for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
-	{
-		if (it->first == "ssl")
-		{
-			ssl = (it->second == "true");
-		}
-		else if (it->first == "connectTimeoutMS")
-		{
-			connectTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
-		}
-		else if (it->first == "socketTimeoutMS")
-		{
-			socketTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
-		}
-		else if (it->first == "authMechanism")
-		{
-			authMechanism = it->second;
-		}
-	}
+        new_uri = str_addresses.front();
+        Poco::URI theURI(new_uri);
+        if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
 
-	connect(socketFactory.createSocket(host, port, connectTimeout, ssl));
+        std::string userInfo = theURI.getUserInfo();
 
-	if (socketTimeout > 0)
-	{
-		_socket.setSendTimeout(socketTimeout);
-		_socket.setReceiveTimeout(socketTimeout);
-	}
+        std::string databaseName = theURI.getPath();
+        if (!databaseName.empty() && databaseName[0] == '/') databaseName.erase(0, 1);
+        if (databaseName.empty()) databaseName = "admin";
 
-	if (!userInfo.empty())
-	{
-		std::string username;
-		std::string password;
-		std::string::size_type pos = userInfo.find(':');
-		if (pos != std::string::npos)
-		{
-			username.assign(userInfo, 0, pos++);
-			password.assign(userInfo, pos, userInfo.size() - pos);
-		}
-		else username = userInfo;
+        bool ssl = false;
+        Poco::Timespan connectTimeout;
+        Poco::Timespan socketTimeout;
+        std::string authMechanism = Database::AUTH_SCRAM_SHA1;
+        std::string readPreference="primary";
 
-		Database database(databaseName);
-		if (!database.authenticate(*this, username, password, authMechanism))
-			throw Poco::NoPermissionException(Poco::format("Access to MongoDB database %s denied for user %s", databaseName, username));
-	}
-}
+        Poco::URI::QueryParameters params = theURI.getQueryParameters();
+        for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
+        {
+            if (it->first == "ssl")
+            {
+                ssl = (it->second == "true");
+            }
+            else if (it->first == "connectTimeoutMS")
+            {
+                connectTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
+            }
+            else if (it->first == "socketTimeoutMS")
+            {
+                socketTimeout = static_cast<Poco::Timespan::TimeDiff>(1000)*Poco::NumberParser::parse(it->second);
+            }
+            else if (it->first == "authMechanism")
+            {
+                authMechanism = it->second;
+            }
+            else if (it->first == "readPreference")
+            {
+                readPreference= it->second;
+                if (readPreference != "primary" or readPreference != "secondary"){
+                    throw Poco::InvalidArgumentException("read preference", readPreference);
+                }
+            }
+        }
 
+        for (std::vector<std::string>::const_iterator it = str_addresses.cbegin();it != str_addresses.cend(); ++it){
+            new_uri = *it;
+            Poco::URI theURI(new_uri);
+
+            std::string host = theURI.getHost();
+            Poco::UInt16 port = theURI.getPort();
+            if (port == 0) port = 27017;
+
+            connect(socketFactory.createSocket(host, port, connectTimeout, ssl));
+            _uri = new_uri;
+            if (socketTimeout > 0)
+            {
+                _socket.setSendTimeout(socketTimeout);
+                _socket.setReceiveTimeout(socketTimeout);
+            }
+            if (str_addresses.size() > 1) {
+                Poco::MongoDB::QueryRequest request("admin.$cmd");
+                request.setNumberToReturn(1);
+                request.selector().add("isMaster", 1);
+                Poco::MongoDB::ResponseMessage response;
+
+                sendRequest(request, response);
+                _uri = new_uri;
+                if (!response.documents().empty()) {
+                    Poco::MongoDB::Document::Ptr doc = response.documents()[0];
+                    if (doc->get<bool>("ismaster") && readPreference == "primary") {
+                        break;
+                    } else if (readPreference == "secondary") {
+                        break;
+                    } else if (it + 1 == str_addresses.cend()) {
+                        throw Poco::URISyntaxException(uri);
+                    }
+                }
+            }
+        }
+        if (!userInfo.empty()) {
+            std::string username;
+            std::string password;
+            std::string::size_type pos = userInfo.find(':');
+            if (pos != std::string::npos)
+            {
+                username.assign(userInfo, 0, pos++);
+                password.assign(userInfo, pos, userInfo.size() - pos);
+            }
+            else username = userInfo;
+
+            Database database(databaseName);
+
+            if (!database.authenticate(*this, username, password, authMechanism))
+                throw Poco::NoPermissionException(Poco::format("Access to MongoDB database %s denied for user %s", databaseName, username));
+        }
+    }
 
 void Connection::disconnect()
 {

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -145,8 +145,8 @@ void Connection::connect(const Poco::Net::StreamSocket& socket)
 
 void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 {
-    std::vector<std::string> str_addresses;
-    std::string new_uri;
+    std::vector<std::string> strAddresses;
+    std::string newURI;
 
     if (uri.find(',') != std::string::npos)
     {
@@ -177,8 +177,8 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
         {
             if (*it == ',')
             {
-                new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
-                str_addresses.push_back(new_uri);
+                newURI = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+                strAddresses.push_back(newURI);
                 token = "";
             }
             else
@@ -186,16 +186,16 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
                 token += *it;
             }
         }
-        new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
-        str_addresses.push_back(new_uri);
+        newURI = uri.substr(0, head) + token + uri.substr(tail, uri.length());
+        strAddresses.push_back(newURI);
     }
     else
     {
-        str_addresses.push_back(uri);
+        strAddresses.push_back(uri);
     }
 
-    new_uri = str_addresses.front();
-    Poco::URI theURI(new_uri);
+    newURI = strAddresses.front();
+    Poco::URI theURI(newURI);
     if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
 
     std::string userInfo = theURI.getUserInfo();
@@ -239,22 +239,22 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
         }
     }
 
-    for (std::vector<std::string>::const_iterator it = str_addresses.cbegin();it != str_addresses.cend(); ++it){
-        new_uri = *it;
-        Poco::URI theURI(new_uri);
+    for (std::vector<std::string>::const_iterator it = strAddresses.cbegin();it != strAddresses.cend(); ++it){
+        newURI = *it;
+        Poco::URI theURI(newURI);
 
         std::string host = theURI.getHost();
         Poco::UInt16 port = theURI.getPort();
         if (port == 0) port = 27017;
 
         connect(socketFactory.createSocket(host, port, connectTimeout, ssl));
-        _uri = new_uri;
+        _uri = newURI;
         if (socketTimeout > 0)
         {
             _socket.setSendTimeout(socketTimeout);
             _socket.setReceiveTimeout(socketTimeout);
         }
-        if (str_addresses.size() > 1)
+        if (strAddresses.size() > 1)
         {
             Poco::MongoDB::QueryRequest request("admin.$cmd");
             request.setNumberToReturn(1);
@@ -262,7 +262,7 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
             Poco::MongoDB::ResponseMessage response;
 
             sendRequest(request, response);
-            _uri = new_uri;
+            _uri = newURI;
             if (!response.documents().empty())
             {
                 Poco::MongoDB::Document::Ptr doc = response.documents()[0];
@@ -274,7 +274,7 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
                 {
                     break;
                 }
-                else if (it + 1 == str_addresses.cend())
+                else if (it + 1 == strAddresses.cend())
                 {
                     throw Poco::URISyntaxException(uri);
                 }

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -148,12 +148,16 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
     std::vector<std::string> str_addresses;
     std::string new_uri;
 
-    if (uri.find(',') != std::string::npos) {
+    if (uri.find(',') != std::string::npos)
+    {
         size_t pos;
         size_t head = 0;
-        if ((pos = uri.find("@")) != std::string::npos){
+        if ((pos = uri.find("@")) != std::string::npos)
+        {
             head = pos + 1;
-        } else if ((pos = uri.find("://")) != std::string::npos){
+        }
+        else if ((pos = uri.find("://")) != std::string::npos)
+        {
             head = pos + 3;
         }
 
@@ -161,25 +165,32 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
         std::string::const_iterator it = uri.begin();
         it += head;
         size_t tail = head;
-        for (;it != uri.end() && *it != '?' && *it != '/'; ++it) {
+        for (;it != uri.end() && *it != '?' && *it != '/'; ++it)
+        {
             tempstr += *it;
             tail++;
         }
 
         it = tempstr.begin();
         std::string token;
-        for (;it != tempstr.end(); ++it) {
-            if (*it == ','){
+        for (;it != tempstr.end(); ++it)
+        {
+            if (*it == ',')
+            {
                 new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
                 str_addresses.push_back(new_uri);
                 token = "";
-            }else {
+            }
+            else
+            {
                 token += *it;
             }
         }
         new_uri = uri.substr(0, head) + token + uri.substr(tail, uri.length());
         str_addresses.push_back(new_uri);
-    }else{
+    }
+    else
+    {
         str_addresses.push_back(uri);
     }
 
@@ -221,7 +232,8 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
         else if (it->first == "readPreference")
         {
             readPreference= it->second;
-            if (readPreference != "primary" and readPreference != "secondary"){
+            if (readPreference != "primary" && readPreference != "secondary")
+            {
                 throw Poco::InvalidArgumentException("read preference", readPreference);
             }
         }
@@ -242,7 +254,8 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
             _socket.setSendTimeout(socketTimeout);
             _socket.setReceiveTimeout(socketTimeout);
         }
-        if (str_addresses.size() > 1) {
+        if (str_addresses.size() > 1)
+        {
             Poco::MongoDB::QueryRequest request("admin.$cmd");
             request.setNumberToReturn(1);
             request.selector().add("isMaster", 1);
@@ -250,19 +263,26 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 
             sendRequest(request, response);
             _uri = new_uri;
-            if (!response.documents().empty()) {
+            if (!response.documents().empty())
+            {
                 Poco::MongoDB::Document::Ptr doc = response.documents()[0];
-                if (doc->get<bool>("ismaster") && readPreference == "primary") {
+                if (doc->get<bool>("ismaster") && readPreference == "primary")
+                {
                     break;
-                } else if (readPreference == "secondary") {
+                }
+                else if (readPreference == "secondary")
+                {
                     break;
-                } else if (it + 1 == str_addresses.cend()) {
+                }
+                else if (it + 1 == str_addresses.cend())
+                {
                     throw Poco::URISyntaxException(uri);
                 }
             }
         }
     }
-    if (!userInfo.empty()) {
+    if (!userInfo.empty())
+    {
         std::string username;
         std::string password;
         std::string::size_type pos = userInfo.find(':');


### PR DESCRIPTION
While working with Poco, I noticed that there is no way to connect to a MongoDB cluster using a replica set uri. Here I made basic support for mongodb replica set uri(uri with host:port enumiration) and readPreference option.