### PR TITLE
Fix platform when building for iPhoneSimulator

### DIFF
--- a/build/config/iPhoneSimulator
+++ b/build/config/iPhoneSimulator
@@ -6,6 +6,6 @@
 
 IPHONE_SDK         = iPhoneSimulator
 POCO_TARGET_OSARCH = x86_64
-OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphonesimulator-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone

--- a/build/config/iPhoneSimulator-clang
+++ b/build/config/iPhoneSimulator-clang
@@ -6,6 +6,6 @@
 
 IPHONE_SDK         = iPhoneSimulator
 POCO_TARGET_OSARCH = x86_64
-OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphonesimulator-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone-clang

--- a/build/config/iPhoneSimulator-clang-libc++
+++ b/build/config/iPhoneSimulator-clang-libc++
@@ -6,6 +6,6 @@
 
 IPHONE_SDK         = iPhoneSimulator
 POCO_TARGET_OSARCH = x86_64
-OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphoneos-version-min=$(IPHONE_SDK_VERSION_MIN)
+OSFLAGS            = -arch $(POCO_TARGET_OSARCH) -isysroot $(IPHONE_SDK_BASE) -miphonesimulator-version-min=$(IPHONE_SDK_VERSION_MIN)
 
 include $(POCO_BASE)/build/config/iPhone-clang-libc++


### PR DESCRIPTION
When building for `iPhoneSimulator`, the minimum OS version parameter should be matched.

Fix #4136.