### PR TITLE
Fix  memleak caused by reference count of StreamSocketImpl

### DIFF
--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -32,7 +32,6 @@ SecureStreamSocketImpl::SecureStreamSocketImpl(StreamSocketImpl* pStreamSocket, 
 	_impl(pStreamSocket, pContext),
 	_lazyHandshake(false)
 {
-	pStreamSocket->duplicate();
 	reset(_impl.sockfd());
 }
 

--- a/NetSSL_Win/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureStreamSocketImpl.cpp
@@ -32,7 +32,6 @@ SecureStreamSocketImpl::SecureStreamSocketImpl(StreamSocketImpl* pStreamSocket, 
 	_impl(pStreamSocket, pContext),
 	_lazyHandshake(false)
 {
-	pStreamSocket->duplicate();
 	reset(_impl.sockfd());
 }
 


### PR DESCRIPTION
Hi,

This pull request fixes #4175.

This patch removes the memory leak and seems to work (only tested on Linux with OpenSSL but I also patched Windows implementation).

This is my first contribution, I don't know if I should write a test for this fix. If so, could you guide me through the process? I couldn't find how to run current tests for a starter 😅

Thanks,
Pierre