### PR TITLE
Fix dead lock on Timer destructor

### DIFF
--- a/Util/src/Timer.cpp
+++ b/Util/src/Timer.cpp
@@ -101,7 +101,6 @@ public:
 			pNf = static_cast<TimerNotification*>(queue().dequeueNotification());
 		}
 
-		queue().clear();
 		_finished.set();
 		return true;
 	}


### PR DESCRIPTION
Consider following situation. A class owns a timer. In destructor of that class we call .cancel() asynchronous on timer before it's destruction. Now timer is executing cancel in it's own internal thread, while it's doing that destructor of timer is called from owning class. Timer destructor enqueues stop notification. If that enqueue is happening just after while loop from cancel notification, stop notification is gonna be dropped and timer will never stop.

fixes #3986