### PR TITLE
fix(NetSSL_Win): Error during handshake: failed to read data

### DIFF
--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -132,6 +132,15 @@ void SecureSocketImpl::initCommon()
 	{
 		_contextFlags |= ISC_REQ_MANUAL_CRED_VALIDATION;
 	}
+
+	if (_mode == MODE_CLIENT)
+	{
+		// If we do not set this, in some cases the InitializeSecurityContext() will return SEC_I_INCOMPLETE_CREDENTIALS. 
+		// That case is not handled in the handshake, it will try to continue reading, thus blocking until timeout.
+		// The handling of this case would be to repeat the InitializeSecurityContext once again, or as we do here,
+		// inform to use a client cert if available. 
+		_contextFlags |= ISC_REQ_USE_SUPPLIED_CREDS;
+	}
 }
 
 


### PR DESCRIPTION
On some machines the InitializeSecurityContext() will return SEC_I_INCOMPLETE_CREDENTIALS during TLS handshake. That case is not handled, it will try to continue reading, thus blocking until timeout. The handling of this case would be to repeat the InitializeSecurityContext once again, or as we do here, inform to use a client cert if available. 

See also:
https://github.com/steffengy/schannel-rs/issues/32
https://stackoverflow.com/a/47479968

Closes #3944