### PR TITLE
Improve c++17 support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -42,7 +42,7 @@
             "forcedInclude": [],
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c11",
-            "cppStandard": "c++14",
+            "cppStandard": "c++17",
             "compileCommands": "",
             "browse": {
                 "path": [
@@ -63,7 +63,7 @@
             "forcedInclude": [],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
-            "cppStandard": "c++14",
+            "cppStandard": "c++17",
             "compileCommands": "",
             "browse": {
                 "path": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 # Setup C/C++ compiler options
 #################################################################################
 
-# C++11/17 compiler flags
+# C++17 compiler flags
 include(CXX1x)
 check_for_cxx17_compiler(CXX17_COMPILER)
 

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -223,11 +223,4 @@
 // Uncomment to explicitly disable SQLParser
 // #define POCO_DATA_NO_SQL_PARSER
 
-// Automatically disable SQL parser for < c++17 compile
-#if !defined(POCO_DATA_NO_SQL_PARSER)
-	#ifndef POCO_HAVE_CPP17_COMPILER
-		#define POCO_DATA_NO_SQL_PARSER
-	#endif
-#endif
-
 #endif // Foundation_Config_INCLUDED

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and [Getting Started](https://pocoproject.org/docs/00200-GettingStarted.html) do
 ### Prerequisites
 
 - CMake 3.5 or newer
-- A C++14 compiler (Visual C++ 2015, GCC 5.0, Clang 3.4, or newer)
+- A C++17 compiler (Visual C++ 2017, GCC 8.0, Clang 5, or newer)
 - OpenSSL headers and libraries (optional, but recommended)
 - MySQL, PostgreSQL and ODBC client libraries (optional)
 

--- a/cmake/CXX1x.cmake
+++ b/cmake/CXX1x.cmake
@@ -18,31 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Determines whether the compiler supports C++11
-macro(check_for_cxx11_compiler _VAR)
-    message(STATUS "Checking for C++11 compiler ...")
-    set(${_VAR})
-    try_compile(_COMPILER_TEST_RESULT ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
-    if(NOT _COMPILER_TEST_RESULT AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      try_compile(_COMPILER_TEST_RESULT ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/test_compiler.cpp CMAKE_FLAGS -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_STANDARD_REQUIRED=ON)
-      if(_COMPILER_TEST_RESULT)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-      else()
-	message(STATUS "To enable C++11 install libc++ standard library from https://libcxx.llvm.org/")
-      endif()
-    endif()
-    if(_COMPILER_TEST_RESULT AND ((MSVC AND (MSVC10 OR MSVC11 OR MSVC12 OR MSVC14)) OR
-    (CMAKE_COMPILER_IS_GNUCXX AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.8.1) OR
-    (CMAKE_CXX_COMPILER_ID STREQUAL "QCC" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.8.1) OR
-    (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.3) OR
-    (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")))
-        set(${_VAR} 1)
-	message(STATUS "Checking for C++11 compiler - available")
-    else()
-        message(STATUS "Checking for C++11 compiler - unavailable")
-    endif()
-endmacro()
-
 # Determines whether the compiler supports C++17
 macro(check_for_cxx17_compiler _VAR)
     message(STATUS "Checking for C++17 compiler")

--- a/release/script/mkdocumentation
+++ b/release/script/mkdocumentation
@@ -123,7 +123,7 @@ done
 
 : ${CC:=gcc}
 : ${CXX:=g++}
-: ${CXXFLAGS:=-std=c++11}
+: ${CXXFLAGS:=-std=c++17}
 
 echo "CC=$CC" >>$build/PocoDoc.ini
 echo "CXX=$CXX" >>$build/PocoDoc.ini


### PR DESCRIPTION
Poco now use C++17. We can take some old code away because of that. We
also raise requiments for C++17 so everything works as excpected with
it.