### PR TITLE
Build.macos.openssl@1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
           ./configure --everything --no-prefix --omit=PDF
           --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib
           --mysql-include=/usr/local/opt/mysql-client/include --mysql-lib=/usr/local/opt/mysql-client/lib &&
+          --include-path="/usr/local/opt/openssl@1.1/include" --library-path="/usr/local/opt/openssl@1.1/lib" &&
           make all -s -j4
       - uses: ./.github/actions/retry-action
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - run: >-
           ./configure --everything --no-prefix --omit=PDF
           --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib
-          --mysql-include=/usr/local/opt/mysql-client/include --mysql-lib=/usr/local/opt/mysql-client/lib &&
+          --mysql-include=/usr/local/opt/mysql-client/include --mysql-lib=/usr/local/opt/mysql-client/lib
           --include-path="/usr/local/opt/openssl@1.1/include" --library-path="/usr/local/opt/openssl@1.1/lib" &&
           make all -s -j4
       - uses: ./.github/actions/retry-action


### PR DESCRIPTION
This PR fixes problem whith poco tests on macos when we use makefiles and openssl version 1.1

Problem root couse is "we hope that we build with openssl@1.1 because we installed it, but default openssl in brew is openssl@3"

Problem visalisation is failed test 
```shell
1: CppUnit::TestCaller<CryptoTest>.testEncryptDecryptGCM
    "Poco::IOException:
I/O error: error:1C800066:Provider routines::cipher operation failed"
    in "<unknown>", line -1
```