### PR TITLE
PageCompiler: Extracted page write from handleRequest

### DIFF
--- a/PageCompiler/src/CodeWriter.cpp
+++ b/PageCompiler/src/CodeWriter.cpp
@@ -160,7 +160,14 @@ void CodeWriter::handlerClass(std::ostream& ostr, const std::string& base, const
 		ostr << "\t" << _class << "(" << ctorArg << ");\n";
 		ostr << "\n";
 	}
-	ostr << "\tvoid handleRequest(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response);\n";
+	ostr << "\tvoid handleRequest(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response) override;\n";
+
+	if (shouldWriteForm()) {
+		ostr << "\tvoid stringify(std::ostream &responseStream, Poco::Net::HTMLForm &form);\n";
+	} else {
+		ostr << "\tvoid stringify(std::ostream &responseStream);\n";
+	}
+
 	writeHandlerMembers(ostr);
 
 	std::string path = _page.get("page.path", "");
@@ -195,6 +202,11 @@ void CodeWriter::factoryImpl(std::ostream& ostr, const std::string& arg)
 void CodeWriter::writeHeaderIncludes(std::ostream& ostr)
 {
 	ostr << "#include \"Poco/Net/HTTPRequestHandler.h\"\n";
+	ostr << "namespace Poco {\n"
+		"namespace Net {\n"
+		"class HTMLForm;\n"
+		"}\n"
+		"}\n";
 }
 
 
@@ -272,8 +284,18 @@ void CodeWriter::writeHandler(std::ostream& ostr)
 		ostr << "\tif (!(" << _page.get("page.precondition") << ")) return;\n\n";
 	}
 	writeForm(ostr);
-	ostr << _page.preHandler().str();
 	writeContent(ostr);
+	ostr << "}\n\n";
+
+	if (shouldWriteForm()) {
+		ostr << "void " << _class << "::stringify(std::ostream &responseStream, [[maybe_unused]] Poco::Net::HTMLForm &form)\n";
+		ostr << "{\n";
+	} else {
+		ostr << "void " << _class << "::stringify(std::ostream &responseStream)\n";
+		ostr << "{\n";
+	}
+	ostr << _page.preHandler().str();
+	ostr << cleanupHandler(_page.handler().str());
 	ostr << "}\n";
 }
 
@@ -287,6 +309,10 @@ void CodeWriter::writeManifest(std::ostream& ostr)
 {
 }
 
+bool CodeWriter::shouldWriteForm() const
+{
+	return _page.getBool("page.form", true);
+}
 
 void CodeWriter::writeSession(std::ostream& ostr)
 {
@@ -295,7 +321,7 @@ void CodeWriter::writeSession(std::ostream& ostr)
 
 void CodeWriter::writeForm(std::ostream& ostr)
 {
-	if (_page.getBool("page.form", true))
+	if (shouldWriteForm())
 	{
 		std::string partHandler(_page.get("page.formPartHandler", ""));
 		if (!partHandler.empty())
@@ -362,6 +388,8 @@ void CodeWriter::writeContent(std::ostream& ostr)
 	if (buffered) compressed = false;
 	if (compressed) chunked = true;
 
+	std::string stringifyCall = shouldWriteForm() ? "\tstringify(responseStream, form);\n" : "\tstringify(responseStream);\n";
+
 	if (buffered)
 	{
 		ostr << "\tstd::stringstream responseStream;\n";
@@ -369,7 +397,7 @@ void CodeWriter::writeContent(std::ostream& ostr)
 		{
 			ostr << "\tPoco::Net::EscapeHTMLOutputStream _escapeStream(responseStream);\n";
 		}
-		ostr << cleanupHandler(_page.handler().str());
+		ostr << stringifyCall;
 		if (!chunked)
 		{
 			ostr << "\tresponse.setContentLength(static_cast<int>(responseStream.tellp()));\n";
@@ -385,7 +413,7 @@ void CodeWriter::writeContent(std::ostream& ostr)
 		{
 			ostr << "\tPoco::Net::EscapeHTMLOutputStream _escapeStream(responseStream);\n";
 		}
-		ostr << cleanupHandler(_page.handler().str());
+		ostr << stringifyCall;
 		ostr << "\tif (_compressResponse) _gzipStream.close();\n";
 	}
 	else
@@ -395,7 +423,7 @@ void CodeWriter::writeContent(std::ostream& ostr)
 		{
 			ostr << "\tPoco::Net::EscapeHTMLOutputStream _escapeStream(responseStream);\n";
 		}
-		ostr << cleanupHandler(_page.handler().str());
+		ostr << stringifyCall;
 	}
 }
 

--- a/PageCompiler/src/CodeWriter.h
+++ b/PageCompiler/src/CodeWriter.h
@@ -58,6 +58,8 @@ protected:
 	virtual void writeContent(std::ostream& ostr);
 	virtual void writeManifest(std::ostream& ostr);
 
+	virtual bool shouldWriteForm() const;
+
 	void beginGuard(std::ostream& ostr, const std::string& headerFileName);
 	void endGuard(std::ostream& ostr, const std::string& headerFileName);
 	void beginNamespace(std::ostream& ostr);


### PR DESCRIPTION
Hi.
I would like to use the Poco PageCompiler to create HTML emails, so I made these tweaks. I hope you will find it useful.

Thanks.

Example:
Input page template
```
<%@ page class="TimeHandler" %>
<%!
    #include "Poco/DateTime.h"
    #include "Poco/DateTimeFormatter.h"
    #include "Poco/DateTimeFormat.h"


    using Poco::DateTime;
    using Poco::DateTimeFormatter;
    using Poco::DateTimeFormat;
%><%
    DateTime now;
    std::string dt(DateTimeFormatter::format(now, DateTimeFormat::SORTABLE_FORMAT));
%>
<html>
<head>
<title>Time Sample</title>
</head>
<body>
<h1>Time Sample</h1>
<p><%= dt %></p>
</body>
</html>

```

Output header TimeHandler.h:
```
#ifndef TimeHandler_INCLUDED
#define TimeHandler_INCLUDED


#include "Poco/Net/HTTPRequestHandler.h"
namespace Poco {
namespace Net {
class HTMLForm;
}
}


class TimeHandler: public Poco::Net::HTTPRequestHandler
{
public:
	void handleRequest(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response) override;
	void stringify(std::ostream &responseStream, Poco::Net::HTMLForm &form);
};


#endif // TimeHandler_INCLUDED
```

Ouput source TimeHandler.cpp:
```
#include "TimeHandler.h"
#include "Poco/Net/HTTPServerRequest.h"
#include "Poco/Net/HTTPServerResponse.h"
#include "Poco/Net/HTMLForm.h"
#line 2 "/mnt/projects/Projects/poco/build/bin/aaa/page.cpsp"

    #include "Poco/DateTime.h"
    #include "Poco/DateTimeFormatter.h"
    #include "Poco/DateTimeFormat.h"


    using Poco::DateTime;
    using Poco::DateTimeFormatter;
    using Poco::DateTimeFormat;


using namespace std::string_literals;


void TimeHandler::handleRequest(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response)
{
	response.setChunkedTransferEncoding(true);
	response.setContentType("text/html"s);

	Poco::Net::HTMLForm form(request, request.stream());
	std::ostream& responseStream = response.send();
	stringify(responseStream, form);
}

void TimeHandler::stringify(std::ostream &responseStream, [[maybe_unused]] Poco::Net::HTMLForm &form)
{
	responseStream << "\n";
#line 11 "/mnt/projects/Projects/poco/build/bin/aaa/page.cpsp"

    DateTime now;
    std::string dt(DateTimeFormatter::format(now, DateTimeFormat::SORTABLE_FORMAT));
	responseStream << "\n";
	responseStream << "<html>\n";
	responseStream << "<head>\n";
	responseStream << "<title>Time Sample</title>\n";
	responseStream << "</head>\n";
	responseStream << "<body>\n";
	responseStream << "<h1>Time Sample</h1>\n";
	responseStream << "<p>";
#line 21 "/mnt/projects/Projects/poco/build/bin/aaa/page.cpsp"
	responseStream << ( dt );
	responseStream << "</p>\n";
	responseStream << "</body>\n";
	responseStream << "</html>\n";
	responseStream << "\n";
}

```


Example use with MailMessage:
```

        Poco::Net::MailMessage message;

        std::stringstream sstr;

        TimeHandler msg;
        Poco::Net::HTMLForm form;
        msg.stringify(sstr,  form);
        
        message.setContentType("text/html; charset=UTF-8");
        message.setContent(sstr.str(), Poco::Net::MailMessage::ENCODING_8BIT);
```