### PR TITLE
EVPPKey constructor for modulus/exponent

### DIFF
--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -85,6 +85,10 @@ public:
 
 #endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	explicit EVPPKey(const std::vector<unsigned char>* public_key, const std::vector<unsigned char>* private_key, unsigned long exponent, int type);
+#endif
+	
 	explicit EVPPKey(EVP_PKEY* pEVPPKey);
 		/// Constructs EVPPKey from EVP_PKEY pointer.
 		/// The content behind the supplied pointer is internally duplicated.
@@ -173,7 +177,9 @@ public:
 
 private:
 	EVPPKey();
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L	
+	void SetKeyFromParameters(OSSL_PARAM* parameters);
+#endif
 	static int type(const EVP_PKEY* pEVPPKey);
 	void checkType();
 	void newECKey(const char* group);

--- a/Crypto/testsuite/src/EVPTest.cpp
+++ b/Crypto/testsuite/src/EVPTest.cpp
@@ -17,6 +17,9 @@
 #include "Poco/Crypto/Cipher.h"
 #include "Poco/Crypto/X509Certificate.h"
 #include "Poco/TemporaryFile.h"
+#include "Poco/Base64Decoder.h"
+#include "Poco/Base64Encoder.h"
+#include "Poco/MemoryStream.h"
 #include "Poco/StreamCopier.h"
 #include "CppUnit/TestCaller.h"
 #include "CppUnit/TestSuite.h"
@@ -682,6 +685,39 @@ void EVPTest::testECEVPKeyByLength()
 	}
 }
 
+void EVPTest::testEVPKeyByModulus()
+{
+	std::string e = "AQAB";
+	std::string n = "ylJgMkU_bDwCLzMlo47igdZ-AC8oUbtGJUOUHnuJdjflpim7FOxw0zXYf9m0tzND0Bt1y7MPyVtf-3rwInvdgi65CZEJ3kt5PE0g6trPbvyW6hJcVeOsQvSErj33mY6RsjndLhNE-RY36G8o603au64lTOYSb9HjzzRFo4F_faEgQ02jpEYkLIWwf7PboExDbd6NGMV0uume8YA6eB3z5BwfMMHyRZA0FcIzj6F0V-hDqBaJkWegpJsukgpfO7JDKaU5rlor7j6CdbfLaWorYTCUH3F-bXZ1ojBe0wHRGEgEZBNa46A3clgNohQuuNzf4K12NFGnEl_TIFRcLm6M0Q";
+        try
+	{
+		unsigned long exponent = 0;
+		if ((e == "AQAB") || (e == "AAEAAQ")) 
+		{
+			exponent = RSA_F4; //Poco::Crypto::RSAKey::Exponent::EXP_LARGE
+		}
+		else
+		{
+			std::cerr << "invalid exponent" << std::endl;
+			throw;
+		}
+		std::string sNbinary;
+		std::ostringstream ofs;
+		Poco::MemoryInputStream cIn(sN.data(), sN.length());
+		Poco::Base64Decoder decoder(cIn, Poco::Base64EncodingOptions::BASE64_URL_ENCODING | Poco::Base64EncodingOptions::BASE64_NO_PADDING);
+		Poco::StreamCopier::copyStream(decoder, ofs);
+		sNbinary=ofs.str();
+		std::vector<unsigned char> public_key(sNbinary.begin(), sNbinary.end());
+		Poco::Crypto::EVPPKey cKey(&public_key, nullptr, exponent, EVP_PKEY_RSA);
+		Poco::SharedPtr<Poco::Crypto::RSAKey> pKey = new Poco::Crypto::RSAKey(cKey);
+	}
+	catch(Poco::Exception& ex)
+	{
+		std::cerr << ex.displayText() << std::endl;
+		throw;
+	}	
+}
+
 #endif // OPENSSL_VERSION_NUMBER >= 0x30000000
 #endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 
@@ -714,6 +750,7 @@ CppUnit::Test* EVPTest::suite()
 	CppUnit_addTest(pSuite, EVPTest, testRSAEVPKeyByLength);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	CppUnit_addTest(pSuite, EVPTest, testECEVPKeyByLength);
+	CppUnit_addTest(pSuite, EVPTest, testEVPKeyByModulus);
 #endif // OPENSSL_VERSION_NUMBER >= 0x30000000
 #endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 

--- a/Crypto/testsuite/src/EVPTest.cpp
+++ b/Crypto/testsuite/src/EVPTest.cpp
@@ -701,13 +701,13 @@ void EVPTest::testEVPKeyByModulus()
 			std::cerr << "invalid exponent" << std::endl;
 			throw;
 		}
-		std::string sNbinary;
+		std::string nBinary;
 		std::ostringstream ofs;
-		Poco::MemoryInputStream cIn(sN.data(), sN.length());
+		Poco::MemoryInputStream cIn(n.data(), n.length());
 		Poco::Base64Decoder decoder(cIn, Poco::Base64EncodingOptions::BASE64_URL_ENCODING | Poco::Base64EncodingOptions::BASE64_NO_PADDING);
 		Poco::StreamCopier::copyStream(decoder, ofs);
-		sNbinary=ofs.str();
-		std::vector<unsigned char> public_key(sNbinary.begin(), sNbinary.end());
+		nBinary=ofs.str();
+		std::vector<unsigned char> public_key(nBinary.begin(), nBinary.end());
 		Poco::Crypto::EVPPKey cKey(&public_key, nullptr, exponent, EVP_PKEY_RSA);
 		Poco::SharedPtr<Poco::Crypto::RSAKey> pKey = new Poco::Crypto::RSAKey(cKey);
 	}

--- a/Crypto/testsuite/src/EVPTest.h
+++ b/Crypto/testsuite/src/EVPTest.h
@@ -41,6 +41,7 @@ public:
 	void testRSAEVPKeyByLength();
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	void testECEVPKeyByLength();
+	void testEVPKeyByModulus();
 #endif // OPENSSL_VERSION_NUMBER >= 0x30000000L
 #endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 


### PR DESCRIPTION
Add EVPPKey constructor to let creating RSA Key using modulus and exponent. Useful when you use the .well-known/jwks.json paradigm so you have to recreate a public key to verify a jwt using just modulus and exponent. modulus usually is base64 URI encoded without padding