### PR TITLE
add sendfile method for streamsocket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON -DCMAKE_CXX_FLAGS="/MP /EHsc" -DCMAKE_C_FLAGS=/MP
+      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON -DCMAKE_CXX_FLAGS="/MP /EHsc /DPOCO_NO_AUTOMATIC_LIBS" -DCMAKE_C_FLAGS="/MP /DPOCO_NO_AUTOMATIC_LIBS"
       - run: cmake --build cmake-build --config Release
       - run: >-
           cd cmake-build;
@@ -197,7 +197,7 @@ jobs:
       CPPUNIT_IGNORE: class CppUnit::TestCaller<class PathTest>.testFind,class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,class CppUnit::TestCaller<class ICMPClientTest>.testPing,class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy
     steps:
       - uses: actions/checkout@v2
-      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON -DCMAKE_CXX_FLAGS="/MP /EHsc" -DCMAKE_C_FLAGS=/MP
+      - run: cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON -DCMAKE_CXX_FLAGS="/MP /EHsc /DPOCO_NO_AUTOMATIC_LIBS" -DCMAKE_C_FLAGS="/MP /DPOCO_NO_AUTOMATIC_LIBS"
       - run: cmake --build cmake-build --config Release
       - run: >-
           cd cmake-build;

--- a/Foundation/include/Poco/FileStream.h
+++ b/Foundation/include/Poco/FileStream.h
@@ -47,6 +47,9 @@ class Foundation_API FileIOS: public virtual std::ios
 	/// On Windows platforms, UTF-8 encoded Unicode paths are correctly handled.
 {
 public:
+
+	using NativeHandle = FileStreamBuf::NativeHandle;
+
 	FileIOS(std::ios::openmode defaultMode);
 		/// Creates the basic stream.
 
@@ -69,6 +72,12 @@ public:
 
 	FileStreamBuf* rdbuf();
 		/// Returns a pointer to the underlying streambuf.
+
+	NativeHandle nativeHandle() const;
+		/// Returns native file descriptor handle
+
+	Poco::UInt64 size() const;
+		/// Returns file size
 
 protected:
 	FileStreamBuf _buf;

--- a/Foundation/include/Poco/FileStream_POSIX.h
+++ b/Foundation/include/Poco/FileStream_POSIX.h
@@ -31,6 +31,8 @@ class Foundation_API FileStreamBuf: public BufferedBidirectionalStreamBuf
 	/// This stream buffer handles Fileio
 {
 public:
+	using NativeHandle = int;
+	
 	FileStreamBuf();
 		/// Creates a FileStreamBuf.
 
@@ -50,6 +52,12 @@ public:
 	std::streampos seekpos(std::streampos pos, std::ios::openmode mode = std::ios::in | std::ios::out);
 		/// Change to specified position, according to mode.
 
+	NativeHandle nativeHandle() const;
+		/// Returns native file descriptor handle
+	
+	Poco::UInt64 size() const;
+		/// Returns file size
+
 protected:
 	enum
 	{
@@ -61,7 +69,7 @@ protected:
 
 private:
 	std::string _path;
-	int _fd;
+	NativeHandle _fd;
 	std::streamoff _pos;
 };
 

--- a/Foundation/include/Poco/FileStream_WIN32.h
+++ b/Foundation/include/Poco/FileStream_WIN32.h
@@ -30,6 +30,8 @@ class Foundation_API FileStreamBuf: public BufferedBidirectionalStreamBuf
 	/// This stream buffer handles Fileio
 {
 public:
+	using NativeHandle = HANDLE;
+	
 	FileStreamBuf();
 		/// Creates a FileStreamBuf.
 
@@ -49,6 +51,12 @@ public:
 	std::streampos seekpos(std::streampos pos, std::ios::openmode mode = std::ios::in | std::ios::out);
 		/// change to specified position, according to mode
 
+	NativeHandle nativeHandle() const;
+		/// Returns native file descriptor handle
+
+	Poco::UInt64 size() const;
+		/// Returns file size
+
 protected:
 	enum
 	{
@@ -60,7 +68,7 @@ protected:
 
 private:
 	std::string _path;
-	HANDLE _handle;
+	NativeHandle _handle;
 	UInt64 _pos;
 };
 

--- a/Foundation/src/FileStream.cpp
+++ b/Foundation/src/FileStream.cpp
@@ -58,6 +58,16 @@ FileStreamBuf* FileIOS::rdbuf()
 }
 
 
+FileIOS::NativeHandle FileIOS::nativeHandle() const
+{
+	return _buf.nativeHandle();
+}
+
+
+Poco::UInt64 FileIOS::size() const {
+	return _buf.size();
+}
+
 FileInputStream::FileInputStream():
 	FileIOS(std::ios::in),
 	std::istream(&_buf)

--- a/Foundation/src/FileStream_POSIX.cpp
+++ b/Foundation/src/FileStream_POSIX.cpp
@@ -19,6 +19,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstring>
 
 
 namespace Poco {
@@ -164,6 +166,23 @@ std::streampos FileStreamBuf::seekpos(std::streampos pos, std::ios::openmode mod
 
 	_pos = lseek(_fd, pos, SEEK_SET);
 	return _pos;
+}
+
+
+FileStreamBuf::NativeHandle FileStreamBuf::nativeHandle() const
+{
+	return _fd;
+}
+
+Poco::UInt64 FileStreamBuf::size() const
+{
+	struct stat stat_buf;
+	int rc = fstat(_fd, &stat_buf);
+	if (rc < 0)
+	{
+		Poco::SystemException(strerror(errno), errno);
+	}
+	return stat_buf.st_size;
 }
 
 

--- a/Foundation/src/FileStream_WIN32.cpp
+++ b/Foundation/src/FileStream_WIN32.cpp
@@ -199,4 +199,23 @@ std::streampos FileStreamBuf::seekpos(std::streampos pos, std::ios::openmode mod
 }
 
 
+FileStreamBuf::NativeHandle FileStreamBuf::nativeHandle() const
+{
+	return _handle;
+}
+
+Poco::UInt64 FileStreamBuf::size() const
+{
+	LARGE_INTEGER result;
+	result.QuadPart = 0;
+	DWORD high = 0;
+	result.LowPart = ::GetFileSize(_handle, &high);
+	if (high > 0)
+	{
+		result.HighPart = high;
+	}
+	return result.QuadPart;
+}
+
+
 } // namespace Poco

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -27,6 +27,11 @@
 
 
 namespace Poco {
+
+
+class FileInputStream;
+
+
 namespace Net {
 
 
@@ -464,6 +469,11 @@ public:
 
 	bool initialized() const;
 		/// Returns true iff the underlying socket is initialized.
+
+	Poco::Int64 sendFile(FileInputStream &FileInputStream, Poco::UInt64 offset = 0);
+		/// Sends file using system function
+		/// for posix systems - with sendfile[64](...)
+		/// for windows - with TransmitFile(...)
 
 protected:
 	SocketImpl();

--- a/Net/include/Poco/Net/StreamSocket.h
+++ b/Net/include/Poco/Net/StreamSocket.h
@@ -24,6 +24,11 @@
 
 
 namespace Poco {
+
+
+class FileInputStream;
+
+
 namespace Net {
 
 
@@ -252,6 +257,11 @@ public:
 		///
 		/// The preferred way for a socket to receive urgent data
 		/// is by enabling the SO_OOBINLINE option.
+
+	Poco::Int64 sendFile(FileInputStream &FileInputStream, Poco::UInt64 offset = 0);
+		/// Sends file using system function
+		/// for posix systems - with sendfile[64](...)
+		/// for windows - with TransmitFile(...)
 
 	StreamSocket(SocketImpl* pImpl);
 		/// Creates the Socket and attaches the given SocketImpl.

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -17,12 +17,15 @@
 #include "Poco/Net/StreamSocketImpl.h"
 #include "Poco/NumberFormatter.h"
 #include "Poco/Timestamp.h"
+#include "Poco/FileStream.h"
+#include "Poco/Error.h"
 #include <string.h> // FD_SET needs memset on some platforms, so we can't use <cstring>
 
 
 #if defined(POCO_HAVE_FD_EPOLL)
 	#ifdef POCO_OS_FAMILY_WINDOWS
 		#include "wepoll.h"
+		#include "mswsock.h"
 	#else
 		#include <sys/epoll.h>
 		#include <sys/eventfd.h>
@@ -42,8 +45,20 @@
 
 #ifdef POCO_OS_FAMILY_WINDOWS
 #include <windows.h>
+#else
+#include <csignal>
 #endif
 
+
+#if POCO_OS == POCO_OS_MAC_OS_X || POCO_OS == POCO_OS_FAMILY_BSD
+#include <sys/uio.h>
+#include <sys/types.h>
+using sighandler_t = sig_t;
+#endif
+
+#if POCO_OS == POCO_OS_LINUX
+#include <sys/sendfile.h>
+#endif
 
 #if defined(_MSC_VER)
 #pragma warning(disable:4996) // deprecation warnings
@@ -1343,5 +1358,78 @@ void SocketImpl::error(int code, const std::string& arg)
 	}
 }
 
+#ifdef POCO_OS_FAMILY_WINDOWS
+Poco::Int64 SocketImpl::sendFile(FileInputStream &fileInputStream, Poco::UInt64 offset)
+{
+	FileIOS::NativeHandle fd = fileInputStream.nativeHandle();
+	Poco::UInt64 fileSize = fileInputStream.size();
+	std::streamoff sentSize = fileSize - offset;
+	LARGE_INTEGER offsetHelper;
+	offsetHelper.QuadPart = offset;
+	OVERLAPPED overlapped;
+	memset(&overlapped, 0, sizeof(overlapped));
+	overlapped.Offset = offsetHelper.LowPart;
+	overlapped.OffsetHigh =  offsetHelper.HighPart;
+	overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+	if (overlapped.hEvent == nullptr)
+	{
+		return -1;
+	}
+	bool result = TransmitFile(_sockfd, fd, sentSize, 0, &overlapped, nullptr, 0);
+	if (!result)
+	{
+		int err = WSAGetLastError();
+		if ((err != ERROR_IO_PENDING) && (WSAGetLastError() != WSA_IO_PENDING)) {
+			CloseHandle(overlapped.hEvent);
+			error(err, Error::getMessage(err));
+		}
+		WaitForSingleObject(overlapped.hEvent, INFINITE);
+	}
+	CloseHandle(overlapped.hEvent);
+	return sentSize;
+}
+#else
+Poco::Int64 _sendfile(poco_socket_t sd, FileIOS::NativeHandle fd, Poco::UInt64 offset,std::streamoff sentSize)
+{
+	Poco::Int64 sent = 0;
+#ifdef __USE_LARGEFILE64
+	sent = sendfile64(sd, fd, (off64_t *)&offset, sentSize);
+#else
+#if POCO_OS == POCO_OS_LINUX
+	sent = sendfile(sd, fd, (off_t *)&offset, sentSize);
+#elif POCO_OS == POCO_OS_MAC_OS_X
+	int result = sendfile(fd, sd, offset, &sentSize, nullptr, 0);
+	if (result < 0)
+	{
+		sent = -1;
+	} 
+	else 
+	{
+		sent = sentSize;
+	}
+#endif
+#endif
+	if (errno == EAGAIN || errno == EWOULDBLOCK) 
+	{
+		sent = 0;
+	}
+	return sent;
+}
+
+Poco::Int64 SocketImpl::sendFile(FileInputStream &fileInputStream, Poco::UInt64 offset)
+{
+	FileIOS::NativeHandle fd = fileInputStream.nativeHandle();
+	Poco::UInt64 fileSize = fileInputStream.size();
+	std::streamoff sentSize = fileSize - offset;
+	Poco::Int64 sent = 0;
+	sighandler_t sigPrev = signal(SIGPIPE, SIG_IGN);
+	while (sent == 0) {
+		errno = 0;
+		sent = _sendfile(_sockfd, fd, offset, sentSize);
+	}
+	signal(SIGPIPE, sigPrev != SIG_ERR ? sigPrev : SIG_DFL);
+	return sent;
+}
+#endif // POCO_OS_FAMILY_WINDOWS
 
 } } // namespace Poco::Net

--- a/Net/src/StreamSocket.cpp
+++ b/Net/src/StreamSocket.cpp
@@ -213,5 +213,9 @@ void StreamSocket::sendUrgent(unsigned char data)
 	impl()->sendUrgent(data);
 }
 
+Poco::Int64 StreamSocket::sendFile(FileInputStream &fileInputStream, Poco::UInt64 offset)
+{
+	return impl()->sendFile(fileInputStream, offset);
+}
 
 } } // namespace Poco::Net

--- a/Net/testsuite/src/SocketStreamTest.h
+++ b/Net/testsuite/src/SocketStreamTest.h
@@ -27,6 +27,7 @@ public:
 	void testStreamEcho();
 	void testLargeStreamEcho();
 	void testEOF();
+	void testSendFile();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
This PR is motivated by #3277
I want add sendfile method to the stream socket
This functionality is cross platform, i.e. on posix systems it uses sendfile, on windows - TransmitFile

@obiltschnig , @aleks-f , Please review this changes and than I'll push changes in vcproj files and cmake files. Because there are many changes which adds mswsock.lib.

P.S. And further I'll add sendfile functionality to the httpserver 