### PR TITLE
Fix multicast leave group

### DIFF
--- a/Net/src/MulticastSocket.cpp
+++ b/Net/src/MulticastSocket.cpp
@@ -257,8 +257,7 @@ NetworkInterface MulticastSocket::findFirstInterface(const IPAddress& groupAddre
 
 void MulticastSocket::leaveGroup(const IPAddress& groupAddress)
 {
-	NetworkInterface intf;
-	leaveGroup(groupAddress, intf);
+	leaveGroup(groupAddress, findFirstInterface(groupAddress));
 }
 
 

--- a/Net/testsuite/src/MulticastSocketTest.cpp
+++ b/Net/testsuite/src/MulticastSocketTest.cpp
@@ -51,6 +51,8 @@ void MulticastSocketTest::testMulticast()
 	{
 		MulticastEchoServer echoServer;
 		MulticastSocket ms(SocketAddress::IPv4);
+		SocketAddress multicastAddress("234.2.2.2", 4040);
+		ms.joinGroup(multicastAddress.host());
 		ms.setReceiveTimeout(Poco::Timespan(5, 0));
 		int n = ms.sendTo("hello", 5, echoServer.group());
 		assertTrue (n == 5);
@@ -58,6 +60,7 @@ void MulticastSocketTest::testMulticast()
 		n = ms.receiveBytes(buffer, sizeof(buffer));
 		assertTrue (n == 5);
 		assertTrue (std::string(buffer, n) == "hello");
+		ms.leaveGroup(multicastAddress.host());
 		ms.close();
 	}
 	catch (Poco::NotImplementedException&)


### PR DESCRIPTION
As exposed in the issue #3923, using the method [`leaveGroup()`](https://github.com/pocoproject/poco/blob/devel/Net/src/MulticastSocket.cpp#L261) on a multicast socket raises an [`NotFoundException`](https://github.com/pocoproject/poco/blob/devel/Net/src/NetworkInterface.cpp#L331). This patch allows to use the same interface than the [`joinGroup()`](https://github.com/pocoproject/poco/blob/devel/Net/src/MulticastSocket.cpp#L197) method. Thus, the interface exists and the exception is not raised.

I have successfully tested my patch on Fedora 37 and Windows 10, using the example given in the issue.

This pull request solves issue #3923.