### PR TITLE
CPPParser fix #4023 for std::function parameter

### DIFF
--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -248,6 +248,8 @@ std::string Symbol::extractName(const std::string& decl)
 
 		std::cout << "end " << pos << std::endl;
 
+		std::cout << decl << pos << std::endl;
+		
 		return decl.substr(pos, end - pos + 1);
 	}
 	else

--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -168,7 +168,15 @@ std::string Symbol::extractName(const std::string& decl)
 		if ((gtPos == std::string::npos || gtPos > pos || (ltPos != std::string::npos && gtPos > ltPos)) && eqPos < pos && eqPos > 0 && decl[eqPos + 1] != '=')
 			pos = eqPos - 1;
 	}
+
+	std::cout << "before: " << pos << std::endl;
+
+
 	while (pos > 0 && std::isspace(decl[pos])) --pos;
+
+
+	std::cout << "middle: " << pos << std::endl;
+
 	while (pos > 0 && decl[pos] == ']')
 	{
 		--pos;
@@ -176,6 +184,9 @@ std::string Symbol::extractName(const std::string& decl)
 		if (pos > 0) --pos;
 		while (pos > 0 && std::isspace(decl[pos])) --pos;
 	}
+
+	std::cout << "after: " << pos << std::endl;
+
 	// iterate over template (specialization)
 	int nestedTemplateCount = 0;
 	if (pos > 1 && decl[pos] == '>' && decl[pos-1] != '-' && decl[pos-1] != '>') // the operators ->, >>
@@ -235,7 +246,7 @@ std::string Symbol::extractName(const std::string& decl)
 		// 	}
 		// }
 
-		std::cout << decl << " after" << decl.substr(pos, end - pos + 1) << std::endl;
+		std::cout << decl << " after " << decl.substr(pos, end - pos + 1) << std::endl;
 
 		return decl.substr(pos, end - pos + 1);
 	}

--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -210,8 +210,31 @@ std::string Symbol::extractName(const std::string& decl)
 		pos -= 3;
 		while (pos > 0 && isIdent(decl[pos - 1])) --pos;
 	}
-	if (pos != std::string::npos)
+	if (pos != std::string::npos){
+		// special case if pointer function
+		// bool example(int x, int y, std::function<bool(int, int)> fcn);
+		if (decl[pos-2] == '<')
+		{
+			uint8_t skipArrow = 0;
+			while (pos < decl.size())
+			{
+				if (decl[pos] == '<')
+				{
+					++skipArrow;
+				}else if (decl[pos] == '>')
+				{
+					if (skipArrow == 0)
+					{
+						return decl.substr(pos+2, decl.size()-pos);
+					}
+					--skipArrow;
+				}
+				++pos;
+			}
+		}
+
 		return decl.substr(pos, end - pos + 1);
+	}
 	else
 		return std::string();
 }

--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -18,6 +18,7 @@
 #include "Poco/String.h"
 #include <cctype>
 #include <cstddef>
+#include <iostream>
 
 
 namespace Poco {
@@ -210,28 +211,31 @@ std::string Symbol::extractName(const std::string& decl)
 		pos -= 3;
 		while (pos > 0 && isIdent(decl[pos - 1])) --pos;
 	}
-	if (pos != std::string::npos){
-		// special case if pointer function
-		// bool example(int x, int y, std::function<bool(int, int)> fcn);
-		if (decl[pos-2] == '<')
-		{
-			uint8_t skipArrow = 0;
-			while (pos < decl.size())
-			{
-				if (decl[pos] == '<')
-				{
-					++skipArrow;
-				}else if (decl[pos] == '>')
-				{
-					if (skipArrow == 0)
-					{
-						return decl.substr(pos+2, decl.size()-pos);
-					}
-					--skipArrow;
-				}
-				++pos;
-			}
-		}
+	if (pos != std::string::npos)
+	{
+		// // special case if pointer function
+		// // bool example(int x, int y, std::function<bool(int, int)> fcn);
+		// if (decl[pos-2] == '<')
+		// {
+		// 	uint8_t skipArrow = 0;
+		// 	while (pos < decl.size())
+		// 	{
+		// 		if (decl[pos] == '<')
+		// 		{
+		// 			++skipArrow;
+		// 		}else if (decl[pos] == '>')
+		// 		{
+		// 			if (skipArrow == 0)
+		// 			{
+		// 				return decl.substr(pos+2, decl.size()-pos);
+		// 			}
+		// 			--skipArrow;
+		// 		}
+		// 		++pos;
+		// 	}
+		// }
+
+		std::cout << decl << std::endl;
 
 		return decl.substr(pos, end - pos + 1);
 	}

--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -246,7 +246,7 @@ std::string Symbol::extractName(const std::string& decl)
 		// 	}
 		// }
 
-		std::cout << decl << " after " << decl.substr(pos, end - pos + 1) << std::endl;
+		std::cout << "end " << pos << std::endl;
 
 		return decl.substr(pos, end - pos + 1);
 	}

--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -235,7 +235,7 @@ std::string Symbol::extractName(const std::string& decl)
 		// 	}
 		// }
 
-		std::cout << decl << std::endl;
+		std::cout << decl << " after" << decl.substr(pos, end - pos + 1) << std::endl;
 
 		return decl.substr(pos, end - pos + 1);
 	}


### PR DESCRIPTION
Fixes #4023 

The CppParser had problems to read a parameter if it was a function.
 `bool example(int x, int y, std::function<bool(int, int)> fcn);` would have cut out all after std::function<.

This solution watches for the `<` (which previously caused problems) and wait's till `>` for closing.

It will also fix all other template parameter in cpp with the same structure (means if they have < and >)