### PR TITLE
Regarding #3918: Fixing Mutex / FastMutex by replacement with std library implementations

### DIFF
--- a/ApacheConnector/include/ApacheApplication.h
+++ b/ApacheConnector/include/ApacheApplication.h
@@ -40,7 +40,7 @@ public:
 private:
 	bool _ready;
 	ApacheRequestHandlerFactory _factory;
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 };
 
 

--- a/ApacheConnector/include/ApacheRequestHandlerFactory.h
+++ b/ApacheConnector/include/ApacheRequestHandlerFactory.h
@@ -48,7 +48,7 @@ private:
 
 	RequestHandlerFactories _requestHandlers;
 	Poco::ClassLoader<Poco::Net::HTTPRequestHandlerFactory> _loader;
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 };
 
 

--- a/ApacheConnector/src/ApacheApplication.cpp
+++ b/ApacheConnector/src/ApacheApplication.cpp
@@ -16,7 +16,6 @@
 
 
 using Poco::Logger;
-using Poco::FastMutex;
 
 
 ApacheApplication::ApacheApplication():
@@ -34,7 +33,7 @@ ApacheApplication::~ApacheApplication()
 
 void ApacheApplication::setup()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ready)
 	{

--- a/ApacheConnector/src/ApacheRequestHandlerFactory.cpp
+++ b/ApacheConnector/src/ApacheRequestHandlerFactory.cpp
@@ -18,7 +18,6 @@
 
 
 using Poco::StringTokenizer;
-using Poco::FastMutex;
 
 
 ApacheRequestHandlerFactory::ApacheRequestHandlerFactory()
@@ -33,7 +32,7 @@ ApacheRequestHandlerFactory::~ApacheRequestHandlerFactory()
 
 Poco::Net::HTTPRequestHandler* ApacheRequestHandlerFactory::createRequestHandler(const Poco::Net::HTTPServerRequest& request)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	// only if the given uri is found in _uris we are
 	// handling this request.
@@ -57,7 +56,7 @@ Poco::Net::HTTPRequestHandler* ApacheRequestHandlerFactory::createRequestHandler
 
 void ApacheRequestHandlerFactory::handleURIs(const std::string& uris)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	StringTokenizer st(uris, " ", StringTokenizer::TOK_TRIM);
 	StringTokenizer::Iterator it = st.begin();
@@ -91,7 +90,7 @@ void ApacheRequestHandlerFactory::addRequestHandlerFactory(const std::string& dl
 
 bool ApacheRequestHandlerFactory::mustHandle(const std::string& uri)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	// only if the given uri is found in _uris we are
 	// handling this request.

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -35,7 +35,7 @@ extern "C"
 {
 	struct CRYPTO_dynlock_value
 	{
-		Poco::FastMutex _mutex;
+		std::mutex _mutex;
 	};
 }
 
@@ -88,7 +88,7 @@ private:
 	static Poco::AtomicCounter _rc;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	static Poco::FastMutex* _mutexes;
+	static std::mutex* _mutexes;
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -62,7 +62,7 @@ namespace Crypto {
 Poco::AtomicCounter OpenSSLInitializer::_rc;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-Poco::FastMutex* OpenSSLInitializer::_mutexes(0);
+std::mutex* OpenSSLInitializer::_mutexes(0);
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -106,7 +106,7 @@ void OpenSSLInitializer::initialize()
 		OpenSSL_add_all_algorithms();
 
 		int nMutexes = CRYPTO_num_locks();
-		_mutexes = new Poco::FastMutex[nMutexes];
+		_mutexes = new std::mutex[nMutexes];
 		CRYPTO_set_locking_callback(&OpenSSLInitializer::lock);
 #ifndef POCO_OS_FAMILY_WINDOWS
 // Not needed on Windows (see SF #110: random unhandled exceptions when linking with ssl).

--- a/Data/MySQL/include/Poco/Data/MySQL/SessionImpl.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/SessionImpl.h
@@ -202,7 +202,7 @@ private:
 	bool                  _failIfInnoReadOnly;
 	std::size_t           _timeout;
 	mutable int           _lastError;
-	Poco::FastMutex       _mutex;
+	std::mutex            _mutex;
 };
 
 

--- a/Data/MySQL/src/SessionImpl.cpp
+++ b/Data/MySQL/src/SessionImpl.cpp
@@ -191,7 +191,7 @@ Poco::Data::StatementImpl::Ptr SessionImpl::createStatementImpl()
 
 void SessionImpl::begin()
 {
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 
 	if (_inTransaction)
 		throw Poco::InvalidAccessException("Already in transaction.");

--- a/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/SessionImpl.h
@@ -205,7 +205,7 @@ private:
 	bool                   _inTransaction;
 	int                    _queryTimeout;
 	std::string            _dbEncoding;
-	Poco::FastMutex        _mutex;
+	std::mutex             _mutex;
 };
 
 

--- a/Data/ODBC/src/SessionImpl.cpp
+++ b/Data/ODBC/src/SessionImpl.cpp
@@ -373,7 +373,7 @@ void SessionImpl::begin()
 		throw InvalidAccessException("Session in auto commit mode.");
 
 	{
-		Poco::FastMutex::ScopedLock l(_mutex);
+		std::lock_guard<std::mutex> l(_mutex);
 
 		if (_inTransaction)
 			throw InvalidAccessException("Transaction in progress.");

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionHandle.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionHandle.h
@@ -173,7 +173,7 @@ public:
 	operator PGconn* ();
 		/// Get the PostgreSQL connection pointer
 
-	Poco::FastMutex& mutex();
+	std::mutex& mutex();
 		/// Get the sessionHandle mutex to protect the connection pointer
 
 private:
@@ -189,7 +189,7 @@ private:
 	SessionHandle& operator= (const SessionHandle&);
 
 private:
-	mutable Poco::FastMutex   _sessionMutex;
+	mutable std::mutex        _sessionMutex;
 	PGconn*                   _pConnection;
 	std::string               _connectionString;
 	bool                      _inTransaction;
@@ -288,7 +288,7 @@ inline SessionHandle::operator PGconn * ()
 }
 
 
-inline Poco::FastMutex&SessionHandle::mutex()
+inline std::mutex&SessionHandle::mutex()
 {
 	return _sessionMutex;
 }

--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -57,7 +57,7 @@ SessionHandle::~SessionHandle()
 
 bool SessionHandle::isConnected() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	return isConnectedNoLock();
 }
@@ -77,7 +77,7 @@ bool SessionHandle::isConnectedNoLock() const
 
 void SessionHandle::connect(const std::string& aConnectionString)
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (isConnectedNoLock())
 	{
@@ -135,7 +135,7 @@ void SessionHandle::connect(const char* aHost, const char* aUser, const char* aP
 
 void SessionHandle::disconnect()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (isConnectedNoLock())
 	{
@@ -155,7 +155,7 @@ void SessionHandle::disconnect()
 // TODO: Figure out what happens if a connection is reset with a pending transaction
 bool SessionHandle::reset()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (_pConnection)
 	{
@@ -173,7 +173,7 @@ bool SessionHandle::reset()
 
 std::string SessionHandle::lastError() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -195,7 +195,7 @@ std::string SessionHandle::lastErrorNoLock() const
 
 void SessionHandle::startTransaction()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -222,7 +222,7 @@ void SessionHandle::startTransaction()
 
 void SessionHandle::commit()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -246,7 +246,7 @@ void SessionHandle::commit()
 
 void SessionHandle::rollback()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -290,7 +290,7 @@ void SessionHandle::setAutoCommit(bool aShouldAutoCommit)
 
 void SessionHandle::setAsynchronousCommit(bool aShouldAsynchronousCommit)
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -317,7 +317,7 @@ void SessionHandle::setAsynchronousCommit(bool aShouldAsynchronousCommit)
 
 void SessionHandle::cancel()
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -334,7 +334,7 @@ void SessionHandle::cancel()
 
 void SessionHandle::setTransactionIsolation(Poco::UInt32 aTI)
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -392,7 +392,7 @@ bool SessionHandle::hasTransactionIsolation(Poco::UInt32 aTI)
 
 void SessionHandle::deallocatePreparedStatement(const std::string& aPreparedStatementToDeAllocate)
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -443,7 +443,7 @@ void SessionHandle::deallocateStoredPreparedStatements()
 
 int SessionHandle::serverVersion() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -456,7 +456,7 @@ int SessionHandle::serverVersion() const
 
 int SessionHandle::serverProcessID() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -469,7 +469,7 @@ int SessionHandle::serverProcessID() const
 
 int SessionHandle::protocoVersion() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -482,7 +482,7 @@ int SessionHandle::protocoVersion() const
 
 std::string SessionHandle::clientEncoding() const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -495,7 +495,7 @@ std::string SessionHandle::clientEncoding() const
 
 std::string SessionHandle::parameterStatus(const std::string& param) const
 {
-	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+	std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 	if (!isConnectedNoLock())
 	{
@@ -567,7 +567,7 @@ SessionParametersMap SessionHandle::connectionParameters() const
 
 	PQconninfoOption* ptrConnInfoOptions = 0;
 	{
-		Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+		std::lock_guard<std::mutex> mutexLocker(_sessionMutex);
 
 		ptrConnInfoOptions = PQconninfo(_pConnection);
 	}

--- a/Data/PostgreSQL/src/StatementExecutor.cpp
+++ b/Data/PostgreSQL/src/StatementExecutor.cpp
@@ -136,7 +136,7 @@ void StatementExecutor::prepare(const std::string& aSQLStatement)
 	PGresult* ptrPGResult = 0;
 
 	{
-		Poco::FastMutex::ScopedLock mutexLocker(_sessionHandle.mutex());
+		std::lock_guard<std::mutex> mutexLocker(_sessionHandle.mutex());
 
 		// prepare the statement - temporary PGresult returned
 		ptrPGResult = PQprepare(_sessionHandle, pStatementName, ptrCSQLStatement, (int)countPlaceholdersInSQLStatement, 0);
@@ -154,7 +154,7 @@ void StatementExecutor::prepare(const std::string& aSQLStatement)
 
 	// Determine what the structure of a statement result will look like
 	{
-		Poco::FastMutex::ScopedLock mutexLocker(_sessionHandle.mutex());
+		std::lock_guard<std::mutex> mutexLocker(_sessionHandle.mutex());
 		ptrPGResult = PQdescribePrepared(_sessionHandle, pStatementName);
 	}
 
@@ -247,7 +247,7 @@ void StatementExecutor::execute()
 
 	PGresult* ptrPGResult = 0;
 	{
-		Poco::FastMutex::ScopedLock mutexLocker(_sessionHandle.mutex());
+		std::lock_guard<std::mutex> mutexLocker(_sessionHandle.mutex());
 
 		ptrPGResult = PQexecPrepared(_sessionHandle,
 			_preparedStatementName.c_str(), (int)_countPlaceholdersInSQLStatement,

--- a/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Notifier.h
@@ -161,7 +161,7 @@ private:
 	Poco::Int64        _row;
 	Poco::Dynamic::Var _value;
 	EnabledEventType   _enabledEvents;
-	Poco::Mutex        _mutex;
+	std::recursive_mutex _mutex;
 };
 
 

--- a/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
@@ -141,7 +141,7 @@ private:
 	TransactionType _transactionType;
 	int         _timeout;
 	mutable
-	Poco::Mutex _mutex;
+	std::recursive_mutex _mutex;
 	static const std::string DEFERRED_BEGIN_TRANSACTION;
 	static const std::string EXCLUSIVE_BEGIN_TRANSACTION;
 	static const std::string IMMEDIATE_BEGIN_TRANSACTION; 

--- a/Data/SQLite/include/Poco/Data/SQLite/Utility.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Utility.h
@@ -216,7 +216,7 @@ private:
 	static void* eventHookRegister(sqlite3* pDB, RollbackCallbackType callbackFn, void* pParam);
 
 	static TypeMap     _types;
-	static Poco::Mutex _mutex;
+	static std::recursive_mutex _mutex;
 	static int         _threadMode;
 };
 

--- a/Data/SQLite/src/Notifier.cpp
+++ b/Data/SQLite/src/Notifier.cpp
@@ -56,7 +56,7 @@ Notifier::~Notifier()
 
 bool Notifier::enableUpdate()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), &sqliteUpdateCallbackFn, this))
 		_enabledEvents |= SQLITE_NOTIFY_UPDATE;
@@ -67,7 +67,7 @@ bool Notifier::enableUpdate()
 
 bool Notifier::disableUpdate()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), (Utility::UpdateCallbackType) 0, this))
 		_enabledEvents &= ~SQLITE_NOTIFY_UPDATE;
@@ -84,7 +84,7 @@ bool Notifier::updateEnabled() const
 
 bool Notifier::enableCommit()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), &sqliteCommitCallbackFn, this))
 		_enabledEvents |= SQLITE_NOTIFY_COMMIT;
@@ -95,7 +95,7 @@ bool Notifier::enableCommit()
 
 bool Notifier::disableCommit()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), (Utility::CommitCallbackType) 0, this))
 		_enabledEvents &= ~SQLITE_NOTIFY_COMMIT;
@@ -112,7 +112,7 @@ bool Notifier::commitEnabled() const
 
 bool Notifier::enableRollback()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), &sqliteRollbackCallbackFn, this))
 		_enabledEvents |= SQLITE_NOTIFY_ROLLBACK;
@@ -123,7 +123,7 @@ bool Notifier::enableRollback()
 
 bool Notifier::disableRollback()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 
 	if (Utility::registerUpdateHandler(Utility::dbHandle(_session), (Utility::RollbackCallbackType) 0, this))
 		_enabledEvents &= ~SQLITE_NOTIFY_ROLLBACK;

--- a/Data/SQLite/src/SessionImpl.cpp
+++ b/Data/SQLite/src/SessionImpl.cpp
@@ -87,7 +87,7 @@ Poco::Data::StatementImpl::Ptr SessionImpl::createStatementImpl()
 
 void SessionImpl::begin()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	SQLiteStatementImpl tmp(*this, _pDB);
 	switch (_transactionType)
 	{
@@ -108,7 +108,7 @@ void SessionImpl::begin()
 
 void SessionImpl::commit()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	SQLiteStatementImpl tmp(*this, _pDB);
 	tmp.add(COMMIT_TRANSACTION);
 	tmp.execute();
@@ -118,7 +118,7 @@ void SessionImpl::commit()
 
 void SessionImpl::rollback()
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	SQLiteStatementImpl tmp(*this, _pDB);
 	tmp.add(ABORT_TRANSACTION);
 	tmp.execute();
@@ -267,7 +267,7 @@ void SessionImpl::autoCommit(const std::string&, bool)
 
 bool SessionImpl::isAutoCommit(const std::string&) const
 {
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	return (0 != sqlite3_get_autocommit(_pDB));
 }
 

--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -58,7 +58,7 @@ const int Utility::OPERATION_UPDATE = SQLITE_UPDATE;
 const std::string Utility::SQLITE_DATE_FORMAT = "%Y-%m-%d";
 const std::string Utility::SQLITE_TIME_FORMAT = "%H:%M:%S";
 Utility::TypeMap Utility::_types;
-Poco::Mutex Utility::_mutex;
+std::recursive_mutex Utility::_mutex;
 
 
 Utility::SQLiteMutex::SQLiteMutex(sqlite3* pDB): _pMutex((pDB) ? sqlite3_db_mutex(pDB) : 0)
@@ -158,7 +158,7 @@ MetaColumn::ColumnDataType Utility::getColumnType(sqlite3_stmt* pStmt, std::size
 
 	// Ensure statics are initialized
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		static Utility u;
 	}
 

--- a/Data/include/Poco/Data/PooledSessionHolder.h
+++ b/Data/include/Poco/Data/PooledSessionHolder.h
@@ -58,7 +58,7 @@ private:
 	SessionPool& _owner;
 	Poco::AutoPtr<SessionImpl> _pImpl;
 	Poco::Timestamp _lastUsed;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 
@@ -79,7 +79,7 @@ inline SessionPool& PooledSessionHolder::owner()
 
 inline void PooledSessionHolder::access()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_lastUsed.update();
 }
@@ -87,7 +87,7 @@ inline void PooledSessionHolder::access()
 
 inline int PooledSessionHolder::idle() const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return (int) (_lastUsed.elapsed()/Poco::Timestamp::resolution());
 }

--- a/Data/include/Poco/Data/SessionFactory.h
+++ b/Data/include/Poco/Data/SessionFactory.h
@@ -89,7 +89,7 @@ private:
 
 	typedef std::map<std::string, SessionInfo, Poco::CILess> Connectors;
 	Connectors      _connectors;
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 };
 
 

--- a/Data/include/Poco/Data/SessionPool.h
+++ b/Data/include/Poco/Data/SessionPool.h
@@ -207,7 +207,7 @@ private:
 	AddPropertyMap _addPropertyMap;
 	AddFeatureMap  _addFeatureMap;
 	mutable
-	Poco::Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 	friend class PooledSessionImpl;
 };

--- a/Data/include/Poco/Data/SessionPoolContainer.h
+++ b/Data/include/Poco/Data/SessionPoolContainer.h
@@ -86,7 +86,7 @@ private:
 	SessionPoolContainer& operator = (const SessionPoolContainer&);
 
 	SessionPoolMap  _sessionPools;
-	Poco::FastMutex _mutex;
+	std::mutex      _mutex;
 };
 
 

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -432,7 +432,7 @@ private:
 	// asynchronous execution related members
 	bool                _async;
 	mutable ResultPtr   _pResult;
-	Mutex               _mutex;
+	std::recursive_mutex _mutex;
 	AsyncExecMethodPtr  _pAsyncExec;
 	std::vector<Any>    _arguments;
 	RowFormatter::Ptr   _pRowFormatter;

--- a/Data/src/SessionFactory.cpp
+++ b/Data/src/SessionFactory.cpp
@@ -40,7 +40,7 @@ SessionFactory& SessionFactory::instance()
 
 void SessionFactory::add(Connector* pIn)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	SessionInfo info(pIn);
 	std::pair<Connectors::iterator, bool> res =
 		_connectors.insert(std::make_pair(pIn->name(), info));
@@ -50,7 +50,7 @@ void SessionFactory::add(Connector* pIn)
 
 void SessionFactory::remove(const std::string& key)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Connectors::iterator it = _connectors.find(key);
 	poco_assert (_connectors.end() != it);
 
@@ -65,7 +65,7 @@ Session SessionFactory::create(const std::string& key,
 {
 	Poco::SharedPtr<Connector> ptrSI;
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		Connectors::iterator it = _connectors.find(key);
 		if (_connectors.end() == it) throw Poco::NotFoundException(key);
 		ptrSI = it->second.ptrSI;

--- a/Data/src/SessionPool.cpp
+++ b/Data/src/SessionPool.cpp
@@ -64,7 +64,7 @@ Session SessionPool::get(const std::string& name, bool value)
 
 Session SessionPool::get()
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
     if (_shutdown) throw InvalidAccessException("Session pool has been shut down.");
 
 	purgeDeadSessions();
@@ -95,7 +95,7 @@ Session SessionPool::get()
 
 void SessionPool::purgeDeadSessions()
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) return;
 
 	SessionList::iterator it = _idleSessions.begin();
@@ -119,14 +119,14 @@ int SessionPool::capacity() const
 
 int SessionPool::used() const
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	return (int) _activeSessions.size();
 }
 
 
 int SessionPool::idle() const
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	return (int) _idleSessions.size();
 }
 
@@ -139,7 +139,7 @@ int SessionPool::connTimeout() const
 
 int SessionPool::dead()
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	int count = 0;
 
 	SessionList::iterator it = _activeSessions.begin();
@@ -156,7 +156,7 @@ int SessionPool::dead()
 
 int SessionPool::allocated() const
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	return _nSessions;
 }
 
@@ -170,7 +170,7 @@ int SessionPool::available() const
 
 void SessionPool::setFeature(const std::string& name, bool state)
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) throw InvalidAccessException("Session pool has been shut down.");
 
 	if (_nSessions > 0)
@@ -194,7 +194,7 @@ bool SessionPool::getFeature(const std::string& name)
 
 void SessionPool::setProperty(const std::string& name, const Poco::Any& value)
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) throw InvalidAccessException("Session pool has been shut down.");
 
 	if (_nSessions > 0)
@@ -234,7 +234,7 @@ void SessionPool::customizeSession(Session&)
 
 void SessionPool::putBack(PooledSessionHolderPtr pHolder)
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) return;
 
 	SessionList::iterator it = std::find(_activeSessions.begin(), _activeSessions.end(), pHolder);
@@ -287,7 +287,7 @@ void SessionPool::putBack(PooledSessionHolderPtr pHolder)
 
 void SessionPool::onJanitorTimer(Poco::Timer&)
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) return;
 
 	SessionList::iterator it = _idleSessions.begin();
@@ -312,7 +312,7 @@ void SessionPool::onJanitorTimer(Poco::Timer&)
 
 void SessionPool::shutdown()
 {
-	Poco::Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (_shutdown) return;
 	_shutdown = true;
 	_janitorTimer.stop();

--- a/Data/src/SessionPoolContainer.cpp
+++ b/Data/src/SessionPoolContainer.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 
 
-using Poco::FastMutex;
 
 
 namespace Poco {
@@ -42,7 +41,7 @@ void SessionPoolContainer::add(SessionPool* pPool)
 {
 	poco_check_ptr (pPool);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_sessionPools.find(pPool->name()) != _sessionPools.end())
 		throw SessionPoolExistsException("Session pool already exists: " + pPool->name());
 
@@ -59,7 +58,7 @@ Session SessionPoolContainer::add(const std::string& sessionKey,
 {
 	std::string name = SessionPool::name(sessionKey, connectionString);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	SessionPoolMap::iterator it = _sessionPools.find(name);
 
 	// pool already exists, silently return a session from it
@@ -104,7 +103,7 @@ SessionPool& SessionPoolContainer::getPool(const std::string& name)
 	poco_assert (!path.empty());
 	std::string n = Session::uri(uri.getScheme(), path.substr(1));
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	SessionPoolMap::iterator it = _sessionPools.find(n);
 	if (_sessionPools.end() == it) throw NotFoundException(n);
 	return *it->second;

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -112,7 +112,7 @@ Statement& Statement::reset(Session& session)
 
 std::size_t Statement::execute(bool reset)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	bool isDone = done();
 	if (initialized() || paused() || isDone)
 	{
@@ -139,7 +139,7 @@ std::size_t Statement::execute(bool reset)
 
 const Statement::Result& Statement::executeAsync(bool reset)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	if (initialized() || paused() || done())
 		return doAsyncExec(reset);
 	else

--- a/Foundation/include/Poco/AbstractCache.h
+++ b/Foundation/include/Poco/AbstractCache.h
@@ -34,7 +34,7 @@
 namespace Poco {
 
 
-template <class TKey, class TValue, class TStrategy, class TMutex = FastMutex, class TEventMutex = FastMutex>
+template <class TKey, class TValue, class TStrategy, class TMutex = std::mutex, class TEventMutex = std::mutex>
 class AbstractCache
 	/// An AbstractCache is the interface of all caches.
 {
@@ -76,7 +76,7 @@ public:
 		/// Adds the key value pair to the cache.
 		/// If for the key already an entry exists, it will be overwritten.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doAdd(key, val);
 	}
 
@@ -87,7 +87,7 @@ public:
 		/// just a simply silent update is performed
 		/// If the key does not exist the behavior is equal to add, ie. an add event is thrown
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doUpdate(key, val);
 	}
 
@@ -96,7 +96,7 @@ public:
 		/// If for the key already an entry exists, it will be overwritten, ie. first a remove event
 		/// is thrown, then a add event
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doAdd(key, val);
 	}
 
@@ -107,7 +107,7 @@ public:
 		/// just an Update is thrown
 		/// If the key does not exist the behavior is equal to add, ie. an add event is thrown
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doUpdate(key, val);
 	}
 
@@ -115,7 +115,7 @@ public:
 		/// Removes an entry from the cache. If the entry is not found,
 		/// the remove is ignored.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		Iterator it = _data.find(key);
 		doRemove(it);
 	}
@@ -123,7 +123,7 @@ public:
 	bool has(const TKey& key) const
 		/// Returns true if the cache contains a value for the key.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return doHas(key);
 	}
 
@@ -132,21 +132,21 @@ public:
 		/// even when cache replacement removes the element.
 		/// If for the key no value exists, an empty SharedPtr is returned.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return doGet (key);
 	}
 
 	void clear()
 		/// Removes all elements from the cache.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doClear();
 	}
 
 	std::size_t size()
 		/// Returns the number of cached elements
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doReplace();
 		return _data.size();
 	}
@@ -158,14 +158,14 @@ public:
 		/// In some cases, i.e. expire based caching where for a long time no access to the cache happens,
 		/// it might be desirable to be able to trigger cache replacement manually.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doReplace();
 	}
 
 	std::set<TKey> getAllKeys()
 		/// Returns a copy of all keys stored in the cache
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		doReplace();
 		ConstIterator it = _data.begin();
 		ConstIterator itEnd = _data.end();
@@ -186,7 +186,7 @@ public:
 		/// as the actual value (or reference),
 		/// not a Poco::SharedPtr.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		for (const auto& p: _data)
 		{
 			fn(p.first, *p.second);

--- a/Foundation/include/Poco/AbstractEvent.h
+++ b/Foundation/include/Poco/AbstractEvent.h
@@ -29,7 +29,7 @@
 namespace Poco {
 
 
-template <class TArgs, class TStrategy, class TDelegate, class TMutex = FastMutex>
+template <class TArgs, class TStrategy, class TDelegate, class TMutex = std::mutex>
 class AbstractEvent
 	/// An AbstractEvent is the base class of all events.
 	/// It works similar to the way C# handles notifications (aka events in C#).
@@ -174,7 +174,7 @@ public:
 		///
 		/// Exact behavior is determined by the TStrategy.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.add(aDelegate);
 	}
 
@@ -183,7 +183,7 @@ public:
 		///
 		/// If the delegate is not found, this function does nothing.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.remove(aDelegate);
 	}
 
@@ -195,7 +195,7 @@ public:
 		/// Returns a DelegateHandle which can be used in call to
 		/// remove() to remove the delegate.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _strategy.add(aDelegate);
 	}
 
@@ -205,7 +205,7 @@ public:
 		///
 		/// If the delegate is not found, this function does nothing.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.remove(delegateHandle);
 	}
 
@@ -264,7 +264,7 @@ public:
 	{
 		NotifyAsyncParams params(pSender, args);
 		{
-			typename TMutex::ScopedLock lock(_mutex);
+			std::lock_guard<TMutex> lock(_mutex);
 
 			// thread-safeness:
 			// copy should be faster and safer than blocking until
@@ -282,7 +282,7 @@ public:
 	void enable()
 		/// Enables the event.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_enabled = true;
 	}
 
@@ -290,28 +290,28 @@ public:
 		/// Disables the event. notify and notifyAsnyc will be ignored,
 		/// but adding/removing delegates is still allowed.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_enabled = false;
 	}
 
 	bool isEnabled() const
 		/// Returns true if event is enabled.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _enabled;
 	}
 
 	void clear()
 		/// Removes all delegates.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.clear();
 	}
 
 	bool empty() const
 		/// Checks if any delegates are registered at the delegate.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _strategy.empty();
 	}
 
@@ -383,7 +383,7 @@ public:
 		///
 		/// Exact behavior is determined by the TStrategy.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.add(aDelegate);
 	}
 
@@ -392,7 +392,7 @@ public:
 		///
 		/// If the delegate is not found, this function does nothing.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.remove(aDelegate);
 	}
 
@@ -404,7 +404,7 @@ public:
 		/// Returns a DelegateHandle which can be used in call to
 		/// remove() to remove the delegate.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _strategy.add(aDelegate);
 	}
 
@@ -414,7 +414,7 @@ public:
 		///
 		/// If the delegate is not found, this function does nothing.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.remove(delegateHandle);
 	}
 
@@ -467,7 +467,7 @@ public:
 	{
 		NotifyAsyncParams params(pSender);
 		{
-			typename TMutex::ScopedLock lock(_mutex);
+			std::lock_guard<TMutex> lock(_mutex);
 
 			// thread-safeness:
 			// copy should be faster and safer than blocking until
@@ -485,7 +485,7 @@ public:
 	void enable()
 		/// Enables the event.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_enabled = true;
 	}
 
@@ -493,27 +493,27 @@ public:
 		/// Disables the event. notify and notifyAsnyc will be ignored,
 		/// but adding/removing delegates is still allowed.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_enabled = false;
 	}
 
 	bool isEnabled() const
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _enabled;
 	}
 
 	void clear()
 		/// Removes all delegates.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		_strategy.clear();
 	}
 
 	bool empty() const
 		/// Checks if any delegates are registered at the delegate.
 	{
-		typename TMutex::ScopedLock lock(_mutex);
+		std::lock_guard<TMutex> lock(_mutex);
 		return _strategy.empty();
 	}
 

--- a/Foundation/include/Poco/AccessExpireCache.h
+++ b/Foundation/include/Poco/AccessExpireCache.h
@@ -28,8 +28,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class AccessExpireCache: public AbstractCache<TKey, TValue, AccessExpireStrategy<TKey, TValue>, TMutex, TEventMutex>
 	/// An AccessExpireCache caches entries for a fixed time period (per default 10 minutes).

--- a/Foundation/include/Poco/AccessExpireLRUCache.h
+++ b/Foundation/include/Poco/AccessExpireLRUCache.h
@@ -30,8 +30,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class AccessExpireLRUCache: public AbstractCache<TKey, TValue, StrategyCollection<TKey, TValue>, TMutex, TEventMutex>
 	/// An AccessExpireLRUCache combines LRU caching and time based expire caching.

--- a/Foundation/include/Poco/Activity.h
+++ b/Foundation/include/Poco/Activity.h
@@ -112,7 +112,7 @@ public:
 
 	void start(ThreadPool& pool)
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		if (!_running)
 		{
@@ -196,7 +196,7 @@ private:
 	std::atomic<bool>   _stopped;
 	std::atomic<bool>   _running;
 	Event               _done;
-	FastMutex           _mutex;
+	std::mutex          _mutex;
 };
 
 

--- a/Foundation/include/Poco/AsyncChannel.h
+++ b/Foundation/include/Poco/AsyncChannel.h
@@ -106,8 +106,8 @@ protected:
 private:
 	Channel::Ptr _pChannel;
 	Thread    _thread;
-	FastMutex _threadMutex;
-	FastMutex _channelMutex;
+	std::mutex _threadMutex;
+	std::mutex _channelMutex;
 	NotificationQueue _queue;
 	std::size_t _queueSize = 0;
 	std::size_t _dropCount = 0;

--- a/Foundation/include/Poco/BasicEvent.h
+++ b/Foundation/include/Poco/BasicEvent.h
@@ -27,7 +27,7 @@
 namespace Poco {
 
 
-template <class TArgs, class TMutex = FastMutex>
+template <class TArgs, class TMutex = std::mutex>
 class BasicEvent: public AbstractEvent <
 	TArgs, DefaultStrategy<TArgs, AbstractDelegate<TArgs>>,
 	AbstractDelegate<TArgs>,

--- a/Foundation/include/Poco/ClassLoader.h
+++ b/Foundation/include/Poco/ClassLoader.h
@@ -150,7 +150,7 @@ public:
 		/// the number of calls to unloadLibrary() must be the same
 		/// for the library to become unloaded.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		typename LibraryMap::iterator it = _map.find(path);
 		if (it == _map.end())
@@ -220,7 +220,7 @@ public:
 		/// library, the number of calls to unloadLibrary() must be the same
 		/// for the library to become unloaded.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		typename LibraryMap::iterator it = _map.find(path);
 		if (it != _map.end())
@@ -245,7 +245,7 @@ public:
 		/// Returns a pointer to the MetaObject for the given
 		/// class, or a null pointer if the class is not known.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		for (const auto& p: _map)
 		{
@@ -312,7 +312,7 @@ public:
 		/// Returns a pointer to the Manifest for the given
 		/// library, or a null pointer if the library has not been loaded.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		typename LibraryMap::const_iterator it = _map.find(path);
 		if (it != _map.end())
@@ -341,21 +341,21 @@ public:
 
 	Iterator begin() const
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return Iterator(_map.begin());
 	}
 
 	Iterator end() const
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return Iterator(_map.end());
 	}
 
 private:
 	LibraryMap _map;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/Condition.h
+++ b/Foundation/include/Poco/Condition.h
@@ -33,7 +33,7 @@ class Foundation_API Condition
 	/// A Condition is a synchronization object used to block a thread
 	/// until a particular condition is met.
 	/// A Condition object is always used in conjunction with
-	/// a Mutex (or FastMutex) object.
+	/// a std::recursive_mutex (or std::mutex) object.
 	///
 	/// Condition objects are similar to POSIX condition variables, which the
 	/// difference that Condition is not subject to spurious wakeups.
@@ -58,7 +58,7 @@ public:
 		ScopedUnlock<Mtx> unlock(mutex, false);
 		Event event;
 		{
-			FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			mutex.unlock();
 			enqueue(event);
 		}
@@ -94,13 +94,13 @@ public:
 		ScopedUnlock<Mtx> unlock(mutex, false);
 		Event event;
 		{
-			FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			mutex.unlock();
 			enqueue(event);
 		}
 		if (!event.tryWait(milliseconds))
 		{
-			FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			dequeue(event);
 			return false;
 		}
@@ -126,7 +126,7 @@ private:
 
 	typedef std::deque<Event*> WaitQueue;
 
-	FastMutex _mutex;
+	std::mutex _mutex;
 	WaitQueue _waitQueue;
 };
 

--- a/Foundation/include/Poco/ConsoleChannel.h
+++ b/Foundation/include/Poco/ConsoleChannel.h
@@ -59,7 +59,7 @@ protected:
 
 private:
 	std::ostream& _str;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 
@@ -178,7 +178,7 @@ private:
 	std::ostream& _str;
 	bool _enableColors;
 	Color _colors[9];
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 	static const std::string CSI;
 };
 

--- a/Foundation/include/Poco/Delegate.h
+++ b/Foundation/include/Poco/Delegate.h
@@ -63,7 +63,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(sender, arguments);
@@ -85,14 +85,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex        _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	Delegate();
@@ -134,7 +134,7 @@ public:
 
 	bool notify(const void*, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(arguments);
@@ -156,14 +156,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex        _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	Delegate();
@@ -275,7 +275,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(sender);
@@ -297,14 +297,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex        _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	Delegate();
@@ -346,7 +346,7 @@ public:
 
 	bool notify(const void*)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)();
@@ -368,14 +368,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex        _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	Delegate();

--- a/Foundation/include/Poco/DynamicFactory.h
+++ b/Foundation/include/Poco/DynamicFactory.h
@@ -56,7 +56,7 @@ public:
 		/// The class must have been registered with registerClass.
 		/// If the class name is unknown, a NotFoundException is thrown.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		typename FactoryMap::const_iterator it = _map.find(className);
 		if (it != _map.end())
@@ -85,7 +85,7 @@ public:
 	{
 		poco_check_ptr (pAbstractFactory);
 
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		std::unique_ptr<AbstractFactory> ptr(pAbstractFactory);
 
@@ -101,7 +101,7 @@ public:
 		/// for the class.
 		/// Throws a NotFoundException if the class has not been registered.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		typename FactoryMap::iterator it = _map.find(className);
 		if (it != _map.end())
@@ -115,7 +115,7 @@ public:
 	bool isClass(const std::string& className) const
 		/// Returns true iff the given class has been registered.
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return _map.find(className) != _map.end();
 	}
@@ -127,7 +127,7 @@ private:
 	typedef std::map<std::string, AbstractFactory*> FactoryMap;
 
 	FactoryMap _map;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/Environment_UNIX.h
+++ b/Foundation/include/Poco/Environment_UNIX.h
@@ -46,7 +46,7 @@ private:
 	typedef std::map<std::string, std::string> StringMap;
 
 	static StringMap _map;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/Environment_VX.h
+++ b/Foundation/include/Poco/Environment_VX.h
@@ -46,7 +46,7 @@ private:
 	typedef std::map<std::string, std::string> StringMap;
 
 	static StringMap _map;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/ErrorHandler.h
+++ b/Foundation/include/Poco/ErrorHandler.h
@@ -101,7 +101,7 @@ protected:
 
 private:
 	static ErrorHandler* _pHandler;
-	static FastMutex     _mutex;
+	static std::mutex    _mutex;
 };
 
 

--- a/Foundation/include/Poco/ExpireCache.h
+++ b/Foundation/include/Poco/ExpireCache.h
@@ -28,8 +28,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class ExpireCache: public AbstractCache<TKey, TValue, ExpireStrategy<TKey, TValue>, TMutex, TEventMutex>
 	/// An ExpireCache caches entries for a fixed time period (per default 10 minutes).

--- a/Foundation/include/Poco/ExpireLRUCache.h
+++ b/Foundation/include/Poco/ExpireLRUCache.h
@@ -30,8 +30,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class ExpireLRUCache: public AbstractCache<TKey, TValue, StrategyCollection<TKey, TValue>, TMutex, TEventMutex>
 	/// An ExpireLRUCache combines LRU caching and time based expire caching.

--- a/Foundation/include/Poco/FIFOBuffer.h
+++ b/Foundation/include/Poco/FIFOBuffer.h
@@ -122,7 +122,7 @@ public:
 		/// than currently used length and preserveContent
 		/// is true, InvalidAccessException is thrown.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (preserveContent && (newSize < _used))
 			throw InvalidAccessException("Can not resize FIFO without data loss.");
@@ -145,7 +145,7 @@ public:
 		/// supplied buffer.
 	{
 		if (0 == length) return 0;
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (!isReadable()) return 0;
 		if (length > _used) length = _used;
 		std::memcpy(pBuffer, _buffer.begin() + _begin, length * sizeof(T));
@@ -164,7 +164,7 @@ public:
 		/// Returns the number of elements copied in the
 		/// supplied buffer.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (!isReadable()) return 0;
 		if (0 == length || length > _used) length = _used;
 		buffer.resize(length);
@@ -180,7 +180,7 @@ public:
 		/// Returns the size of the copied data.
 	{
 		if (0 == length) return 0;
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (!isReadable()) return 0;
 		std::size_t usedBefore = _used;
 		std::size_t readLen = peek(pBuffer, length);
@@ -202,7 +202,7 @@ public:
 		///
 		/// Returns the size of the copied data.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (!isReadable()) return 0;
 		std::size_t usedBefore = _used;
 		std::size_t readLen = peek(buffer, length);
@@ -229,7 +229,7 @@ public:
 	{
 		if (0 == length) return 0;
 
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (!isWritable()) return 0;
 
@@ -290,7 +290,7 @@ public:
 		/// If length is zero or greater than buffer current
 		/// content length, buffer is emptied.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		std::size_t usedBefore = _used;
 
@@ -315,7 +315,7 @@ public:
 		poco_check_ptr(ptr);
 		if (0 == length) return;
 
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (length > available())
 			throw Poco::InvalidAccessException("Cannot extend buffer.");
@@ -335,7 +335,7 @@ public:
 		/// was copied into the buffer.
 	{
 		if (0 == length) return;
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (length > available())
 			throw Poco::InvalidAccessException("Cannot extend buffer.");
@@ -357,7 +357,7 @@ public:
 	T* begin()
 		/// Returns the pointer to the beginning of the buffer.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_begin != 0)
 		{
 			// Move the data to the start of the buffer so begin() and next()
@@ -372,7 +372,7 @@ public:
 	T* next()
 		/// Returns the pointer to the next available position in the buffer.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		return begin() + _used;
 	}
 
@@ -381,7 +381,7 @@ public:
 		/// Throws InvalidAccessException if index is larger than
 		/// the last valid (used) buffer position.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (index >= _used)
 			throw InvalidAccessException(format("Index out of bounds: %z (max index allowed: %z)", index, _used - 1));
 
@@ -393,7 +393,7 @@ public:
 		/// Throws InvalidAccessException if index is larger than
 		/// the last valid (used) buffer position.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (index >= _used)
 			throw InvalidAccessException(format("Index out of bounds: %z (max index allowed: %z)", index, _used - 1));
 
@@ -418,7 +418,7 @@ public:
 		if (error)
 		{
 			bool f = false;
-			Mutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::recursive_mutex> lock(_mutex);
 			if (isReadable() && _notify) readable.notify(this, f);
 			if (isWritable() && _notify) writable.notify(this, f);
 			_error = error;
@@ -427,7 +427,7 @@ public:
 		else
 		{
 			bool t = true;
-			Mutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::recursive_mutex> lock(_mutex);
 			_error = false;
 			if (_notify && !_eof) writable.notify(this, t);
 		}
@@ -454,7 +454,7 @@ public:
 		/// was previously set. If EOF was not set, it has no
 		/// effect.
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		bool flag = !eof;
 		if (_notify) writable.notify(this, flag);
 		_eof = eof;
@@ -510,7 +510,7 @@ public:
 		return _notify;
 	}
 
-	Mutex& mutex()
+	std::recursive_mutex& mutex()
 		/// Returns reference to mutex.
 	{
 		return _mutex;
@@ -539,7 +539,7 @@ private:
 	std::size_t   _begin;
 	std::size_t   _used;
 	bool          _notify;
-	mutable Mutex _mutex;
+	mutable std::recursive_mutex _mutex;
 	bool          _eof;
 	bool          _error;
 };

--- a/Foundation/include/Poco/FIFOEvent.h
+++ b/Foundation/include/Poco/FIFOEvent.h
@@ -27,7 +27,7 @@ namespace Poco {
 
 
 //@ deprecated
-template <class TArgs, class TMutex = FastMutex>
+template <class TArgs, class TMutex = std::mutex>
 class FIFOEvent: public AbstractEvent <
 	TArgs,
 	FIFOStrategy<TArgs, AbstractDelegate<TArgs>>,

--- a/Foundation/include/Poco/FileChannel.h
+++ b/Foundation/include/Poco/FileChannel.h
@@ -260,7 +260,7 @@ private:
 	RotateStrategy*  _pRotateStrategy;
 	ArchiveStrategy* _pArchiveStrategy;
 	PurgeStrategy*   _pPurgeStrategy;
-	FastMutex        _mutex;
+	std::mutex        _mutex;
 };
 
 

--- a/Foundation/include/Poco/FunctionDelegate.h
+++ b/Foundation/include/Poco/FunctionDelegate.h
@@ -60,7 +60,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(sender, arguments);
@@ -82,13 +82,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();
@@ -127,7 +127,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(const_cast<void*>(sender), arguments);
@@ -149,13 +149,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();
@@ -194,7 +194,7 @@ public:
 
 	bool notify(const void* /*sender*/, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(arguments);
@@ -216,13 +216,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();
@@ -263,7 +263,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(sender);
@@ -285,13 +285,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();
@@ -330,7 +330,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(const_cast<void*>(sender));
@@ -352,13 +352,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();
@@ -397,7 +397,7 @@ public:
 
 	bool notify(const void* /*sender*/)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)();
@@ -419,13 +419,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionDelegate();

--- a/Foundation/include/Poco/FunctionPriorityDelegate.h
+++ b/Foundation/include/Poco/FunctionPriorityDelegate.h
@@ -62,7 +62,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(sender, arguments);
@@ -84,13 +84,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();
@@ -131,7 +131,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(const_cast<void*>(sender), arguments);
@@ -153,13 +153,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();
@@ -200,7 +200,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(arguments);
@@ -222,13 +222,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();
@@ -271,7 +271,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(sender);
@@ -293,13 +293,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();
@@ -340,7 +340,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)(const_cast<void*>(sender));
@@ -362,13 +362,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();
@@ -409,7 +409,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_function)
 		{
 			(*_function)();
@@ -431,13 +431,13 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_function = 0;
 	}
 
 protected:
 	NotifyFunction _function;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	FunctionPriorityDelegate();

--- a/Foundation/include/Poco/LRUCache.h
+++ b/Foundation/include/Poco/LRUCache.h
@@ -28,8 +28,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class LRUCache: public AbstractCache<TKey, TValue, LRUStrategy<TKey, TValue>, TMutex, TEventMutex>
 	/// An LRUCache implements Least Recently Used caching. The default size for a cache is 1024 entries.

--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -484,7 +484,7 @@ private:
 
 	// definitions in Foundation.cpp
 	static LoggerMapPtr _pLoggerMap;
-	static Mutex      _mapMtx;
+	static std::recursive_mutex _mapMtx;
 };
 
 

--- a/Foundation/include/Poco/LoggingRegistry.h
+++ b/Foundation/include/Poco/LoggingRegistry.h
@@ -89,7 +89,7 @@ private:
 
 	ChannelMap   _channelMap;
 	FormatterMap _formatterMap;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/MemoryPool.h
+++ b/Foundation/include/Poco/MemoryPool.h
@@ -85,7 +85,7 @@ private:
 	int         _maxAlloc;
 	int         _allocated;
 	BlockVec    _blocks;
-	FastMutex   _mutex;
+	std::mutex  _mutex;
 };
 
 
@@ -99,7 +99,7 @@ private:
 #define POCO_FAST_MEMORY_POOL_PREALLOC 1000
 
 
-template <typename T, typename M = FastMutex>
+template <typename T, typename M = std::mutex>
 class FastMemoryPool
 	/// FastMemoryPool is a class for pooling fixed-size blocks of memory.
 	///
@@ -178,7 +178,7 @@ class FastMemoryPool
 	/// pool destruction, any memory that was taken, but not returned to
 	/// it becomes invalid.
 	///
-	/// FastMemoryPool is thread safe; it uses Poco::FastMutex by
+	/// FastMemoryPool is thread safe; it uses std::mutex by
 	/// default, but other mutexes can be specified through the template
 	/// parameter, if needed. Poco::NullMutex can be specified as template
 	/// parameter to avoid locking and improve speed in single-threaded
@@ -250,7 +250,7 @@ private:
 
 public:
 	typedef M MutexType;
-	typedef typename M::ScopedLock ScopedLock;
+	typedef std::lock_guard<M> ScopedLock;
 
 	typedef Block* Bucket;
 	typedef std::vector<Bucket> BucketVec;

--- a/Foundation/include/Poco/Mutex.h
+++ b/Foundation/include/Poco/Mutex.h
@@ -23,6 +23,7 @@
 #include "Poco/ScopedLock.h"
 #include "Poco/Timestamp.h"
 #include <atomic>
+#include <mutex>
 
 
 #if defined(POCO_OS_FAMILY_WINDOWS)
@@ -52,7 +53,7 @@ class Foundation_API Mutex: private MutexImpl
 	/// lock and unlock a mutex.
 {
 public:
-	using ScopedLock = Poco::ScopedLock<Mutex>;
+	using ScopedLock = Poco::ScopedLock<std::recursive_mutex>;
 
 	Mutex();
 		/// creates the Mutex.
@@ -107,7 +108,7 @@ class Foundation_API FastMutex: private FastMutexImpl
 	/// lock and unlock a mutex.
 {
 public:
-	using ScopedLock = Poco::ScopedLock<FastMutex>;
+	using ScopedLock = Poco::ScopedLock<std::mutex>;
 
 	FastMutex();
 		/// creates the Mutex.

--- a/Foundation/include/Poco/NObserver.h
+++ b/Foundation/include/Poco/NObserver.h
@@ -75,7 +75,7 @@ public:
 
 	void notify(Notification* pNf) const
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (_pObject)
 		{
@@ -106,7 +106,7 @@ public:
 
 	void disable()
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		_pObject = 0;
 	}
@@ -116,7 +116,7 @@ private:
 
 	C*       _pObject;
 	Callback _method;
-	mutable Poco::Mutex _mutex;
+	mutable std::recursive_mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/NamedMutex.h
+++ b/Foundation/include/Poco/NamedMutex.h
@@ -41,7 +41,7 @@ class Foundation_API NamedMutex: private NamedMutexImpl
 	/// Using the ScopedLock class is the preferred way to automatically
 	/// lock and unlock a mutex.
 	///
-	/// Unlike a Mutex or a FastMutex, which itself is the unit of synchronization,
+	/// Unlike a std::recursive_mutex or a std::mutex, which itself is the unit of synchronization,
 	/// a NamedMutex refers to a named operating system resource being the
 	/// unit of synchronization.
 	/// In other words, there can be multiple instances of NamedMutex referring

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -129,7 +129,7 @@ private:
 	typedef std::vector<AbstractObserverPtr> ObserverList;
 
 	ObserverList  _observers;
-	mutable Mutex _mutex;
+	mutable std::recursive_mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/NotificationQueue.h
+++ b/Foundation/include/Poco/NotificationQueue.h
@@ -149,7 +149,7 @@ private:
 
 	NfQueue           _nfQueue;
 	WaitQueue         _waitQueue;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/ObjectPool.h
+++ b/Foundation/include/Poco/ObjectPool.h
@@ -215,7 +215,7 @@ public:
 		/// If activating the object fails, the object is destroyed and
 		/// the exception is passed on to the caller.
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		if (_size >= _peakCapacity && _pool.empty())
 		{
@@ -252,7 +252,7 @@ public:
 	void returnObject(P pObject)
 		/// Returns an object to the pool.
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		if (_factory.validateObject(pObject))
 		{
@@ -287,14 +287,14 @@ public:
 
 	std::size_t size() const
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return _size;
 	}
 
 	std::size_t available() const
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return _pool.size() + _peakCapacity - _size;
 	}
@@ -324,7 +324,7 @@ private:
 	std::size_t _peakCapacity;
 	std::size_t _size;
 	std::vector<P> _pool;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 	Poco::Condition _availableCondition;
 };
 

--- a/Foundation/include/Poco/Observer.h
+++ b/Foundation/include/Poco/Observer.h
@@ -73,7 +73,7 @@ public:
 
 	void notify(Notification* pNf) const
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		if (_pObject)
 		{
@@ -104,7 +104,7 @@ public:
 
 	void disable()
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 		_pObject = 0;
 	}
@@ -114,7 +114,7 @@ private:
 
 	C*       _pObject;
 	Callback _method;
-	mutable Poco::Mutex _mutex;
+	mutable std::recursive_mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/PriorityDelegate.h
+++ b/Foundation/include/Poco/PriorityDelegate.h
@@ -66,7 +66,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(sender, arguments);
@@ -88,14 +88,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	PriorityDelegate();
@@ -140,7 +140,7 @@ public:
 
 	bool notify(const void* sender, TArgs& arguments)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(arguments);
@@ -162,14 +162,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	PriorityDelegate();
@@ -214,7 +214,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)(sender);
@@ -236,14 +236,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	PriorityDelegate();
@@ -288,7 +288,7 @@ public:
 
 	bool notify(const void* sender)
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		if (_receiverObject)
 		{
 			(_receiverObject->*_receiverMethod)();
@@ -310,14 +310,14 @@ public:
 
 	void disable()
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		_receiverObject = 0;
 	}
 
 protected:
 	TObj*        _receiverObject;
 	NotifyMethod _receiverMethod;
-	Mutex _mutex;
+	std::recursive_mutex _mutex;
 
 private:
 	PriorityDelegate();

--- a/Foundation/include/Poco/PriorityEvent.h
+++ b/Foundation/include/Poco/PriorityEvent.h
@@ -26,7 +26,7 @@
 namespace Poco {
 
 
-template <class TArgs, class TMutex = FastMutex>
+template <class TArgs, class TMutex = std::mutex>
 class PriorityEvent: public AbstractEvent <
 	TArgs,
 	PriorityStrategy<TArgs, AbstractPriorityDelegate<TArgs> >,

--- a/Foundation/include/Poco/PriorityNotificationQueue.h
+++ b/Foundation/include/Poco/PriorityNotificationQueue.h
@@ -148,7 +148,7 @@ private:
 
 	NfQueue           _nfQueue;
 	WaitQueue         _waitQueue;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/SharedLibrary_HPUX.h
+++ b/Foundation/include/Poco/SharedLibrary_HPUX.h
@@ -42,7 +42,7 @@ protected:
 private:
 	std::string _path;
 	shl_t _handle;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/SharedLibrary_UNIX.h
+++ b/Foundation/include/Poco/SharedLibrary_UNIX.h
@@ -47,7 +47,7 @@ protected:
 private:
 	std::string _path;
 	void* _handle;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/SharedLibrary_VX.h
+++ b/Foundation/include/Poco/SharedLibrary_VX.h
@@ -42,7 +42,7 @@ protected:
 private:
 	std::string _path;
 	MODULE_ID _moduleId;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/SharedLibrary_WIN32U.h
+++ b/Foundation/include/Poco/SharedLibrary_WIN32U.h
@@ -41,7 +41,7 @@ protected:
 private:
 	std::string _path;
 	void* _handle;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/SimpleFileChannel.h
+++ b/Foundation/include/Poco/SimpleFileChannel.h
@@ -142,7 +142,7 @@ private:
 	UInt64           _limit;
 	bool             _flush;
 	LogFile*         _pFile;
-	FastMutex        _mutex;
+	std::mutex       _mutex;
 };
 
 

--- a/Foundation/include/Poco/SingletonHolder.h
+++ b/Foundation/include/Poco/SingletonHolder.h
@@ -52,7 +52,7 @@ public:
 		/// hold by the SingletonHolder. The first call
 		/// to get will create the singleton.
 	{
-		FastMutex::ScopedLock lock(_m);
+		std::lock_guard<std::mutex> lock(_m);
 		if (!_pS) _pS = new S;
 		return _pS;
 	}
@@ -60,14 +60,14 @@ public:
 	void reset()
 		/// Deletes the singleton object.
 	{
-		FastMutex::ScopedLock lock(_m);
+		std::lock_guard<std::mutex> lock(_m);
 		delete _pS;
 		_pS = 0;
 	}
 
 private:
 	S* _pS;
-	FastMutex _m;
+	std::mutex _m;
 };
 
 

--- a/Foundation/include/Poco/SplitterChannel.h
+++ b/Foundation/include/Poco/SplitterChannel.h
@@ -70,7 +70,7 @@ private:
 	typedef std::vector<Channel::Ptr> ChannelVec;
 
 	ChannelVec        _channels;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/StreamChannel.h
+++ b/Foundation/include/Poco/StreamChannel.h
@@ -51,7 +51,7 @@ protected:
 
 private:
 	std::ostream& _str;
-	FastMutex     _mutex;
+	std::mutex    _mutex;
 };
 
 

--- a/Foundation/include/Poco/SynchronizedObject.h
+++ b/Foundation/include/Poco/SynchronizedObject.h
@@ -27,7 +27,7 @@ namespace Poco {
 
 
 class Foundation_API SynchronizedObject
-	/// This class aggregates a Mutex and an Event
+	/// This class aggregates a std::timed_mutex and an Event
 	/// and can act as a base class for all objects
 	/// requiring synchronization in a multithreaded
 	/// scenario.
@@ -75,7 +75,7 @@ public:
 		/// time interval, false otherwise.
 
 private:
-	mutable Mutex _mutex;
+	mutable std::timed_mutex _mutex;
 	mutable Event _event;
 };
 
@@ -91,7 +91,7 @@ inline void SynchronizedObject::lock() const
 
 inline bool SynchronizedObject::tryLock() const
 {
-	return _mutex.tryLock();
+	return _mutex.try_lock();
 }
 
 

--- a/Foundation/include/Poco/Task.h
+++ b/Foundation/include/Poco/Task.h
@@ -150,7 +150,7 @@ private:
 	float             _progress;
 	std::atomic<TaskState> _state;
 	Event             _cancelEvent;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 
 	friend class TaskManager;
 };
@@ -167,7 +167,7 @@ inline const std::string& Task::name() const
 
 inline float Task::progress() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return _progress;
 }
@@ -187,7 +187,7 @@ inline Task::TaskState Task::state() const
 
 inline TaskManager* Task::getOwner() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return _pOwner;
 }

--- a/Foundation/include/Poco/TaskManager.h
+++ b/Foundation/include/Poco/TaskManager.h
@@ -122,7 +122,7 @@ private:
 	TaskList           _taskList;
 	Timestamp          _lastProgressNotification;
 	NotificationCenter _nc;
-	mutable MutexT  _mutex;
+	mutable std::mutex _mutex;
 
 	friend class Task;
 };

--- a/Foundation/include/Poco/ThreadPool.h
+++ b/Foundation/include/Poco/ThreadPool.h
@@ -177,7 +177,7 @@ private:
 	int _age;
 	int _stackSize;
 	ThreadVec _threads;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/Thread_POSIX.h
+++ b/Foundation/include/Poco/Thread_POSIX.h
@@ -58,39 +58,39 @@ public:
 		POLICY_DEFAULT_IMPL = SCHED_OTHER
 	};
 
-	ThreadImpl();
-	~ThreadImpl();
+  ThreadImpl();
+  ~ThreadImpl();
 
-	TIDImpl tidImpl() const;
-	void setNameImpl(const std::string& threadName);
-	std::string getNameImpl() const;
-	std::string getOSThreadNameImpl();
-		/// Returns the thread's name, expressed as an operating system
-		/// specific name value. Return empty string if thread is not running.
-		/// For test used only.
-	void setPriorityImpl(int prio);
-	int getPriorityImpl() const;
-	void setOSPriorityImpl(int prio, int policy = SCHED_OTHER);
-	int getOSPriorityImpl() const;
-	static int getMinOSPriorityImpl(int policy);
-	static int getMaxOSPriorityImpl(int policy);
-	void setStackSizeImpl(int size);
-	int getStackSizeImpl() const;
-	void startImpl(SharedPtr<Runnable> pTarget);
-	void joinImpl();
-	bool joinImpl(long milliseconds);
-	bool isRunningImpl() const;
-	static void yieldImpl();
-	static ThreadImpl* currentImpl();
-	static TIDImpl currentTidImpl();
-	static long currentOsTidImpl();
-	bool setAffinityImpl(int coreID);
-	int getAffinityImpl() const;
+  TIDImpl tidImpl() const;
+  void setNameImpl(const std::string& threadName);
+  std::string getNameImpl() const;
+  std::string getOSThreadNameImpl();
+  /// Returns the thread's name, expressed as an operating system
+  /// specific name value. Return empty string if thread is not running.
+  /// For test used only.
+  void setPriorityImpl(int prio);
+  int getPriorityImpl() const;
+  void setOSPriorityImpl(int prio, int policy = SCHED_OTHER);
+  int getOSPriorityImpl() const;
+  static int getMinOSPriorityImpl(int policy);
+  static int getMaxOSPriorityImpl(int policy);
+  void setStackSizeImpl(int size);
+  int getStackSizeImpl() const;
+  void startImpl(SharedPtr<Runnable> pTarget);
+  void joinImpl();
+  bool joinImpl(long milliseconds);
+  bool isRunningImpl() const;
+  static void yieldImpl();
+  static ThreadImpl* currentImpl();
+  static TIDImpl currentTidImpl();
+  static long currentOsTidImpl();
+  bool setAffinityImpl(int coreID);
+  int getAffinityImpl() const;
 
-protected:
-	static void* runnableEntry(void* pThread);
-	static int mapPrio(int prio, int policy = SCHED_OTHER);
-	static int reverseMapPrio(int osPrio, int policy = SCHED_OTHER);
+ protected:
+  static void* runnableEntry(void* pThread);
+  static int mapPrio(int prio, int policy = SCHED_OTHER);
+  static int reverseMapPrio(int osPrio, int policy = SCHED_OTHER);
 
 private:
 	class CurrentThreadHolder
@@ -148,15 +148,15 @@ private:
 		bool          joined;
 		std::string   name;
 		int           affinity;
-		mutable FastMutex mutex;
-	};
+		mutable std::mutex mutex;
+  };
 
-	AutoPtr<ThreadData> _pData;
-	static CurrentThreadHolder _currentThreadHolder;
+  AutoPtr<ThreadData> _pData;
+  static CurrentThreadHolder _currentThreadHolder;
 
 #if defined(POCO_OS_FAMILY_UNIX) && !defined(POCO_VXWORKS)
-	SignalHandler::JumpBufferVec _jumpBufferVec;
-	friend class SignalHandler;
+  SignalHandler::JumpBufferVec _jumpBufferVec;
+  friend class SignalHandler;
 #endif
 };
 
@@ -178,8 +178,8 @@ inline int ThreadImpl::getOSPriorityImpl() const
 
 inline bool ThreadImpl::isRunningImpl() const
 {
-	FastMutex::ScopedLock l(_pData->mutex);
-	return !_pData->pRunnableTarget.isNull();
+  std::lock_guard<std::mutex> l(_pData->mutex);
+  return !_pData->pRunnableTarget.isNull();
 }
 
 

--- a/Foundation/include/Poco/Thread_POSIX.h
+++ b/Foundation/include/Poco/Thread_POSIX.h
@@ -58,39 +58,39 @@ public:
 		POLICY_DEFAULT_IMPL = SCHED_OTHER
 	};
 
-  ThreadImpl();
-  ~ThreadImpl();
+	ThreadImpl();
+	~ThreadImpl();
 
-  TIDImpl tidImpl() const;
-  void setNameImpl(const std::string& threadName);
-  std::string getNameImpl() const;
-  std::string getOSThreadNameImpl();
-  /// Returns the thread's name, expressed as an operating system
-  /// specific name value. Return empty string if thread is not running.
-  /// For test used only.
-  void setPriorityImpl(int prio);
-  int getPriorityImpl() const;
-  void setOSPriorityImpl(int prio, int policy = SCHED_OTHER);
-  int getOSPriorityImpl() const;
-  static int getMinOSPriorityImpl(int policy);
-  static int getMaxOSPriorityImpl(int policy);
-  void setStackSizeImpl(int size);
-  int getStackSizeImpl() const;
-  void startImpl(SharedPtr<Runnable> pTarget);
-  void joinImpl();
-  bool joinImpl(long milliseconds);
-  bool isRunningImpl() const;
-  static void yieldImpl();
-  static ThreadImpl* currentImpl();
-  static TIDImpl currentTidImpl();
-  static long currentOsTidImpl();
-  bool setAffinityImpl(int coreID);
-  int getAffinityImpl() const;
+	TIDImpl tidImpl() const;
+	void setNameImpl(const std::string& threadName);
+	std::string getNameImpl() const;
+	std::string getOSThreadNameImpl();
+		/// Returns the thread's name, expressed as an operating system
+		/// specific name value. Return empty string if thread is not running.
+		/// For test used only.
+	void setPriorityImpl(int prio);
+	int getPriorityImpl() const;
+	void setOSPriorityImpl(int prio, int policy = SCHED_OTHER);
+	int getOSPriorityImpl() const;
+	static int getMinOSPriorityImpl(int policy);
+	static int getMaxOSPriorityImpl(int policy);
+	void setStackSizeImpl(int size);
+	int getStackSizeImpl() const;
+	void startImpl(SharedPtr<Runnable> pTarget);
+	void joinImpl();
+	bool joinImpl(long milliseconds);
+	bool isRunningImpl() const;
+	static void yieldImpl();
+	static ThreadImpl* currentImpl();
+	static TIDImpl currentTidImpl();
+	static long currentOsTidImpl();
+	bool setAffinityImpl(int coreID);
+	int getAffinityImpl() const;
 
- protected:
-  static void* runnableEntry(void* pThread);
-  static int mapPrio(int prio, int policy = SCHED_OTHER);
-  static int reverseMapPrio(int osPrio, int policy = SCHED_OTHER);
+protected:
+	static void* runnableEntry(void* pThread);
+	static int mapPrio(int prio, int policy = SCHED_OTHER);
+	static int reverseMapPrio(int osPrio, int policy = SCHED_OTHER);
 
 private:
 	class CurrentThreadHolder

--- a/Foundation/include/Poco/TimedNotificationQueue.h
+++ b/Foundation/include/Poco/TimedNotificationQueue.h
@@ -133,7 +133,7 @@ protected:
 private:
 	NfQueue _nfQueue;
 	Event   _nfAvailable;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/Timer.h
+++ b/Foundation/include/Poco/Timer.h
@@ -148,7 +148,7 @@ private:
 	long          _skipped;
 	AbstractTimerCallback* _pCallback;
 	Clock                  _nextInvocation;
-	mutable FastMutex      _mutex;
+	mutable std::mutex     _mutex;
 
 	Timer(const Timer&);
 	Timer& operator = (const Timer&);

--- a/Foundation/include/Poco/URIStreamOpener.h
+++ b/Foundation/include/Poco/URIStreamOpener.h
@@ -125,7 +125,7 @@ private:
 	typedef std::map<std::string, URIStreamFactory*> FactoryMap;
 
 	FactoryMap        _map;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Foundation/include/Poco/UUIDGenerator.h
+++ b/Foundation/include/Poco/UUIDGenerator.h
@@ -93,7 +93,7 @@ protected:
 	void getNode();
 
 private:
-	FastMutex           _mutex;
+	std::mutex          _mutex;
 	Random              _random;
 	Timestamp           _lastTime;
 	int                 _ticks;

--- a/Foundation/include/Poco/UniqueAccessExpireCache.h
+++ b/Foundation/include/Poco/UniqueAccessExpireCache.h
@@ -28,8 +28,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class UniqueAccessExpireCache: public AbstractCache<TKey, TValue, UniqueAccessExpireStrategy<TKey, TValue>, TMutex, TEventMutex>
 	/// An UniqueAccessExpireCache caches entries for a given time span. In contrast

--- a/Foundation/include/Poco/UniqueAccessExpireLRUCache.h
+++ b/Foundation/include/Poco/UniqueAccessExpireLRUCache.h
@@ -30,8 +30,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class UniqueAccessExpireLRUCache: public AbstractCache<TKey, TValue, StrategyCollection<TKey, TValue>, TMutex, TEventMutex>
 	/// A UniqueAccessExpireLRUCache combines LRU caching and time based per entry expire caching.

--- a/Foundation/include/Poco/UniqueExpireCache.h
+++ b/Foundation/include/Poco/UniqueExpireCache.h
@@ -28,8 +28,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class UniqueExpireCache: public AbstractCache<TKey, TValue, UniqueExpireStrategy<TKey, TValue>, TMutex, TEventMutex>
 	/// An UniqueExpireCache caches entries for a given time amount. In contrast

--- a/Foundation/include/Poco/UniqueExpireLRUCache.h
+++ b/Foundation/include/Poco/UniqueExpireLRUCache.h
@@ -30,8 +30,8 @@ namespace Poco {
 template <
 	class TKey,
 	class TValue,
-	class TMutex = FastMutex,
-	class TEventMutex = FastMutex
+	class TMutex = std::mutex,
+	class TEventMutex = std::mutex
 >
 class UniqueExpireLRUCache: public AbstractCache<TKey, TValue, StrategyCollection<TKey, TValue>, TMutex, TEventMutex>
 	/// A UniqueExpireLRUCache combines LRU caching and time based per entry expire caching.

--- a/Foundation/samples/NotificationQueue/src/NotificationQueue.cpp
+++ b/Foundation/samples/NotificationQueue/src/NotificationQueue.cpp
@@ -2,7 +2,7 @@
 // NotificationQueue.cpp
 //
 // This sample demonstrates the NotificationQueue, ThreadPool,
-// FastMutex and ScopedLock classes.
+// std::mutex and ScopedLock classes.
 //
 // Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH.
 // and Contributors.
@@ -27,7 +27,6 @@ using Poco::NotificationQueue;
 using Poco::ThreadPool;
 using Poco::Thread;
 using Poco::Runnable;
-using Poco::FastMutex;
 using Poco::AutoPtr;
 
 
@@ -75,7 +74,7 @@ public:
 				if (pWorkNf)
 				{
 					{
-						FastMutex::ScopedLock lock(_mutex);
+						std::lock_guard<std::mutex> lock(_mutex);
 						std::cout << _name << " got work notification " << pWorkNf->data() << std::endl;
 					}
 					Thread::sleep(rnd.next(200));
@@ -88,11 +87,11 @@ public:
 private:
 	std::string        _name;
 	NotificationQueue& _queue;
-	static FastMutex   _mutex;
+	static std::mutex  _mutex;
 };
 
 
-FastMutex Worker::_mutex;
+std::mutex Worker::_mutex;
 
 
 int main(int argc, char** argv)

--- a/Foundation/src/AsyncChannel.cpp
+++ b/Foundation/src/AsyncChannel.cpp
@@ -73,7 +73,7 @@ AsyncChannel::~AsyncChannel()
 
 void AsyncChannel::setChannel(Channel::Ptr pChannel)
 {
-	FastMutex::ScopedLock lock(_channelMutex);
+	std::lock_guard<std::mutex> lock(_channelMutex);
 
 	_pChannel = pChannel;
 }
@@ -87,7 +87,7 @@ Channel::Ptr AsyncChannel::getChannel() const
 
 void AsyncChannel::open()
 {
-	FastMutex::ScopedLock lock(_threadMutex);
+	std::lock_guard<std::mutex> lock(_threadMutex);
 
 	if (!_thread.isRunning()) _thread.start(*this);
 }
@@ -163,7 +163,7 @@ void AsyncChannel::run()
 	{
 		MessageNotification* pNf = dynamic_cast<MessageNotification*>(nf.get());
 		{
-			FastMutex::ScopedLock lock(_channelMutex);
+			std::lock_guard<std::mutex> lock(_channelMutex);
 
 			if (pNf && _pChannel) _pChannel->log(pNf->message());
 		}

--- a/Foundation/src/Base32Decoder.cpp
+++ b/Foundation/src/Base32Decoder.cpp
@@ -28,7 +28,7 @@ bool Base32DecoderBuf::IN_ENCODING_INIT = false;
 
 namespace
 {
-	static FastMutex mutex;
+	static std::mutex mutex;
 }
 
 
@@ -37,7 +37,7 @@ Base32DecoderBuf::Base32DecoderBuf(std::istream& istr):
 	_groupIndex(0),
 	_buf(*istr.rdbuf())
 {
-	FastMutex::ScopedLock lock(mutex);
+	std::lock_guard<std::mutex> lock(mutex);
 	if (!IN_ENCODING_INIT)
 	{
 		for (unsigned i = 0; i < sizeof(IN_ENCODING); i++)

--- a/Foundation/src/Base64Decoder.cpp
+++ b/Foundation/src/Base64Decoder.cpp
@@ -29,7 +29,7 @@ bool Base64DecoderBuf::IN_ENCODING_URL_INIT = false;
 
 namespace
 {
-	static FastMutex mutex;
+	static std::mutex mutex;
 }
 
 
@@ -40,7 +40,7 @@ Base64DecoderBuf::Base64DecoderBuf(std::istream& istr, int options):
 	_buf(*istr.rdbuf()),
 	_pInEncoding((options & BASE64_URL_ENCODING) ? IN_ENCODING_URL : IN_ENCODING)
 {
-	FastMutex::ScopedLock lock(mutex);
+	std::lock_guard<std::mutex> lock(mutex);
 	if (options & BASE64_URL_ENCODING)
 	{
 		if (!IN_ENCODING_URL_INIT)

--- a/Foundation/src/Condition.cpp
+++ b/Foundation/src/Condition.cpp
@@ -29,7 +29,7 @@ Condition::~Condition()
 
 void Condition::signal()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_waitQueue.empty())
 	{
@@ -41,7 +41,7 @@ void Condition::signal()
 
 void Condition::broadcast()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (auto p: _waitQueue)
 	{

--- a/Foundation/src/ConsoleChannel.cpp
+++ b/Foundation/src/ConsoleChannel.cpp
@@ -22,7 +22,7 @@
 namespace Poco {
 
 
-FastMutex ConsoleChannel::_mutex;
+std::mutex ConsoleChannel::_mutex;
 
 
 ConsoleChannel::ConsoleChannel(): _str(std::clog)
@@ -42,13 +42,13 @@ ConsoleChannel::~ConsoleChannel()
 
 void ConsoleChannel::log(const Message& msg)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_str << msg.getText() << std::endl;
 }
 
 
-FastMutex ColorConsoleChannel::_mutex;
+std::mutex ColorConsoleChannel::_mutex;
 const std::string ColorConsoleChannel::CSI("\033[");
 
 
@@ -75,7 +75,7 @@ ColorConsoleChannel::~ColorConsoleChannel()
 
 void ColorConsoleChannel::log(const Message& msg)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_enableColors)
 	{

--- a/Foundation/src/Environment_UNIX.cpp
+++ b/Foundation/src/Environment_UNIX.cpp
@@ -31,12 +31,12 @@ namespace Poco {
 
 
 EnvironmentImpl::StringMap EnvironmentImpl::_map;
-FastMutex EnvironmentImpl::_mutex;
+std::mutex EnvironmentImpl::_mutex;
 
 
 std::string EnvironmentImpl::getImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	const char* val = getenv(name.c_str());
 	if (val)
@@ -48,7 +48,7 @@ std::string EnvironmentImpl::getImpl(const std::string& name)
 
 bool EnvironmentImpl::hasImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return getenv(name.c_str()) != 0;
 }
@@ -56,7 +56,7 @@ bool EnvironmentImpl::hasImpl(const std::string& name)
 
 void EnvironmentImpl::setImpl(const std::string& name, const std::string& value)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string var = name;
 	var.append("=");

--- a/Foundation/src/Environment_VX.cpp
+++ b/Foundation/src/Environment_VX.cpp
@@ -40,12 +40,12 @@ namespace Poco {
 
 
 EnvironmentImpl::StringMap EnvironmentImpl::_map;
-FastMutex EnvironmentImpl::_mutex;
+std::mutex EnvironmentImpl::_mutex;
 
 
 std::string EnvironmentImpl::getImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	const char* val = getenv(name.c_str());
 	if (val)
@@ -57,7 +57,7 @@ std::string EnvironmentImpl::getImpl(const std::string& name)
 
 bool EnvironmentImpl::hasImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return getenv(name.c_str()) != 0;
 }
@@ -65,7 +65,7 @@ bool EnvironmentImpl::hasImpl(const std::string& name)
 
 void EnvironmentImpl::setImpl(const std::string& name, const std::string& value)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string var = name;
 	var.append("=");

--- a/Foundation/src/ErrorHandler.cpp
+++ b/Foundation/src/ErrorHandler.cpp
@@ -20,7 +20,7 @@ namespace Poco {
 
 
 ErrorHandler* ErrorHandler::_pHandler = ErrorHandler::defaultHandler();
-FastMutex ErrorHandler::_mutex;
+std::mutex ErrorHandler::_mutex;
 
 
 ErrorHandler::ErrorHandler()
@@ -53,7 +53,7 @@ void ErrorHandler::exception()
 
 void ErrorHandler::handle(const Exception& exc)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	try
 	{
 		_pHandler->exception(exc);
@@ -66,7 +66,7 @@ void ErrorHandler::handle(const Exception& exc)
 
 void ErrorHandler::handle(const std::exception& exc)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	try
 	{
 		_pHandler->exception(exc);
@@ -79,7 +79,7 @@ void ErrorHandler::handle(const std::exception& exc)
 
 void ErrorHandler::handle()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	try
 	{
 		_pHandler->exception();
@@ -94,7 +94,7 @@ ErrorHandler* ErrorHandler::set(ErrorHandler* pHandler)
 {
 	poco_check_ptr(pHandler);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	ErrorHandler* pOld = _pHandler;
 	_pHandler = pHandler;
 	return pOld;

--- a/Foundation/src/FileChannel.cpp
+++ b/Foundation/src/FileChannel.cpp
@@ -84,7 +84,7 @@ FileChannel::~FileChannel()
 
 void FileChannel::open()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_pFile)
 	{
@@ -107,7 +107,7 @@ void FileChannel::open()
 
 void FileChannel::close()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	delete _pFile;
 	_pFile = 0;
@@ -118,7 +118,7 @@ void FileChannel::log(const Message& msg)
 {
 	open();
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_pRotateStrategy && _pArchiveStrategy && _pRotateStrategy->mustRotate(_pFile))
 	{
@@ -142,7 +142,7 @@ void FileChannel::log(const Message& msg)
 
 void FileChannel::setProperty(const std::string& name, const std::string& value)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (name == PROP_TIMES)
 	{

--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -25,7 +25,7 @@ namespace Poco {
 
 
 Logger::LoggerMapPtr Logger::_pLoggerMap;
-Mutex                Logger::_mapMtx;
+std::recursive_mutex Logger::_mapMtx;
 const std::string    Logger::ROOT;
 
 
@@ -108,7 +108,7 @@ void Logger::dump(const std::string& msg, const void* buffer, std::size_t length
 
 void Logger::setLevel(const std::string& name, int level)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	if (_pLoggerMap)
 	{
@@ -126,7 +126,7 @@ void Logger::setLevel(const std::string& name, int level)
 
 void Logger::setChannel(const std::string& name, Channel::Ptr pChannel)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	if (_pLoggerMap)
 	{
@@ -144,7 +144,7 @@ void Logger::setChannel(const std::string& name, Channel::Ptr pChannel)
 
 void Logger::setProperty(const std::string& loggerName, const std::string& propertyName, const std::string& value)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	if (_pLoggerMap)
 	{
@@ -275,7 +275,7 @@ void Logger::formatDump(std::string& message, const void* buffer, std::size_t le
 
 Logger& Logger::get(const std::string& name)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	return unsafeGet(name);
 }
@@ -303,7 +303,7 @@ Logger& Logger::unsafeGet(const std::string& name)
 
 Logger& Logger::create(const std::string& name, Channel::Ptr pChannel, int level)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	if (find(name)) throw ExistsException();
 	Ptr pLogger = new Logger(name, pChannel, level);
@@ -314,7 +314,7 @@ Logger& Logger::create(const std::string& name, Channel::Ptr pChannel, int level
 
 Logger& Logger::root()
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	return unsafeGet(ROOT);
 }
@@ -322,7 +322,7 @@ Logger& Logger::root()
 
 Logger::Ptr Logger::has(const std::string& name)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	return find(name);
 }
@@ -330,7 +330,7 @@ Logger::Ptr Logger::has(const std::string& name)
 
 void Logger::shutdown()
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	_pLoggerMap.reset();
 }
@@ -349,7 +349,7 @@ Logger::Ptr Logger::find(const std::string& name)
 
 void Logger::destroy(const std::string& name)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	if (_pLoggerMap)
 	{
@@ -361,7 +361,7 @@ void Logger::destroy(const std::string& name)
 
 void Logger::names(std::vector<std::string>& names)
 {
-	Mutex::ScopedLock lock(_mapMtx);
+	std::lock_guard<std::recursive_mutex> lock(_mapMtx);
 
 	names.clear();
 	if (_pLoggerMap)

--- a/Foundation/src/LoggingRegistry.cpp
+++ b/Foundation/src/LoggingRegistry.cpp
@@ -31,7 +31,7 @@ LoggingRegistry::~LoggingRegistry()
 
 Channel::Ptr LoggingRegistry::channelForName(const std::string& name) const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	ChannelMap::const_iterator it = _channelMap.find(name);
 	if (it != _channelMap.end())
@@ -43,7 +43,7 @@ Channel::Ptr LoggingRegistry::channelForName(const std::string& name) const
 
 Formatter::Ptr LoggingRegistry::formatterForName(const std::string& name) const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	FormatterMap::const_iterator it = _formatterMap.find(name);
 	if (it != _formatterMap.end())
@@ -55,7 +55,7 @@ Formatter::Ptr LoggingRegistry::formatterForName(const std::string& name) const
 
 void LoggingRegistry::registerChannel(const std::string& name, Channel::Ptr pChannel)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_channelMap[name] = ChannelPtr(pChannel, true);
 }
@@ -63,7 +63,7 @@ void LoggingRegistry::registerChannel(const std::string& name, Channel::Ptr pCha
 
 void LoggingRegistry::registerFormatter(const std::string& name, Formatter::Ptr pFormatter)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_formatterMap[name] = FormatterPtr(pFormatter, true);
 }
@@ -71,7 +71,7 @@ void LoggingRegistry::registerFormatter(const std::string& name, Formatter::Ptr 
 
 void LoggingRegistry::unregisterChannel(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	ChannelMap::iterator it = _channelMap.find(name);
 	if (it != _channelMap.end())
@@ -83,7 +83,7 @@ void LoggingRegistry::unregisterChannel(const std::string& name)
 
 void LoggingRegistry::unregisterFormatter(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	FormatterMap::iterator it = _formatterMap.find(name);
 	if (it != _formatterMap.end())
@@ -95,7 +95,7 @@ void LoggingRegistry::unregisterFormatter(const std::string& name)
 
 void LoggingRegistry::clear()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_channelMap.clear();
 	_formatterMap.clear();

--- a/Foundation/src/MemoryPool.cpp
+++ b/Foundation/src/MemoryPool.cpp
@@ -67,7 +67,7 @@ void MemoryPool::clear()
 
 void* MemoryPool::get()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_blocks.empty())
 	{
@@ -89,7 +89,7 @@ void* MemoryPool::get()
 
 void MemoryPool::release(void* ptr)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	try
 	{

--- a/Foundation/src/NotificationCenter.cpp
+++ b/Foundation/src/NotificationCenter.cpp
@@ -34,14 +34,14 @@ NotificationCenter::~NotificationCenter()
 
 void NotificationCenter::addObserver(const AbstractObserver& observer)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	_observers.push_back(observer.clone());
 }
 
 
 void NotificationCenter::removeObserver(const AbstractObserver& observer)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	for (ObserverList::iterator it = _observers.begin(); it != _observers.end(); ++it)
 	{
 		if (observer.equals(**it))
@@ -56,7 +56,7 @@ void NotificationCenter::removeObserver(const AbstractObserver& observer)
 
 bool NotificationCenter::hasObserver(const AbstractObserver& observer) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	for (const auto& p: _observers)
 		if (observer.equals(*p)) return true;
 
@@ -68,7 +68,7 @@ void NotificationCenter::postNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
 
-	ScopedLockWithUnlock<Mutex> lock(_mutex);
+	ScopedLockWithUnlock<std::recursive_mutex> lock(_mutex);
 	ObserverList observersToNotify(_observers);
 	lock.unlock();
 	for (auto& p: observersToNotify)
@@ -80,7 +80,7 @@ void NotificationCenter::postNotification(Notification::Ptr pNotification)
 
 bool NotificationCenter::hasObservers() const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	return !_observers.empty();
 }
@@ -88,7 +88,7 @@ bool NotificationCenter::hasObservers() const
 
 std::size_t NotificationCenter::countObservers() const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	return _observers.size();
 }

--- a/Foundation/src/NotificationQueue.cpp
+++ b/Foundation/src/NotificationQueue.cpp
@@ -42,7 +42,7 @@ NotificationQueue::~NotificationQueue()
 void NotificationQueue::enqueueNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_waitQueue.empty())
 	{
 		_nfQueue.push_back(pNotification);
@@ -60,7 +60,7 @@ void NotificationQueue::enqueueNotification(Notification::Ptr pNotification)
 void NotificationQueue::enqueueUrgentNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_waitQueue.empty())
 	{
 		_nfQueue.push_front(pNotification);
@@ -77,7 +77,7 @@ void NotificationQueue::enqueueUrgentNotification(Notification::Ptr pNotificatio
 
 Notification* NotificationQueue::dequeueNotification()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return dequeueOne().duplicate();
 }
 
@@ -87,7 +87,7 @@ Notification* NotificationQueue::waitDequeueNotification()
 	Notification::Ptr pNf;
 	WaitInfo* pWI = 0;
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = dequeueOne();
 		if (pNf) return pNf.duplicate();
 		pWI = new WaitInfo;
@@ -105,7 +105,7 @@ Notification* NotificationQueue::waitDequeueNotification(long milliseconds)
 	Notification::Ptr pNf;
 	WaitInfo* pWI = 0;
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = dequeueOne();
 		if (pNf) return pNf.duplicate();
 		pWI = new WaitInfo;
@@ -117,7 +117,7 @@ Notification* NotificationQueue::waitDequeueNotification(long milliseconds)
 	}
 	else
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = pWI->pNf;
 		for (WaitQueue::iterator it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
 		{
@@ -135,7 +135,7 @@ Notification* NotificationQueue::waitDequeueNotification(long milliseconds)
 
 void NotificationQueue::dispatch(NotificationCenter& notificationCenter)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Notification::Ptr pNf = dequeueOne();
 	while (pNf)
 	{
@@ -147,7 +147,7 @@ void NotificationQueue::dispatch(NotificationCenter& notificationCenter)
 
 void NotificationQueue::wakeUpAll()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	for (auto p: _waitQueue)
 	{
 		p->nfAvailable.set();
@@ -158,28 +158,28 @@ void NotificationQueue::wakeUpAll()
 
 bool NotificationQueue::empty() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _nfQueue.empty();
 }
 
 
 int NotificationQueue::size() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return static_cast<int>(_nfQueue.size());
 }
 
 
 void NotificationQueue::clear()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_nfQueue.clear();
 }
 
 
 bool NotificationQueue::remove(Notification::Ptr pNotification)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	NfQueue::iterator it = std::find(_nfQueue.begin(), _nfQueue.end(), pNotification);
 	if (it == _nfQueue.end())
 	{
@@ -192,7 +192,7 @@ bool NotificationQueue::remove(Notification::Ptr pNotification)
 
 bool NotificationQueue::hasIdleThreads() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return !_waitQueue.empty();
 }
 

--- a/Foundation/src/PriorityNotificationQueue.cpp
+++ b/Foundation/src/PriorityNotificationQueue.cpp
@@ -42,7 +42,7 @@ PriorityNotificationQueue::~PriorityNotificationQueue()
 void PriorityNotificationQueue::enqueueNotification(Notification::Ptr pNotification, int priority)
 {
 	poco_check_ptr (pNotification);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_waitQueue.empty())
 	{
 		_nfQueue.insert(NfQueue::value_type(priority, pNotification));
@@ -60,7 +60,7 @@ void PriorityNotificationQueue::enqueueNotification(Notification::Ptr pNotificat
 
 Notification* PriorityNotificationQueue::dequeueNotification()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return dequeueOne().duplicate();
 }
 
@@ -70,7 +70,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification()
 	Notification::Ptr pNf;
 	WaitInfo* pWI = 0;
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = dequeueOne();
 		if (pNf) return pNf.duplicate();
 		pWI = new WaitInfo;
@@ -88,7 +88,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification(long millisecon
 	Notification::Ptr pNf;
 	WaitInfo* pWI = 0;
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = dequeueOne();
 		if (pNf) return pNf.duplicate();
 		pWI = new WaitInfo;
@@ -100,7 +100,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification(long millisecon
 	}
 	else
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		pNf = pWI->pNf;
 		for (WaitQueue::iterator it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
 		{
@@ -118,7 +118,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification(long millisecon
 
 void PriorityNotificationQueue::dispatch(NotificationCenter& notificationCenter)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Notification::Ptr pNf = dequeueOne();
 	while (pNf)
 	{
@@ -130,7 +130,7 @@ void PriorityNotificationQueue::dispatch(NotificationCenter& notificationCenter)
 
 void PriorityNotificationQueue::wakeUpAll()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	for (auto p: _waitQueue)
 	{
 		p->nfAvailable.set();
@@ -141,28 +141,28 @@ void PriorityNotificationQueue::wakeUpAll()
 
 bool PriorityNotificationQueue::empty() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _nfQueue.empty();
 }
 
 
 int PriorityNotificationQueue::size() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return static_cast<int>(_nfQueue.size());
 }
 
 
 void PriorityNotificationQueue::clear()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_nfQueue.clear();
 }
 
 
 bool PriorityNotificationQueue::hasIdleThreads() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return !_waitQueue.empty();
 }
 

--- a/Foundation/src/SharedLibrary_HPUX.cpp
+++ b/Foundation/src/SharedLibrary_HPUX.cpp
@@ -19,7 +19,7 @@
 namespace Poco {
 
 
-FastMutex SharedLibraryImpl::_mutex;
+std::mutex SharedLibraryImpl::_mutex;
 
 
 SharedLibraryImpl::SharedLibraryImpl()
@@ -35,7 +35,7 @@ SharedLibraryImpl::~SharedLibraryImpl()
 
 void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle) throw LibraryAlreadyLoadedException(path);
 	_handle = shl_load(path.c_str(), BIND_DEFERRED, 0);
@@ -46,7 +46,7 @@ void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 
 void SharedLibraryImpl::unloadImpl()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle)
 	{
@@ -59,14 +59,14 @@ void SharedLibraryImpl::unloadImpl()
 
 bool SharedLibraryImpl::isLoadedImpl() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _handle != 0;
 }
 
 
 void* SharedLibraryImpl::findSymbolImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	void* result = 0;
 	if (_handle && shl_findsym(&_handle, name.c_str(), TYPE_UNDEFINED, &result) !=  -1)

--- a/Foundation/src/SharedLibrary_UNIX.cpp
+++ b/Foundation/src/SharedLibrary_UNIX.cpp
@@ -26,7 +26,7 @@
 namespace Poco {
 
 
-FastMutex SharedLibraryImpl::_mutex;
+std::mutex SharedLibraryImpl::_mutex;
 
 
 SharedLibraryImpl::SharedLibraryImpl()
@@ -42,7 +42,7 @@ SharedLibraryImpl::~SharedLibraryImpl()
 
 void SharedLibraryImpl::loadImpl(const std::string& path, int flags)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle) throw LibraryAlreadyLoadedException(path);
 	int realFlags = RTLD_LAZY;
@@ -62,7 +62,7 @@ void SharedLibraryImpl::loadImpl(const std::string& path, int flags)
 
 void SharedLibraryImpl::unloadImpl()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle)
 	{
@@ -74,14 +74,14 @@ void SharedLibraryImpl::unloadImpl()
 
 bool SharedLibraryImpl::isLoadedImpl() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _handle != 0;
 }
 
 
 void* SharedLibraryImpl::findSymbolImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	void* result = 0;
 	if (_handle)

--- a/Foundation/src/SharedLibrary_VX.cpp
+++ b/Foundation/src/SharedLibrary_VX.cpp
@@ -46,7 +46,7 @@ extern "C" bool lookupFunc(char* name, int val, SYM_TYPE type, int arg, UINT16 g
 namespace Poco {
 
 
-FastMutex SharedLibraryImpl::_mutex;
+std::mutex SharedLibraryImpl::_mutex;
 
 
 SharedLibraryImpl::SharedLibraryImpl():
@@ -62,7 +62,7 @@ SharedLibraryImpl::~SharedLibraryImpl()
 
 void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_moduleId) throw LibraryAlreadyLoadedException(path);
 	int fd = open(const_cast<char*>(path.c_str()), O_RDONLY, 0);
@@ -87,7 +87,7 @@ void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 
 void SharedLibraryImpl::unloadImpl()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_moduleId)
 	{
@@ -99,7 +99,7 @@ void SharedLibraryImpl::unloadImpl()
 
 bool SharedLibraryImpl::isLoadedImpl() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _moduleId != 0;
 }
 
@@ -108,7 +108,7 @@ void* SharedLibraryImpl::findSymbolImpl(const std::string& name)
 {
 	poco_assert (_moduleId != 0);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	MODULE_INFO mi;
 	if (!moduleInfoGet(_moduleId, &mi)) return 0;

--- a/Foundation/src/SharedLibrary_WIN32U.cpp
+++ b/Foundation/src/SharedLibrary_WIN32U.cpp
@@ -24,7 +24,7 @@
 namespace Poco {
 
 
-FastMutex SharedLibraryImpl::_mutex;
+std::mutex SharedLibraryImpl::_mutex;
 
 
 SharedLibraryImpl::SharedLibraryImpl()
@@ -40,7 +40,7 @@ SharedLibraryImpl::~SharedLibraryImpl()
 
 void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle) throw LibraryAlreadyLoadedException(_path);
 	DWORD flags(0);
@@ -64,7 +64,7 @@ void SharedLibraryImpl::loadImpl(const std::string& path, int /*flags*/)
 
 void SharedLibraryImpl::unloadImpl()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle)
 	{
@@ -77,14 +77,14 @@ void SharedLibraryImpl::unloadImpl()
 
 bool SharedLibraryImpl::isLoadedImpl() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _handle != 0;
 }
 
 
 void* SharedLibraryImpl::findSymbolImpl(const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_handle)
 	{

--- a/Foundation/src/SimpleFileChannel.cpp
+++ b/Foundation/src/SimpleFileChannel.cpp
@@ -63,7 +63,7 @@ SimpleFileChannel::~SimpleFileChannel()
 
 void SimpleFileChannel::open()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_pFile)
 	{
@@ -83,7 +83,7 @@ void SimpleFileChannel::open()
 
 void SimpleFileChannel::close()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	delete _pFile;
 	_pFile = 0;
@@ -94,7 +94,7 @@ void SimpleFileChannel::log(const Message& msg)
 {
 	open();
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_limit > 0 && _pFile->size() >= _limit)
 	{
@@ -106,7 +106,7 @@ void SimpleFileChannel::log(const Message& msg)
 
 void SimpleFileChannel::setProperty(const std::string& name, const std::string& value)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (name == PROP_PATH)
 	{

--- a/Foundation/src/SplitterChannel.cpp
+++ b/Foundation/src/SplitterChannel.cpp
@@ -42,14 +42,14 @@ void SplitterChannel::addChannel(Channel::Ptr pChannel)
 {
 	poco_check_ptr (pChannel);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_channels.push_back(pChannel);
 }
 
 
 void SplitterChannel::removeChannel(Channel::Ptr pChannel)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (ChannelVec::iterator it = _channels.begin(); it != _channels.end(); ++it)
 	{
@@ -78,7 +78,7 @@ void SplitterChannel::setProperty(const std::string& name, const std::string& va
 
 void SplitterChannel::log(const Message& msg)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (auto& p: _channels)
 	{
@@ -89,14 +89,14 @@ void SplitterChannel::log(const Message& msg)
 
 void SplitterChannel::close()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_channels.clear();
 }
 
 
 int SplitterChannel::count() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return (int) _channels.size();
 }

--- a/Foundation/src/StreamChannel.cpp
+++ b/Foundation/src/StreamChannel.cpp
@@ -31,7 +31,7 @@ StreamChannel::~StreamChannel()
 
 void StreamChannel::log(const Message& msg)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_str << msg.getText() << std::endl;
 }

--- a/Foundation/src/Task.cpp
+++ b/Foundation/src/Task.cpp
@@ -98,7 +98,7 @@ bool Task::yield()
 
 void Task::setProgress(float progress)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_progress != progress)
 	{
@@ -111,7 +111,7 @@ void Task::setProgress(float progress)
 
 void Task::setOwner(TaskManager* pOwner)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_pOwner = pOwner;
 }
@@ -127,7 +127,7 @@ void Task::postNotification(Notification* pNf)
 {
 	poco_check_ptr (pNf);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_pOwner)
 		_pOwner->postNotification(pNf);

--- a/Foundation/src/TaskManager.cpp
+++ b/Foundation/src/TaskManager.cpp
@@ -55,10 +55,10 @@ TaskManager::~TaskManager()
 void TaskManager::start(Task* pTask)
 {
 	TaskPtr pAutoTask(pTask); // take ownership immediately
-	pAutoTask->setOwner(this);
-	pAutoTask->setState(Task::TASK_STARTING);
+  pAutoTask->setOwner(this);
+  pAutoTask->setState(Task::TASK_STARTING);
 
-	ScopedLockT lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
 	_taskList.push_back(pAutoTask);
 	try
 	{
@@ -77,7 +77,7 @@ void TaskManager::start(Task* pTask)
 
 void TaskManager::cancelAll()
 {
-	ScopedLockT lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
 
 	for (auto& pTask: _taskList)
 	{
@@ -94,9 +94,9 @@ void TaskManager::joinAll()
 
 TaskManager::TaskList TaskManager::taskList() const
 {
-	ScopedLockT lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
 
-	return _taskList;
+  return _taskList;
 }
 
 
@@ -126,7 +126,7 @@ void TaskManager::taskStarted(Task* pTask)
 
 void TaskManager::taskProgress(Task* pTask, float progress)
 {
-	ScopedLockWithUnlock<MutexT> lock(_mutex);
+  ScopedLockWithUnlock<std::mutex> lock(_mutex);
 
 	if (_lastProgressNotification.isElapsed(MIN_PROGRESS_NOTIFICATION_INTERVAL))
 	{
@@ -147,7 +147,7 @@ void TaskManager::taskFinished(Task* pTask)
 {
 	_nc.postNotification(new TaskFinishedNotification(pTask));
 
-	ScopedLockT lock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
 	for (TaskList::iterator it = _taskList.begin(); it != _taskList.end(); ++it)
 	{
 		if (*it == pTask)

--- a/Foundation/src/TemporaryFile.cpp
+++ b/Foundation/src/TemporaryFile.cpp
@@ -58,7 +58,7 @@ public:
 
 	void registerFile(const std::string& path)
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		Path p(path);
 		_files.insert(p.absolute().toString());
@@ -66,7 +66,7 @@ public:
 
 private:
 	std::set<std::string> _files;
-	FastMutex _mutex;
+	std::mutex _mutex;
 };
 
 
@@ -134,7 +134,7 @@ void TemporaryFile::registerForDeletion(const std::string& path)
 
 namespace
 {
-	static FastMutex mutex;
+	static std::mutex mutex;
 }
 
 

--- a/Foundation/src/ThreadPool.cpp
+++ b/Foundation/src/ThreadPool.cpp
@@ -53,7 +53,7 @@ private:
 	Event                _targetReady;
 	Event                _targetCompleted;
 	Event                _started;
-	FastMutex            _mutex;
+	std::mutex           _mutex;
 };
 
 
@@ -89,7 +89,7 @@ void PooledThread::start()
 
 void PooledThread::start(Thread::Priority priority, Runnable& target)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	poco_assert (_pTarget == 0);
 
@@ -101,7 +101,7 @@ void PooledThread::start(Thread::Priority priority, Runnable& target)
 
 void PooledThread::start(Thread::Priority priority, Runnable& target, const std::string& name)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string fullName(name);
 	if (name.empty())
@@ -126,14 +126,14 @@ void PooledThread::start(Thread::Priority priority, Runnable& target, const std:
 
 inline bool PooledThread::idle()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _idle;
 }
 
 
 int PooledThread::idleTime()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 #if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
 	return (int) (wceex_time(NULL) - _idleTime);
@@ -155,7 +155,7 @@ void PooledThread::join()
 
 void PooledThread::activate()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	poco_assert (_idle);
 	_idle = false;
@@ -210,7 +210,7 @@ void PooledThread::run()
 			{
 				ErrorHandler::handle();
 			}
-			FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			_pTarget  = 0;
 #if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
 			_idleTime = wceex_time(NULL);
@@ -293,7 +293,7 @@ ThreadPool::~ThreadPool()
 
 void ThreadPool::addCapacity(int n)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	poco_assert (_maxCapacity + n >= _minCapacity);
 	_maxCapacity += n;
@@ -303,14 +303,14 @@ void ThreadPool::addCapacity(int n)
 
 int ThreadPool::capacity() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _maxCapacity;
 }
 
 
 int ThreadPool::available() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	int count = 0;
 	for (auto pThread: _threads)
@@ -323,7 +323,7 @@ int ThreadPool::available() const
 
 int ThreadPool::used() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	int count = 0;
 	for (auto pThread: _threads)
@@ -336,7 +336,7 @@ int ThreadPool::used() const
 
 int ThreadPool::allocated() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return int(_threads.size());
 }
@@ -368,7 +368,7 @@ void ThreadPool::startWithPriority(Thread::Priority priority, Runnable& target, 
 
 void ThreadPool::stopAll()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (auto pThread: _threads)
 	{
@@ -380,7 +380,7 @@ void ThreadPool::stopAll()
 
 void ThreadPool::joinAll()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (auto pThread: _threads)
 	{
@@ -392,7 +392,7 @@ void ThreadPool::joinAll()
 
 void ThreadPool::collect()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	housekeep();
 }
 
@@ -440,7 +440,7 @@ void ThreadPool::housekeep()
 
 PooledThread* ThreadPool::getThread()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (++_age == 32)
 		housekeep();
@@ -495,7 +495,7 @@ public:
 	}
 	ThreadPool* pool()
 	{
-		FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		if (!_pPool)
 		{
@@ -508,7 +508,7 @@ public:
 
 private:
 	ThreadPool* _pPool;
-	FastMutex   _mutex;
+	std::mutex  _mutex;
 };
 
 

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -126,7 +126,7 @@ void ThreadImpl::setNameImpl(const std::string& threadName)
 		realName = truncName;
 	}
 
-	ScopedLock<FastMutex> lock(_pData->mutex);
+	std::lock_guard<std::mutex> lock(_pData->mutex);
 	if (realName != _pData->name)
 	{
 		_pData->name = realName;
@@ -136,7 +136,7 @@ void ThreadImpl::setNameImpl(const std::string& threadName)
 
 std::string ThreadImpl::getNameImpl() const
 {
-	ScopedLock<FastMutex> lock(_pData->mutex);
+	std::lock_guard<std::mutex> lock(_pData->mutex);
 	return _pData->name;
 }
 
@@ -229,7 +229,7 @@ void ThreadImpl::setStackSizeImpl(int size)
 void ThreadImpl::startImpl(SharedPtr<Runnable> pTarget)
 {
 	{
-		FastMutex::ScopedLock l(_pData->mutex);
+		std::lock_guard<std::mutex> l(_pData->mutex);
 		if (_pData->pRunnableTarget)
 			throw SystemException("thread already running");
 	}
@@ -247,7 +247,7 @@ void ThreadImpl::startImpl(SharedPtr<Runnable> pTarget)
 	}
 
 	{
-		FastMutex::ScopedLock l(_pData->mutex);
+		std::lock_guard<std::mutex> l(_pData->mutex);
 		_pData->pRunnableTarget = pTarget;
 		if (pthread_create(&_pData->thread, &attributes, runnableEntry, this))
 		{
@@ -345,7 +345,7 @@ void* ThreadImpl::runnableEntry(void* pThread)
 	AutoPtr<ThreadData> pData = pThreadImpl->_pData;
 
 	{
-		FastMutex::ScopedLock lock(pData->mutex);
+		std::lock_guard<std::mutex> lock(pData->mutex);
 		setThreadName(pData->name);
 	}
 
@@ -366,7 +366,7 @@ void* ThreadImpl::runnableEntry(void* pThread)
 		ErrorHandler::handle();
 	}
 
-	FastMutex::ScopedLock l(pData->mutex);
+	std::lock_guard<std::mutex> l(pData->mutex);
 	pData->pRunnableTarget = 0;
 	pData->done.set();
 	return 0;

--- a/Foundation/src/TimedNotificationQueue.cpp
+++ b/Foundation/src/TimedNotificationQueue.cpp
@@ -47,7 +47,7 @@ void TimedNotificationQueue::enqueueNotification(Notification::Ptr pNotification
 	Timestamp::TimeDiff diff = timestamp - tsNow;
 	clock += diff;
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_nfQueue.insert(NfQueue::value_type(clock, pNotification));
 	_nfAvailable.set();
 }
@@ -57,7 +57,7 @@ void TimedNotificationQueue::enqueueNotification(Notification::Ptr pNotification
 {
 	poco_check_ptr (pNotification);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_nfQueue.insert(NfQueue::value_type(clock, pNotification));
 	_nfAvailable.set();
 }
@@ -65,7 +65,7 @@ void TimedNotificationQueue::enqueueNotification(Notification::Ptr pNotification
 
 Notification* TimedNotificationQueue::dequeueNotification()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	NfQueue::iterator it = _nfQueue.begin();
 	if (it != _nfQueue.end())
@@ -172,28 +172,28 @@ bool TimedNotificationQueue::wait(Clock::ClockDiff interval)
 
 bool TimedNotificationQueue::empty() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _nfQueue.empty();
 }
 
 
 int TimedNotificationQueue::size() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return static_cast<int>(_nfQueue.size());
 }
 
 
 void TimedNotificationQueue::clear()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_nfQueue.clear();
 }
 
 
 Notification::Ptr TimedNotificationQueue::dequeueOne(NfQueue::iterator& it)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Notification::Ptr pNf = it->second;
 	_nfQueue.erase(it);
 	return pNf;

--- a/Foundation/src/Timer.cpp
+++ b/Foundation/src/Timer.cpp
@@ -67,7 +67,7 @@ void Timer::start(const AbstractTimerCallback& method, Thread::Priority priority
 	Clock nextInvocation;
 	nextInvocation += static_cast<Clock::ClockVal>(_startInterval)*1000;
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_pCallback)
 	{
@@ -92,7 +92,7 @@ void Timer::start(const AbstractTimerCallback& method, Thread::Priority priority
 
 void Timer::stop()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_pCallback)
 	{
 		_periodicInterval = 0;
@@ -108,7 +108,7 @@ void Timer::stop()
 
 void Timer::restart()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_pCallback)
 	{
 		_wakeUp.set();
@@ -119,7 +119,7 @@ void Timer::restart()
 void Timer::restart(long milliseconds)
 {
 	poco_assert (milliseconds >= 0);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_pCallback)
 	{
 		_periodicInterval = milliseconds;
@@ -130,7 +130,7 @@ void Timer::restart(long milliseconds)
 
 long Timer::getStartInterval() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _startInterval;
 }
 
@@ -138,14 +138,14 @@ long Timer::getStartInterval() const
 void Timer::setStartInterval(long milliseconds)
 {
 	poco_assert (milliseconds >= 0);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_startInterval = milliseconds;
 }
 
 
 long Timer::getPeriodicInterval() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _periodicInterval;
 }
 
@@ -153,7 +153,7 @@ long Timer::getPeriodicInterval() const
 void Timer::setPeriodicInterval(long milliseconds)
 {
 	poco_assert (milliseconds >= 0);
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_periodicInterval = milliseconds;
 }
 
@@ -184,7 +184,7 @@ void Timer::run()
 
 		if (_wakeUp.tryWait(sleep))
 		{
-			Poco::FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			_nextInvocation.update();
 			interval = _periodicInterval;
 		}
@@ -206,7 +206,7 @@ void Timer::run()
 			{
 				Poco::ErrorHandler::handle();
 			}
-			Poco::FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			interval = _periodicInterval;
 		}
 		_nextInvocation += static_cast<Clock::ClockVal>(interval)*1000;

--- a/Foundation/src/URIStreamOpener.cpp
+++ b/Foundation/src/URIStreamOpener.cpp
@@ -38,7 +38,7 @@ URIStreamOpener::~URIStreamOpener()
 
 std::istream* URIStreamOpener::open(const URI& uri) const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string scheme;
 	if (uri.isRelative())
@@ -51,7 +51,7 @@ std::istream* URIStreamOpener::open(const URI& uri) const
 
 std::istream* URIStreamOpener::open(const std::string& pathOrURI) const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	try
 	{
@@ -85,7 +85,7 @@ std::istream* URIStreamOpener::open(const std::string& pathOrURI) const
 
 std::istream* URIStreamOpener::open(const std::string& basePathOrURI, const std::string& pathOrURI) const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	try
 	{
@@ -128,7 +128,7 @@ void URIStreamOpener::registerStreamFactory(const std::string& scheme, URIStream
 {
 	poco_check_ptr (pFactory);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (_map.find(scheme) == _map.end())
 	{
 		_map[scheme] = pFactory;
@@ -139,7 +139,7 @@ void URIStreamOpener::registerStreamFactory(const std::string& scheme, URIStream
 
 void URIStreamOpener::unregisterStreamFactory(const std::string& scheme)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	FactoryMap::iterator it = _map.find(scheme);
 	if (it != _map.end())
@@ -154,7 +154,7 @@ void URIStreamOpener::unregisterStreamFactory(const std::string& scheme)
 
 bool URIStreamOpener::supportsScheme(const std::string& scheme)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _map.find(scheme) != _map.end();
 }
 

--- a/Foundation/src/UUIDGenerator.cpp
+++ b/Foundation/src/UUIDGenerator.cpp
@@ -37,7 +37,7 @@ UUIDGenerator::~UUIDGenerator()
 
 UUID UUIDGenerator::create()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_haveNode)
 	{
@@ -138,7 +138,7 @@ UUID UUIDGenerator::createOne()
 
 void UUIDGenerator::seed()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_random.seed();
 }
@@ -146,7 +146,7 @@ void UUIDGenerator::seed()
 
 void UUIDGenerator::seed(UInt32 n)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_random.seed(n);
 }

--- a/Foundation/testsuite/src/ConditionTest.cpp
+++ b/Foundation/testsuite/src/ConditionTest.cpp
@@ -21,7 +21,6 @@
 using Poco::Thread;
 using Poco::Runnable;
 using Poco::Condition;
-using Poco::Mutex;
 using Poco::TimeoutException;
 
 
@@ -30,7 +29,7 @@ namespace
 	class WaitRunnable: public Runnable
 	{
 	public:
-		WaitRunnable(Condition& cond, Mutex& mutex):
+		WaitRunnable(Condition& cond, std::recursive_mutex& mutex):
 			_ran(false),
 			_cond(cond),
 			_mutex(mutex)
@@ -53,13 +52,13 @@ namespace
 	private:
 		bool _ran;
 		Condition& _cond;
-		Mutex& _mutex;
+		std::recursive_mutex& _mutex;
 	};
 
 	class TryWaitRunnable: public Runnable
 	{
 	public:
-		TryWaitRunnable(Condition& cond, Mutex& mutex):
+		TryWaitRunnable(Condition& cond, std::recursive_mutex& mutex):
 			_ran(false),
 			_cond(cond),
 			_mutex(mutex)
@@ -84,7 +83,7 @@ namespace
 	private:
 		bool _ran;
 		Condition& _cond;
-		Mutex& _mutex;
+		std::recursive_mutex& _mutex;
 	};
 
 }
@@ -103,7 +102,7 @@ ConditionTest::~ConditionTest()
 void ConditionTest::testSignal()
 {
 	Condition cond;
-	Mutex mtx;
+	std::recursive_mutex mtx;
 	WaitRunnable r1(cond, mtx);
 	WaitRunnable r2(cond, mtx);
 
@@ -135,7 +134,7 @@ void ConditionTest::testSignal()
 void ConditionTest::testBroadcast()
 {
 	Condition cond;
-	Mutex mtx;
+	std::recursive_mutex mtx;
 	WaitRunnable r1(cond, mtx);
 	WaitRunnable r2(cond, mtx);
 	TryWaitRunnable r3(cond, mtx);

--- a/Foundation/testsuite/src/DirectoryWatcherTest.cpp
+++ b/Foundation/testsuite/src/DirectoryWatcherTest.cpp
@@ -56,7 +56,7 @@ void DirectoryWatcherTest::testAdded()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() >= 1);
 	assertTrue (_events[0].callback == "onItemAdded");
 	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
@@ -88,7 +88,7 @@ void DirectoryWatcherTest::testRemoved()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() >= 1);
 	assertTrue (_events[0].callback == "onItemRemoved");
 	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
@@ -121,7 +121,7 @@ void DirectoryWatcherTest::testModified()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() >= 1);
 	assertTrue (_events[0].callback == "onItemModified");
 	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
@@ -155,7 +155,7 @@ void DirectoryWatcherTest::testMoved()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	if (dw.supportsMoveEvents())
 	{
 		assertTrue (_events.size() >= 2);
@@ -218,7 +218,7 @@ void DirectoryWatcherTest::testSuspend()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() == 0);
 	assertTrue (!_error);
 }
@@ -249,7 +249,7 @@ void DirectoryWatcherTest::testResume()
 	fos2.close();
 
 	{
-		Poco::Mutex::ScopedLock l(_mutex);
+		std::lock_guard<std::recursive_mutex> l(_mutex);
 		assertTrue (_events.size() == 0);
 		assertTrue (!_error);
 	}
@@ -262,7 +262,7 @@ void DirectoryWatcherTest::testResume()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() >= 1);
 	assertTrue (_events[0].callback == "onItemModified");
 	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
@@ -311,7 +311,7 @@ void DirectoryWatcherTest::testSuspendMultipleTimes()
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
 	{
-		Poco::Mutex::ScopedLock l(_mutex);
+		std::lock_guard<std::recursive_mutex> l(_mutex);
 		assertTrue (_events.size() == 0);
 		assertTrue (!_error);
 	}
@@ -325,7 +325,7 @@ void DirectoryWatcherTest::testSuspendMultipleTimes()
 
 	Poco::Thread::sleep(2000*dw.scanInterval());
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	assertTrue (_events.size() >= 1);
 	assertTrue (_events[0].callback == "onItemModified");
 	assertTrue (Poco::Path(_events[0].path).getFileName() == "test.txt");
@@ -373,7 +373,7 @@ void DirectoryWatcherTest::onItemAdded(const Poco::DirectoryWatcher::DirectoryEv
 	de.path = ev.item.path();
 	de.type = ev.event;
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	_events.push_back(de);
 }
 
@@ -385,7 +385,7 @@ void DirectoryWatcherTest::onItemRemoved(const Poco::DirectoryWatcher::Directory
 	de.path = ev.item.path();
 	de.type = ev.event;
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	_events.push_back(de);
 }
 
@@ -397,7 +397,7 @@ void DirectoryWatcherTest::onItemModified(const Poco::DirectoryWatcher::Director
 	de.path = ev.item.path();
 	de.type = ev.event;
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	_events.push_back(de);
 }
 
@@ -409,7 +409,7 @@ void DirectoryWatcherTest::onItemMovedFrom(const Poco::DirectoryWatcher::Directo
 	de.path = ev.item.path();
 	de.type = ev.event;
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	_events.push_back(de);
 }
 
@@ -421,7 +421,7 @@ void DirectoryWatcherTest::onItemMovedTo(const Poco::DirectoryWatcher::Directory
 	de.path = ev.item.path();
 	de.type = ev.event;
 
-	Poco::Mutex::ScopedLock l(_mutex);
+	std::lock_guard<std::recursive_mutex> l(_mutex);
 	_events.push_back(de);
 }
 

--- a/Foundation/testsuite/src/DirectoryWatcherTest.h
+++ b/Foundation/testsuite/src/DirectoryWatcherTest.h
@@ -64,7 +64,7 @@ private:
 	};
 	std::vector<DirEvent> _events;
 	bool _error;
-	Poco::Mutex _mutex;
+	std::recursive_mutex _mutex;
 };
 
 

--- a/Foundation/testsuite/src/NotificationQueueTest.h
+++ b/Foundation/testsuite/src/NotificationQueueTest.h
@@ -44,7 +44,7 @@ protected:
 private:
 	Poco::NotificationQueue    _queue;
 	std::multiset<std::string> _handled;
-	Poco::FastMutex            _mutex;
+	std::mutex                 _mutex;
 };
 
 

--- a/Foundation/testsuite/src/PriorityNotificationQueueTest.h
+++ b/Foundation/testsuite/src/PriorityNotificationQueueTest.h
@@ -43,7 +43,7 @@ protected:
 private:
 	Poco::PriorityNotificationQueue    _queue;
 	std::multiset<std::string> _handled;
-	Poco::FastMutex            _mutex;
+	std::mutex                 _mutex;
 };
 
 

--- a/Foundation/testsuite/src/ThreadPoolTest.h
+++ b/Foundation/testsuite/src/ThreadPoolTest.h
@@ -37,7 +37,7 @@ protected:
 	void count();
 
 private:
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 	Poco::Event _event;
 	int   _count;
 };

--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -361,7 +361,7 @@ private:
 	bool _isLoggedIn = false;
 	Poco::Timespan _timeout = DEFAULT_TIMEOUT;
 	std::string _welcomeMessage;
-	Poco::FastMutex _wmMutex;
+	std::mutex _wmMutex;
 };
 
 
@@ -418,7 +418,7 @@ inline bool FTPClientSession::isSecure() const
 
 inline const std::string& FTPClientSession::welcomeMessage()
 {
-	Poco::FastMutex::ScopedLock lock(_wmMutex);
+	std::lock_guard<std::mutex> lock(_wmMutex);
 	return _welcomeMessage;
 }
 

--- a/Net/include/Poco/Net/HTTPDigestCredentials.h
+++ b/Net/include/Poco/Net/HTTPDigestCredentials.h
@@ -170,7 +170,7 @@ private:
 	NonceCounterMap _nc;
 
 	static int _nonceCounter;
-	static Poco::FastMutex _nonceMutex;
+	static std::mutex _nonceMutex;
 };
 
 

--- a/Net/include/Poco/Net/HTTPServerConnection.h
+++ b/Net/include/Poco/Net/HTTPServerConnection.h
@@ -55,7 +55,7 @@ private:
 	HTTPServerParams::Ptr          _pParams;
 	HTTPRequestHandlerFactory::Ptr _pFactory;
 	bool _stopped;
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 };
 
 

--- a/Net/include/Poco/Net/HTTPSessionFactory.h
+++ b/Net/include/Poco/Net/HTTPSessionFactory.h
@@ -124,7 +124,7 @@ private:
 	Instantiators _instantiators;
 	HTTPClientSession::ProxyConfig _proxyConfig;
 
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Net/include/Poco/Net/NetworkInterface.h
+++ b/Net/include/Poco/Net/NetworkInterface.h
@@ -319,7 +319,7 @@ protected:
 private:
 	NetworkInterfaceImpl* _pImpl;
 
-	static Poco::FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Net/include/Poco/Net/RemoteSyslogChannel.h
+++ b/Net/include/Poco/Net/RemoteSyslogChannel.h
@@ -157,7 +157,7 @@ private:
 	DatagramSocket _socket;
 	SocketAddress _socketAddress;
 	bool _open;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Net/include/Poco/Net/SocketNotifier.h
+++ b/Net/include/Poco/Net/SocketNotifier.h
@@ -70,8 +70,8 @@ protected:
 
 private:
 	typedef std::multiset<SocketNotification*> EventSet;
-	typedef Poco::FastMutex                    MutexType;
-	typedef MutexType::ScopedLock              ScopedLock;
+	typedef std::mutex                         MutexType;
+	typedef std::lock_guard<std::mutex>        ScopedLock;
 
 	EventSet                 _events;
 	Poco::NotificationCenter _nc;

--- a/Net/include/Poco/Net/SocketProactor.h
+++ b/Net/include/Poco/Net/SocketProactor.h
@@ -211,8 +211,8 @@ private:
 		/// If expiredOnly is true, only expired temporary functions
 		/// are called.
 
-	typedef Poco::Mutex MutexType;
-	typedef MutexType::ScopedLock ScopedLock;
+	typedef std::recursive_mutex MutexType;
+	typedef std::lock_guard<std::recursive_mutex> ScopedLock;
 
 	static const long DEFAULT_MAX_TIMEOUT_MS = 250;
 
@@ -381,9 +381,9 @@ private:
 	void deleteHandler(IOHandlerList& handlers, IOHandlerList::iterator& it);
 
 	template <typename T>
-	int errorImpl(Socket& sock, T& handlerMap, Poco::Mutex& mutex)
+	int errorImpl(Socket& sock, T& handlerMap, std::recursive_mutex& mutex)
 	{
-		Poco::Mutex::ScopedLock l(mutex);
+		std::lock_guard<std::recursive_mutex> l(mutex);
 		auto hIt = handlerMap.find(sock.impl()->sockfd());
 		if (hIt == handlerMap.end()) return 0;
 		unsigned err = 0;
@@ -450,8 +450,8 @@ private:
 	SubscriberMap _readHandlers;
 	SubscriberMap _writeHandlers;
 	IOCompletion  _ioCompletion;
-	Poco::Mutex   _writeMutex;
-	Poco::Mutex   _readMutex;
+	MutexType     _writeMutex;
+	MutexType     _readMutex;
 
 	std::unique_ptr<Worker> _pWorker;
 	friend class Worker;

--- a/Net/include/Poco/Net/SocketReactor.h
+++ b/Net/include/Poco/Net/SocketReactor.h
@@ -260,8 +260,6 @@ private:
 	typedef Poco::AutoPtr<SocketNotifier>        NotifierPtr;
 	typedef Poco::AutoPtr<SocketNotification>    NotificationPtr;
 	typedef std::map<poco_socket_t, NotifierPtr> EventHandlerMap;
-	typedef Poco::FastMutex                      MutexType;
-	typedef MutexType::ScopedLock                ScopedLock;
 
 	bool hasSocketHandlers();
 	void dispatch(NotifierPtr& pNotifier, SocketNotification* pNotification);
@@ -287,7 +285,7 @@ private:
 	NotificationPtr   _pErrorNotification;
 	NotificationPtr   _pTimeoutNotification;
 	NotificationPtr   _pShutdownNotification;
-	MutexType         _mutex;
+	std::mutex        _mutex;
 	Poco::Event       _event;
 
 	friend class SocketNotifier;

--- a/Net/include/Poco/Net/TCPServerDispatcher.h
+++ b/Net/include/Poco/Net/TCPServerDispatcher.h
@@ -110,7 +110,7 @@ private:
 
 		~ThreadCountWatcher()
 		{
-			FastMutex::ScopedLock lock(_pDisp->_mutex);
+			std::lock_guard<std::mutex> lock(_pDisp->_mutex);
 			if (_pDisp->_currentThreads > 1 && _pDisp->_queue.empty())
 			{
 				--_pDisp->_currentThreads;
@@ -136,7 +136,7 @@ private:
 	Poco::NotificationQueue         _queue;
 	TCPServerConnectionFactory::Ptr _pConnectionFactory;
 	Poco::ThreadPool&               _threadPool;
-	mutable Poco::FastMutex         _mutex;
+	mutable std::mutex              _mutex;
 };
 
 

--- a/Net/samples/HTTPLoadTest/src/HTTPLoadTest.cpp
+++ b/Net/samples/HTTPLoadTest/src/HTTPLoadTest.cpp
@@ -47,7 +47,6 @@ using Poco::Util::HelpFormatter;
 using Poco::Util::AbstractConfiguration;
 using Poco::AutoPtr;
 using Poco::Thread;
-using Poco::FastMutex;
 using Poco::Runnable;
 using Poco::Stopwatch;
 using Poco::NumberParser;
@@ -115,7 +114,7 @@ public:
 
 				if (_verbose)
 				{
-					FastMutex::ScopedLock lock(_mutex);
+					std::lock_guard<std::mutex> lock(_mutex);
 					std::cout
 					<< _uri.toString() << ' ' << res.getStatus() << ' ' << res.getReason()
 					<< ' ' << usec/1000.0 << "ms" << std::endl;
@@ -125,13 +124,13 @@ public:
 			}
 			catch (Exception& exc)
 			{
-				FastMutex::ScopedLock lock(_mutex);
+				std::lock_guard<std::mutex> lock(_mutex);
 				std::cerr << exc.displayText() << std::endl;
 			}
 		}
 
 		{
-			FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			_gSuccess += _success;
 			_gUsec += _usec;
 		}
@@ -156,10 +155,10 @@ private:
 	static int _gRepetitions;
 	static Poco::UInt64 _gUsec;
 	static int _gSuccess;
-	static FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
-FastMutex HTTPClient::_mutex;
+std::mutex HTTPClient::_mutex;
 int HTTPClient::_gRepetitions;
 Poco::UInt64 HTTPClient::_gUsec;
 int HTTPClient::_gSuccess;
@@ -181,7 +180,7 @@ int HTTPClient::totalSuccessCount()
 
 void HTTPClient::printStats(std::string uri, int repetitions, int success, Poco::UInt64 usec)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::cout << std::endl << "--------------" << std::endl
 		<< "Statistics for " << uri << std::endl << "--------------"

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -166,7 +166,7 @@ void  FTPClientSession::receiveServerReadyReply()
 		throw FTPException("Cannot receive status message", response, status);
 
 	{
-		Poco::FastMutex::ScopedLock lock(_wmMutex);
+		std::lock_guard<std::mutex> lock(_wmMutex);
 		_welcomeMessage = response;
 	}
 	_serverReady = true;

--- a/Net/src/HTTPDigestCredentials.cpp
+++ b/Net/src/HTTPDigestCredentials.cpp
@@ -106,7 +106,7 @@ const std::string HTTPDigestCredentials::AUTH_PARAM("auth");
 const std::string HTTPDigestCredentials::CNONCE_PARAM("cnonce");
 const std::string HTTPDigestCredentials::NC_PARAM("nc");
 int HTTPDigestCredentials::_nonceCounter(0);
-Poco::FastMutex HTTPDigestCredentials::_nonceMutex;
+std::mutex HTTPDigestCredentials::_nonceMutex;
 
 class HTTPDigestCredentials::DigestEngineProvider {
 public:
@@ -232,7 +232,7 @@ void HTTPDigestCredentials::updateProxyAuthInfo(HTTPRequest& request)
 
 std::string HTTPDigestCredentials::createNonce()
 {
-	Poco::FastMutex::ScopedLock lock(_nonceMutex);
+	std::lock_guard<std::mutex> lock(_nonceMutex);
 
 	MD5Engine md5;
 	Timestamp::TimeVal now = Timestamp().epochMicroseconds();

--- a/Net/src/HTTPServerConnection.cpp
+++ b/Net/src/HTTPServerConnection.cpp
@@ -62,7 +62,7 @@ void HTTPServerConnection::run()
 	{
 		try
 		{
-			Poco::FastMutex::ScopedLock lock(_mutex);
+			std::lock_guard<std::mutex> lock(_mutex);
 			if (!_stopped)
 			{
 				HTTPServerResponseImpl response(session);
@@ -158,7 +158,7 @@ void HTTPServerConnection::onServerStopped(const bool& abortCurrent)
 	}
 	else
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		try
 		{

--- a/Net/src/HTTPSessionFactory.cpp
+++ b/Net/src/HTTPSessionFactory.cpp
@@ -18,7 +18,6 @@
 
 
 using Poco::SingletonHolder;
-using Poco::FastMutex;
 using Poco::NotFoundException;
 using Poco::ExistsException;
 
@@ -58,7 +57,7 @@ void HTTPSessionFactory::registerProtocol(const std::string& protocol, HTTPSessi
 {
 	poco_assert_dbg(pSessionInstantiator);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	std::pair<Instantiators::iterator, bool> tmp = _instantiators.insert(make_pair(protocol, InstantiatorInfo(pSessionInstantiator)));
 	if (!tmp.second)
 	{
@@ -70,7 +69,7 @@ void HTTPSessionFactory::registerProtocol(const std::string& protocol, HTTPSessi
 
 void HTTPSessionFactory::unregisterProtocol(const std::string& protocol)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	Instantiators::iterator it = _instantiators.find(protocol);
 	if (it != _instantiators.end())
@@ -88,7 +87,7 @@ void HTTPSessionFactory::unregisterProtocol(const std::string& protocol)
 
 bool HTTPSessionFactory::supportsProtocol(const std::string& protocol)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	Instantiators::iterator it = _instantiators.find(protocol);
 	return it != _instantiators.end();
@@ -97,7 +96,7 @@ bool HTTPSessionFactory::supportsProtocol(const std::string& protocol)
 
 HTTPClientSession* HTTPSessionFactory::createClientSession(const Poco::URI& uri)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (uri.isRelative()) throw Poco::UnknownURISchemeException("Relative URIs are not supported by HTTPSessionFactory.");
 
@@ -113,7 +112,7 @@ HTTPClientSession* HTTPSessionFactory::createClientSession(const Poco::URI& uri)
 
 void HTTPSessionFactory::setProxy(const std::string& host, Poco::UInt16 port)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_proxyConfig.host = host;
 	_proxyConfig.port = port;
@@ -122,7 +121,7 @@ void HTTPSessionFactory::setProxy(const std::string& host, Poco::UInt16 port)
 
 void HTTPSessionFactory::setProxyCredentials(const std::string& username, const std::string& password)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_proxyConfig.username = username;
 	_proxyConfig.password = password;
@@ -131,7 +130,7 @@ void HTTPSessionFactory::setProxyCredentials(const std::string& username, const 
 
 void HTTPSessionFactory::setProxyConfig(const HTTPClientSession::ProxyConfig& proxyConfig)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_proxyConfig = proxyConfig;
 }

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -44,7 +44,6 @@
 
 
 using Poco::NumberFormatter;
-using Poco::FastMutex;
 using Poco::format;
 
 
@@ -565,7 +564,7 @@ inline void NetworkInterfaceImpl::setMACAddress(const void *addr, std::size_t le
 //
 
 
-FastMutex NetworkInterface::_mutex;
+std::mutex NetworkInterface::_mutex;
 
 
 NetworkInterface::NetworkInterface(unsigned index):
@@ -1048,7 +1047,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 	GetVersionEx(&osvi);
 
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Map result;
 	ULONG outBufLen = 16384;
 	Poco::Buffer<UCHAR> memory(outBufLen);
@@ -1281,7 +1280,7 @@ namespace Net {
 
 NetworkInterface::NetworkInterfaceList NetworkInterface::list()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	NetworkInterfaceList result;
 
 	int ifIndex = 1;
@@ -1385,7 +1384,7 @@ void setInterfaceParams(struct ifaddrs* iface, NetworkInterfaceImpl& impl)
 
 NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Map result;
 	unsigned ifIndex = 0;
 	NetworkInterface intf;
@@ -1603,7 +1602,7 @@ void setInterfaceParams(struct ifaddrs* iface, NetworkInterfaceImpl& impl)
 NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 {
 #if POCO_OS != POCO_OS_ANDROID
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	Map result;
 	unsigned ifIndex = 0;
 	NetworkInterface intf;
@@ -1735,7 +1734,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 /*
 NetworkInterface::NetworkInterfaceList NetworkInterface::list()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	NetworkInterfaceList result;
 	DatagramSocket socket;
 	// the following code is loosely based

--- a/Net/src/RemoteSyslogChannel.cpp
+++ b/Net/src/RemoteSyslogChannel.cpp
@@ -120,7 +120,7 @@ void RemoteSyslogChannel::close()
 
 void RemoteSyslogChannel::log(const Message& msg)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_open) open();
 

--- a/Net/src/SocketReactor.cpp
+++ b/Net/src/SocketReactor.cpp
@@ -176,7 +176,7 @@ bool SocketReactor::hasSocketHandlers()
 {
 	if (!_pollSet.empty())
 	{
-		ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		for (auto& p: _handlers)
 		{
 			if (p.second->accepts(_pReadableNotification) ||
@@ -217,7 +217,7 @@ SocketReactor::NotifierPtr SocketReactor::getNotifier(const Socket& socket, bool
 	const SocketImpl* pImpl = socket.impl();
 	if (pImpl == nullptr) return 0;
 	poco_socket_t sockfd = pImpl->sockfd();
-	ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	EventHandlerMap::iterator it = _handlers.find(sockfd);
 	if (it != _handlers.end()) return it->second;
@@ -237,7 +237,7 @@ void SocketReactor::removeEventHandler(const Socket& socket, const Poco::Abstrac
 		if(pNotifier->countObservers() == 1)
 		{
 			{
-				ScopedLock lock(_mutex);
+				std::lock_guard<std::mutex> lock(_mutex);
 				_handlers.erase(pImpl->sockfd());
 			}
 			_pollSet.remove(socket);
@@ -280,7 +280,7 @@ void SocketReactor::dispatch(SocketNotification* pNotification)
 {
 	std::vector<NotifierPtr> delegates;
 	{
-		ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 		delegates.reserve(_handlers.size());
 		for (EventHandlerMap::iterator it = _handlers.begin(); it != _handlers.end(); ++it)
 			delegates.push_back(it->second);

--- a/Net/src/StreamSocket.cpp
+++ b/Net/src/StreamSocket.cpp
@@ -20,7 +20,6 @@
 
 
 using Poco::InvalidArgumentException;
-using Poco::Mutex;
 using Poco::ScopedLock;
 
 
@@ -172,7 +171,7 @@ int StreamSocket::sendBytes(const SocketBufVec& buffers, int flags)
 
 int StreamSocket::sendBytes(FIFOBuffer& fifoBuf)
 {
-	ScopedLock<Mutex> l(fifoBuf.mutex());
+	ScopedLock<std::recursive_mutex> l(fifoBuf.mutex());
 
 	int ret = impl()->sendBytes(fifoBuf.begin(), (int) fifoBuf.used());
 	if (ret > 0) fifoBuf.drain(ret);
@@ -200,7 +199,7 @@ int StreamSocket::receiveBytes(Poco::Buffer<char>& buffer, int flags, const Poco
 
 int StreamSocket::receiveBytes(FIFOBuffer& fifoBuf)
 {
-	ScopedLock<Mutex> l(fifoBuf.mutex());
+	ScopedLock<std::recursive_mutex> l(fifoBuf.mutex());
 
 	int ret = impl()->receiveBytes(fifoBuf.next(), (int)fifoBuf.available());
 	if (ret > 0) fifoBuf.advance(ret);

--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -21,7 +21,6 @@
 
 
 using Poco::Notification;
-using Poco::FastMutex;
 using Poco::AutoPtr;
 
 
@@ -138,7 +137,7 @@ namespace
 
 void TCPServerDispatcher::enqueue(const StreamSocket& socket)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_queue.size() < _pParams->getMaxQueued())
 	{
@@ -187,7 +186,7 @@ int TCPServerDispatcher::currentThreads() const
 
 int TCPServerDispatcher::maxThreads() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	return _threadPool.capacity();
 }
@@ -225,7 +224,7 @@ int TCPServerDispatcher::refusedConnections() const
 
 void TCPServerDispatcher::beginConnection()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	++_totalConnections;
 	++_currentConnections;

--- a/Net/testsuite/src/DialogServer.cpp
+++ b/Net/testsuite/src/DialogServer.cpp
@@ -18,7 +18,6 @@
 using Poco::Net::Socket;
 using Poco::Net::DialogSocket;
 using Poco::Net::SocketAddress;
-using Poco::FastMutex;
 using Poco::Thread;
 
 
@@ -57,7 +56,7 @@ void DialogServer::run()
 		{
 			DialogSocket ds = _socket.acceptConnection();
 			{
-				FastMutex::ScopedLock lock(_mutex);
+				std::lock_guard<std::mutex> lock(_mutex);
 				if (!_nextResponses.empty())
 				{
 					ds.sendMessage(_nextResponses.front());
@@ -73,7 +72,7 @@ void DialogServer::run()
 					{
 						if (_log) std::cout << ">> " << command << std::endl;
 						{
-							FastMutex::ScopedLock lock(_mutex);
+							std::lock_guard<std::mutex> lock(_mutex);
 							_lastCommands.push_back(command);
 							if (!_nextResponses.empty())
 							{
@@ -96,7 +95,7 @@ void DialogServer::run()
 
 const std::string& DialogServer::lastCommand() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	static const std::string EMPTY;
 	if (_lastCommands.empty())
@@ -114,7 +113,7 @@ const std::vector<std::string>& DialogServer::lastCommands() const
 
 std::string DialogServer::popCommand()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string command;
 	if (!_lastCommands.empty())
@@ -140,7 +139,7 @@ std::string DialogServer::popCommandWait()
 
 void DialogServer::addResponse(const std::string& response)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_nextResponses.push_back(response);
 }
@@ -148,7 +147,7 @@ void DialogServer::addResponse(const std::string& response)
 
 void DialogServer::clearCommands()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_lastCommands.clear();
 }
@@ -156,7 +155,7 @@ void DialogServer::clearCommands()
 
 void DialogServer::clearResponses()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_nextResponses.clear();
 }

--- a/Net/testsuite/src/DialogServer.h
+++ b/Net/testsuite/src/DialogServer.h
@@ -69,7 +69,7 @@ private:
 	Poco::Net::ServerSocket  _socket;
 	Poco::Thread             _thread;
 	Poco::Event              _ready;
-	mutable Poco::FastMutex  _mutex;
+	mutable std::mutex       _mutex;
 	std::atomic<bool>        _stop;
 	std::vector<std::string> _nextResponses;
 	std::vector<std::string> _lastCommands;

--- a/Net/testsuite/src/ICMPClientTest.cpp
+++ b/Net/testsuite/src/ICMPClientTest.cpp
@@ -32,7 +32,7 @@ using Poco::Delegate;
 using Poco::AutoPtr;
 
 
-Poco::FastMutex ICMPClientTest::_mutex;
+std::mutex ICMPClientTest::_mutex;
 
 
 ICMPClientTest::ICMPClientTest(const std::string& name):
@@ -69,7 +69,7 @@ void ICMPClientTest::testPing()
 
 	unregisterDelegates(icmpClient);
 	// wait for delegates to finish printing
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 }
 
 
@@ -96,7 +96,7 @@ void ICMPClientTest::testBigPing()
 
 	unregisterDelegates(icmpClient);
 	// wait for delegates to finish printing
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 }
 
 
@@ -130,7 +130,7 @@ void ICMPClientTest::tearDown()
 
 void ICMPClientTest::onBegin(const void* pSender, ICMPEventArgs& args)
 {
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	std::ostringstream os;
 	os << std::endl << "Pinging " << args.hostName() << " [" << args.hostAddress() << "] with "
 		<< args.dataSize() << " bytes of data:"
@@ -141,7 +141,7 @@ void ICMPClientTest::onBegin(const void* pSender, ICMPEventArgs& args)
 
 void ICMPClientTest::onReply(const void* pSender, ICMPEventArgs& args)
 {
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	std::ostringstream os;
 	os << "Reply from " << args.hostAddress()
 		<< " bytes=" << args.dataSize()
@@ -153,7 +153,7 @@ void ICMPClientTest::onReply(const void* pSender, ICMPEventArgs& args)
 
 void ICMPClientTest::onError(const void* pSender, ICMPEventArgs& args)
 {
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	std::ostringstream os;
 	os << args.error();
 	std::cerr << os.str() << std::endl;
@@ -162,7 +162,7 @@ void ICMPClientTest::onError(const void* pSender, ICMPEventArgs& args)
 
 void ICMPClientTest::onEnd(const void* pSender, ICMPEventArgs& args)
 {
-	Poco::FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	std::ostringstream os;
 	int received = args.received();
 	os << std::endl << "--- Ping statistics for " << args.hostAddress() << " ---"

--- a/Net/testsuite/src/ICMPClientTest.h
+++ b/Net/testsuite/src/ICMPClientTest.h
@@ -43,7 +43,7 @@ public:
 private:
 	void registerDelegates(const Poco::Net::ICMPClient& icmpClient);
 	void unregisterDelegates(const Poco::Net::ICMPClient& icmpClient);
-	static Poco::FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/Net/testsuite/src/SyslogTest.cpp
+++ b/Net/testsuite/src/SyslogTest.cpp
@@ -51,7 +51,7 @@ private:
 	Messages   _cache;
 	std::size_t _size;
 	std::size_t _maxSize;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 
@@ -63,7 +63,7 @@ std::size_t CachingChannel::getMaxSize() const
 
 std::size_t CachingChannel::getCurrentSize() const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	return _size;
 }
 
@@ -84,7 +84,7 @@ CachingChannel::~CachingChannel()
 
 void CachingChannel::log(const Poco::Message& msg)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_cache.push_front(msg);
 	if (_size == _maxSize)
 	{

--- a/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -320,7 +320,7 @@ private:
 	PrivateKeyPassphraseHandlerPtr   _ptrClientPassphraseHandler;
 	InvalidCertificateHandlerPtr     _ptrClientCertificateHandler;
 	int                              _contextIndex;
-	Poco::FastMutex                  _mutex;
+	std::mutex                       _mutex;
 
 	static const std::string CFG_PRIV_KEY_FILE;
 	static const std::string CFG_CERTIFICATE_FILE;

--- a/NetSSL_OpenSSL/src/SSLManager.cpp
+++ b/NetSSL_OpenSSL/src/SSLManager.cpp
@@ -119,7 +119,7 @@ SSLManager& SSLManager::instance()
 
 void SSLManager::initializeServer(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, InvalidCertificateHandlerPtr ptrHandler, Context::Ptr ptrContext)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_ptrServerPassphraseHandler  = ptrPassphraseHandler;
 	_ptrServerCertificateHandler = ptrHandler;
 	_ptrDefaultServerContext     = ptrContext;
@@ -128,7 +128,7 @@ void SSLManager::initializeServer(PrivateKeyPassphraseHandlerPtr ptrPassphraseHa
 
 void SSLManager::initializeClient(PrivateKeyPassphraseHandlerPtr ptrPassphraseHandler, InvalidCertificateHandlerPtr ptrHandler, Context::Ptr ptrContext)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	_ptrClientPassphraseHandler  = ptrPassphraseHandler;
 	_ptrClientCertificateHandler = ptrHandler;
 	_ptrDefaultClientContext     = ptrContext;
@@ -137,7 +137,7 @@ void SSLManager::initializeClient(PrivateKeyPassphraseHandlerPtr ptrPassphraseHa
 
 Context::Ptr SSLManager::defaultServerContext()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrDefaultServerContext)
 		initDefaultContext(true);
@@ -148,7 +148,7 @@ Context::Ptr SSLManager::defaultServerContext()
 
 Context::Ptr SSLManager::defaultClientContext()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrDefaultClientContext)
 	{
@@ -170,7 +170,7 @@ Context::Ptr SSLManager::defaultClientContext()
 
 SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::serverPassphraseHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrServerPassphraseHandler)
 		initPassphraseHandler(true);
@@ -181,7 +181,7 @@ SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::serverPassphraseHandler()
 
 SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::clientPassphraseHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrClientPassphraseHandler)
 		initPassphraseHandler(false);
@@ -192,7 +192,7 @@ SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::clientPassphraseHandler()
 
 SSLManager::InvalidCertificateHandlerPtr SSLManager::serverCertificateHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrServerCertificateHandler)
 		initCertificateHandler(true);
@@ -203,7 +203,7 @@ SSLManager::InvalidCertificateHandlerPtr SSLManager::serverCertificateHandler()
 
 SSLManager::InvalidCertificateHandlerPtr SSLManager::clientCertificateHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrClientCertificateHandler)
 		initCertificateHandler(false);

--- a/NetSSL_OpenSSL/testsuite/src/DialogServer.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/DialogServer.cpp
@@ -22,7 +22,6 @@
 using Poco::Net::Socket;
 using Poco::Net::DialogSocket;
 using Poco::Net::SocketAddress;
-using Poco::FastMutex;
 using Poco::Thread;
 using Poco::Net::SecureStreamSocket;
 using Poco::Net::SSLManager;
@@ -127,7 +126,7 @@ void DialogServer::run()
 				handleDataSSLrequest(ds, _ssl, _SSLsession);
 			}
 			{
-				FastMutex::ScopedLock lock(_mutex);
+				std::lock_guard<std::mutex> lock(_mutex);
 				if (!_nextResponses.empty())
 				{
 					ds.sendMessage(_nextResponses.front());
@@ -155,7 +154,7 @@ void DialogServer::run()
 
 						if (_log) std::cout << ">> " << command << std::endl;
 						{
-							FastMutex::ScopedLock lock(_mutex);
+							std::lock_guard<std::mutex> lock(_mutex);
 							_lastCommands.push_back(command);
 							if (!_nextResponses.empty())
 							{
@@ -178,7 +177,7 @@ void DialogServer::run()
 
 const std::string& DialogServer::lastCommand() const
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	static const std::string EMPTY;
 	if (_lastCommands.empty())
@@ -196,7 +195,7 @@ const std::vector<std::string>& DialogServer::lastCommands() const
 
 std::string DialogServer::popCommand()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	std::string command;
 	if (!_lastCommands.empty())
@@ -222,7 +221,7 @@ std::string DialogServer::popCommandWait()
 
 void DialogServer::addResponse(const std::string& response)
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_nextResponses.push_back(response);
 }
@@ -230,7 +229,7 @@ void DialogServer::addResponse(const std::string& response)
 
 void DialogServer::clearCommands()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_lastCommands.clear();
 }
@@ -238,7 +237,7 @@ void DialogServer::clearCommands()
 
 void DialogServer::clearResponses()
 {
-	FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_nextResponses.clear();
 }

--- a/NetSSL_OpenSSL/testsuite/src/DialogServer.h
+++ b/NetSSL_OpenSSL/testsuite/src/DialogServer.h
@@ -73,7 +73,7 @@ private:
 	Poco::Net::ServerSocket _socket;
 	Poco::Thread             _thread;
 	Poco::Event              _ready;
-	mutable Poco::FastMutex  _mutex;
+	mutable std::mutex       _mutex;
 	std::atomic<bool>        _stop;
 	std::vector<std::string> _nextResponses;
 	std::vector<std::string> _lastCommands;

--- a/NetSSL_Win/include/Poco/Net/Context.h
+++ b/NetSSL_Win/include/Poco/Net/Context.h
@@ -249,7 +249,7 @@ private:
 	PCCERT_CONTEXT             _pCert;
 	CredHandle                 _hCreds;
 	SecurityFunctionTableW&    _securityFunctions;
-	mutable Poco::FastMutex    _mutex;
+	mutable std::mutex         _mutex;
 };
 
 

--- a/NetSSL_Win/include/Poco/Net/SSLManager.h
+++ b/NetSSL_Win/include/Poco/Net/SSLManager.h
@@ -265,7 +265,7 @@ private:
 	Context::Ptr                   _ptrDefaultClientContext;
 	PrivateKeyPassphraseHandlerPtr _ptrClientPassphraseHandler;
 	InvalidCertificateHandlerPtr   _ptrClientCertificateHandler;
-	Poco::FastMutex _mutex;
+	std::mutex _mutex;
 
 	static const std::string CFG_CERT_NAME;
 	static const std::string VAL_CERT_NAME;

--- a/NetSSL_Win/include/Poco/Net/Utility.h
+++ b/NetSSL_Win/include/Poco/Net/Utility.h
@@ -40,7 +40,7 @@ public:
 
 private:
 	static std::map<long, const std::string> initSSPIErr();
-	static Poco::FastMutex _mutex;
+	static std::mutex _mutex;
 };
 
 

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -134,7 +134,7 @@ void Context::enableExtendedCertificateVerification(bool flag)
 
 void Context::addTrustedCert(const Poco::Net::X509Certificate& cert)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 	if (!CertAddCertificateContextToStore(_hMemCertStore, cert.system(), CERT_STORE_ADD_REPLACE_EXISTING, 0))
 		throw CertificateException("Failed to add certificate to store", GetLastError());
 }
@@ -251,7 +251,7 @@ void Context::importCertificate(const char* pBuffer, std::size_t size)
 
 CredHandle& Context::credentials()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (_hCreds.dwLower == 0 && _hCreds.dwUpper == 0)
 	{

--- a/NetSSL_Win/src/SSLManager.cpp
+++ b/NetSSL_Win/src/SSLManager.cpp
@@ -111,7 +111,7 @@ void SSLManager::initializeClient(PrivateKeyPassphraseHandlerPtr pPassphraseHand
 
 Context::Ptr SSLManager::defaultServerContext()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrDefaultServerContext)
 		initDefaultContext(true);
@@ -122,7 +122,7 @@ Context::Ptr SSLManager::defaultServerContext()
 
 Context::Ptr SSLManager::defaultClientContext()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrDefaultClientContext)
 	{
@@ -143,7 +143,7 @@ Context::Ptr SSLManager::defaultClientContext()
 
 SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::serverPassphraseHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrServerPassphraseHandler)
 		initPassphraseHandler(true);
@@ -154,7 +154,7 @@ SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::serverPassphraseHandler()
 
 SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::clientPassphraseHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrClientPassphraseHandler)
 		initPassphraseHandler(false);
@@ -165,7 +165,7 @@ SSLManager::PrivateKeyPassphraseHandlerPtr SSLManager::clientPassphraseHandler()
 
 SSLManager::InvalidCertificateHandlerPtr SSLManager::serverCertificateHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrServerCertificateHandler)
 		initCertificateHandler(true);
@@ -176,7 +176,7 @@ SSLManager::InvalidCertificateHandlerPtr SSLManager::serverCertificateHandler()
 
 SSLManager::InvalidCertificateHandlerPtr SSLManager::clientCertificateHandler()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	if (!_ptrClientCertificateHandler)
 		initCertificateHandler(false);

--- a/NetSSL_Win/src/Utility.cpp
+++ b/NetSSL_Win/src/Utility.cpp
@@ -24,7 +24,7 @@ namespace Poco {
 namespace Net {
 
 
-Poco::FastMutex Utility::_mutex;
+std::mutex Utility::_mutex;
 
 
 Context::VerificationMode Utility::convertVerificationMode(const std::string& vMode)
@@ -187,7 +187,7 @@ std::map<long, const std::string> Utility::initSSPIErr()
 
 const std::string& Utility::formatError(long errCode)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	static const std::string def("Internal SSPI error");
 	static const std::map<long, const std::string> errs(initSSPIErr());

--- a/Prometheus/include/Poco/Prometheus/Histogram.h
+++ b/Prometheus/include/Poco/Prometheus/Histogram.h
@@ -72,7 +72,7 @@ private:
 	std::vector<Poco::UInt64> _bucketCounts;
 	Poco::UInt64 _count = 0;
 	double _sum = 0.0;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 
 	HistogramSample() = delete;
 	HistogramSample(const HistogramSample&) = delete;
@@ -182,7 +182,7 @@ public:
 
 private:
 	std::vector<double> _bucketBounds;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 
@@ -199,7 +199,7 @@ inline const std::vector<double>& HistogramSample::bucketBounds() const
 
 inline HistogramData HistogramSample::data() const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	HistogramData data;
 	data.bucketCounts = _bucketCounts;

--- a/Prometheus/include/Poco/Prometheus/LabeledMetricImpl.h
+++ b/Prometheus/include/Poco/Prometheus/LabeledMetricImpl.h
@@ -71,7 +71,7 @@ public:
 				throw Poco::InvalidArgumentException(Poco::format("Metric %s requires label values for %s"s, name(), Poco::cat(", "s, labelNames().begin(), labelNames().end())));
 		}
 
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		const auto it = _samples.find(labelValues);
 		if (it != _samples.end())
@@ -97,7 +97,7 @@ public:
 		if (labelValues.size() != labelNames().size())
 			throw Poco::InvalidArgumentException(Poco::format("Metric %s requires label values for %s"s, name(), Poco::cat(", "s, labelNames().begin(), labelNames().end())));
 
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		const auto it = _samples.find(labelValues);
 		if (it != _samples.end())
@@ -119,7 +119,7 @@ public:
 		if (labelNames().empty())
 			throw Poco::InvalidAccessException("Metric has no labels"s);
 
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		_samples.erase(labelValues);
 	}
@@ -127,7 +127,7 @@ public:
 	void clear()
 		/// Removes all samples.
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		_samples.clear();
 	}
@@ -135,7 +135,7 @@ public:
 	std::size_t sampleCount() const
 		/// Returns the number of samples.
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		return _samples.size();
 	}
@@ -144,7 +144,7 @@ public:
 	void forEach(ProcessingFunction func) const
 		/// Calls the given function for each Sample.
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		for (const auto& p: _samples)
 		{
@@ -155,7 +155,7 @@ public:
 	// Collector
 	void exportTo(Exporter& exporter) const override
 	{
-		Poco::FastMutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::mutex> lock(_mutex);
 
 		exporter.writeHeader(*this);
 		for (const auto& p: _samples)
@@ -183,7 +183,7 @@ protected:
 
 private:
 	std::map<std::vector<std::string>, std::unique_ptr<Sample>> _samples;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 

--- a/Prometheus/include/Poco/Prometheus/Registry.h
+++ b/Prometheus/include/Poco/Prometheus/Registry.h
@@ -86,7 +86,7 @@ public:
 
 private:
 	std::map<std::string, Collector*> _collectors;
-	mutable Poco::FastMutex _mutex;
+	mutable std::mutex _mutex;
 
 	Registry(const Registry&) = delete;
 	Registry(Registry&&) = delete;

--- a/Prometheus/src/Histogram.cpp
+++ b/Prometheus/src/Histogram.cpp
@@ -33,7 +33,7 @@ HistogramSample::HistogramSample(const std::vector<double>& bucketBounds):
 
 void HistogramSample::observe(double value)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	const std::size_t n = _bucketBounds.size();
 	for (std::size_t i = 0; i < n; i++)
@@ -117,7 +117,7 @@ std::unique_ptr<HistogramSample> Histogram::createSample() const
 
 void Histogram::exportTo(Exporter& exporter) const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	Gauge bucket(name() + "_bucket"s, nullptr);
 	Gauge sum(name() + "_sum"s, nullptr);

--- a/Prometheus/src/Registry.cpp
+++ b/Prometheus/src/Registry.cpp
@@ -29,7 +29,7 @@ void Registry::registerCollector(Collector* pCollector)
 {
 	poco_check_ptr (pCollector);
 
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	const auto it = _collectors.find(pCollector->name());
 	if (it == _collectors.end())
@@ -53,7 +53,7 @@ void Registry::unregisterCollector(Collector* pCollector)
 
 void Registry::unregisterCollector(const std::string& collectorName)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_collectors.erase(collectorName);
 }
@@ -61,7 +61,7 @@ void Registry::unregisterCollector(const std::string& collectorName)
 
 Collector* Registry::findCollector(const std::string& collectorName) const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	const auto it = _collectors.find(collectorName);
 	if (it != _collectors.end())
@@ -73,7 +73,7 @@ Collector* Registry::findCollector(const std::string& collectorName) const
 
 void Registry::clear()
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	_collectors.clear();
 }
@@ -81,7 +81,7 @@ void Registry::clear()
 
 void Registry::exportTo(Exporter& exporter) const
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::mutex> lock(_mutex);
 
 	for (const auto& p: _collectors)
 	{

--- a/SevenZip/src/Archive.cpp
+++ b/SevenZip/src/Archive.cpp
@@ -150,7 +150,7 @@ protected:
 		FileInStream_CreateVTable(&_archiveStream);
 		LookToRead_CreateVTable(&_lookStream, False);
 
-		Poco::FastMutex::ScopedLock lock(_initMutex);
+		std::lock_guard<std::mutex> lock(_initMutex);
 		if (!_initialized)
 		{
 			CrcGenerateTable();
@@ -287,14 +287,14 @@ private:
 	CSzArEx _db;
 	static ISzAlloc _szAlloc;
 	static ISzAlloc _szAllocTemp;
-	static Poco::FastMutex _initMutex;
+	static std::mutex _initMutex;
 	static bool _initialized;
 };
 
 
 ISzAlloc ArchiveImpl::_szAlloc     = { SzAlloc, SzFree };
 ISzAlloc ArchiveImpl::_szAllocTemp = { SzAlloc, SzFree };
-Poco::FastMutex ArchiveImpl::_initMutex;
+std::mutex ArchiveImpl::_initMutex;
 bool ArchiveImpl::_initialized(false);
 
 

--- a/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/Util/include/Poco/Util/AbstractConfiguration.h
@@ -385,7 +385,7 @@ private:
 
 	mutable int _depth;
 	bool        _eventsEnabled;
-	mutable Poco::Mutex _mutex;
+	mutable std::recursive_mutex _mutex;
 
 	friend class LayeredConfiguration;
 	friend class ConfigurationView;

--- a/Util/include/Poco/Util/TimerTask.h
+++ b/Util/include/Poco/Util/TimerTask.h
@@ -76,7 +76,7 @@ private:
 
 	Poco::Timestamp _lastExecution;
 	std::atomic<bool> _isCancelled;
-	mutable FastMutex _mutex;
+	mutable std::mutex _mutex;
 };
 
 
@@ -117,14 +117,14 @@ inline bool TimerTask::isCancelled() const
 
 inline Poco::Timestamp TimerTask::lastExecution() const
 {
-	FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	return _lastExecution;
 }
 
 
 inline void TimerTask::updateLastExecution()
 {
-	FastMutex::ScopedLock l(_mutex);
+	std::lock_guard<std::mutex> l(_mutex);
 	_lastExecution.update();
 }
 

--- a/Util/src/AbstractConfiguration.cpp
+++ b/Util/src/AbstractConfiguration.cpp
@@ -21,7 +21,6 @@
 #include "Poco/String.h"
 
 
-using Poco::Mutex;
 using Poco::NotFoundException;
 using Poco::SyntaxException;
 using Poco::CircularReferenceException;
@@ -48,7 +47,7 @@ AbstractConfiguration::~AbstractConfiguration()
 
 bool AbstractConfiguration::hasProperty(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	return getRaw(key, value);
@@ -69,7 +68,7 @@ bool AbstractConfiguration::has(const std::string& key) const
 
 std::string AbstractConfiguration::getString(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -81,7 +80,7 @@ std::string AbstractConfiguration::getString(const std::string& key) const
 
 std::string AbstractConfiguration::getString(const std::string& key, const std::string& defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -93,7 +92,7 @@ std::string AbstractConfiguration::getString(const std::string& key, const std::
 
 std::string AbstractConfiguration::getRawString(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -106,7 +105,7 @@ std::string AbstractConfiguration::getRawString(const std::string& key) const
 std::string AbstractConfiguration::getRawString(const std::string& key, const std::string& defaultValue) const
 {
 
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -118,7 +117,7 @@ std::string AbstractConfiguration::getRawString(const std::string& key, const st
 
 int AbstractConfiguration::getInt(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -130,7 +129,7 @@ int AbstractConfiguration::getInt(const std::string& key) const
 
 int AbstractConfiguration::getInt(const std::string& key, int defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -142,7 +141,7 @@ int AbstractConfiguration::getInt(const std::string& key, int defaultValue) cons
 
 unsigned AbstractConfiguration::getUInt(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -154,7 +153,7 @@ unsigned AbstractConfiguration::getUInt(const std::string& key) const
 
 unsigned AbstractConfiguration::getUInt(const std::string& key, unsigned defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -169,7 +168,7 @@ unsigned AbstractConfiguration::getUInt(const std::string& key, unsigned default
 
 Int64 AbstractConfiguration::getInt64(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -181,7 +180,7 @@ Int64 AbstractConfiguration::getInt64(const std::string& key) const
 
 Int64 AbstractConfiguration::getInt64(const std::string& key, Int64 defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -193,7 +192,7 @@ Int64 AbstractConfiguration::getInt64(const std::string& key, Int64 defaultValue
 
 UInt64 AbstractConfiguration::getUInt64(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -205,7 +204,7 @@ UInt64 AbstractConfiguration::getUInt64(const std::string& key) const
 
 UInt64 AbstractConfiguration::getUInt64(const std::string& key, UInt64 defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -220,7 +219,7 @@ UInt64 AbstractConfiguration::getUInt64(const std::string& key, UInt64 defaultVa
 
 double AbstractConfiguration::getDouble(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -232,7 +231,7 @@ double AbstractConfiguration::getDouble(const std::string& key) const
 
 double AbstractConfiguration::getDouble(const std::string& key, double defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -244,7 +243,7 @@ double AbstractConfiguration::getDouble(const std::string& key, double defaultVa
 
 bool AbstractConfiguration::getBool(const std::string& key) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -256,7 +255,7 @@ bool AbstractConfiguration::getBool(const std::string& key) const
 
 bool AbstractConfiguration::getBool(const std::string& key, bool defaultValue) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string value;
 	if (getRaw(key, value))
@@ -289,7 +288,7 @@ void AbstractConfiguration::setUInt(const std::string& key, unsigned int value)
 
 void AbstractConfiguration::setInt64(const std::string& key, Int64 value)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	setRawWithEvent(key, NumberFormatter::format(value));
 }
@@ -297,7 +296,7 @@ void AbstractConfiguration::setInt64(const std::string& key, Int64 value)
 
 void AbstractConfiguration::setUInt64(const std::string& key, UInt64 value)
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	setRawWithEvent(key, NumberFormatter::format(value));
 }
@@ -320,7 +319,7 @@ void AbstractConfiguration::setBool(const std::string& key, bool value)
 
 void AbstractConfiguration::keys(Keys& range) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	std::string key;
 	range.clear();
@@ -330,7 +329,7 @@ void AbstractConfiguration::keys(Keys& range) const
 
 void AbstractConfiguration::keys(const std::string& key, Keys& range) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	range.clear();
 	enumerate(key, range);
@@ -384,7 +383,7 @@ namespace
 
 std::string AbstractConfiguration::expand(const std::string& value) const
 {
-	Mutex::ScopedLock lock(_mutex);
+	std::lock_guard<std::recursive_mutex> lock(_mutex);
 
 	return internalExpand(value);
 }
@@ -398,7 +397,7 @@ void AbstractConfiguration::remove(const std::string& key)
 	}
 	{
 
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		removeRaw(key);
 	}
 	if (_eventsEnabled)
@@ -536,7 +535,7 @@ void AbstractConfiguration::setRawWithEvent(const std::string& key, std::string 
 		propertyChanging(this, kv);
 	}
 	{
-		Mutex::ScopedLock lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex);
 		setRaw(key, value);
 	}
 	if (_eventsEnabled)


### PR DESCRIPTION
As described in #3918 , `Poco::Mutex` and `Poco::FastMutex` being used in contexts (e.g. `static`) where they are accessed by multiple threads leads to `EINVAL` errors during access of the lock.

This does not happen with the standard implementation of `mutex` and `recursive_mutex` which is what was used to fix the very occurrence of this issue mentioned in #3918 .
Thus this pullrequest prepares the Poco codebase for the deprecation of `Poco::Mutex` and `Poco::FastMutex` classes and replaces all occurrences with standard implementations.