### PR TITLE
Do not free EVP key in initDH when OpenSSL version is >= 3

### DIFF
--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -797,6 +797,7 @@ void Context::initDH(bool use2048Bits, const std::string& dhParamsFile)
 	}
 	else
 	{
+		freeEVPPKey = false;
 		pKeyCtx = EVP_PKEY_CTX_new_from_name(NULL, "DH", NULL);
 		if (!pKeyCtx)
 		{


### PR DESCRIPTION
(ssl stack takes ownership of the key ptr)