### PR TITLE
FIX: PostgeSQL support in ActiveRecord

### DIFF
--- a/ActiveRecord/Compiler/src/CodeGenerator.cpp
+++ b/ActiveRecord/Compiler/src/CodeGenerator.cpp
@@ -68,13 +68,13 @@ void CodeGenerator::writeHeaderComment(const std::string& fileName) const
 
 void CodeGenerator::writeInclude(const std::string& nameSpace, const std::string& name) const
 {
-	_stream << "#include \"";
+	_stream << "#include <";
 	auto ns = splitNameSpace(nameSpace);
 	for (const auto& s: ns)
 	{
 		_stream << s << '/';
 	}
-	_stream << name << ".h\"\n";
+	_stream << name << ".h>\n";
 }
 
 

--- a/ActiveRecord/Compiler/src/HeaderGenerator.cpp
+++ b/ActiveRecord/Compiler/src/HeaderGenerator.cpp
@@ -33,10 +33,13 @@ void HeaderGenerator::generate() const
 	writeHeaderComment(_class.name + ".h");
 	std::string guard = includeGuard(_class.nameSpace, _class.name);
 	stream()
+		<< "#pragma once\n"
 		<< "#ifndef " << guard << "\n"
 		<< "#define " << guard << "\n"
 		<< "\n\n";
-	stream() << "#include \"Poco/ActiveRecord/ActiveRecord.h\"\n";
+	stream() << "#include <Poco/ActiveRecord/ActiveRecord.h>\n";
+	if (!_class.dllExport.empty())
+		writeInclude(_class.nameSpace, "Config"s);
 	for (const auto& ref: _class.references)
 	{
 		writeInclude(_class.nameSpace, ref);
@@ -71,7 +74,10 @@ std::string HeaderGenerator::includeGuard(const std::string& nameSpace, const st
 
 void HeaderGenerator::writeClass() const
 {
-	stream() << "class " << _class.name << ": public ";
+	stream() << "class ";
+	if (!_class.dllExport.empty())
+		stream() << _class.dllExport << " ";
+	stream() << _class.name << ": public ";
 	if (_class.key.empty())
 		stream() << "Poco::ActiveRecord::KeylessActiveRecord";
 	else
@@ -235,7 +241,6 @@ void HeaderGenerator::writeVariables() const
 void HeaderGenerator::writeGetter(const Property& property) const
 {
 	stream() << "\t" << paramType(property) << " " << property.name << "() const;\n";
-
 }
 
 

--- a/ActiveRecord/Compiler/src/ImplGenerator.cpp
+++ b/ActiveRecord/Compiler/src/ImplGenerator.cpp
@@ -30,7 +30,9 @@ ImplGenerator::ImplGenerator(const std::string& source, std::ostream& stream, co
 
 void ImplGenerator::generate() const
 {
-	stream() << "#include \"pch.h\"\n\n";
+	if (!_class.precompiledHeader.empty())
+		stream() << "#include \"" << _class.precompiledHeader <<"\"\n\n";
+
 	writeHeaderComment(_class.name + ".cpp");
 	writeInclude(_class.nameSpace, _class.name);
 
@@ -274,7 +276,7 @@ void ImplGenerator::writeInsert() const
 
 	if (_class.autoIncrementID)
 	{
-		stream() << "\tupdateID(context()->session(), \"" << _class.table << "\", \"" << keyProperty(_class).column << "\"); \n";
+		stream() << "\tupdateID(context()->session(), \"" << _class.table << "\"s, \"" << keyProperty(_class).column << "\"s); \n";
 	}
 
 	stream() << "}\n";

--- a/ActiveRecord/Compiler/src/ImplGenerator.cpp
+++ b/ActiveRecord/Compiler/src/ImplGenerator.cpp
@@ -30,6 +30,7 @@ ImplGenerator::ImplGenerator(const std::string& source, std::ostream& stream, co
 
 void ImplGenerator::generate() const
 {
+	stream() << "#include \"pch.h\"\n\n";
 	writeHeaderComment(_class.name + ".cpp");
 	writeInclude(_class.nameSpace, _class.name);
 
@@ -37,7 +38,7 @@ void ImplGenerator::generate() const
 	{
 		if (keyType(_class) == "Poco::UUID")
 		{
-			stream() << "#include \"Poco/UUIDGenerator.h\"\n";
+			stream() << "#include <Poco/UUIDGenerator.h>\n";
 		}
 	}
 
@@ -224,7 +225,7 @@ void ImplGenerator::writeInsert() const
 		<< "\t\t<< \"INSERT INTO " << _class.table << " (";
 
 	bool needComma = false;
-	if (!_class.key.empty())
+	if (!_class.key.empty() && !_class.autoIncrementID)
 	{
 		stream() << keyProperty(_class).column;
 		needComma = true;
@@ -245,12 +246,9 @@ void ImplGenerator::writeInsert() const
 		<< "\t\t<< \"  VALUES (";
 
 	needComma = false;
-	if (!_class.key.empty())
+	if (!_class.key.empty() && !_class.autoIncrementID)
 	{
-		if (_class.autoIncrementID)
-			stream() << "NULL";
-		else
-			stream() << "\" << pSPP->next() << \"";
+		stream() << "\" << pSPP->next() << \"";
 		needComma = true;
 	}
 
@@ -276,7 +274,7 @@ void ImplGenerator::writeInsert() const
 
 	if (_class.autoIncrementID)
 	{
-		stream() << "\tupdateID(context()->session());\n";
+		stream() << "\tupdateID(context()->session(), \"" << _class.table << "\", \"" << keyProperty(_class).column << "\"); \n";
 	}
 
 	stream() << "}\n";

--- a/ActiveRecord/Compiler/src/Parser.cpp
+++ b/ActiveRecord/Compiler/src/Parser.cpp
@@ -103,6 +103,7 @@ void Parser::endElement(const Poco::XML::XMLString& uri, const Poco::XML::XMLStr
 void Parser::handleProject(const Poco::XML::Attributes& attributes)
 {
 	_nameSpace = attributes.getValue("namespace"s);
+	_dllExport = attributes.getValue("dllexport"s);
 	_convertCamelCase = parseBool("convertCamelCase"s, attributes.getValue("convertCamelCase"s));
 }
 
@@ -111,6 +112,7 @@ void Parser::handleClass(const Poco::XML::Attributes& attributes)
 {
 	_class.name = attributes.getValue("name"s);
 	_class.nameSpace = _nameSpace;
+	_class.dllExport = _dllExport;
 	_class.table = attributes.getValue("table"s);
 	if (_class.table.empty()) _class.table = toDatabaseName(_class.name);
 	_class.key = attributes.getValue("key"s);
@@ -231,14 +233,14 @@ char Parser::parseCardinality(const std::string& cardinality) const
 }
 
 
-bool Parser::parseBool(const std::string& name, const std::string& value, bool deflt) const
+bool Parser::parseBool(const std::string& name, const std::string& value, bool defaultValue) const
 {
 	if (value == "true")
 		return true;
 	else if (value == "false")
 		return false;
 	else if (value.empty())
-		return deflt;
+		return defaultValue;
 	else throw Poco::InvalidArgumentException(Poco::format("%s: %s value must be 'true' or 'false'", name, where()));
 }
 

--- a/ActiveRecord/Compiler/src/Parser.cpp
+++ b/ActiveRecord/Compiler/src/Parser.cpp
@@ -104,6 +104,7 @@ void Parser::handleProject(const Poco::XML::Attributes& attributes)
 {
 	_nameSpace = attributes.getValue("namespace"s);
 	_dllExport = attributes.getValue("dllexport"s);
+	_precompiledHeader = attributes.getValue("precompiledHeader"s);
 	_convertCamelCase = parseBool("convertCamelCase"s, attributes.getValue("convertCamelCase"s));
 }
 
@@ -113,6 +114,7 @@ void Parser::handleClass(const Poco::XML::Attributes& attributes)
 	_class.name = attributes.getValue("name"s);
 	_class.nameSpace = _nameSpace;
 	_class.dllExport = _dllExport;
+	_class.precompiledHeader = _precompiledHeader;
 	_class.table = attributes.getValue("table"s);
 	if (_class.table.empty()) _class.table = toDatabaseName(_class.name);
 	_class.key = attributes.getValue("key"s);

--- a/ActiveRecord/Compiler/src/Parser.h
+++ b/ActiveRecord/Compiler/src/Parser.h
@@ -51,6 +51,7 @@ private:
 	const Poco::XML::Locator* _pLocator = nullptr;
 	bool _convertCamelCase = false;
 	std::string _nameSpace;
+	std::string _dllExport;
 	Class _class;
 	ClassMap _classes;
 	std::vector<std::string> _elemStack;

--- a/ActiveRecord/Compiler/src/Parser.h
+++ b/ActiveRecord/Compiler/src/Parser.h
@@ -52,6 +52,7 @@ private:
 	bool _convertCamelCase = false;
 	std::string _nameSpace;
 	std::string _dllExport;
+	std::string _precompiledHeader;
 	Class _class;
 	ClassMap _classes;
 	std::vector<std::string> _elemStack;

--- a/ActiveRecord/Compiler/src/Types.h
+++ b/ActiveRecord/Compiler/src/Types.h
@@ -44,6 +44,7 @@ struct Class
 	std::string name;
 	std::string nameSpace;
 	std::string dllExport;
+	std::string precompiledHeader;
 	std::string table;
 	std::string key;
 	bool autoIncrementID = false;

--- a/ActiveRecord/Compiler/src/Types.h
+++ b/ActiveRecord/Compiler/src/Types.h
@@ -43,6 +43,7 @@ struct Class
 {
 	std::string name;
 	std::string nameSpace;
+	std::string dllExport;
 	std::string table;
 	std::string key;
 	bool autoIncrementID = false;

--- a/ActiveRecord/testsuite/include/ORM/Employee.h
+++ b/ActiveRecord/testsuite/include/ORM/Employee.h
@@ -5,12 +5,13 @@
 //
 
 
+#pragma once
 #ifndef ORM_Employee_INCLUDED
 #define ORM_Employee_INCLUDED
 
 
-#include "Poco/ActiveRecord/ActiveRecord.h"
-#include "ORM/Role.h"
+#include <Poco/ActiveRecord/ActiveRecord.h>
+#include <ORM/Role.h>
 
 
 namespace ORM {

--- a/ActiveRecord/testsuite/include/ORM/Role.h
+++ b/ActiveRecord/testsuite/include/ORM/Role.h
@@ -5,11 +5,12 @@
 //
 
 
+#pragma once
 #ifndef ORM_Role_INCLUDED
 #define ORM_Role_INCLUDED
 
 
-#include "Poco/ActiveRecord/ActiveRecord.h"
+#include <Poco/ActiveRecord/ActiveRecord.h>
 
 
 namespace ORM {

--- a/ActiveRecord/testsuite/src/Employee.cpp
+++ b/ActiveRecord/testsuite/src/Employee.cpp
@@ -5,8 +5,8 @@
 //
 
 
-#include "ORM/Employee.h"
-#include "Poco/UUIDGenerator.h"
+#include <ORM/Employee.h>
+#include <Poco/UUIDGenerator.h>
 
 
 using namespace std::string_literals;

--- a/ActiveRecord/testsuite/src/Role.cpp
+++ b/ActiveRecord/testsuite/src/Role.cpp
@@ -5,7 +5,7 @@
 //
 
 
-#include "ORM/Role.h"
+#include <ORM/Role.h>
 
 
 using namespace std::string_literals;
@@ -52,11 +52,11 @@ void Role::insert()
 	Poco::ActiveRecord::StatementPlaceholderProvider::Ptr pSPP(context()->statementPlaceholderProvider());
 
 	context()->session()
-		<< "INSERT INTO roles (id, name, description)"
-		<< "  VALUES (NULL, " << pSPP->next() << ", " << pSPP->next() << ")",
+		<< "INSERT INTO roles (name, description)"
+		<< "  VALUES (" << pSPP->next() << ", " << pSPP->next() << ")",
 		use(*this),
 		now;
-	updateID(context()->session());
+	updateID(context()->session(), "roles"s, "id"s); 
 }
 
 

--- a/Data/PostgreSQL/src/SessionImpl.cpp
+++ b/Data/PostgreSQL/src/SessionImpl.cpp
@@ -12,6 +12,7 @@
 //
 
 
+#include "Poco/Data/PostgreSQL/Connector.h"
 #include "Poco/Data/PostgreSQL/SessionImpl.h"
 #include "Poco/Data/PostgreSQL/PostgreSQLException.h"
 #include "Poco/Data/PostgreSQL/PostgreSQLStatementImpl.h"
@@ -58,7 +59,7 @@ namespace PostgreSQL {
 
 SessionImpl::SessionImpl(const std::string& aConnectionString, std::size_t aLoginTimeout):
 	Poco::Data::AbstractSessionImpl<SessionImpl>(aConnectionString, aLoginTimeout),
-	_connectorName("postgresql")
+	_connectorName(Connector::KEY)
 {
 	setProperty("handle", static_cast<SessionHandle*>(&_sessionHandle));
 	setConnectionTimeout(CONNECTION_TIMEOUT_DEFAULT);


### PR DESCRIPTION
FIXES
- PostgreSQL does not support NULL value for generated ID
- `ActiveRecord<IDType>::lastInsertID` uses `pg_get_serial_sequence` for obtaining last generated ID in PostgreSQL
- `ActiveRecord<IDType>::lastInsertID` uses correct connector names for PostgeSQL and MySQL

ADDED
- support for dll exports in ARC
- support for precompiled headers

MODIFICATIONS
- generated includes use correct reference format (`"externalInclude.h"`->`<externalInclude.h>`)
