### PR TITLE
Implement MySQL::SessionHandle::startTransaction as submitting the SQL statement 'BEGIN'

### DIFF
--- a/Data/MySQL/src/SessionHandle.cpp
+++ b/Data/MySQL/src/SessionHandle.cpp
@@ -153,14 +153,14 @@ void SessionHandle::close()
 
 void SessionHandle::startTransaction()
 {
-	int rc = mysql_autocommit(_pHandle, false);
+	int rc = mysql_query(_pHandle, "BEGIN");
 	if (rc != 0)
 	{
 		// retry if connection lost
 		int err = mysql_errno(_pHandle);
 		if (err == 2006 /* CR_SERVER_GONE_ERROR */ || err == 2013 /* CR_SERVER_LOST */)
 		{
-			rc = mysql_autocommit(_pHandle, false);
+			rc = mysql_query(_pHandle, "BEGIN");
 		}
 	}
 	if (rc != 0) throw TransactionException("Start transaction failed.", _pHandle);


### PR DESCRIPTION
Makes the MySQL backend to behave similar to the PostgreSQL backend