### PR TITLE
fix #3979 dangled pointer in AutoPtr assign

### DIFF
--- a/Foundation/include/Poco/AutoPtr.h
+++ b/Foundation/include/Poco/AutoPtr.h
@@ -119,7 +119,7 @@ public:
 
 	AutoPtr& assign(const AutoPtr& ptr)
 	{
-		if (&ptr != this)
+		if (ptr.get() != _ptr)
 		{
 			if (_ptr) _ptr->release();
 			_ptr = ptr._ptr;


### PR DESCRIPTION
1. fixes #3979 
2. use `ptr.get() != _ptr` not `&ptr != this`, and avoid the situation where internal pointers are the same