### PR TITLE
enh(ci): Add ENABLE_COMPILER_WARNINGS to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,9 @@ endif()
 option(ENABLE_TESTS
 	"Set to OFF|ON (default is OFF) to control build of POCO tests" OFF)
 
+option(ENABLE_COMPILER_WARNINGS
+	"Set to OFF|ON (default is OFF) to enable additional compiler warnings. Intended primarily for maintainers." OFF)
+
 option(ENABLE_SAMPLES
 	"Set to OFF|ON (default is OFF) to control build of POCO samples" OFF)
 

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -49,7 +49,20 @@ else(MSVC)
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
 endif(MSVC)
 
-
+if (ENABLE_COMPILER_WARNINGS)
+    message(STATUS "Enabling additional compiler warning flags.")
+    # Additional compiler-specific warning flags
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # using clang
+        add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # using GCC
+        add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        # using Visual Studio C++
+        add_compile_options(/W4)
+    endif()
+endif()
 
 # Add a d postfix to the debug libraries
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
This option enables more compiler warnings for clang, gcc and MSVC. It is off by default.