### PR TITLE
Resolves #3484: support for OP_MSG in Poco::MongoDB

### DIFF
--- a/Foundation/include/Poco/BinaryReader.h
+++ b/Foundation/include/Poco/BinaryReader.h
@@ -117,6 +117,9 @@ public:
 	void readRaw(char* buffer, std::streamsize length);
 		/// Reads length bytes of raw data into buffer.
 
+	void readCString(std::string& value);
+		/// Reads zero-terminated C-string into value.
+
 	void readBOM();
 		/// Reads a byte-order mark from the stream and configures
 		/// the reader for the encountered byte order.

--- a/Foundation/include/Poco/BinaryWriter.h
+++ b/Foundation/include/Poco/BinaryWriter.h
@@ -55,6 +55,8 @@ public:
 		LITTLE_ENDIAN_BYTE_ORDER = 3  /// little-endian byte-order
 	};
 
+	static const std::streamsize	DEFAULT_MAX_CSTR_LENGTH { 1024 };
+
 	BinaryWriter(std::ostream& ostr, StreamByteOrder byteOrder = NATIVE_BYTE_ORDER);
 		/// Creates the BinaryWriter.
 
@@ -131,6 +133,9 @@ public:
 
 	void writeRaw(const char* buffer, std::streamsize length);
 		/// Writes length raw bytes from the given buffer to the stream.
+
+	void writeCString(const char* cString, std::streamsize maxLength = DEFAULT_MAX_CSTR_LENGTH);
+		/// Writes zero-terminated C-string.
 
 	void writeBOM();
 		/// Writes a byte-order mark to the stream. A byte order mark is

--- a/Foundation/src/BinaryReader.cpp
+++ b/Foundation/src/BinaryReader.cpp
@@ -276,6 +276,31 @@ void BinaryReader::readRaw(char* buffer, std::streamsize length)
 }
 
 
+void BinaryReader::readCString(std::string& value)
+{
+	value.clear();
+	if (!_istr.good())
+	{
+		return;
+	}
+	value.reserve(256);
+	while (true)
+	{
+		char c;
+		_istr.get(c);
+		if (!_istr.good())
+		{
+			break;
+		}
+		if (c == '\0')
+		{
+			break;
+		}
+		value += c;
+	}
+}
+
+
 void BinaryReader::readBOM()
 {
 	UInt16 bom;

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -334,6 +334,14 @@ void BinaryWriter::writeRaw(const char* buffer, std::streamsize length)
 }
 
 
+void BinaryWriter::writeCString(const char* cString, std::streamsize maxLength)
+{
+	const std::size_t len = ::strnlen(cString, maxLength);
+	writeRaw(cString, len);
+	_ostr << '\0';
+}
+
+
 void BinaryWriter::writeBOM()
 {
 	UInt16 value = 0xFEFF;

--- a/Foundation/src/BinaryWriter.cpp
+++ b/Foundation/src/BinaryWriter.cpp
@@ -338,7 +338,8 @@ void BinaryWriter::writeCString(const char* cString, std::streamsize maxLength)
 {
 	const std::size_t len = ::strnlen(cString, maxLength);
 	writeRaw(cString, len);
-	_ostr << '\0';
+	static const char zero = '\0';
+	_ostr.write(&zero, sizeof(zero));
 }
 
 

--- a/MongoDB/Makefile
+++ b/MongoDB/Makefile
@@ -12,7 +12,7 @@ objects = Array Binary Connection Cursor DeleteRequest  Database \
 	Document Element GetMoreRequest InsertRequest JavaScriptCode \
 	KillCursorsRequest Message MessageHeader ObjectId QueryRequest \
 	RegularExpression ReplicaSet RequestMessage ResponseMessage \
-	UpdateRequest
+	UpdateRequest OpMsgMessage OpMsgCursor
 
 target         = PocoMongoDB
 target_version = $(LIBVERSION)

--- a/MongoDB/MongoDB_vs140.vcxproj
+++ b/MongoDB/MongoDB_vs140.vcxproj
@@ -604,6 +604,12 @@
     <ClCompile Include="src\UpdateRequest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\OpMsgMessage.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ClCompile Include="src\OpMsgCursor.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\MongoDB\Array.h"/>
@@ -631,6 +637,8 @@
     <ClInclude Include="include\Poco\MongoDB\RequestMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\ResponseMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\UpdateRequest.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgMessage.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgCursor.h"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">

--- a/MongoDB/MongoDB_vs150.vcxproj
+++ b/MongoDB/MongoDB_vs150.vcxproj
@@ -604,6 +604,12 @@
     <ClCompile Include="src\UpdateRequest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\OpMsgMessage.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ClCompile Include="src\OpMsgCursor.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\MongoDB\Array.h"/>
@@ -631,6 +637,8 @@
     <ClInclude Include="include\Poco\MongoDB\RequestMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\ResponseMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\UpdateRequest.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgMessage.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgCursor.h"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">

--- a/MongoDB/MongoDB_vs160.vcxproj
+++ b/MongoDB/MongoDB_vs160.vcxproj
@@ -604,6 +604,12 @@
     <ClCompile Include="src\UpdateRequest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\OpMsgMessage.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ClCompile Include="src\OpMsgCursor.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\MongoDB\Array.h"/>
@@ -631,6 +637,8 @@
     <ClInclude Include="include\Poco\MongoDB\RequestMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\ResponseMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\UpdateRequest.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgMessage.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgCursor.h"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">

--- a/MongoDB/MongoDB_vs170.vcxproj
+++ b/MongoDB/MongoDB_vs170.vcxproj
@@ -867,6 +867,12 @@
     <ClCompile Include="src\UpdateRequest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\OpMsgMessage.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ClCompile Include="src\OpMsgCursor.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Poco\MongoDB\Array.h"/>
@@ -894,6 +900,8 @@
     <ClInclude Include="include\Poco\MongoDB\RequestMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\ResponseMessage.h"/>
     <ClInclude Include="include\Poco\MongoDB\UpdateRequest.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgMessage.h"/>
+    <ClInclude Include="include\Poco\MongoDB\OpMsgCursor.h"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\DLLVersion.rc">

--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -23,6 +23,7 @@
 #include "Poco/Mutex.h"
 #include "Poco/MongoDB/RequestMessage.h"
 #include "Poco/MongoDB/ResponseMessage.h"
+#include "Poco/MongoDB/OpMsgMessage.h"
 
 
 namespace Poco {
@@ -139,6 +140,10 @@ public:
 		///
 		/// Use this when a response is expected: only a "query" or "getmore"
 		/// request will return a response.
+
+	void sendRequest(OpMsgMessage& request, OpMsgMessage& response);
+		/// Sends a request to the MongoDB server and receives the response
+		/// using newer wire protocol with OP_MSG which always returns response.
 
 protected:
 	void connect();

--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -143,7 +143,18 @@ public:
 
 	void sendRequest(OpMsgMessage& request, OpMsgMessage& response);
 		/// Sends a request to the MongoDB server and receives the response
-		/// using newer wire protocol with OP_MSG which always returns response.
+		/// using newer wire protocol with OP_MSG.
+
+	void sendRequest(OpMsgMessage& request);
+		/// Sends an unacknowledged request to the MongoDB server using newer
+		/// wire protocol with OP_MSG.
+		/// No response is sent by the server.
+
+	void readResponse(OpMsgMessage& response);
+		/// Reads additional response data when previous message's flag moreToCome
+		/// indicates that server will send more data.
+		/// NOTE: See comments in OpMsgCursor code.
+
 
 protected:
 	void connect();

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -90,6 +90,9 @@ public:
 		/// Creates an UpdateRequest.
 		/// The collectionname must not contain the database name.
 
+	Poco::SharedPtr<Poco::MongoDB::OpMsgMessage> createOpMsgMessage(const std::string& collectionName) const;
+		/// Creates OpMsgMessage.
+
 	Poco::MongoDB::Document::Ptr ensureIndex(Connection& connection,
 		const std::string& collection,
 		const std::string& indexName,
@@ -180,6 +183,13 @@ inline Poco::SharedPtr<Poco::MongoDB::UpdateRequest>
 Database::createUpdateRequest(const std::string& collectionName) const
 {
 	return new Poco::MongoDB::UpdateRequest(_dbname + '.' + collectionName);
+}
+
+
+inline Poco::SharedPtr<Poco::MongoDB::OpMsgMessage>
+Database::createOpMsgMessage(const std::string& collectionName) const
+{
+	return new Poco::MongoDB::OpMsgMessage(_dbname, collectionName);
 }
 
 

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -56,6 +56,12 @@ public:
 		/// May throw a Poco::ProtocolException if authentication fails for a reason other than
 		/// invalid credentials.
 
+	Document::Ptr queryBuildInfo(Connection& connection) const;
+			/// Queries server build info
+
+	Document::Ptr queryServerHello(Connection& connection) const;
+			/// Queries hello response from server
+
 	Int64 count(Connection& connection, const std::string& collectionName) const;
 		/// Sends a count request for the given collection to MongoDB.
 		///
@@ -107,6 +113,27 @@ public:
 
 	static const std::string AUTH_SCRAM_SHA1;
 		/// Default authentication mechanism for MongoDB 3.0.
+	
+	enum WireVersion
+		/// Wire version as reported by the command hello.
+		/// See details in MongoDB github, repository specifications.
+		/// @see queryServerHello
+	{
+		VER_26		= 1,
+		VER_26_2	= 2,
+		VER_30		= 3,
+		VER_32		= 4,
+		VER_34		= 5,
+		VER_36		= 6, ///< First wire version that supports OP_MSG
+		VER_40		= 7,
+		VER_42		= 8,
+		VER_44		= 9,
+		VER_50		= 13,
+		VER_51		= 14, ///< First wire version that supports only OP_MSG
+		VER_52		= 15,
+		VER_53		= 16,
+		VER_60		= 17
+	};
 
 protected:
 	bool authCR(Connection& connection, const std::string& username, const std::string& password);

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -57,41 +57,41 @@ public:
 		/// invalid credentials.
 
 	Document::Ptr queryBuildInfo(Connection& connection) const;
-			/// Queries server build info
+			/// Queries server build info (all wire protocols)
 
 	Document::Ptr queryServerHello(Connection& connection) const;
-			/// Queries hello response from server
+			/// Queries hello response from server (all wire protocols)
 
 	Int64 count(Connection& connection, const std::string& collectionName) const;
-		/// Sends a count request for the given collection to MongoDB.
+		/// Sends a count request for the given collection to MongoDB. (old wire protocol)
 		///
 		/// If the command fails, -1 is returned.
 
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> createCommand() const;
-		/// Creates a QueryRequest for a command.
+		/// Creates a QueryRequest for a command. (old wire protocol)
 
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> createCountRequest(const std::string& collectionName) const;
 		/// Creates a QueryRequest to count the given collection.
-		/// The collectionname must not contain the database name.
+		/// The collectionname must not contain the database name. (old wire protocol)
 
 	Poco::SharedPtr<Poco::MongoDB::DeleteRequest> createDeleteRequest(const std::string& collectionName) const;
 		/// Creates a DeleteRequest to delete documents in the given collection.
-		/// The collectionname must not contain the database name.
+		/// The collectionname must not contain the database name. (old wire protocol)
 
 	Poco::SharedPtr<Poco::MongoDB::InsertRequest> createInsertRequest(const std::string& collectionName) const;
 		/// Creates an InsertRequest to insert new documents in the given collection.
-		/// The collectionname must not contain the database name.
+		/// The collectionname must not contain the database name. (old wire protocol)
 
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> createQueryRequest(const std::string& collectionName) const;
-		/// Creates a QueryRequest.
+		/// Creates a QueryRequest. (old wire protocol)
 		/// The collectionname must not contain the database name.
 
 	Poco::SharedPtr<Poco::MongoDB::UpdateRequest> createUpdateRequest(const std::string& collectionName) const;
-		/// Creates an UpdateRequest.
+		/// Creates an UpdateRequest. (old wire protocol)
 		/// The collectionname must not contain the database name.
 
 	Poco::SharedPtr<Poco::MongoDB::OpMsgMessage> createOpMsgMessage(const std::string& collectionName) const;
-		/// Creates OpMsgMessage.
+		/// Creates OpMsgMessage. (new wire protocol)
 
 	Poco::MongoDB::Document::Ptr ensureIndex(Connection& connection,
 		const std::string& collection,
@@ -102,14 +102,16 @@ public:
 		int version = 0,
 		int ttl = 0);
 		/// Creates an index. The document returned is the result of a getLastError call.
-		/// For more info look at the ensureIndex information on the MongoDB website.
+		/// For more info look at the ensureIndex information on the MongoDB website. (old wire protocol)
 
 	Document::Ptr getLastErrorDoc(Connection& connection) const;
 		/// Sends the getLastError command to the database and returns the error document.
+		/// (old wire protocol)
 
 	std::string getLastError(Connection& connection) const;
 		/// Sends the getLastError command to the database and returns the err element
 		/// from the error document. When err is null, an empty string is returned.
+		/// (old wire protocol)
 
 	static const std::string AUTH_MONGODB_CR;
 		/// Default authentication mechanism prior to MongoDB 3.0.

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -26,6 +26,8 @@
 #include "Poco/MongoDB/UpdateRequest.h"
 #include "Poco/MongoDB/DeleteRequest.h"
 
+#include "Poco/MongoDB/OpMsgMessage.h"
+#include "Poco/MongoDB/OpMsgCursor.h"
 
 namespace Poco {
 namespace MongoDB {
@@ -92,6 +94,12 @@ public:
 
 	Poco::SharedPtr<Poco::MongoDB::OpMsgMessage> createOpMsgMessage(const std::string& collectionName) const;
 		/// Creates OpMsgMessage. (new wire protocol)
+
+	Poco::SharedPtr<Poco::MongoDB::OpMsgMessage> createOpMsgMessage() const;
+		/// Creates OpMsgMessage for database commands. (new wire protocol)
+
+	Poco::SharedPtr<Poco::MongoDB::OpMsgCursor> createOpMsgCursor(const std::string& collectionName) const;
+		/// Creates OpMsgCursor. (new wire protocol)
 
 	Poco::MongoDB::Document::Ptr ensureIndex(Connection& connection,
 		const std::string& collection,
@@ -187,11 +195,25 @@ Database::createUpdateRequest(const std::string& collectionName) const
 	return new Poco::MongoDB::UpdateRequest(_dbname + '.' + collectionName);
 }
 
+// -- New wire protocol commands
 
 inline Poco::SharedPtr<Poco::MongoDB::OpMsgMessage>
 Database::createOpMsgMessage(const std::string& collectionName) const
 {
 	return new Poco::MongoDB::OpMsgMessage(_dbname, collectionName);
+}
+
+inline Poco::SharedPtr<Poco::MongoDB::OpMsgMessage>
+Database::createOpMsgMessage() const
+{
+	// Collection name for database commands is ignored and any value will do.
+	return createOpMsgMessage("1");
+}
+
+inline Poco::SharedPtr<Poco::MongoDB::OpMsgCursor>
+Database::createOpMsgCursor(const std::string& collectionName) const
+{
+	return new Poco::MongoDB::OpMsgCursor(_dbname, collectionName);
 }
 
 

--- a/MongoDB/include/Poco/MongoDB/Document.h
+++ b/MongoDB/include/Poco/MongoDB/Document.h
@@ -29,6 +29,7 @@
 namespace Poco {
 namespace MongoDB {
 
+class Array;
 
 class ElementFindByName
 {
@@ -90,6 +91,10 @@ public:
 		/// Unlike the other add methods, this method returns
 		/// a reference to the new document.
 
+	Array& addNewArray(const std::string& name);
+		/// Create a new array and add it to this document.
+		/// Method returns a reference to the new array.
+
 	void clear();
 		/// Removes all elements from the document.
 
@@ -99,7 +104,7 @@ public:
 	bool empty() const;
 		/// Returns true if the document doesn't contain any documents.
 
-	bool exists(const std::string& name);
+	bool exists(const std::string& name) const;
 		/// Returns true if the document has an element with the given name.
 
 	template<typename T>
@@ -161,6 +166,9 @@ public:
 		/// or double for a number (count for example). This method will always
 		/// return an Int64. When the element is not found, a
 		/// Poco::NotFoundException will be thrown.
+
+	bool remove(const std::string& name);
+		/// Removes an element from the document.
 
 	template<typename T>
 	bool isType(const std::string& name) const
@@ -231,9 +239,20 @@ inline void Document::elementNames(std::vector<std::string>& keys) const
 }
 
 
-inline bool Document::exists(const std::string& name)
+inline bool Document::exists(const std::string& name) const
 {
 	return std::find_if(_elements.begin(), _elements.end(), ElementFindByName(name)) != _elements.end();
+}
+
+
+inline bool Document::remove(const std::string& name)
+{
+	auto it = std::find_if(_elements.begin(), _elements.end(), ElementFindByName(name));
+	if (it == _elements.end())
+		return false;
+
+	_elements.erase(it);
+	return true;
 }
 
 

--- a/MongoDB/include/Poco/MongoDB/MessageHeader.h
+++ b/MongoDB/include/Poco/MongoDB/MessageHeader.h
@@ -38,14 +38,18 @@ public:
 
 	enum OpCode
 	{
+		// Opcodes deprecated in MongoDB 5.0
 		OP_REPLY = 1,
-		OP_MSG = 1000,
 		OP_UPDATE = 2001,
 		OP_INSERT = 2002,
 		OP_QUERY = 2004,
 		OP_GET_MORE = 2005,
 		OP_DELETE = 2006,
-		OP_KILL_CURSORS = 2007
+		OP_KILL_CURSORS = 2007,
+
+		/// Opcodes supported in MongoDB 5.1 and later
+		OP_COMPRESSED = 2012,
+		OP_MSG = 2013
 	};
 
 	explicit MessageHeader(OpCode);

--- a/MongoDB/include/Poco/MongoDB/OpMsgCursor.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgCursor.h
@@ -1,0 +1,87 @@
+//
+// OpMsgCursor.h
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  OpMsgCursor
+//
+// Definition of the OpMsgCursor class.
+//
+// Copyright (c) 2012, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_OpMsgCursor_INCLUDED
+#define MongoDB_OpMsgCursor_INCLUDED
+
+
+#include "Poco/MongoDB/MongoDB.h"
+#include "Poco/MongoDB/Connection.h"
+#include "Poco/MongoDB/OpMsgMessage.h"
+
+namespace Poco {
+namespace MongoDB {
+
+
+class MongoDB_API OpMsgCursor: public Document
+	/// OpMsgCursor is an helper class for querying multiple documents using OpMsgMessage.
+{
+public:
+	OpMsgCursor(const std::string& dbname, const std::string& collectionName);
+		/// Creates a OpMsgCursor for the given database and collection.
+
+	virtual ~OpMsgCursor();
+		/// Destroys the OpMsgCursor.
+
+	void setBatchSize(Int32 batchSize);
+		/// Set non-default batch size
+
+	Int32 batchSize() const;
+		/// Current batch size (negative number indicates default batch size)
+
+	Int64 cursorID() const;
+
+	OpMsgMessage& next(Connection& connection);
+		/// Tries to get the next documents. As long as response message has a
+		/// cursor ID next can be called to retrieve the next bunch of documents.
+		///
+		/// The cursor must be killed (see kill()) when not all documents are needed.
+
+	OpMsgMessage& query();
+		/// Returns the associated query.
+
+	void kill(Connection& connection);
+		/// Kills the cursor and reset it so that it can be reused.
+
+private:
+	OpMsgMessage    _query;
+	OpMsgMessage 	_response;
+
+	Int32			_batchSize { -1 };
+		/// Batch size used in the cursor. Negative value means that default shall be used.
+
+	Int64			_cursorID { 0 };
+};
+
+
+//
+// inlines
+//
+inline OpMsgMessage& OpMsgCursor::query()
+{
+	return _query;
+}
+
+inline Int64 OpMsgCursor::cursorID() const
+{
+	return _cursorID;
+}
+
+
+} } // namespace Poco::MongoDB
+
+
+#endif // MongoDB_OpMsgCursor_INCLUDED

--- a/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
@@ -81,28 +81,50 @@ public:
 			/// Client is prepared for multiple replies (using the moreToCome bit) to this request
 	};
 
-    OpMsgMessage();
-        /// Creates an OpMsgMessage for response.
+	OpMsgMessage();
+		/// Creates an OpMsgMessage for response.
 
-	OpMsgMessage(const std::string& databaseName, const std::string& collectionName);
+	OpMsgMessage(const std::string& databaseName, const std::string& collectionName, UInt32 flags = MSG_FLAGS_DEFAULT);
 		/// Creates an OpMsgMessage for requests.
 
-#if false
-    OpMsgMessage(const Int64& cursorID);
-        /// Creates an OpMsgMessage for existing cursor ID.
-#endif
+	virtual ~OpMsgMessage();
 
-    virtual ~OpMsgMessage();
+	const std::string& databaseName() const;
 
-    void setCommandName(const std::string& command);
-    	/// Sets the command name and clears the command document
+	const std::string& collectionName() const;	
 
-    Document& body();
-    	/// Access to body document.
-    	/// Additional query arguments shall be added after setting the command name.
+	void setCommandName(const std::string& command);
+		/// Sets the command name and clears the command document
 
-    Document::Vector& documents();
-    	/// Documents prepared for request or retrieved in response.
+	void setCursor(Poco::Int64 cursorID, Poco::Int32 batchSize = -1);
+		/// Sets the command "getMore" for the cursor id with batch size (if it is not negative).
+
+	const std::string& commandName() const;
+		/// Current command name.
+
+	void setAcknowledgedRequest(bool ack);
+		/// Set false to create request that does not return response. 
+		/// It has effect only for commands that write or delete documents.
+		/// Default is true (request returns acknowledge response).
+
+	bool acknowledgedRequest() const;
+
+	UInt32 flags() const;
+
+	Document& body();
+		/// Access to body document.
+		/// Additional query arguments shall be added after setting the command name.
+
+	const Document& body() const;
+
+	Document::Vector& documents();
+		/// Documents prepared for request or retrieved in response.
+
+	const Document::Vector& documents() const;
+		/// Documents prepared for request or retrieved in response.
+
+	bool responseOk() const;
+		/// Reads "ok" status from the response message.
 
 	void clear();
 		/// Clears the message.
@@ -121,13 +143,14 @@ private:
 		PAYLOAD_TYPE_1	= 1
 	};
 
-	const std::string	_databaseName;
-	const std::string	_collectionName;
-	std::string 		_commandName;
-	Flags       		_flags { MSG_FLAGS_DEFAULT };
+	std::string			_databaseName;
+	std::string			_collectionName;
+	UInt32				_flags { MSG_FLAGS_DEFAULT };
+	std::string			_commandName;
+	bool				_acknowledged {true};
 
-	Document    		_body;
-	Document::Vector    _documents;
+	Document			_body;
+	Document::Vector	_documents;
 
 };
 

--- a/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
@@ -1,0 +1,138 @@
+//
+// OpMsgMessage.h
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  OpMsgMessage
+//
+// Definition of the OpMsgMessage class.
+//
+// Copyright (c) 2022, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_OpMsgMessage_INCLUDED
+#define MongoDB_OpMsgMessage_INCLUDED
+
+
+#include "Poco/MongoDB/MongoDB.h"
+#include "Poco/MongoDB/Message.h"
+#include "Poco/MongoDB/Document.h"
+
+#include <string>
+
+namespace Poco {
+namespace MongoDB {
+
+
+class MongoDB_API OpMsgMessage: public Message
+	/// This class represents a request/response (OP_MSG) to send requests and receive responses to/from MongoDB.
+{
+public:
+
+	// Constants for most often used MongoDB commands that can be sent using OP_MSG
+	// For complete list see: https://www.mongodb.com/docs/manual/reference/command/ 
+
+	// Query and write
+	static const std::string CMD_INSERT;
+	static const std::string CMD_DELETE;
+	static const std::string CMD_UPDATE;
+	static const std::string CMD_FIND;
+	static const std::string CMD_FIND_AND_MODIFY;
+	static const std::string CMD_GET_MORE;
+
+	// Aggregation
+	static const std::string CMD_AGGREGATE;
+	static const std::string CMD_COUNT;
+	static const std::string CMD_DISTINCT;
+	static const std::string CMD_MAP_REDUCE;
+
+	// Replication and administration 
+	static const std::string CMD_HELLO;
+
+	static const std::string CMD_CREATE;
+	static const std::string CMD_CREATE_INDEXES;
+	static const std::string CMD_DROP;
+	static const std::string CMD_DROP_DATABASE;
+	static const std::string CMD_KILL_CURSORS;
+	static const std::string CMD_LIST_DATABASES;
+	static const std::string CMD_LIST_INDEXES;
+
+	// Diagnostic
+	static const std::string CMD_BUILD_INFO;
+	static const std::string CMD_COLL_STATS;
+	static const std::string CMD_DB_STATS;
+	static const std::string CMD_HOST_INFO;
+
+
+	enum Flags : UInt32
+	{
+		MSG_FLAGS_DEFAULT		= 0,
+
+		MSG_CHECKSUM_PRESENT	= (1 << 0),
+
+		MSG_MORE_TO_COME		= (1 << 1),
+			/// Sender will send another message and is not prepared for overlapping messages
+
+		MSG_EXHAUST_ALLOWED		= (1 << 16)
+			/// Client is prepared for multiple replies (using the moreToCome bit) to this request
+	};
+
+    OpMsgMessage();
+        /// Creates an OpMsgMessage for response.
+
+	OpMsgMessage(const std::string& databaseName, const std::string& collectionName);
+		/// Creates an OpMsgMessage for requests.
+
+#if false
+    OpMsgMessage(const Int64& cursorID);
+        /// Creates an OpMsgMessage for existing cursor ID.
+#endif
+
+    virtual ~OpMsgMessage();
+
+    void setCommandName(const std::string& command);
+    	/// Sets the command name and clears the command document
+
+    Document& body();
+    	/// Access to body document.
+    	/// Additional query arguments shall be added after setting the command name.
+
+    Document::Vector& documents();
+    	/// Documents prepared for request or retrieved in response.
+
+	void clear();
+		/// Clears the message.
+
+	void send(std::ostream& ostr);
+		/// Writes the request to stream.
+
+	void read(std::istream& istr);
+		/// Reads the response from the stream.
+
+private:
+
+	enum PayloadType : UInt8
+	{
+		PAYLOAD_TYPE_0	= 0,
+		PAYLOAD_TYPE_1	= 1
+	};
+
+	const std::string	_databaseName;
+	const std::string	_collectionName;
+	std::string 		_commandName;
+	Flags       		_flags { MSG_FLAGS_DEFAULT };
+
+	Document    		_body;
+	Document::Vector    _documents;
+
+};
+
+
+} } // namespace Poco::MongoDB
+
+
+#endif // MongoDB_OpMsgMessage_INCLUDED

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -237,9 +237,25 @@ void Connection::sendRequest(OpMsgMessage& request, OpMsgMessage& response)
 	Poco::Net::SocketOutputStream sos(_socket);
 	request.send(sos);
 
+	response.clear();
+	readResponse(response);
+}
+
+
+void Connection::sendRequest(OpMsgMessage& request)
+{
+	request.setAcknowledgedRequest(false);
+	Poco::Net::SocketOutputStream sos(_socket);
+	request.send(sos);
+}
+
+
+void Connection::readResponse(OpMsgMessage& response)
+{
 	Poco::Net::SocketInputStream sis(_socket);
 	response.read(sis);
 }
+
 
 
 } } // Poco::MongoDB

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -232,4 +232,14 @@ void Connection::sendRequest(RequestMessage& request, ResponseMessage& response)
 }
 
 
+void Connection::sendRequest(OpMsgMessage& request, OpMsgMessage& response)
+{
+	Poco::Net::SocketOutputStream sos(_socket);
+	request.send(sos);
+
+	Poco::Net::SocketInputStream sis(_socket);
+	response.read(sis);
+}
+
+
 } } // Poco::MongoDB

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -301,6 +301,50 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 }
 
 
+Document::Ptr Database::queryBuildInfo(Connection& connection) const
+{
+	// build info can be issued on "config" system database
+	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createCommand();
+	request->selector().add("buildInfo", 1);
+
+	Poco::MongoDB::ResponseMessage response;
+	connection.sendRequest(*request, response);
+
+	Document::Ptr buildInfo;
+	if ( response.documents().size() > 0 )
+	{
+		buildInfo = response.documents()[0];
+	}
+	else
+	{
+		throw Poco::ProtocolException("Didn't get a response from the buildinfo command");
+	}
+	return buildInfo;
+}
+
+
+Document::Ptr Database::queryServerHello(Connection& connection) const
+{
+	// hello can be issued on "config" system database
+	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createCommand();
+	request->selector().add("hello", 1);
+
+	Poco::MongoDB::ResponseMessage response;
+	connection.sendRequest(*request, response);
+
+	Document::Ptr hello;
+	if ( response.documents().size() > 0 )
+	{
+		hello = response.documents()[0];
+	}
+	else
+	{
+		throw Poco::ProtocolException("Didn't get a response from the hello command");
+	}
+	return hello;
+}
+
+
 Int64 Database::count(Connection& connection, const std::string& collectionName) const
 {
 	Poco::SharedPtr<Poco::MongoDB::QueryRequest> countRequest = createCountRequest(collectionName);
@@ -357,7 +401,7 @@ Document::Ptr Database::getLastErrorDoc(Connection& connection) const
 {
 	Document::Ptr errorDoc;
 
-	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createQueryRequest("$cmd");
+	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createCommand();
 	request->setNumberToReturn(1);
 	request->selector().add("getLastError", 1);
 
@@ -387,7 +431,7 @@ std::string Database::getLastError(Connection& connection) const
 
 Poco::SharedPtr<Poco::MongoDB::QueryRequest> Database::createCountRequest(const std::string& collectionName) const
 {
-	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createQueryRequest("$cmd");
+	Poco::SharedPtr<Poco::MongoDB::QueryRequest> request = createCommand();
 	request->setNumberToReturn(1);
 	request->selector().add("count", collectionName);
 	return request;

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -35,6 +35,14 @@ Document::~Document()
 }
 
 
+Array& Document::addNewArray(const std::string& name)
+{
+	Array::Ptr newArray = new Array();
+	add(name, newArray);
+	return *newArray;
+}
+
+
 Element::Ptr Document::get(const std::string& name) const
 {
 	Element::Ptr element;

--- a/MongoDB/src/MessageHeader.cpp
+++ b/MongoDB/src/MessageHeader.cpp
@@ -42,7 +42,7 @@ void MessageHeader::read(BinaryReader& reader)
 
 	Int32 opCode;
 	reader >> opCode;
-	_opCode = (OpCode) opCode;
+	_opCode = static_cast<OpCode>(opCode);
 
 	if (!reader.good())
 	{
@@ -56,7 +56,7 @@ void MessageHeader::write(BinaryWriter& writer)
 	writer << _messageLength;
 	writer << _requestID;
 	writer << _responseTo;
-	writer << (Int32) _opCode;
+	writer << static_cast<Int32>(_opCode);
 }
 
 

--- a/MongoDB/src/OpMsgCursor.cpp
+++ b/MongoDB/src/OpMsgCursor.cpp
@@ -63,7 +63,7 @@ OpMsgCursor::~OpMsgCursor()
 {
 	try
 	{
-		poco_assert_dbg(_cursorId == 0);
+		poco_assert_dbg(_cursorID == 0);
 	}
 	catch (...)
 	{

--- a/MongoDB/src/OpMsgCursor.cpp
+++ b/MongoDB/src/OpMsgCursor.cpp
@@ -1,0 +1,172 @@
+//
+// OpMsgCursor.cpp
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  OpMsgCursor
+//
+// Copyright (c) 2022, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/MongoDB/OpMsgCursor.h"
+#include "Poco/MongoDB/Array.h"
+
+//
+// NOTE:
+//
+// MongoDB specification indicates that the flag MSG_EXHAUST_ALLOWED shall be
+// used in the request when the receiver is ready to receive multiple messages
+// without sending additional requests in between. Sender (MongoDB) indicates
+// that more messages follow with flag MSG_MORE_TO_COME.
+//
+// It seems that this does not work properly. MSG_MORE_TO_COME is set and reading
+// next messages sometimes works, however often the data is missing in response
+// or the message header contains wrong message length and reading blocks.
+// Opcode in the header is correct.
+//
+// Using MSG_EXHAUST_ALLOWED is therefore currently disabled.
+//
+// It seems that related JIRA ticket is:
+//
+// https://jira.mongodb.org/browse/SERVER-57297
+//
+// https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst
+//
+
+#define _MONGODB_EXHAUST_ALLOWED_WORKS	false
+
+namespace Poco {
+namespace MongoDB {
+
+
+static const std::string keyCursor		{"cursor"};
+static const std::string keyFirstBatch	{"firstBatch"};
+static const std::string keyNextBatch	{"nextBatch"};
+
+static Poco::Int64 cursorIdFromResponse(const MongoDB::Document& doc);
+
+
+OpMsgCursor::OpMsgCursor(const std::string& db, const std::string& collection):
+#if _MONGODB_EXHAUST_ALLOWED_WORKS
+	_query(db, collection, OpMsgMessage::MSG_EXHAUST_ALLOWED)
+#else
+	_query(db, collection)
+#endif
+{
+}
+
+OpMsgCursor::~OpMsgCursor()
+{
+	try
+	{
+		poco_assert_dbg(_cursorId == 0);
+	}
+	catch (...)
+	{
+	}
+}
+
+
+void OpMsgCursor::setBatchSize(Int32 batchSize)
+{
+	_batchSize = batchSize;
+}
+
+
+Int32 OpMsgCursor::batchSize() const
+{
+	return _batchSize;
+}
+
+
+OpMsgMessage& OpMsgCursor::next(Connection& connection)
+{
+	if (_cursorID == 0)
+	{
+		_response.clear();
+
+		if (_query.commandName() == OpMsgMessage::CMD_FIND)
+		{
+			if (_batchSize >= 0)
+				_query.body().add("batchSize", _batchSize);
+		}
+		else if (_query.commandName() == OpMsgMessage::CMD_AGGREGATE)
+		{
+			auto cursorDoc = _query.body().addNewDocument("cursor");
+			if (_batchSize >= 0)
+				cursorDoc.add("batchSize", _batchSize);
+		}
+
+		connection.sendRequest(_query, _response);
+
+		const auto& rdoc = _response.body();
+		_cursorID = cursorIdFromResponse(rdoc);
+	}
+	else
+	{
+		_response.clear();
+		_query.setCursor(_cursorID, _batchSize);
+		connection.sendRequest(_query, _response);
+	}
+
+#if _MONGODB_EXHAUST_ALLOWED_WORKS
+	std::cout << "Response flags: " << _response.flags() << std::endl;
+
+	while (_response.flags() & OpMsgMessage::MSG_MORE_TO_COME)
+	{
+		std::cout << "More to come. Reading more response: " << std::endl;
+		_response.body().clear();
+		connection.readResponse(_response);
+	}
+#endif
+
+	const auto& rdoc = _response.body();
+	_cursorID = cursorIdFromResponse(rdoc);
+
+	return _response;
+}
+
+
+void OpMsgCursor::kill(Connection& connection)
+{
+	_response.clear();
+	if (_cursorID != 0)
+	{
+		_query.setCommandName(OpMsgMessage::CMD_KILL_CURSORS);
+
+		MongoDB::Array::Ptr cursors = new MongoDB::Array();
+		cursors->add<Poco::Int64>(_cursorID);
+		_query.body().add("cursors", cursors);
+
+		connection.sendRequest(_query, _response);
+
+		const auto killed = _response.body().get<MongoDB::Array::Ptr>("cursorsKilled", nullptr);
+		if (!killed || killed->size() != 1 || killed->get<Poco::Int64>(0, -1) != _cursorID)
+		{
+			throw Poco::ProtocolException("Cursor not killed as expected: " + std::to_string(_cursorID));
+		}
+
+		_cursorID = 0;
+		_query.clear();
+		_response.clear();
+	}
+}
+
+
+Poco::Int64 cursorIdFromResponse(const MongoDB::Document& doc)
+{
+	Poco::Int64 id {0};
+	auto cursorDoc = doc.get<Document::Ptr>(keyCursor, nullptr);
+	if(cursorDoc)
+	{
+		id = cursorDoc->get<Poco::Int64>("id", 0);
+	}
+	return id;
+}
+
+
+} } // Namespace Poco::MongoDB

--- a/MongoDB/src/OpMsgCursor.cpp
+++ b/MongoDB/src/OpMsgCursor.cpp
@@ -108,21 +108,22 @@ OpMsgMessage& OpMsgCursor::next(Connection& connection)
 	}
 	else
 	{
-		_response.clear();
-		_query.setCursor(_cursorID, _batchSize);
-		connection.sendRequest(_query, _response);
-	}
-
 #if _MONGODB_EXHAUST_ALLOWED_WORKS
-	std::cout << "Response flags: " << _response.flags() << std::endl;
-
-	while (_response.flags() & OpMsgMessage::MSG_MORE_TO_COME)
-	{
-		std::cout << "More to come. Reading more response: " << std::endl;
-		_response.body().clear();
-		connection.readResponse(_response);
+		std::cout << "Response flags: " << _response.flags() << std::endl;
+		if (_response.flags() & OpMsgMessage::MSG_MORE_TO_COME)
+		{
+			std::cout << "More to come. Reading more response: " << std::endl;
+			_response.clear();
+			connection.readResponse(_response);
+		}
+		else
+#endif		
+		{
+			_response.clear();
+			_query.setCursor(_cursorID, _batchSize);
+			connection.sendRequest(_query, _response);
+		}
 	}
-#endif
 
 	const auto& rdoc = _response.body();
 	_cursorID = cursorIdFromResponse(rdoc);

--- a/MongoDB/src/OpMsgMessage.cpp
+++ b/MongoDB/src/OpMsgMessage.cpp
@@ -292,7 +292,6 @@ void OpMsgMessage::read(std::istream& istr)
 	std::istringstream msgss(message);
 	BinaryReader reader(msgss, BinaryReader::LITTLE_ENDIAN_BYTE_ORDER);
 
-	Poco::UInt32 flags {0xFFFFFFFF};
 	Poco::UInt8 payloadType {0xFF};
 
 	reader >> _flags;

--- a/MongoDB/src/OpMsgMessage.cpp
+++ b/MongoDB/src/OpMsgMessage.cpp
@@ -1,0 +1,268 @@
+//
+// OpMsgMessage.cpp
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  OpMsgMessage
+//
+// Copyright (c) 2022, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+#include "Poco/MongoDB/OpMsgMessage.h"
+#include "Poco/MongoDB/MessageHeader.h"
+#include "Poco/StreamCopier.h"
+#include "Poco/Logger.h"
+
+namespace Poco {
+namespace MongoDB {
+
+// Query and write
+const std::string OpMsgMessage::CMD_INSERT { "insert" };
+const std::string OpMsgMessage::CMD_DELETE { "delete" };
+const std::string OpMsgMessage::CMD_UPDATE { "update" };
+const std::string OpMsgMessage::CMD_FIND { "find" };
+const std::string OpMsgMessage::CMD_FIND_AND_MODIFY { "findAndModify" };
+const std::string OpMsgMessage::CMD_GET_MORE { "getMore" };
+
+// Aggregation
+const std::string OpMsgMessage::CMD_AGGREGATE { "aggregate" };
+const std::string OpMsgMessage::CMD_COUNT { "count" };
+const std::string OpMsgMessage::CMD_DISTINCT { "distinct" };
+const std::string OpMsgMessage::CMD_MAP_REDUCE { "mapReduce" };
+
+// Replication and administration 
+const std::string OpMsgMessage::CMD_HELLO { "hello" };
+
+const std::string OpMsgMessage::CMD_CREATE { "create" };
+const std::string OpMsgMessage::CMD_CREATE_INDEXES { "createIndexes" };
+const std::string OpMsgMessage::CMD_DROP { "drop" };
+const std::string OpMsgMessage::CMD_DROP_DATABASE { "dropDatabase" };
+const std::string OpMsgMessage::CMD_KILL_CURSORS { "killCursors" };
+const std::string OpMsgMessage::CMD_LIST_DATABASES { "listDatabases" };
+const std::string OpMsgMessage::CMD_LIST_INDEXES { "listIndexes" };
+
+// Diagnostic
+const std::string OpMsgMessage::CMD_BUILD_INFO { "buildInfo" };
+const std::string OpMsgMessage::CMD_COLL_STATS { "collStats" };
+const std::string OpMsgMessage::CMD_DB_STATS { "dbStats" };
+const std::string OpMsgMessage::CMD_HOST_INFO { "hostInfo" };
+
+
+static const std::string& commandIdentifier(const std::string& command);
+	/// Commands have different names for the payload that is sent in a separate section
+
+OpMsgMessage::OpMsgMessage() :
+	Message(MessageHeader::OP_MSG)
+{
+}
+
+
+OpMsgMessage::OpMsgMessage(const std::string& databaseName, const std::string& collectionName) :
+	Message(MessageHeader::OP_MSG),
+	_databaseName(databaseName),
+	_collectionName(collectionName)
+{
+}
+
+
+#if false
+OpMsgMessage::OpMsgMessage(const Int64& cursorID) :
+	Message(MessageHeader::OP_MSG)
+{
+}
+#endif
+
+
+OpMsgMessage::~OpMsgMessage()
+{
+}
+
+
+void OpMsgMessage::setCommandName(const std::string& command)
+{
+	_commandName = command;
+	_body.clear();
+
+	// IMPORTANT: Command name must be first
+	_body.add(_commandName, _collectionName);
+	_body.add("$db", _databaseName);
+}
+
+
+Document& OpMsgMessage::body()
+{
+	return _body;
+}
+
+
+Document::Vector& OpMsgMessage::documents()
+{
+	return _documents;
+}
+
+
+void OpMsgMessage::clear()
+{
+	_flags = MSG_FLAGS_DEFAULT;
+	_commandName.clear();
+	_documents.clear();
+	_body.clear();
+}
+
+
+void OpMsgMessage::send(std::ostream& ostr)
+{
+
+	std::cout << "send body: " << _body.toString() << std::endl;
+
+	BinaryWriter socketWriter(ostr, BinaryWriter::LITTLE_ENDIAN_BYTE_ORDER);
+
+	// Serialise the body
+	std::stringstream ss;
+	BinaryWriter writer(ss, BinaryWriter::LITTLE_ENDIAN_BYTE_ORDER);
+	writer << _flags;
+
+	writer << PAYLOAD_TYPE_0;
+	_body.write(writer);
+
+	if (!_documents.empty())
+	{
+		// Serialise attached documents
+
+		std::stringstream ssdoc;
+		BinaryWriter wdoc(ssdoc, BinaryWriter::LITTLE_ENDIAN_BYTE_ORDER);
+		for (auto& doc: _documents)
+		{
+			doc->write(wdoc);
+		}
+		wdoc.flush();
+
+		const std::string& identifier = commandIdentifier(_commandName);
+		const Poco::Int32 size = sizeof(size) + identifier.size() + 1 + ssdoc.tellp();
+		writer << PAYLOAD_TYPE_1;
+		writer << size;
+		writer.writeCString(identifier.c_str());
+		StreamCopier::copyStream(ssdoc, ss);
+	}
+	writer.flush();
+
+	const std::string section = ss.str();
+	std::string dump;
+	Logger::formatDump(dump, section.data(), section.length());
+
+	std::cout << dump << std::endl;
+
+	messageLength(static_cast<Poco::Int32>(ss.tellp()));
+
+	_header.write(socketWriter);
+	StreamCopier::copyStream(ss, ostr);
+
+	ostr.flush();
+}
+
+
+void OpMsgMessage::read(std::istream& istr)
+{
+	clear();
+
+	std::string message;
+	{
+		BinaryReader reader(istr, BinaryReader::LITTLE_ENDIAN_BYTE_ORDER);
+		_header.read(reader);
+
+		poco_assert_dbg(_header.opCode() == _header.OP_MSG);
+
+		const std::streamsize remainingSize {_header.getMessageLength() - _header.MSG_HEADER_SIZE };
+		message.reserve(remainingSize);
+
+		reader.readRaw(remainingSize, message);
+
+		std::string dump;
+		Logger::formatDump(dump, message.data(), message.length());
+
+		std::cout << dump << std::endl;
+	}
+	// Read complete message and then interpret it.
+
+	std::istringstream msgss(message);
+	BinaryReader reader(msgss, BinaryReader::LITTLE_ENDIAN_BYTE_ORDER);
+
+	Poco::UInt32 flags {0xFFFFFFFF};
+	Poco::UInt8 payloadType {0xFF};
+
+	reader >> flags;
+	_flags = static_cast<Flags>(flags);
+
+	reader >> payloadType;
+	poco_assert_dbg(payloadType == PAYLOAD_TYPE_0);
+
+	_body.read(reader);
+
+	// Read next sections from the buffer
+	while (msgss.good())
+	{
+		// NOTE: Not tested yet with database, because it returns everything in the body.
+		reader >> payloadType;
+		if (!msgss.good())
+		{
+			break;
+		}
+		poco_assert_dbg(payloadType == PAYLOAD_TYPE_1);
+		std::cout << "section payload: " << payloadType << std::endl;
+
+		Poco::Int32 sectionSize {0};
+		reader >> sectionSize;
+		poco_assert_dbg(sectionSize > 0);
+
+		std::cout << "section size: " << sectionSize << std::endl;
+		std::streamoff offset = sectionSize - sizeof(sectionSize);
+		std::streampos endOfSection = msgss.tellg() + offset;
+
+		std::string identifier;
+		reader.readCString(identifier);
+		std::cout << "section identifier: " << identifier << std::endl;
+
+		// Loop to read documents from this section.
+		while (msgss.tellg() < endOfSection)
+		{
+			std::cout << "section doc: " << msgss.tellg() << " " << endOfSection << std::endl;
+			Document::Ptr doc = new Document();
+			doc->read(reader);
+			_documents.push_back(doc);
+			if (msgss.tellg() < 0)
+			{
+				break;
+			}
+		}
+	}
+
+}
+
+const std::string& commandIdentifier(const std::string& command)
+{
+	// Names of identifiers for commands that send bulk documents in the request
+	// The identifier is set in the section type 1.
+	static std::map<std::string, std::string> identifiers {
+		{ OpMsgMessage::CMD_INSERT, "documents" },
+		{ OpMsgMessage::CMD_DELETE, "deletes" },
+		{ OpMsgMessage::CMD_UPDATE, "updates" },
+		{ OpMsgMessage::CMD_CREATE_INDEXES, "indexes" }
+	};
+
+	static const std::string emptyIdentifier;
+
+	const auto i = identifiers.find(command);
+	if (i != identifiers.end())
+	{
+		return i->second;
+	}
+	// This likely means that documents are incorrectly set for a command
+	// that does not send list of documents.
+	return emptyIdentifier;
+}
+
+
+} } // namespace Poco::MongoDB

--- a/MongoDB/testsuite/Makefile
+++ b/MongoDB/testsuite/Makefile
@@ -6,7 +6,7 @@
 
 include $(POCO_BASE)/build/rules/global
 
-objects = Driver MongoDBTest MongoDBTestSuite
+objects = Driver MongoDBTest MongoDBTestOpMsg MongoDBTestSuite
 
 target         = testrunner
 target_version = 1

--- a/MongoDB/testsuite/TestSuite_vs140.vcxproj
+++ b/MongoDB/testsuite/TestSuite_vs140.vcxproj
@@ -604,6 +604,9 @@
     <ClCompile Include="src\MongoDBTest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\MongoDBTestOpMsg.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
     <ClCompile Include="src\MongoDBTestSuite.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/MongoDB/testsuite/TestSuite_vs150.vcxproj
+++ b/MongoDB/testsuite/TestSuite_vs150.vcxproj
@@ -604,6 +604,9 @@
     <ClCompile Include="src\MongoDBTest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\MongoDBTestOpMsg.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
     <ClCompile Include="src\MongoDBTestSuite.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/MongoDB/testsuite/TestSuite_vs160.vcxproj
+++ b/MongoDB/testsuite/TestSuite_vs160.vcxproj
@@ -604,6 +604,9 @@
     <ClCompile Include="src\MongoDBTest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\MongoDBTestOpMsg.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
     <ClCompile Include="src\MongoDBTestSuite.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/MongoDB/testsuite/TestSuite_vs170.vcxproj
+++ b/MongoDB/testsuite/TestSuite_vs170.vcxproj
@@ -896,6 +896,9 @@
     <ClCompile Include="src\MongoDBTest.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <ClCompile Include="src\MongoDBTestOpMsg.cpp">
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
     <ClCompile Include="src\MongoDBTestSuite.cpp">
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -35,6 +35,13 @@ public:
 	void testDBCount2Command();
 	void testDeleteRequest();
 	void testBuildInfo();
+	void testHello();
+
+	void testOpCmdWriteRead();
+	void testOpCmdHello();
+	void testOpCmdInsert();
+	void testOpCmdFind();
+
 	void testConnectionPool();
 	void testCursorRequest();
 	void testObjectID();

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -25,36 +25,49 @@ public:
 	MongoDBTest(const std::string& name);
 
 	virtual ~MongoDBTest();
+	
+	void setUp();
+	void tearDown();
 
-	void testInsertRequest();
+	void testObjectID();
 	void testArray();
+	void testBuildInfo();
+	void testHello();
+	void testConnectURI();
+
+	// Old wire protocol
+	void testInsertRequest();
 	void testQueryRequest();
 	void testDBQueryRequest();
 	void testCountCommand();
 	void testDBCountCommand();
 	void testDBCount2Command();
 	void testDeleteRequest();
-	void testBuildInfo();
-	void testHello();
-
-	void testOpCmdWriteRead();
-	void testOpCmdHello();
-	void testOpCmdInsert();
-	void testOpCmdFind();
 
 	void testConnectionPool();
 	void testCursorRequest();
-	void testObjectID();
 	void testCommand();
 	void testUUID();
-	void testConnectURI();
-	void setUp();
-	void tearDown();
+
+	// New wire protocol using OP_CMD
+	void testOpCmdUUID();
+	void testOpCmdHello();
+	void testOpCmdWriteRead();
+	void testOpCmdInsert();
+	void testOpCmdFind();
+	void testOpCmdCursor();
+	void testOpCmdCursorAggregate();
+	void testOpCmdKillCursor();
+	void testOpCmdCount();
+	void testOpCmdDelete();
+	void testOpCmdUnaknowledgedInsert();
+	void testOpCmdConnectionPool();
 
 	static CppUnit::Test* suite();
 
 private:
-	static Poco::MongoDB::Connection::Ptr _mongo;
+	static Poco::MongoDB::Connection::Ptr	_mongo;
+	static Poco::Int64						_wireVersion;
 };
 
 

--- a/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
+++ b/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
@@ -82,7 +82,7 @@ void MongoDBTest::testOpCmdUUID()
 void MongoDBTest::testOpCmdHello()
 {
 	Database db("config");
-	Poco::SharedPtr<OpMsgMessage> helloRequest = db.createOpMsgMessage("1");
+	Poco::SharedPtr<OpMsgMessage> helloRequest = db.createOpMsgMessage();
 	helloRequest->setCommandName(OpMsgMessage::CMD_HELLO);
 
 	try
@@ -316,21 +316,21 @@ void MongoDBTest::testOpCmdCursorAggregate()
 	_mongo->sendRequest(*request, response);
 	assertTrue(response.responseOk());
 
-	OpMsgCursor cursor("team", "numbers");
-	cursor.query().setCommandName(OpMsgMessage::CMD_AGGREGATE);
-	cursor.setBatchSize(1000);
+	Poco::SharedPtr<OpMsgCursor> cursor = db.createOpMsgCursor("numbers");
+	cursor->query().setCommandName(OpMsgMessage::CMD_AGGREGATE);
+	cursor->setBatchSize(1000);
 
 	// Empty pipeline: get all documents
-	cursor.query().body().addNewArray("pipeline");
+	cursor->query().body().addNewArray("pipeline");
 
 	int n = 0;
-	auto cresponse = cursor.next(*_mongo);
+	auto cresponse = cursor->next(*_mongo);
 	while(true)
 	{
 		n += static_cast<int>(cresponse.documents().size());
-		if ( cursor.cursorID() == 0 )
+		if ( cursor->cursorID() == 0 )
 			break;
-		cresponse = cursor.next(*_mongo);
+		cresponse = cursor->next(*_mongo);
 	}
 	assertEquals (10000, n);
 

--- a/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
+++ b/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
@@ -1,0 +1,444 @@
+//
+// MongoDBTest.cpp
+//
+// Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/DateTime.h"
+#include "Poco/MongoDB/Array.h"
+#include "Poco/MongoDB/OpMsgMessage.h"
+#include "Poco/MongoDB/OpMsgCursor.h"
+#include "Poco/MongoDB/Database.h"
+#include "Poco/MongoDB/Connection.h"
+#include "Poco/MongoDB/PoolableConnectionFactory.h"
+#include "Poco/MongoDB/Binary.h"
+#include "Poco/Net/NetException.h"
+#include "Poco/UUIDGenerator.h"
+#include "MongoDBTest.h"
+#include <iostream>
+
+
+using namespace Poco::MongoDB;
+
+
+void MongoDBTest::testOpCmdUUID()
+{
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("club");
+	OpMsgMessage response;
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+
+	Document::Ptr club = new Document();
+	club->add("name", std::string("Barcelona"));
+
+	Poco::UUIDGenerator generator;
+	Poco::UUID uuid = generator.create();
+	Binary::Ptr uuidBinary = new Binary(uuid);
+	club->add("uuid", uuidBinary);
+
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	request->documents().push_back(club);
+
+	_mongo->sendRequest(*request, response);
+
+	assertTrue(response.responseOk());
+
+	request->setCommandName(OpMsgMessage::CMD_FIND);
+	request->body().addNewDocument("filter").add("name", std::string("Barcelona"));
+
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	if ( response.documents().size() > 0 )
+	{
+		Document::Ptr doc = response.documents()[0];
+		try
+		{
+			std::string name = doc->get<std::string>("name");
+			assertEquals ("Barcelona", name );
+
+			Binary::Ptr uuidBinary = doc->get<Binary::Ptr>("uuid");
+			assertTrue (uuid == uuidBinary->uuid());
+		}
+		catch(Poco::NotFoundException& nfe)
+		{
+			fail(nfe.message() + " not found.");
+		}
+	}
+	else
+	{
+		fail("No document returned");
+	}
+
+}
+
+
+void MongoDBTest::testOpCmdHello()
+{
+	Database db("config");
+	Poco::SharedPtr<OpMsgMessage> helloRequest = db.createOpMsgMessage("1");
+	helloRequest->setCommandName(OpMsgMessage::CMD_HELLO);
+
+	try
+	{
+		OpMsgMessage response;
+		_mongo->sendRequest(*helloRequest, response);
+		assertTrue(response.responseOk());
+	}
+	catch(Poco::NotImplementedException& nie)
+	{
+		std::cout << nie.message() << std::endl;
+	}
+}
+
+
+void MongoDBTest::testOpCmdWriteRead()
+{
+	// Writes request to a stream and then reads it back
+	// Tests send and read of a message with multiple sections without
+	// the server.
+	// NOTE: MongoDB 6.0 does not send responses with segments of type 1.
+
+	Database db("abc");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("col");
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+
+	Document::Ptr doc = new Document();
+	doc->add("name", "John").add("number", -2);
+	request->documents().push_back(doc);
+
+	doc = new Document();
+	doc->add("name", "Franz").add("number", -2.8);
+	request->documents().push_back(doc);
+
+	try
+	{
+		OpMsgMessage response;
+
+		std::stringstream ss;
+		request->send(ss);
+
+		ss.seekg(0, std::ios_base::beg);
+		response.read(ss);
+
+		for (const auto& doc: response.documents())
+		{
+			std::cout << doc->toString(2);
+		}
+	}
+	catch(Poco::NotImplementedException& nie)
+	{
+		std::cout << nie.message() << std::endl;
+	}
+}
+
+
+void MongoDBTest::testOpCmdInsert()
+{
+	Document::Ptr player = new Document();
+	player->add("lastname", std::string("Braem"));
+	player->add("firstname", std::string("Franky"));
+
+	Poco::DateTime birthdate;
+	birthdate.assign(1969, 3, 9);
+	player->add("birthdate", birthdate.timestamp());
+
+	player->add("start", 1993);
+	player->add("active", false);
+
+	Poco::DateTime now;
+	player->add("lastupdated", now.timestamp());
+
+	player->add("unknown", NullValue());
+
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	request->documents().push_back(player);
+
+	try
+	{
+		OpMsgMessage response;
+		_mongo->sendRequest(*request, response);
+		
+		assertTrue(response.responseOk());
+	}
+	catch(Poco::NotImplementedException& nie)
+	{
+		std::cout << nie.message() << std::endl;
+	}
+}
+
+void MongoDBTest::testOpCmdFind()
+{
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_FIND);
+
+	request->body().add("limit", 1).addNewDocument("filter").add("lastname" , std::string("Braem"));
+
+	OpMsgMessage response;
+	_mongo->sendRequest(*request, response);
+
+	assertTrue(response.responseOk());
+
+	if ( response.documents().size() > 0 )
+	{
+		Document::Ptr doc = response.documents()[0];
+
+		try
+		{
+			std::string lastname = doc->get<std::string>("lastname");
+			assertEquals ("Braem", lastname);
+			std::string firstname = doc->get<std::string>("firstname");
+			assertEquals ("Franky", firstname);
+			Poco::Timestamp birthDateTimestamp = doc->get<Poco::Timestamp>("birthdate");
+			Poco::DateTime birthDate(birthDateTimestamp);
+			assertTrue (birthDate.year() == 1969 && birthDate.month() == 3 && birthDate.day() == 9);
+			Poco::Timestamp lastupdatedTimestamp = doc->get<Poco::Timestamp>("lastupdated");
+			assertTrue (doc->isType<NullValue>("unknown"));
+			bool active = doc->get<bool>("active");
+			assertEquals (false, active);
+
+			std::string id = doc->get("_id")->toString();
+		}
+		catch(Poco::NotFoundException& nfe)
+		{
+			fail(nfe.message() + " not found.");
+		}
+	}
+	else
+	{
+		fail("No document returned");
+	}
+}
+
+
+void MongoDBTest::testOpCmdUnaknowledgedInsert()
+{
+	Document::Ptr player = new Document();
+	player->add("lastname", std::string("Braem"));
+	player->add("firstname", std::string("Franky"));
+
+	Poco::DateTime birthdate;
+	birthdate.assign(1969, 3, 9);
+	player->add("birthdate", birthdate.timestamp());
+
+	player->add("start", 1993);
+	player->add("active", false);
+
+	Poco::DateTime now;
+	player->add("lastupdated", now.timestamp());
+
+	player->add("unknown", NullValue());
+
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	request->setAcknowledgedRequest(false);
+	request->documents().push_back(player);
+
+	try
+	{
+		_mongo->sendRequest(*request);
+	}
+	catch(Poco::NotImplementedException& nie)
+	{
+		std::cout << nie.message() << std::endl;
+	}
+}
+
+
+void MongoDBTest::testOpCmdCursor()
+{
+	Database db("team");
+
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("numbers");
+	OpMsgMessage response;
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	for(int i = 0; i < 10000; ++i)
+	{
+		Document::Ptr doc = new Document();
+		doc->add("number", i);
+		request->documents().push_back(doc);
+	}
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	OpMsgCursor cursor("team", "numbers");
+	cursor.query().setCommandName(OpMsgMessage::CMD_FIND);
+	cursor.setBatchSize(1000);
+
+	int n = 0;
+	auto cresponse = cursor.next(*_mongo);
+	while(true)
+	{
+		n += static_cast<int>(cresponse.documents().size());
+		if ( cursor.cursorID() == 0 )
+			break;
+		cresponse = cursor.next(*_mongo);
+	}
+	assertEquals (10000, n);
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+}
+
+
+void MongoDBTest::testOpCmdCursorAggregate()
+{
+	Database db("team");
+
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("numbers");
+	OpMsgMessage response;
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	for(int i = 0; i < 10000; ++i)
+	{
+		Document::Ptr doc = new Document();
+		doc->add("number", i);
+		request->documents().push_back(doc);
+	}
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	OpMsgCursor cursor("team", "numbers");
+	cursor.query().setCommandName(OpMsgMessage::CMD_AGGREGATE);
+	cursor.setBatchSize(1000);
+
+	// Empty pipeline: get all documents
+	cursor.query().body().addNewArray("pipeline");
+
+	int n = 0;
+	auto cresponse = cursor.next(*_mongo);
+	while(true)
+	{
+		n += static_cast<int>(cresponse.documents().size());
+		if ( cursor.cursorID() == 0 )
+			break;
+		cresponse = cursor.next(*_mongo);
+	}
+	assertEquals (10000, n);
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+}
+
+
+
+void MongoDBTest::testOpCmdKillCursor()
+{
+	Database db("team");
+
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("numbers");
+	OpMsgMessage response;
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	for(int i = 0; i < 10000; ++i)
+	{
+		Document::Ptr doc = new Document();
+		doc->add("number", i);
+		request->documents().push_back(doc);
+	}
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	OpMsgCursor cursor("team", "numbers");
+	cursor.query().setCommandName(OpMsgMessage::CMD_FIND);
+	cursor.setBatchSize(1000);
+
+	int n = 0;
+	auto cresponse = cursor.next(*_mongo);
+	while(true)
+	{
+		n += static_cast<int>(cresponse.documents().size());
+		if ( cursor.cursorID() == 0 )
+			break;
+
+		cursor.kill(*_mongo);
+		cresponse = cursor.next(*_mongo);
+	}
+	assertEquals (1000, n);
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+}
+
+void MongoDBTest::testOpCmdCount()
+{
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_COUNT);
+
+	OpMsgMessage response;
+	_mongo->sendRequest(*request, response);
+
+	assertTrue(response.responseOk());
+	const auto& doc = response.body();
+	assertEquals (1, doc.getInteger("n"));
+}
+
+
+void MongoDBTest::testOpCmdDelete()
+{
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_DELETE);
+
+	Document::Ptr del = new Document();
+	del->add("limit", 0).addNewDocument("q").add("lastname" , std::string("Braem"));
+	request->documents().push_back(del);
+
+	OpMsgMessage response;
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+}
+
+void MongoDBTest::testOpCmdConnectionPool()
+{
+#if POCO_OS == POCO_OS_ANDROID
+		std::string host = "10.0.2.2";
+#else
+		std::string host = "127.0.0.1";
+#endif
+
+	Poco::Net::SocketAddress sa(host, 27017);
+	Poco::PoolableObjectFactory<Connection, Connection::Ptr> factory(sa);
+	Poco::ObjectPool<Connection, Connection::Ptr> pool(factory, 10, 15);
+
+	PooledConnection pooledConnection(pool);
+
+	Database db("team");
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_COUNT);
+
+	OpMsgMessage response;
+
+	((Connection::Ptr) pooledConnection)->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	const auto& doc = response.body();
+	assertEquals (1, doc.getInteger("n"));
+}
+


### PR DESCRIPTION
Pull request contains changes as described in #3484.

Support for latest wire protocol using OP_MSG is implemented in addition to older wire protocol.

Helper functions and constants are added for the user to be able to determine which wire protocol is supported by the database server.

Plenty new test cases for the new wire protocol are added.

Functionality "more to come on responses" that is described in the specification is also implemented but disabled with preprocessor definition because it seems that it is not yet implemented in MongoDB server.