### PR TITLE
Fix: define NOMINMAX only if not defined yet

### DIFF
--- a/Foundation/include/Poco/UnWindows.h
+++ b/Foundation/include/Poco/UnWindows.h
@@ -26,7 +26,9 @@
 #endif
 
 // disable min/max macros
-#define NOMINMAX
+#if !defined(NOMINMAX)
+    #define NOMINMAX
+#endif
 
 #if !defined(POCO_NO_WINDOWS_H)
     #include <windows.h>


### PR DESCRIPTION
Fixes compiler warnings when NOMINMAX is already defined in a project using Poco.