### PR TITLE
Fix typo in example

### DIFF
--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -46,7 +46,7 @@ class JSON_API Array
 	///    Array::Ptr arr = result.extract<Array::Ptr>();
 	///    Object::Ptr object = arr->getObject(0); // object == {\"test\" : 0}
 	///    int i = object->getElement<int>("test"); // i == 0;
-	///    Object::Ptr subObject = *arr->getObject(1); // subObject == {\"test\" : 0}
+	///    Object::Ptr subObject = arr->getObject(1); // subObject == {\"test\" : 0}
 	///    Array subArr::Ptr = subObject->getArray("test1"); // subArr == [1, 2, 3]
 	///    i = result = subArr->get(0); // i == 1;
 	///


### PR DESCRIPTION
To my understanding, using a dereference operator does not work here.  I think it should be exactly like in line 47.