### PR TITLE
Fix: MongoDB::OpMsgCursor fail with "Batch size for getMore must be positive, but received: 0"

### DIFF
--- a/MongoDB/include/Poco/MongoDB/OpMsgCursor.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgCursor.h
@@ -36,11 +36,16 @@ public:
 	virtual ~OpMsgCursor();
 		/// Destroys the OpMsgCursor.
 
+	void setEmptyFirstBatch(bool empty);
+		/// Empty first batch is used to get error response faster with little server processing
+
+	bool emptyFirstBatch() const;
+
 	void setBatchSize(Int32 batchSize);
 		/// Set non-default batch size
 
 	Int32 batchSize() const;
-		/// Current batch size (negative number indicates default batch size)
+		/// Current batch size (zero or negative number indicates default batch size)
 
 	Int64 cursorID() const;
 
@@ -60,8 +65,9 @@ private:
 	OpMsgMessage    _query;
 	OpMsgMessage 	_response;
 
+	bool			_emptyFirstBatch { false };
 	Int32			_batchSize { -1 };
-		/// Batch size used in the cursor. Negative value means that default shall be used.
+		/// Batch size used in the cursor. Zero or negative value means that default shall be used.
 
 	Int64			_cursorID { 0 };
 };

--- a/MongoDB/src/OpMsgMessage.cpp
+++ b/MongoDB/src/OpMsgMessage.cpp
@@ -114,7 +114,7 @@ void OpMsgMessage::setCursor(Poco::Int64 cursorID, Poco::Int32 batchSize)
 	_body.add(_commandName, cursorID);
 	_body.add("$db", _databaseName);
 	_body.add("collection", _collectionName);
-	if (batchSize >= 0)
+	if (batchSize > 0)
 	{
 		_body.add("batchSize", batchSize);
 	}

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -556,6 +556,8 @@ CppUnit::Test* MongoDBTest::suite()
 		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdCursor);
 		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdCursorAggregate);
 		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdKillCursor);
+		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdCursorEmptyFirstBatch);
+		
 		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdUUID);
 	}
 

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -57,6 +57,7 @@ public:
 	void testOpCmdFind();
 	void testOpCmdCursor();
 	void testOpCmdCursorAggregate();
+	void testOpCmdCursorEmptyFirstBatch();
 	void testOpCmdKillCursor();
 	void testOpCmdCount();
 	void testOpCmdDelete();

--- a/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
+++ b/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
@@ -327,7 +327,11 @@ void MongoDBTest::testOpCmdCursorAggregate()
 	auto cresponse = cursor->next(*_mongo);
 	while(true)
 	{
-		n += static_cast<int>(cresponse.documents().size());
+		int batchDocSize = cresponse.documents().size();
+		if (cursor->cursorID() != 0)
+			assertEquals (1000, batchDocSize);
+
+		n += batchDocSize;
 		if ( cursor->cursorID() == 0 )
 			break;
 		cresponse = cursor->next(*_mongo);
@@ -397,6 +401,53 @@ void MongoDBTest::testOpCmdCount()
 	assertTrue(response.responseOk());
 	const auto& doc = response.body();
 	assertEquals (1, doc.getInteger("n"));
+}
+
+
+void MongoDBTest::testOpCmdCursorEmptyFirstBatch()
+{
+	Database db("team");
+
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("numbers");
+	OpMsgMessage response;
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	for(int i = 0; i < 10000; ++i)
+	{
+		Document::Ptr doc = new Document();
+		doc->add("number", i);
+		request->documents().push_back(doc);
+	}
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	Poco::SharedPtr<OpMsgCursor> cursor = db.createOpMsgCursor("numbers");
+	cursor->query().setCommandName(OpMsgMessage::CMD_AGGREGATE);
+	cursor->setEmptyFirstBatch(true);
+	cursor->setBatchSize(0); // Will be ignored, default is used
+
+	// Empty pipeline: get all documents
+	cursor->query().body().addNewArray("pipeline");
+
+	auto cresponse = cursor->next(*_mongo);
+	assertEquals (0, cresponse.documents().size()); // First batch is empty
+
+	int n = 0;
+	while(true)
+	{
+		n += static_cast<int>(cresponse.documents().size());
+		if ( cursor->cursorID() == 0 )
+			break;
+		cresponse = cursor->next(*_mongo);
+	}
+	assertEquals (10000, n);
+
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
 }
 
 


### PR DESCRIPTION
Zero batch size for the first batch is performance optimisation to get errors fast from the server without much processing. Implementation of OpMsgCursor did not handle it properly and server responded with:

```
{
	"ok": 0,
	"errmsg": "Batch size for getMore must be positive, but received: 0",
	"code": 2,
	"codeName": "BadValue"
}

```

This pull request contains two changes:

* Fix: MongoDB::OpMsgCursor did not handle zero batch size properly: cursor requests failed.

* Improvement: Add emptyFirstBatch to indicate that the size of the first batch shall be zero for performance to get potential error ASAP from the server.

@aleks-f: This PR fixes new MongoDB wire protocol that was merged to branch devel, but is not yet released.