### PR TITLE
Remove std::aligned_storage as it is deprecated in C++23.

### DIFF
--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <typeinfo>
 #include <cstring>
+#include <cstddef>
 
 
 #define poco_any_assert(cond) do { if (!(cond)) std::abort(); } while (0)
@@ -137,7 +138,8 @@ public:
 	}
 
 private:
-	typedef typename std::aligned_storage<SizeV+1>::type AlignerType;
+	typedef std::max_align_t AlignerType;
+	static_assert(sizeof(AlignerType) >= SizeV + 1, "Aligner type is bigger than the actual storage, so SizeV should be made bigger otherwise you simply waste unused memory.");
 
 	void setLocal(bool local) const
 	{


### PR DESCRIPTION
Instead, replace it with std::max_align_t in the Any implementation, as really we would like to be able to store any object with any alignment in the small object optimization case. Typically the size and alignment of std::max_align_t is 8 or 16 on most platforms. Added a static assert to ensure that this change doesn't result in wasting more unused memory in case the size of the storage buffer is smaller than this maximum alignment (which is right now 64, so shall be ok on all platforms).