### PR TITLE
Make Binding and CopyBinding specializations final

### DIFF
--- a/Data/include/Poco/Data/Binding.h
+++ b/Data/include/Poco/Data/Binding.h
@@ -38,7 +38,7 @@ namespace Data {
 
 
 template <class T>
-class Binding: public AbstractBinding
+class Binding final: public AbstractBinding
 	/// Binding maps a value or multiple values (see Binding specializations for STL containers as
 	/// well as type handlers) to database column(s). Values to be bound can be either mapped
 	/// directly (by reference) or a copy can be created, depending on the value of the copy argument.
@@ -110,7 +110,7 @@ private:
 
 
 template <class T>
-class CopyBinding: public AbstractBinding
+class CopyBinding final: public AbstractBinding
 	/// Binding maps a value or multiple values (see Binding specializations for STL containers as
 	/// well as type handlers) to database column(s). Values to be bound can be either mapped
 	/// directly (by reference) or a copy can be created, depending on the value of the copy argument.
@@ -180,7 +180,7 @@ private:
 
 
 template <>
-class Binding<const char*>: public AbstractBinding
+class Binding<const char*> final: public AbstractBinding
 	/// Binding const char* specialization wraps char pointer into string.
 {
 public:
@@ -242,7 +242,7 @@ private:
 
 
 template <>
-class CopyBinding<const char*>: public AbstractBinding
+class CopyBinding<const char*> final: public AbstractBinding
 	/// Binding const char* specialization wraps char pointer into string.
 {
 public:
@@ -303,7 +303,7 @@ private:
 
 
 template <class T>
-class Binding<std::vector<T>>: public AbstractBinding
+class Binding<std::vector<T>> final: public AbstractBinding
 	/// Specialization for std::vector.
 {
 public:
@@ -369,7 +369,7 @@ private:
 
 
 template <class T>
-class CopyBinding<std::vector<T>>: public AbstractBinding
+class CopyBinding<std::vector<T>> final: public AbstractBinding
 	/// Specialization for std::vector.
 {
 public:
@@ -436,7 +436,7 @@ private:
 
 
 template <>
-class Binding<std::vector<bool>>: public AbstractBinding
+class Binding<std::vector<bool>> final: public AbstractBinding
 	/// Specialization for std::vector<bool>.
 	/// This specialization is necessary due to the nature of std::vector<bool>.
 	/// For details, see the standard library implementation of std::vector<bool>
@@ -517,7 +517,7 @@ private:
 
 
 template <>
-class CopyBinding<std::vector<bool>>: public AbstractBinding
+class CopyBinding<std::vector<bool>> final: public AbstractBinding
 	/// Specialization for std::vector<bool>.
 	/// This specialization is necessary due to the nature of std::vector<bool>.
 	/// For details, see the standard library implementation of std::vector<bool>
@@ -597,7 +597,7 @@ private:
 
 
 template <class T>
-class Binding<std::list<T>>: public AbstractBinding
+class Binding<std::list<T>> final: public AbstractBinding
 	/// Specialization for std::list.
 {
 public:
@@ -662,7 +662,7 @@ private:
 
 
 template <class T>
-class CopyBinding<std::list<T>>: public AbstractBinding
+class CopyBinding<std::list<T>> final: public AbstractBinding
 	/// Specialization for std::list.
 {
 public:
@@ -727,7 +727,7 @@ private:
 
 
 template <class T>
-class Binding<std::deque<T>>: public AbstractBinding
+class Binding<std::deque<T>> final: public AbstractBinding
 	/// Specialization for std::deque.
 {
 public:
@@ -792,7 +792,7 @@ private:
 
 
 template <class T>
-class CopyBinding<std::deque<T>>: public AbstractBinding
+class CopyBinding<std::deque<T>> final: public AbstractBinding
 	/// Specialization for std::deque.
 {
 public:
@@ -857,7 +857,7 @@ private:
 
 
 template <class T>
-class Binding<std::set<T>>: public AbstractBinding
+class Binding<std::set<T>> final: public AbstractBinding
 	/// Specialization for std::set.
 {
 public:
@@ -922,7 +922,7 @@ private:
 
 
 template <class T>
-class CopyBinding<std::set<T>>: public AbstractBinding
+class CopyBinding<std::set<T>> final: public AbstractBinding
 	/// Specialization for std::set.
 {
 public:
@@ -987,7 +987,7 @@ private:
 
 
 template <class T>
-class Binding<std::multiset<T>>: public AbstractBinding
+class Binding<std::multiset<T>> final: public AbstractBinding
 	/// Specialization for std::multiset.
 {
 public:
@@ -1052,7 +1052,7 @@ private:
 
 
 template <class T>
-class CopyBinding<std::multiset<T>>: public AbstractBinding
+class CopyBinding<std::multiset<T>> final: public AbstractBinding
 	/// Specialization for std::multiset.
 {
 public:
@@ -1117,7 +1117,7 @@ private:
 
 
 template <class K, class V>
-class Binding<std::map<K, V>>: public AbstractBinding
+class Binding<std::map<K, V>> final: public AbstractBinding
 	/// Specialization for std::map.
 {
 public:
@@ -1182,7 +1182,7 @@ private:
 
 
 template <class K, class V>
-class CopyBinding<std::map<K, V>>: public AbstractBinding
+class CopyBinding<std::map<K, V>> final: public AbstractBinding
 	/// Specialization for std::map.
 {
 public:
@@ -1247,7 +1247,7 @@ private:
 
 
 template <class K, class V>
-class Binding<std::multimap<K, V>>: public AbstractBinding
+class Binding<std::multimap<K, V>> final: public AbstractBinding
 	/// Specialization for std::multimap.
 {
 public:
@@ -1312,7 +1312,7 @@ private:
 
 
 template <class K, class V>
-class CopyBinding<std::multimap<K, V>>: public AbstractBinding
+class CopyBinding<std::multimap<K, V>> final: public AbstractBinding
 	/// Specialization for std::multimap.
 {
 public:


### PR DESCRIPTION
The Binding specializations call it virtual functions numOfRowsHandled() and reset() from their constructors. This is fine assuming virtual function dispatch to a further derived class was not intended. In this case the assumption is solid, however this triggers the Clang diagnostic clang-analyzer-optin.cplusplus.VirtualCall

Adding the final specifyer to these specializations gives Clang enough of a hint to silence