### PR TITLE
Use map from key to count instead of multiset

### DIFF
--- a/Util/src/XMLConfiguration.cpp
+++ b/Util/src/XMLConfiguration.cpp
@@ -266,7 +266,7 @@ void XMLConfiguration::enumerate(const std::string& key, Keys& range) const
 {
 	using Poco::NumberFormatter;
 
-	std::multiset<std::string> keys;
+	std::map<std::string, size_t> keys;
 	const Poco::XML::Node* pNode = findNode(key);
 	if (pNode)
 	{
@@ -276,12 +276,12 @@ void XMLConfiguration::enumerate(const std::string& key, Keys& range) const
 			if (pChild->nodeType() == Poco::XML::Node::ELEMENT_NODE)
 			{
 				const std::string& nodeName = pChild->nodeName();
-				int n = (int) keys.count(nodeName);
-				if (n)
-					range.push_back(nodeName + "[" + NumberFormatter::format(n) + "]");
+				size_t& count = keys[nodeName];
+				if (count)
+					range.push_back(nodeName + "[" + NumberFormatter::format(count) + "]");
 				else
 					range.push_back(nodeName);
-				keys.insert(nodeName);
+				++count;
 			}
 			pChild = pChild->nextSibling();
 		}

--- a/Util/testsuite/src/XMLConfigurationTest.cpp
+++ b/Util/testsuite/src/XMLConfigurationTest.cpp
@@ -300,6 +300,27 @@ void XMLConfigurationTest::testLoadEmpty()
 }
 
 
+void XMLConfigurationTest::testManyKeys()
+{
+	std::ostringstream ostr;
+	ostr << "<config>\n";
+	const size_t count = 200000;
+	for (size_t i = 0; i < count; ++i)
+	{
+		ostr << "<element>" << i << "</element>\n";
+	}
+	ostr << "</config>\n";
+
+	std::istringstream istr(ostr.str());
+	AutoPtr<XMLConfiguration> pConf = new XMLConfiguration(istr);
+
+	AbstractConfiguration::Keys all_elements;
+	pConf->keys("", all_elements);
+
+	assertTrue(all_elements.size() == count);
+}
+
+
 void XMLConfigurationTest::setUp()
 {
 }
@@ -322,6 +343,7 @@ CppUnit::Test* XMLConfigurationTest::suite()
 	CppUnit_addTest(pSuite, XMLConfigurationTest, testSaveEmpty);
 	CppUnit_addTest(pSuite, XMLConfigurationTest, testFromScratch);
 	CppUnit_addTest(pSuite, XMLConfigurationTest, testLoadEmpty);
+	CppUnit_addTest(pSuite, XMLConfigurationTest, testManyKeys);
 
 	return pSuite;
 }

--- a/Util/testsuite/src/XMLConfigurationTest.h
+++ b/Util/testsuite/src/XMLConfigurationTest.h
@@ -31,6 +31,7 @@ public:
 	void testSaveEmpty();
 	void testFromScratch();
 	void testLoadEmpty();
+	void testManyKeys();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
We noticed slow performance of XMLConfiguration::enumerate when a node had lots of children with the same name. In this case std::multiset is not needed for assigning consequent indexes to children, std::map is better in terms of number allocations and memory consumption.