### PR TITLE
mingw 11: fixes to compile some libraries

### DIFF
--- a/Data/CMakeLists.txt
+++ b/Data/CMakeLists.txt
@@ -14,6 +14,9 @@ POCO_HEADERS_AUTO(SRCS ${HDRS_G})
 if(MSVC AND NOT(MSVC_VERSION LESS 1400))
 	set_source_files_properties(src/StatementImpl.cpp
 		PROPERTIES COMPILE_FLAGS "/bigobj")
+elseif(MINGW)
+	set_source_files_properties(src/StatementImpl.cpp
+		PROPERTIES COMPILE_FLAGS "-Wa,-mbig-obj")
 endif()
 
 # Version Resource

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -181,7 +181,7 @@ if(CMAKE_SYSTEM MATCHES "SunOS")
 	target_link_libraries(Foundation PUBLIC pthread socket xnet nsl resolv rt ${CMAKE_DL_LIBS})
 endif()
 
-if(CMAKE_COMPILER_IS_MINGW)
+if(MINGW)
 	target_compile_definitions(Foundation
 		PUBLIC
 			WC_NO_BEST_FIT_CHARS=0x400

--- a/Foundation/src/File_WIN32U.cpp
+++ b/Foundation/src/File_WIN32U.cpp
@@ -308,7 +308,7 @@ void FileImpl::renameToImpl(const std::string& path, int options)
 	std::wstring upath;
 	convertPath(path, upath);
 	if (options & OPT_FAIL_ON_OVERWRITE_IMPL) {
-		if (MoveFileExW(_upath.c_str(), upath.c_str(), NULL) == 0)
+		if (MoveFileExW(_upath.c_str(), upath.c_str(), 0) == 0)
 			handleLastErrorImpl(_path);
 	} else {
 		if (MoveFileExW(_upath.c_str(), upath.c_str(), MOVEFILE_REPLACE_EXISTING) == 0)

--- a/Foundation/src/Thread_WIN32.cpp
+++ b/Foundation/src/Thread_WIN32.cpp
@@ -45,6 +45,7 @@ namespace
 		info.dwThreadID = dwThreadID;
 		info.dwFlags    = 0;
 
+#if !defined(POCO_COMPILER_MINGW)
 		__try
 		{
 			RaiseException(MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info);
@@ -52,7 +53,8 @@ namespace
 		__except (EXCEPTION_CONTINUE_EXECUTION)
 		{
 		}
-	}
+#endif
+    }
 }
 
 

--- a/Net/CMakeLists.txt
+++ b/Net/CMakeLists.txt
@@ -30,6 +30,9 @@ target_link_libraries(Net PUBLIC Poco::Foundation)
 if(WIN32)
 	target_link_libraries(Net PUBLIC "iphlpapi.lib")
 	target_link_libraries(Net PUBLIC "ws2_32.lib")
+	if (MINGW)
+		target_link_libraries(Net PUBLIC "mswsock.lib")
+	endif()
 endif(WIN32)
 
 target_include_directories(Net

--- a/Net/include/Poco/Net/SocketDefs.h
+++ b/Net/include/Poco/Net/SocketDefs.h
@@ -26,7 +26,9 @@
 
 #if defined(POCO_OS_FAMILY_WINDOWS)
 	#include "Poco/UnWindows.h"
-	#define FD_SETSIZE 1024 // increase as needed
+	#ifndef FD_SETSIZE
+		#define FD_SETSIZE 1024 // increase as needed
+	#endif
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
 	#include <ws2def.h>

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -49,6 +49,10 @@ else(MSVC)
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
 endif(MSVC)
 
+if(MINGW)
+    add_link_options("-municode")
+endif()
+
 if (ENABLE_COMPILER_WARNINGS)
     message(STATUS "Enabling additional compiler warning flags.")
     # Additional compiler-specific warning flags

--- a/cmake/PocoMacros.cmake
+++ b/cmake/PocoMacros.cmake
@@ -11,7 +11,7 @@
 # CMAKE_MC_COMPILER - where to find mc.exe
 if(WIN32)
 	# cmake has CMAKE_RC_COMPILER, but no message compiler
-	if("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+	if("${CMAKE_GENERATOR}" MATCHES "Visual Studio" OR MINGW)
 		# this path is only present for 2008+, but we currently require PATH to
 		# be set up anyway
 		get_filename_component(sdk_dir "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]" REALPATH)


### PR DESCRIPTION
When verifying #2967 with mingw 11 that is provided with Qt installation I encountered more compile issues.

This pull requests solves some of them in Foundation, Net, Data and CMake files.

The following components compile:

- Encodings, XML, JSON, Util, Net, MongoDB, Redis, Prometheus, Data, Data/SQLite, Zip, PageCompiler, File2Page

Others don't and it would make lots of effort to make them compile and work.

The tests don't compile and fail with different errors.