### PR TITLE
CppParser: Support return values which are specified to be in the global namespace

### DIFF
--- a/CppParser/src/Parser.cpp
+++ b/CppParser/src/Parser.cpp
@@ -379,7 +379,7 @@ const Token* Parser::parseClassMembers(const Token* pNext, Struct* /*pClass*/)
 	poco_assert (isOperator(pNext, OperatorToken::OP_OPENBRACE));
 
 	pNext = next();
-	while (pNext->is(Token::IDENTIFIER_TOKEN) || pNext->is(Token::KEYWORD_TOKEN) || isOperator(pNext, OperatorToken::OP_COMPL))
+	while (pNext->is(Token::IDENTIFIER_TOKEN) || pNext->is(Token::KEYWORD_TOKEN) || isOperator(pNext, OperatorToken::OP_COMPL) || isOperator(pNext, OperatorToken::OP_DBL_COLON))
 	{
 		switch (pNext->asInteger())
 		{

--- a/CppParser/src/Parser.cpp
+++ b/CppParser/src/Parser.cpp
@@ -133,6 +133,7 @@ inline void Parser::append(std::string& decl, const std::string& token)
 	 || token == "static"
 	 || token == "mutable"
 	 || token == "inline"
+	 || token == "virtual"
 	 || token == "volatile"
 	 || token == "register"
 	 || token == "thread_local")


### PR DESCRIPTION
Fix: https://github.com/pocoproject/poco/issues/3926