### PR TITLE
Fix deadlock in Timer when one sync and one async cancel requests are issued

### DIFF
--- a/Util/src/Timer.cpp
+++ b/Util/src/Timer.cpp
@@ -93,6 +93,11 @@ public:
 				_finished.set();
 				return false;
 			}
+			Poco::AutoPtr<CancelNotification> pCnf = pNf.cast<CancelNotification>();
+			if (pCnf)
+			{
+				pCnf->_finished.set();
+			}
 			pNf = static_cast<TimerNotification*>(queue().dequeueNotification());
 		}
 

--- a/Util/testsuite/src/TimerTest.h
+++ b/Util/testsuite/src/TimerTest.h
@@ -35,6 +35,7 @@ public:
 	void testCancel();
 	void testCancelAllStop();
 	void testCancelAllWaitStop();
+	void testMultiCancelAllWaitStop();
 	void testFunc();
 
 	void setUp();


### PR DESCRIPTION
Merging to 1.12.5

Timer is implemented with internal queue. If a user wants to cancel all pending tasks it can call .cancel to schedule CancelNotification. As a part of processing of CancelNotification it will just flush the whole queue. It does have special processing for StopNotification so that Timer destruction doesn't get blocked. Now if we first schedule async cancel and before this first cancel is processed we schedule another cancel but this time a sync second one will block because it is never notified that all tasks are canceled, _finished event is never set on that flushed CancelNotification.

Fix: add diffrent processing in case of CancelNotification to set all of it's _finished events. Also add a test for this situation.
fixes #3921