### PR TITLE
Pass `pServerCert->hCertStore` for `hAdditionalStore` argument in `CertGetCertificateChain` call

### DIFF
--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -1223,7 +1223,7 @@ void SecureSocketImpl::verifyCertificateChainClient(PCCERT_CONTEXT pServerCert)
 							NULL,
 							_pPeerCertificate,
 							NULL,
-							NULL,
+							pServerCert->hCertStore,
 							&chainPara,
 							0,
 							NULL,


### PR DESCRIPTION
Fix for #3907 
- Passing `hCertStore` member of the CERT_CONTEXT as `hAdditionalStore` parameter to `CertGetCertificateChain` call
- When the intermediate certificates are not installed on the machine, this will be able to build the entire chain.