### PR TITLE
Revert "Fix dead lock on Timer destructor (#3987)"

### DIFF
--- a/Util/src/Timer.cpp
+++ b/Util/src/Timer.cpp
@@ -101,6 +101,7 @@ public:
 			pNf = static_cast<TimerNotification*>(queue().dequeueNotification());
 		}
 
+		queue().clear();
 		_finished.set();
 		return true;
 	}


### PR DESCRIPTION
This reverts commit 39a8b9a7c7a03e7a8c46d4f6531d216ec3ed95da.
It actually brakes cancel since dequeueNotification only returns notification which is due to execute now.
And there is no test which checks if notifications is executed after cancel.

fixes #3986