### PR TITLE
Revert "Fix dead lock on Timer destructor (#3987)"

### DIFF
--- a/Util/src/Timer.cpp
+++ b/Util/src/Timer.cpp
@@ -101,6 +101,7 @@ public:
 			pNf = static_cast<TimerNotification*>(queue().dequeueNotification());
 		}
 
+		queue().clear();
 		_finished.set();
 		return true;
 	}


### PR DESCRIPTION
This reverts commit 5124431d5aea4d462d7f5ed019c93b1a44edc5c5.
It actually brakes cancel since dequeueNotification only returns notification which is due to execute now.
And there is no test which checks if notifications is executed after cancel.

fixes #3986