### PR TITLE
4244 postgres set auto commit should not call start transaction

### DIFF
--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionHandle.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/SessionHandle.h
@@ -106,7 +106,7 @@ public:
 	void startTransaction();
 		/// Start transaction
 
-	bool isTransaction();
+	bool isTransaction() const;
 		/// Returns true iff a transaction is a transaction is in progress, false otherwise.
 
 	void commit();
@@ -115,13 +115,13 @@ public:
 	void rollback();
 		/// Rollback trabsaction
 
-	bool isAutoCommit();
+	bool isAutoCommit() const;
 		/// is the connection in auto commit mode?
 
 	void setAutoCommit(bool aShouldAutoCommit = true);
 		/// is the connection in auto commit mode?
 
-	bool isAsynchronousCommit();
+	bool isAsynchronousCommit() const;
 		/// is the connection in Asynchronous commit mode?
 
 	void setAsynchronousCommit(bool aShouldAsynchronousCommit = true);
@@ -133,10 +133,10 @@ public:
 	void setTransactionIsolation(Poco::UInt32 aTI);
 		/// Sets the transaction isolation level.
 
-	Poco::UInt32 transactionIsolation();
+	Poco::UInt32 transactionIsolation() const;
 		/// Returns the transaction isolation level.
 
-	bool hasTransactionIsolation(Poco::UInt32 aTI);
+	static bool hasTransactionIsolation(Poco::UInt32 aTI);
 		/// Returns true iff the transaction isolation level corresponding
 		/// to the supplied bitmask is supported.
 
@@ -288,7 +288,7 @@ inline SessionHandle::operator PGconn * ()
 }
 
 
-inline Poco::FastMutex&SessionHandle::mutex()
+inline Poco::FastMutex& SessionHandle::mutex()
 {
 	return _sessionMutex;
 }
@@ -300,19 +300,19 @@ inline std::string SessionHandle::connectionString() const
 }
 
 
-inline bool SessionHandle::isTransaction()
+inline bool SessionHandle::isTransaction() const
 {
 	return _inTransaction;
 }
 
 
-inline bool SessionHandle::isAutoCommit()
+inline bool SessionHandle::isAutoCommit() const
 {
 	return _isAutoCommit;
 }
 
 
-inline bool SessionHandle::isAsynchronousCommit()
+inline bool SessionHandle::isAsynchronousCommit() const
 {
 	return _isAsynchronousCommit;
 }

--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -277,11 +277,9 @@ void SessionHandle::setAutoCommit(bool aShouldAutoCommit)
 
 	if (aShouldAutoCommit)
 	{
-		commit();  // end any in process transaction
-	}
-	else
-	{
-		startTransaction();  // start a new transaction
+		Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
+		if (_inTransaction)
+			commit();  // end any in process transaction
 	}
 
 	_isAutoCommit = aShouldAutoCommit;

--- a/Data/PostgreSQL/src/SessionHandle.cpp
+++ b/Data/PostgreSQL/src/SessionHandle.cpp
@@ -270,6 +270,7 @@ void SessionHandle::rollback()
 
 void SessionHandle::setAutoCommit(bool aShouldAutoCommit)
 {
+	// There is no PostgreSQL API call to switch autocommit (unchained) mode off.
 	if (aShouldAutoCommit == _isAutoCommit)
 	{
 		return;
@@ -277,8 +278,7 @@ void SessionHandle::setAutoCommit(bool aShouldAutoCommit)
 
 	if (aShouldAutoCommit)
 	{
-		Poco::FastMutex::ScopedLock mutexLocker(_sessionMutex);
-		if (_inTransaction)
+		if (isTransaction())
 			commit();  // end any in process transaction
 	}
 
@@ -374,7 +374,7 @@ void SessionHandle::setTransactionIsolation(Poco::UInt32 aTI)
 }
 
 
-Poco::UInt32 SessionHandle::transactionIsolation()
+Poco::UInt32 SessionHandle::transactionIsolation() const
 {
 	return _tranactionIsolationLevel;
 }

--- a/Data/PostgreSQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/PostgreSQL/testsuite/src/SQLExecutor.cpp
@@ -1897,11 +1897,7 @@ void SQLExecutor::sessionTransaction(const std::string& connect)
 
 	bool autoCommit = _pSession->getFeature("autoCommit");
 
-	// Next four lines inverted as autoCommit set to true is the normal mode
-// autocommit set to false is the same as issuing a "begin" statement
-_pSession->setFeature("autoCommit", false);
-	assertTrue (_pSession->isTransaction());
-
+	// autoCommit set to true is the normal mode
 	_pSession->setFeature("autoCommit", true);
 	assertTrue (!_pSession->isTransaction());
 
@@ -1995,11 +1991,11 @@ void SQLExecutor::transaction(const std::string& connect)
 
 	bool autoCommit = _pSession->getFeature("autoCommit");
 
-	_pSession->setFeature("autoCommit", false);
+/*	_pSession->setFeature("autoCommit", false);
 	assertTrue (_pSession->isTransaction());
 	_pSession->setFeature("autoCommit", true);
 	assertTrue (!_pSession->isTransaction());
-
+*/
 	_pSession->setTransactionIsolation(Session::TRANSACTION_READ_COMMITTED);
 
 	{

--- a/Data/PostgreSQL/testsuite/src/SQLExecutor.cpp
+++ b/Data/PostgreSQL/testsuite/src/SQLExecutor.cpp
@@ -1991,11 +1991,10 @@ void SQLExecutor::transaction(const std::string& connect)
 
 	bool autoCommit = _pSession->getFeature("autoCommit");
 
-/*	_pSession->setFeature("autoCommit", false);
-	assertTrue (_pSession->isTransaction());
+	_pSession->setFeature("autoCommit", false);
 	_pSession->setFeature("autoCommit", true);
 	assertTrue (!_pSession->isTransaction());
-*/
+
 	_pSession->setTransactionIsolation(Session::TRANSACTION_READ_COMMITTED);
 
 	{


### PR DESCRIPTION
Resolves the conflict between the PostgreSQL backend and the new code that temporarily sets the autocommit mode to false when a transaction starts.