### PR TITLE
Fix error handling with OpenSSL 3.0 in SecureSocketImpl.cpp (fixes #3806)

### DIFF
--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -537,11 +537,13 @@ int SecureSocketImpl::handleError(int rc)
 	// SSL_ERROR_SYSCALL, nothing was added to the error stack, and
 	// errno was 0.  Since OpenSSL 3.0 the returned error is
 	// SSL_ERROR_SSL with a meaningful error on the error stack.
+	// However, we still need to check for socket errors in both
+	// cases with OpenSSL 3.0 or later.
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	case SSL_ERROR_SSL:
-#else
-	case SSL_ERROR_SYSCALL:
+		// fallthrough to handle socket errors first
 #endif
+	case SSL_ERROR_SYSCALL:
 		if (socketError)
 		{
 			SocketImpl::error(socketError);
@@ -557,6 +559,11 @@ int SecureSocketImpl::handleError(int rc)
 				ERR_error_string_n(lastError, buffer, sizeof(buffer));
 				msg = buffer;
 			}
+			// SSL_GET_ERROR(3ossl):
+			// On an unexpected EOF, versions before OpenSSL 3.0 returned
+			// SSL_ERROR_SYSCALL, nothing was added to the error stack, and
+			// errno was 0.  Since OpenSSL 3.0 the returned error is
+			// SSL_ERROR_SSL with a meaningful error on the error stack.
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 			if (sslError == SSL_ERROR_SSL)
 #else


### PR DESCRIPTION
As described in #3806, the changes to add OpenSSL 3.0 support are incorrect. They result in socket errors not being handled at all because the `SSL_ERROR_SYSCALL` switch statement is not present when compiling with OpenSSL 3.0.