### PR TITLE
added new memeber SqlState to PostgreSQLException and made use of it.

### DIFF
--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
@@ -69,12 +69,12 @@ public:
 		/// copy of an exception (see clone()), then
 		/// throwing it again.
 
-        const char* SqlState() const noexcept;
-                /// Returns the SqlState
+	const char* sqlState() const noexcept;
+		/// Returns the SqlState
 
 
 private:
-	char _SqlState[6];
+	char _sqlState[6];
 };
 
 
@@ -145,9 +145,9 @@ inline void PostgreSQLException::rethrow() const
 }
 
 
-inline const char* PostgreSQLException::SqlState() const noexcept
+inline const char* PostgreSQLException::sqlState() const noexcept
 {
-	return _SqlState;
+	return _sqlState;
 }
 
 

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
@@ -36,6 +36,11 @@ public:
 	explicit PostgreSQLException(const std::string& aMessage);
 		/// Creates PostgreSQLException.
 
+
+	explicit PostgreSQLException(const std::string& aMessage,const char * pAnSqlState);
+		/// Creates PostgreSQLException.
+
+
 	PostgreSQLException(const PostgreSQLException& exc);
 		/// Creates PostgreSQLException.
 
@@ -63,6 +68,13 @@ public:
 		/// This is useful for temporarily storing a
 		/// copy of an exception (see clone()), then
 		/// throwing it again.
+
+        const char* SqlState() const noexcept;
+                /// Returns the SqlState
+
+
+private:
+	char _SqlState[6];
 };
 
 
@@ -90,6 +102,10 @@ class StatementException: public PostgreSQLException
 public:
 	StatementException(const std::string& aMessage);
 		/// Creates StatementException from string.
+
+	StatementException(const std::string& aMessage,const char* pAnSqlState);
+		/// Creates StatementException from string with support for sqlState.
+
 };
 
 
@@ -127,6 +143,13 @@ inline void PostgreSQLException::rethrow() const
 {
 	throw *this;
 }
+
+
+inline const char* PostgreSQLException::SqlState() const noexcept
+{
+	return _SqlState;
+}
+
 
 
 } } } // namespace Poco::Data::PostgreSQL

--- a/Data/PostgreSQL/src/PostgreSQLException.cpp
+++ b/Data/PostgreSQL/src/PostgreSQLException.cpp
@@ -29,9 +29,12 @@ PostgreSQLException::PostgreSQLException(const std::string& aMessage,const char*
 	Poco::Data::DataException(std::string("[PostgreSQL]: ") + aMessage)
 {
         // handle anSqlState
-        if (pAnSqlState == nullptr) _SqlState[0] = '\0';
-	else strncpy(_SqlState,pAnSqlState,5);
-
+        if (pAnSqlState == nullptr) _sqlState[0] = '\0';
+	else
+	{
+		strncpy(_sqlState,pAnSqlState,5);
+                _sqlState[5] = '\0';
+	}
 	
 }
 

--- a/Data/PostgreSQL/src/PostgreSQLException.cpp
+++ b/Data/PostgreSQL/src/PostgreSQLException.cpp
@@ -13,7 +13,7 @@
 
 
 #include "Poco/Data/PostgreSQL/PostgreSQLException.h"
-
+#include <cstring> 
 
 namespace Poco {
 namespace Data {
@@ -23,6 +23,16 @@ namespace PostgreSQL {
 PostgreSQLException::PostgreSQLException(const std::string& aMessage):
 	Poco::Data::DataException(std::string("[PostgreSQL]: ") + aMessage)
 {
+}
+
+PostgreSQLException::PostgreSQLException(const std::string& aMessage,const char* pAnSqlState):
+	Poco::Data::DataException(std::string("[PostgreSQL]: ") + aMessage)
+{
+        // handle anSqlState
+        if (pAnSqlState == nullptr) _SqlState[0] = '\0';
+	else strncpy(_SqlState,pAnSqlState,5);
+
+	
 }
 
 
@@ -67,6 +77,13 @@ StatementException::StatementException(const std::string& aMessage):
 	PostgreSQLException(aMessage)
 {
 }
+
+StatementException::StatementException(const std::string& aMessage,const char* pAnSqlState):
+	PostgreSQLException(aMessage,pAnSqlState)
+{
+}
+
+
 
 
 } } } // namespace Poco::Data::PostgreSQL

--- a/Data/PostgreSQL/src/StatementExecutor.cpp
+++ b/Data/PostgreSQL/src/StatementExecutor.cpp
@@ -143,13 +143,18 @@ void StatementExecutor::prepare(const std::string& aSQLStatement)
 	}
 
 	{
+                // get the sqlState
+                const char* pSQLState	= PQresultErrorField(ptrPGResult, PG_DIAG_SQLSTATE);		
+
 		// setup to clear the result from PQprepare
 		PQResultClear resultClearer(ptrPGResult);
 
-		if	(!ptrPGResult || PQresultStatus(ptrPGResult) != PGRES_COMMAND_OK)
+                //
+		if  (!ptrPGResult || PQresultStatus(ptrPGResult) != PGRES_COMMAND_OK )
 		{
-			throw StatementException(std::string("postgresql_stmt_prepare error: ") + PQresultErrorMessage (ptrPGResult) + " " + aSQLStatement);
+			throw StatementException(std::string("postgresql_stmt_prepare error: ") + PQresultErrorMessage (ptrPGResult) + " " + aSQLStatement,pSQLState);
 		}
+
 	}
 
 	// Determine what the structure of a statement result will look like
@@ -159,11 +164,15 @@ void StatementExecutor::prepare(const std::string& aSQLStatement)
 	}
 
 	{
+ 		// get the sqlState
+                const char* pSQLState	= PQresultErrorField(ptrPGResult, PG_DIAG_SQLSTATE);
+	
 		PQResultClear resultClearer(ptrPGResult);
+
 		if (!ptrPGResult || PQresultStatus(ptrPGResult) != PGRES_COMMAND_OK)
 		{
 			throw StatementException(std::string("postgresql_stmt_describe error: ") +
-				PQresultErrorMessage (ptrPGResult) + " " + aSQLStatement);
+				PQresultErrorMessage (ptrPGResult) + " " + aSQLStatement,pSQLState);
 		}
 
 		// remember the structure of the statement result
@@ -270,13 +279,14 @@ void StatementExecutor::execute()
 		const char* pHint		= PQresultErrorField(ptrPGResult, PG_DIAG_MESSAGE_HINT);
 		const char* pConstraint	= PQresultErrorField(ptrPGResult, PG_DIAG_CONSTRAINT_NAME);
 
+                
 		throw StatementException(std::string("postgresql_stmt_execute error: ")
 			+ PQresultErrorMessage (ptrPGResult)
 			+ " Severity: " + (pSeverity   ? pSeverity   : "N/A")
 			+ " State: " + (pSQLState   ? pSQLState   : "N/A")
 			+ " Detail: " + (pDetail ? pDetail : "N/A")
 			+ " Hint: " + (pHint   ? pHint   : "N/A")
-			+ " Constraint: " + (pConstraint ? pConstraint : "N/A"));
+			+ " Constraint: " + (pConstraint ? pConstraint : "N/A"),pSQLState);
 	}
 
 	_pResultHandle = ptrPGResult;

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
@@ -767,16 +767,16 @@ void PostgreSQLTest::testReconnect()
 
 void PostgreSQLTest::testSqlState()
 {
-        if (!_pSession) fail ("Test not available.");
+	if (!_pSession) fail ("Test not available.");
 
-        try
-        {
-	    *_pSession << "syntax error", now;
-        }
-	catch (const Poco::Data::PostgreSQL::PostgreSQLException & Except)
+	try
 	{
-        	assertTrue(Except.SqlState() == std::string("42601"));    
-        }
+		*_pSession << "syntax error", now;
+	}
+	catch (const Poco::Data::PostgreSQL::PostgreSQLException & exception)
+	{
+		assertTrue(exception.sqlState() == std::string("42601"));    
+	}
 }
 
 void PostgreSQLTest::testNullableInt()

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
@@ -765,6 +765,20 @@ void PostgreSQLTest::testReconnect()
 }
 
 
+void PostgreSQLTest::testSqlState()
+{
+        if (!_pSession) fail ("Test not available.");
+
+        try
+        {
+	    *_pSession << "syntax error", now;
+        }
+	catch (const Poco::Data::PostgreSQL::PostgreSQLException & Except)
+	{
+        	assertTrue(Except.SqlState() == std::string("42601"));    
+        }
+}
+
 void PostgreSQLTest::testNullableInt()
 {
 	if (!_pSession) fail ("Test not available.");
@@ -1271,6 +1285,7 @@ CppUnit::Test* PostgreSQLTest::suite()
 	CppUnit_addTest(pSuite, PostgreSQLTest, testNullableInt);
 	CppUnit_addTest(pSuite, PostgreSQLTest, testNullableString);
 	CppUnit_addTest(pSuite, PostgreSQLTest, testTupleWithNullable);
+        CppUnit_addTest(pSuite, PostgreSQLTest, testSqlState);
 
 	CppUnit_addTest(pSuite, PostgreSQLTest, testBinarySimpleAccess);
 	CppUnit_addTest(pSuite, PostgreSQLTest, testBinaryComplexType);

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
@@ -27,8 +27,8 @@ class PostgreSQLTest: public CppUnit::TestCase
 	///
 	/// Driver			|	DB						| OS
 	/// ----------------+---------------------------+------------------------------------------
-	/// 03.51.12.00		| PostgreSQL 9.3.1.0(18)   	| Mac OSX  10.9.1
-	///
+	/// 03.51.12.00		        | PostgreSQL 9.3.1.0(18)   	                        | Mac OSX  10.9.1
+	///                             | PostgreSQL 15.3          	                        | Ubuntu 16.04
 
 {
 public:
@@ -112,6 +112,8 @@ public:
 	void testTransaction();
 
 	void testReconnect();
+
+        void testSqlState();
 
 	void setUp();
 	void tearDown();

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
@@ -113,7 +113,7 @@ public:
 
 	void testReconnect();
 
-        void testSqlState();
+	void testSqlState();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
added support for SqlState in data::poco::postgresql.

----------------------------------------------------------------------
tested locally against postgresql 15.3.
was not able to find a suitable "location" for adding a "test" to the repo.

---------------------------------------------------------------------

tried to make it as simple as I could:

added a data member _SqlState to PostgreSQLException, 
added a getter SqlState(), 
added ctor  PostgreSQLException(const std::string& aMessage,**const char * pAnSqlState**);

added ctor StatementException::StatementException(const std::string& aMessage,**const char* pAnSqlState**);

modified StatementExecutor::prepare & StatementExecutor::execute(),
to make use of the new ctor for StatementException, such that the SqlState will be made available to the catcher of the exception.

:-)
