### PR TITLE
Fix some issues found with clang-tidy

### DIFF
--- a/CppUnit/include/CppUnit/CppUnitException.h
+++ b/CppUnit/include/CppUnit/CppUnitException.h
@@ -33,11 +33,11 @@ public:
 	                 long data2lineNumber,
 	                 const std::string& fileName);
 	CppUnitException(const CppUnitException& other);
-	virtual ~CppUnitException() throw();
+	virtual ~CppUnitException() noexcept;
 
 	CppUnitException& operator = (const CppUnitException& other);
 
-	const char* what() const throw ();
+	const char* what() const noexcept;
 
 	long lineNumber() const;
 	long data1LineNumber() const;
@@ -81,7 +81,7 @@ inline CppUnitException::CppUnitException (const std::string& message, long line
 }
 
 
-inline CppUnitException::~CppUnitException () throw()
+inline CppUnitException::~CppUnitException () noexcept
 {
 }
 
@@ -102,7 +102,7 @@ inline CppUnitException& CppUnitException::operator = (const CppUnitException& o
 }
 
 
-inline const char* CppUnitException::what() const throw ()
+inline const char* CppUnitException::what() const noexcept
 {
 	return _message.c_str();
 }

--- a/Data/PostgreSQL/src/PostgreSQLException.cpp
+++ b/Data/PostgreSQL/src/PostgreSQLException.cpp
@@ -45,7 +45,7 @@ PostgreSQLException::PostgreSQLException(const PostgreSQLException& anException)
 }
 
 
-PostgreSQLException::~PostgreSQLException() throw()
+PostgreSQLException::~PostgreSQLException() noexcept
 {
 }
 

--- a/Data/src/SessionPoolContainer.cpp
+++ b/Data/src/SessionPoolContainer.cpp
@@ -100,7 +100,7 @@ Session SessionPoolContainer::get(const std::string& name)
 SessionPool& SessionPoolContainer::getPool(const std::string& name)
 {
 	URI uri(name);
-	std::string path = uri.getPath();
+	const std::string& path = uri.getPath();
 	poco_assert (!path.empty());
 	std::string n = Session::uri(uri.getScheme(), path.substr(1));
 

--- a/Foundation/include/Poco/DirectoryIterator_UNIX.h
+++ b/Foundation/include/Poco/DirectoryIterator_UNIX.h
@@ -47,7 +47,7 @@ private:
 //
 // inlines
 //
-const std::string& DirectoryIteratorImpl::get() const
+inline const std::string& DirectoryIteratorImpl::get() const
 {
 	return _current;
 }

--- a/Foundation/src/URIStreamOpener.cpp
+++ b/Foundation/src/URIStreamOpener.cpp
@@ -56,7 +56,7 @@ std::istream* URIStreamOpener::open(const std::string& pathOrURI) const
 	try
 	{
 		URI uri(pathOrURI);
-		std::string scheme(uri.getScheme());
+		const std::string& scheme(uri.getScheme());
 		FactoryMap::const_iterator it = _map.find(scheme);
 		if (it != _map.end())
 		{

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -148,8 +148,8 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 	Poco::URI theURI(uri);
 	if (theURI.getScheme() != "mongodb") throw Poco::UnknownURISchemeException(uri);
 
-	std::string userInfo = theURI.getUserInfo();
-	std::string host = theURI.getHost();
+	const std::string& userInfo = theURI.getUserInfo();
+	const std::string& host = theURI.getHost();
 	Poco::UInt16 port = theURI.getPort();
 	if (port == 0) port = 27017;
 

--- a/Net/include/Poco/Net/IPAddress.h
+++ b/Net/include/Poco/Net/IPAddress.h
@@ -397,7 +397,7 @@ private:
 	void newIPv6(const void* hostAddr, Poco::UInt32 scope);
 	void newIPv6(unsigned prefix);
 	static std::string& compressV6(std::string& v6addr);
-	static std::string trimIPv6(const std::string v6Addr);
+	static std::string trimIPv6(const std::string& v6Addr);
 #endif
 	Ptr _pImpl;
 };

--- a/Net/include/Poco/Net/MailMessage.h
+++ b/Net/include/Poco/Net/MailMessage.h
@@ -297,7 +297,7 @@ class Net_API MultipartSource: public PartSource
 	/// mail messages consisting of multiple nested parts.
 {
 public:
-	explicit MultipartSource(const std::string contentType = "multipart/alternative");
+	explicit MultipartSource(const std::string& contentType = "multipart/alternative");
 		/// Creates an empty MultipartSource.
 		///
 		/// At least one part must be added with addPart().

--- a/Net/src/IPAddress.cpp
+++ b/Net/src/IPAddress.cpp
@@ -549,7 +549,7 @@ std::string& IPAddress::compressV6(std::string& v6addr)
 }
 
 
-std::string IPAddress::trimIPv6(const std::string v6Addr)
+std::string IPAddress::trimIPv6(const std::string& v6Addr)
 {
 	std::string v6addr(v6Addr);
 	std::string::size_type len = v6addr.length();

--- a/Net/src/MailMessage.cpp
+++ b/Net/src/MailMessage.cpp
@@ -83,7 +83,7 @@ namespace
 				MailMessage::ContentTransferEncoding cte = MailMessage::ENCODING_7BIT;
 				if (header.has(MailMessage::HEADER_CONTENT_TRANSFER_ENCODING))
 				{
-					std::string enc = header[MailMessage::HEADER_CONTENT_TRANSFER_ENCODING];
+					const std::string& enc = header[MailMessage::HEADER_CONTENT_TRANSFER_ENCODING];
 					if (enc == MailMessage::CTE_8BIT)
 						cte = MailMessage::ENCODING_8BIT;
 					else if (enc == MailMessage::CTE_QUOTED_PRINTABLE)

--- a/Net/src/MailMessage.cpp
+++ b/Net/src/MailMessage.cpp
@@ -692,7 +692,7 @@ PartSource* MailMessage::createPartStore(const std::string& content, const std::
 }
 
 
-MultipartSource::MultipartSource(const std::string contentType):
+MultipartSource::MultipartSource(const std::string& contentType):
 	PartSource(contentTypeWithBoundary(contentType))
 {
 }

--- a/Redis/include/Poco/Redis/Type.h
+++ b/Redis/include/Poco/Redis/Type.h
@@ -197,7 +197,7 @@ struct RedisTypeTraits<BulkString>
 		}
 		else
 		{
-			std::string s = value.value();
+			const std::string& s = value.value();
 			return marker
 				+ NumberFormatter::format(s.length())
 				+ LineEnding::NEWLINE_CRLF

--- a/XML/include/Poco/XML/XMLStreamParserException.h
+++ b/XML/include/Poco/XML/XMLStreamParserException.h
@@ -33,13 +33,13 @@ class XML_API XMLStreamParserException: public Poco::XML::XMLException
 public:
 	XMLStreamParserException(const std::string& name, Poco::UInt64 line, Poco::UInt64 column, const std::string& description);
 	XMLStreamParserException(const XMLStreamParser&, const std::string& description);
-	virtual ~XMLStreamParserException() throw ();
+	virtual ~XMLStreamParserException() noexcept;
 
 	const char* name() const noexcept;
 	Poco::UInt64 line() const;
 	Poco::UInt64 column() const;
 	const std::string& description() const;
-	virtual const char* what() const throw ();
+	virtual const char* what() const noexcept;
 
 private:
 	void init();

--- a/XML/src/XMLStreamParserException.cpp
+++ b/XML/src/XMLStreamParserException.cpp
@@ -20,7 +20,7 @@ namespace Poco {
 namespace XML {
 
 
-XMLStreamParserException::~XMLStreamParserException() throw ()
+XMLStreamParserException::~XMLStreamParserException() noexcept
 {
 }
 
@@ -79,7 +79,7 @@ const std::string& XMLStreamParserException::description() const
 }
 
 
-char const* XMLStreamParserException::what() const throw ()
+char const* XMLStreamParserException::what() const noexcept
 {
 	return _what.c_str();
 }

--- a/XML/src/XMLWriter.cpp
+++ b/XML/src/XMLWriter.cpp
@@ -724,8 +724,7 @@ void XMLWriter::declareNamespaces(const XMLString& namespaceURI, const XMLString
 	for (int i = 0; i < attributes.getLength(); i++)
 	{
 		XMLString attributeNamespaceURI = attributes.getURI(i);
-		XMLString attributeLocalName    = attributes.getLocalName(i);
-		XMLString attributeQName        = attributes.getQName(i);
+		const XMLString& attributeQName = attributes.getQName(i);
 
 		XMLString attributePrefix;
 		XMLString attributeLocal;
@@ -774,9 +773,9 @@ void XMLWriter::declareAttributeNamespaces(const Attributes& attributes)
 {
 	for (int i = 0; i < attributes.getLength(); i++)
 	{
-		XMLString namespaceURI = attributes.getURI(i);
-		XMLString localName    = attributes.getLocalName(i);
-		XMLString qname        = attributes.getQName(i);
+		const XMLString& namespaceURI = attributes.getURI(i);
+		const XMLString& localName    = attributes.getLocalName(i);
+		const XMLString& qname        = attributes.getQName(i);
 		if (!localName.empty())
 		{
 			XMLString prefix;
@@ -841,8 +840,8 @@ void XMLWriter::addAttributes(AttributeMap& attributeMap, const Attributes& attr
 {
 	for (int i = 0; i < attributes.getLength(); i++)
 	{
-		XMLString namespaceURI = attributes.getURI(i);
-		XMLString localName    = attributes.getLocalName(i);
+		const XMLString& namespaceURI = attributes.getURI(i);
+		const XMLString& localName    = attributes.getLocalName(i);
 		XMLString qname        = attributes.getQName(i);
 		if (!localName.empty())
 		{
@@ -866,8 +865,8 @@ void XMLWriter::addAttributes(CanonicalAttributeMap& attributeMap, const Attribu
 {
 	for (int i = 0; i < attributes.getLength(); i++)
 	{
-		XMLString namespaceURI = attributes.getURI(i);
-		XMLString localName    = attributes.getLocalName(i);
+		const XMLString& namespaceURI = attributes.getURI(i);
+		const XMLString& localName    = attributes.getLocalName(i);
 		XMLString qname        = attributes.getQName(i);
 		XMLString fullQName    = qname;
 		if (!localName.empty())

--- a/Zip/src/Decompress.cpp
+++ b/Zip/src/Decompress.cpp
@@ -79,7 +79,7 @@ bool Decompress::handleZipEntry(std::istream& zipStream, const ZipLocalFileHeade
 		// directory have 0 size, nth to read
 		if (!_flattenDirs)
 		{
-			std::string dirName = hdr.getFileName();
+			const std::string& dirName = hdr.getFileName();
 			if (!ZipCommon::isValidPath(dirName))
 				throw ZipException("Illegal entry name", dirName);
 			Poco::Path dir(_outDir, dirName);


### PR DESCRIPTION
Clang-tidy did find some problems from code. I choose to fix these separately as it makes it easier to automate clang-tidy at some point.

---

Every commit has  own fix type and they have messages. Look them separately so reviewing is easier.