### PR TITLE
Silence gcc -Wsign-compare warning when instantiating Poco::Dynamic::VarHolder::convertSignedToUnsigned.

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -38,6 +38,7 @@
 #include <list>
 #include <deque>
 #include <typeinfo>
+#include <type_traits>
 #undef min
 #undef max
 #include <limits>
@@ -360,7 +361,7 @@ protected:
 
 		if (from < 0)
 			throw RangeException("Value too small.");
-		checkUpperLimit<F,T>(from);
+		checkUpperLimit<std::make_unsigned<F>,T>(from);
 		to = static_cast<T>(from);
 	}
 


### PR DESCRIPTION

```
/data/mwrep/res/osp/Poco/Foundation/23-0-0-0/include/Poco/Dynamic/VarHolder.h: In instantiation of 'void Poco::Dynamic::VarHolder::checkUpperLimit(const F&) const [with F = signed char; T = unsigned int; typename std::enable_if<std::is_integral<_Tp>::value, bool>::type <anonymous> = true]':
/data/mwrep/res/osp/Poco/Foundation/23-0-0-0/include/Poco/Dynamic/VarHolder.h:361:23:   required from 'void Poco::Dynamic::VarHolder::convertSignedToUnsigned(const F&, T&) const [with F = signed char; T = unsigned int]'
/data/mwrep/res/osp/Poco/Foundation/23-0-0-0/include/Poco/Dynamic/VarHolder.h:799:26:   required from here
/data/mwrep/res/osp/Poco/Foundation/23-0-0-0/include/Poco/Dynamic/VarHolder.h:405:26: error: comparison of integer expressions of different signedness: 'const signed char' and 'unsigned int' [-Werror=sign-compare]
  405 |                 if (from > std::numeric_limits<T>::max())
      |                     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```