### PR TITLE
CppParser: fix for std::function<void()> parameter

### DIFF
--- a/CppParser/src/Symbol.cpp
+++ b/CppParser/src/Symbol.cpp
@@ -121,6 +121,29 @@ std::string Symbol::extractName(const std::string& decl)
 		return "operator []";
 
 	std::string::size_type pos = decl.find('(');
+	if (pos != std::string::npos) {
+		// special case std::function<void(int)> a
+		//                                ^   ^^
+		// In case the marked patterns are found,
+		// reset pos to npos to make sure "(" is not seen as the beginning of a function
+		int bracket = 1;
+		std::string::size_type i = pos + 1;
+		while (i < decl.size() && bracket != 0){
+			if (decl[i] == '('){
+				bracket++;
+			} else if (decl[i] == ')'){
+				bracket--;
+			}
+			
+			i++;
+		}
+		
+		while (i < decl.size() && std::isspace(decl[i])) i++;
+		if (i < decl.size() && decl[i] == '>') {
+			pos = std::string::npos;
+		}
+	}
+
 	// another special case: function pointer
 	if (pos != std::string::npos && pos < decl.size() - 1)
 	{

--- a/CppParser/testsuite/src/CppParserTest.cpp
+++ b/CppParser/testsuite/src/CppParserTest.cpp
@@ -77,6 +77,22 @@ void CppParserTest::testExtractName()
 	decl = "void func(int arg1, int arg2)";
 	name = Symbol::extractName(decl);
 	assertTrue (name == "func");
+	
+	decl = "std::function<bool> func";
+	name = Symbol::extractName(decl);
+	assertTrue (name == "func");
+
+	decl = "std::function<void(bool)> func";
+	name = Symbol::extractName(decl);
+	assertTrue (name == "func");
+
+	decl = "std::function<std::vector<int>(std::vector<bool>)> func";
+	name = Symbol::extractName(decl);
+	assertTrue (name == "func");
+
+	decl = "std::function<void*(std::function<const int*(void)>)> func";
+	name = Symbol::extractName(decl);
+	assertTrue (name == "func");
 
 	decl = "const std::vector<NS::MyType>* var";
 	name = Symbol::extractName(decl);


### PR DESCRIPTION
fixes #4023 

The parameter was previously seen as a function because of it's brackets after the void.
I also added some test cases.