### PR TITLE
After wakeUpAll(), waitDequeueNotification should as soon as possible return

### DIFF
--- a/Foundation/include/Poco/NotificationQueue.h
+++ b/Foundation/include/Poco/NotificationQueue.h
@@ -150,6 +150,7 @@ private:
 	NfQueue           _nfQueue;
 	WaitQueue         _waitQueue;
 	mutable FastMutex _mutex;
+	volatile bool     _cannotWait;
 };
 
 

--- a/Foundation/src/NotificationQueue.cpp
+++ b/Foundation/src/NotificationQueue.cpp
@@ -43,7 +43,6 @@ void NotificationQueue::enqueueNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
 	FastMutex::ScopedLock lock(_mutex);
-	_cannotWait = false;
 	if (_waitQueue.empty())
 	{
 		_nfQueue.push_back(pNotification);
@@ -62,7 +61,6 @@ void NotificationQueue::enqueueUrgentNotification(Notification::Ptr pNotificatio
 {
 	poco_check_ptr (pNotification);
 	FastMutex::ScopedLock lock(_mutex);
-	_cannotWait = false;
 	if (_waitQueue.empty())
 	{
 		_nfQueue.push_front(pNotification);


### PR DESCRIPTION
In a demo, queue initializs in threadMain, threadPool initializs in threadMain, runnabler and queue are contacted with threadPool in threadMain, threadPool.joinAll() works in threadMain.
Producer works in threadA, such as, queue.enqueueNotification(xxx).
Consumer works in threadB, such as, task = queue.waitDequeueNotification(), consumer processes concrete tasks.
After a while, the producer does not work, threadA normally exits.
For instance, in threadB, consumer gets the last task from queue, then it spend a lot of time to process the task, so it is still in threadB.
At this moment, in threadC, queue.wakeUpAll() happens.
Then, in threadMain, threadPool.joinAll() will not finish and will block.
Because, consumer is not at waitDequeueNotification, is doing something when queue.wakeUpAll() happens; when it's the consumer's turn, it is at waitDequeueNotification, but no queue.wakeUpAll() happens, so threadMain will not exit.


#include "Poco/Notification.h"
#include "Poco/NotificationQueue.h"
#include "Poco/ThreadPool.h"
#include "Poco/Runnable.h"
#include "Poco/AutoPtr.h"
class TaskNotification : public Poco::Notification
{
public:
    TaskNotification(int data) : _data(data) {}
    int data() const
    {
        return _data;
    }
private:
    int _data;
};
class ConsumerRunnable : public Poco::Runnable
{
public:
    ConsumerRunnable(Poco::NotificationQueue& queue) : _queue(queue) {}
    void run()
    {
        while (true)
        {
            Poco::AutoPtr<Poco::Notification> pNf = _queue.waitDequeueNotification();
            if (!pNf)
            {
                break;
            }
            TaskNotification* pTN = dynamic_cast<TaskNotification*>(pNf.get());
            if (pTN)
            {
                // do some work, it will spend some time.
                Poco::Thread::sleep(5000);
            }
        }
    }
private:
    Poco::NotificationQueue& _queue;
};
class ProducerRunnable : public Poco::Runnable
{
public:
    ProducerRunnable(Poco::NotificationQueue& queue) : _queue(queue) {}
    void run()
    {
        Poco::Thread::sleep(1000);
        _queue.enqueueNotification(new TaskNotification(100));
    }
private:
    Poco::NotificationQueue& _queue;
};
class FinisherRunnable : public Poco::Runnable
{
public:
    FinisherRunnable(Poco::NotificationQueue& queue) : _queue(queue) {}
    void run()
    {
        Poco::Thread::sleep(3000);
        _queue.wakeUpAll();
    }
private:
    Poco::NotificationQueue& _queue;
};
int main(int argc, char** argv)
{
    Poco::NotificationQueue queue;
    ConsumerRunnable consumer(queue);
    ProducerRunnable producer(queue);
    FinisherRunnable finisher(queue);
    auto& pool = Poco::ThreadPool::defaultPool();
    pool.start(consumer);
    pool.start(producer);
    pool.start(finisher);
    pool.joinAll(); // It will not exit
    return 0;
}