### PR TITLE
optimize checkUpperLimit and checkLowerLimit in VarHolder.h 

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -323,16 +323,8 @@ protected:
 		poco_static_assert (std::numeric_limits<F>::is_signed);
 		poco_static_assert (std::numeric_limits<T>::is_signed);
 
-		if (std::numeric_limits<F>::is_integer)
-		{
-			checkUpperLimit<F,T>(from);
-			checkLowerLimit<F,T>(from);
-		}
-		else
-		{
-			checkUpperLimitFloat<F,T>(from);
-			checkLowerLimitFloat<F,T>(from);
-		}
+		checkUpperLimit<F,T>(from);
+		checkLowerLimit<F,T>(from);
 
 		to = static_cast<T>(from);
 	}
@@ -372,7 +364,7 @@ protected:
 		to = static_cast<T>(from);
 	}
 
-	template <typename F, typename T>
+	template <typename F, typename T, std::enable_if_t<std::is_floating_point<F>::value, bool> = true>
 	void convertSignedFloatToUnsigned(const F& from, T& to) const
 		/// This function is meant for converting floating point data types to
 		/// unsigned integral data types. Negative values can not be converted and if one
@@ -387,7 +379,7 @@ protected:
 
 		if (from < 0)
 			throw RangeException("Value too small.");
-		checkUpperLimitFloat<F,T>(from);
+		checkUpperLimit<F,T>(from);
 		to = static_cast<T>(from);
 	}
 
@@ -409,22 +401,22 @@ protected:
 
 private:
 
-	template <typename F, typename T>
+	template <typename F, typename T, std::enable_if_t<std::is_integral<F>::value, bool> = true>
 	void checkUpperLimit(const F& from) const
 	{
 		if (from > std::numeric_limits<T>::max())
 			throw RangeException("Value too large.");
 	}
 
-	template <typename F, typename T>
+	template <typename F, typename T, std::enable_if_t<std::is_integral<F>::value, bool> = true>
 	void checkLowerLimit(const F& from) const
 	{
 		if (from < std::numeric_limits<T>::min())
 			throw RangeException("Value too small.");
 	}
 
-	template <typename F, typename T>
-	void checkUpperLimitFloat(const F& from) const
+	template <typename F, typename T, std::enable_if_t<std::is_floating_point<F>::value, bool> = true>
+	void checkUpperLimit(const F& from) const
 	{
 		if (std::is_floating_point<T>::value)
 		{
@@ -439,8 +431,8 @@ private:
 		}
 	}
 
-	template <typename F, typename T>
-	void checkLowerLimitFloat(const F& from) const
+	template <typename F, typename T, std::enable_if_t<std::is_floating_point<F>::value, bool> = true>
+	void checkLowerLimit(const F& from) const
 	{
 		if (std::is_floating_point<T>::value)
 		{


### PR DESCRIPTION
optimize checkUpperLimit and checkLowerLimit in VarHolder.h  and avoid compile-time warnings when argument type is float and condition is always true