### PR TITLE
4231 postgre sql leaks memory for failed connections

### DIFF
--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -143,7 +143,7 @@ void SessionHandle::disconnect()
 {
 	Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
 
-	if (isConnectedNoLock())
+	if (_pConnection)
 	{
 		PQfinish(_pConnection);
 

--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -88,7 +88,13 @@ void SessionHandle::connect(const std::string& aConnectionString)
 
 	if (!isConnectedNoLock())
 	{
-		throw ConnectionFailedException(std::string("Connection Error: ") + lastErrorNoLock());
+		std::string msg = std::string("Connection Error: ") + lastErrorNoLock();
+		if (_pConnection)
+		{
+			PQfinish(_pConnection);
+			_pConnection = 0;
+		}
+		throw ConnectionFailedException(msg);
 	}
 
 	_connectionString = aConnectionString;

--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -83,6 +83,12 @@ void SessionHandle::connect(const std::string& aConnectionString)
 	{
 		throw ConnectionFailedException("Already Connected");
 	}
+	else if (_pConnection)
+	{
+		// free bad connection
+		PQfinish(_pConnection);
+		_pConnection = 0;
+	}
 
 	_pConnection = PQconnectdb(aConnectionString.c_str());
 

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
@@ -149,7 +149,6 @@ void PostgreSQLTest::testFailedConnect()
 	dbConnString +=	" password=invalid";
 	dbConnString += " port=" + getPort();
 
-	Poco::SharedPtr<Poco::Data::Session> pInvalidSession;
 	try
 	{
 		std::cout << "Attempting to Connect to [" << dbConnString << "] with invalid credentials: " << std::endl;

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.cpp
@@ -140,6 +140,33 @@ void PostgreSQLTest::testConnectNoDB()
 	}
 }
 
+
+void PostgreSQLTest::testFailedConnect()
+{
+	std::string dbConnString;
+	dbConnString +=  "host=" + getHost();
+	dbConnString += " user=invalid";
+	dbConnString +=	" password=invalid";
+	dbConnString += " port=" + getPort();
+
+	Poco::SharedPtr<Poco::Data::Session> pInvalidSession;
+	try
+	{
+		std::cout << "Attempting to Connect to [" << dbConnString << "] with invalid credentials: " << std::endl;
+		Session session(PostgreSQL::Connector::KEY, dbConnString);
+		fail ("must fail");
+	}
+	catch (ConnectionFailedException& ex)
+	{
+		std::cout  << ex.displayText() << std::endl;
+	}
+	catch (ConnectionException& ex)
+	{
+		std::cout << ex.displayText() << std::endl;
+	}
+}
+
+
 void PostgreSQLTest::testPostgreSQLOIDs()
 {
 	if (!_pSession) fail ("Test not available.");
@@ -307,6 +334,7 @@ void PostgreSQLTest::testBarebonePostgreSQL()
 	_pExecutor->barebonePostgreSQLTest(POSTGRESQL_HOST, POSTGRESQL_USER, POSTGRESQL_PWD, POSTGRESQL_DB, POSTGRESQL_PORT, tableCreateString.c_str());
 */
 }
+
 
 
 void PostgreSQLTest::testSimpleAccess()
@@ -775,7 +803,7 @@ void PostgreSQLTest::testSqlState()
 	}
 	catch (const Poco::Data::PostgreSQL::PostgreSQLException & exception)
 	{
-		assertTrue(exception.sqlState() == std::string("42601"));    
+		assertTrue(exception.sqlState() == std::string("42601"));
 	}
 }
 
@@ -1236,6 +1264,7 @@ CppUnit::Test* PostgreSQLTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("PostgreSQLTest");
 
 	CppUnit_addTest(pSuite, PostgreSQLTest, testConnectNoDB);
+	CppUnit_addTest(pSuite, PostgreSQLTest, testFailedConnect);
 	CppUnit_addTest(pSuite, PostgreSQLTest, testPostgreSQLOIDs);
 	//CppUnit_addTest(pSuite, PostgreSQLTest, testBarebonePostgreSQL);
 	CppUnit_addTest(pSuite, PostgreSQLTest, testSimpleAccess);

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
@@ -36,8 +36,10 @@ public:
 	~PostgreSQLTest();
 
 	void testConnectNoDB();
+	void testFailedConnect();
 	void testPostgreSQLOIDs();
 	void testBarebonePostgreSQL();
+
 
 	void testSimpleAccess();
 	void testComplexType();

--- a/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
+++ b/Data/PostgreSQL/testsuite/src/PostgreSQLTest.h
@@ -40,7 +40,6 @@ public:
 	void testPostgreSQLOIDs();
 	void testBarebonePostgreSQL();
 
-
 	void testSimpleAccess();
 	void testComplexType();
 	void testSimpleAccessVector();


### PR DESCRIPTION
This should fix #4231. I added a test case that provokes a failed connection attempt. The test case checks that an exception is raised. It's hard to test that there is no memory leak, but at least the test case verifies that the added code is executed without problems.