### PR TITLE
add missing check when activerecord is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,10 @@ if(ENABLE_ACTIVERECORD AND NOT ENABLE_DATA)
   set(ENABLE_DATA ON CACHE BOOL "Enable Data" FORCE)
 endif()
 
+if(ENABLE_ACTIVERECORD AND NOT ENABLE_XML)
+  set(ENABLE_XML ON CACHE BOOL "Enable XML" FORCE)
+endif()
+
 option(ENABLE_TESTS
 	"Set to OFF|ON (default is OFF) to control build of POCO tests & samples" OFF)
 


### PR DESCRIPTION
If ENABLE_ACTIVERECORD is on, XML should also be enabled.

Building without XML support produces some errors like:
```
ld: ActiveRecord/Compiler/CMakeFiles/ActiveRecordCompiler.dir/src/Parser.cpp.o:(.data.rel.ro._ZTVN4Poco12ActiveRecord8Compiler6ParserE[_ZTVN4Poco12ActiveRecord8Compiler6ParserE]+0x170): undefined reference to `non-virtual thunk to Poco::XML::DefaultHandler::error(Poco::XML::SAXException const&)'
ld: ActiveRecord/Compiler/CMakeFiles/ActiveRecordCompiler.dir/src/Parser.cpp.o:(.data.rel.ro._ZTVN4Poco12ActiveRecord8Compiler6ParserE[_ZTVN4Poco12ActiveRecord8Compiler6ParserE]+0x178): undefined reference to `non-virtual thunk to Poco::XML::DefaultHandler::fatalError(Poco::XML::SAXException const&)'
```