### PR TITLE
fix #4005 Poco::Path::getExtension()

### DIFF
--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -537,7 +537,7 @@ Path& Path::setBaseName(const std::string& name)
 std::string Path::getBaseName() const
 {
 	std::string::size_type pos = _name.rfind('.');
-	if (pos != std::string::npos)
+	if (pos != std::string::npos && pos != 0)
 		return _name.substr(0, pos);
 	else
 		return _name;
@@ -559,7 +559,7 @@ Path& Path::setExtension(const std::string& extension)
 std::string Path::getExtension() const
 {
 	std::string::size_type pos = _name.rfind('.');
-	if (pos != std::string::npos)
+	if (pos != std::string::npos && pos != 0)
 		return _name.substr(pos + 1);
 	else
 		return std::string();

--- a/Foundation/testsuite/src/FileTest.cpp
+++ b/Foundation/testsuite/src/FileTest.cpp
@@ -605,6 +605,20 @@ void FileTest::testLongPath()
 #endif
 }
 
+void FileTest::testUnixFileExtension()
+{
+	std::string filePath1 = "/a/b/c/.notextension";
+	Poco::Path path1(filePath1, Poco::Path::Style::PATH_UNIX);
+
+	assertEqual(".notextension", path1.getBaseName());
+	assertEqual("", path1.getExtension());
+
+	std::string filePath2 = "/a/b/c/emptyextension.";
+	Poco::Path path2(filePath2, Poco::Path::Style::PATH_UNIX);
+
+	assertEqual("emptyextension", path2.getBaseName());
+	assertEqual("", path2.getExtension());
+}
 
 void FileTest::setUp()
 {
@@ -654,6 +668,7 @@ CppUnit::Test* FileTest::suite()
 	CppUnit_addTest(pSuite, FileTest, testRenameFailIfExists);
 	CppUnit_addTest(pSuite, FileTest, testRootDir);
 	CppUnit_addTest(pSuite, FileTest, testLongPath);
+	CppUnit_addTest(pSuite, FileTest, testUnixFileExtension);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/FileTest.h
+++ b/Foundation/testsuite/src/FileTest.h
@@ -42,6 +42,7 @@ public:
 	void testRenameFailIfExists();
 	void testRootDir();
 	void testLongPath();
+	void testUnixFileExtension();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
fix #4005

if dot is a first symbol of filename or last symbol of filename then Poco::Path::getBaseName() and Poco::Path::getExtension() returns correct values

```cpp
	std::string filePath1 = "/a/b/c/.notextension";
	Poco::Path path1(filePath1, Poco::Path::Style::PATH_UNIX);

	assertEqual(".notextension", path1.getBaseName());
	assertEqual("", path1.getExtension());

	std::string filePath2 = "/a/b/c/emptyextension.";
	Poco::Path path2(filePath2, Poco::Path::Style::PATH_UNIX);

	assertEqual("emptyextension", path2.getBaseName());
	assertEqual("", path2.getExtension());
```