### PR TITLE
fix(NamedEvent): Release semaphore ID in dtor when created with semget (fixes #2971)

### DIFF
--- a/Foundation/include/Poco/NamedEvent_UNIX.h
+++ b/Foundation/include/Poco/NamedEvent_UNIX.h
@@ -43,6 +43,7 @@ private:
 	sem_t* _sem;
 #else
 	int _semid;  // semaphore id
+	bool _createdId; // semaphore id was created with this instance
 #endif
 };
 

--- a/Foundation/include/Poco/NamedEvent_UNIX.h
+++ b/Foundation/include/Poco/NamedEvent_UNIX.h
@@ -17,12 +17,21 @@
 #ifndef Foundation_NamedEvent_UNIX_INCLUDED
 #define Foundation_NamedEvent_UNIX_INCLUDED
 
-
 #include "Poco/Foundation.h"
+
+#include <Poco/Platform.h>
+
 #if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-#include <semaphore.h>
+	#define POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES 1
+	#define POCO_NAMED_EVENT_USE_SYS_V_SEMAPHORES 0
+#else
+	#define POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES 0
+	#define POCO_NAMED_EVENT_USE_SYS_V_SEMAPHORES 1
 #endif
 
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	#include <semaphore.h>
+#endif
 
 namespace Poco {
 
@@ -39,8 +48,8 @@ private:
 	std::string getFileName();
 
 	std::string _name;
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-	sem_t* _sem;
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	::sem_t* _sem;
 #else
 	int _semid;  // semaphore id
 	bool _createdId; // semaphore id was created with this instance

--- a/Foundation/src/NamedEvent_UNIX.cpp
+++ b/Foundation/src/NamedEvent_UNIX.cpp
@@ -90,6 +90,7 @@ NamedEventImpl::~NamedEventImpl()
 {
 #if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
 	sem_close(_sem);
+	sem_unlink(_name.c_str());
 #else
 	if (_createdId)
 	{

--- a/Foundation/src/NamedEvent_UNIX.cpp
+++ b/Foundation/src/NamedEvent_UNIX.cpp
@@ -11,20 +11,21 @@
 // SPDX-License-Identifier:	BSL-1.0
 //
 
-
 #include "Poco/NamedEvent_UNIX.h"
 #include "Poco/Format.h"
 #include "Poco/Exception.h"
+
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <errno.h>
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-#include <semaphore.h>
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	#include <semaphore.h>
 #else
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/ipc.h>
-#include <sys/sem.h>
+	// System V semaphores
+	#include <unistd.h>
+	#include <sys/types.h>
+	#include <sys/ipc.h>
+	#include <sys/sem.h>
 #endif
 
 
@@ -53,48 +54,51 @@ NamedEventImpl::NamedEventImpl(const std::string& name):
 	_name(name)
 {
 	std::string fileName = getFileName();
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-	_sem = sem_open(fileName.c_str(), O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO, 0);
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	_sem = ::sem_open(fileName.c_str(), O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO, 0);
 	if ((long) _sem == (long) SEM_FAILED)
-		throw SystemException(Poco::format("cannot create named mutex %s (sem_open() failed, errno=%d)", fileName, errno), _name);
+		throw SystemException(Poco::format("cannot create named event %s (sem_open() failed, errno=%d)", fileName, errno), _name);
 #else
 	_createdId = false;
-	int fd = open(fileName.c_str(), O_RDONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	int fd = ::open(fileName.c_str(), O_RDONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (fd == -1 && errno == ENOENT)
-		fd = open(fileName.c_str(), O_RDONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+		fd = ::open(fileName.c_str(), O_RDONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (fd != -1)
-		close(fd);
+		::close(fd);
 	else
 		throw SystemException(Poco::format("cannot create named event %s (lockfile)", fileName), _name);
-	key_t key = ftok(fileName.c_str(), 'p');
+
+	key_t key = ::ftok(fileName.c_str(), 'p');
 	if (key == -1)
-		throw SystemException(Poco::format("cannot create named mutex %s (ftok() failed, errno=%d)", fileName, errno), _name);
-	_semid = semget(key, 1, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH | IPC_CREAT | IPC_EXCL);
+		throw SystemException(Poco::format("cannot create named event %s (ftok() failed, errno=%d)", fileName, errno), _name);
+
+	_semid = ::semget(key, 1, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH | IPC_CREAT | IPC_EXCL);
 	if (_semid >= 0)
 	{
 		_createdId = true;
 		union semun arg;
 		arg.val = 0;
-		semctl(_semid, 0, SETVAL, arg);
+		::semctl(_semid, 0, SETVAL, arg);
 	}
 	else if (errno == EEXIST)
 	{
-		_semid = semget(key, 1, 0);
+		_semid = ::semget(key, 1, 0);
 	}
-	else throw SystemException(Poco::format("cannot create named mutex %s (semget() failed, errno=%d)", fileName, errno), _name);
-#endif // defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
+	else
+		throw SystemException(Poco::format("cannot create named event %s (semget() failed, errno=%d)", fileName, errno), _name);
+#endif // POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
 }
 
 
 NamedEventImpl::~NamedEventImpl()
 {
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-	sem_close(_sem);
-	sem_unlink(_name.c_str());
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	::sem_close(_sem);
+	::sem_unlink(_name.c_str());
 #else
 	if (_createdId)
 	{
-		semctl(_semid, 0, IPC_RMID);
+		::semctl(_semid, 0, IPC_RMID);
 	}
 #endif
 }
@@ -102,30 +106,31 @@ NamedEventImpl::~NamedEventImpl()
 
 void NamedEventImpl::setImpl()
 {
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
-	if (sem_post(_sem) != 0)
-	   	throw SystemException("cannot set named event", _name);
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
+	if (::sem_post(_sem) != 0)
+		throw SystemException("cannot set named event", _name);
 #else
 	struct sembuf op;
 	op.sem_num = 0;
 	op.sem_op  = 1;
 	op.sem_flg = 0;
-	if (semop(_semid, &op, 1) != 0)
-	   	throw SystemException("cannot set named event", _name);
+	if (::semop(_semid, &op, 1) != 0)
+		throw SystemException("cannot set named event", _name);
 #endif
 }
 
 
 void NamedEventImpl::waitImpl()
 {
-#if defined(sun) || defined(__APPLE__) || defined(__osf__) || defined(__QNX__) || defined(_AIX) || defined(__GNU__)
+#if POCO_NAMED_EVENT_USE_POSIX_SEMAPHORES
 	int err;
 	do
 	{
-		err = sem_wait(_sem);
+		err = ::sem_wait(_sem);
 	}
 	while (err && errno == EINTR);
-	if (err) throw SystemException("cannot wait for named event", _name);
+	if (err)
+		throw SystemException("cannot wait for named event", _name);
 #else
 	struct sembuf op;
 	op.sem_num = 0;
@@ -134,10 +139,11 @@ void NamedEventImpl::waitImpl()
 	int err;
 	do
 	{
-		err = semop(_semid, &op, 1);
+		err = ::semop(_semid, &op, 1);
 	}
 	while (err && errno == EINTR);
-	if (err) throw SystemException("cannot wait for named event", _name);
+	if (err)
+		throw SystemException("cannot wait for named event", _name);
 #endif
 }
 

--- a/Foundation/testsuite/src/NamedEventTest.cpp
+++ b/Foundation/testsuite/src/NamedEventTest.cpp
@@ -15,7 +15,7 @@
 #include "Poco/Thread.h"
 #include "Poco/Runnable.h"
 #include "Poco/Timestamp.h"
-
+#include "Poco/Exception.h"
 
 using Poco::NamedEvent;
 using Poco::Thread;
@@ -101,6 +101,27 @@ void NamedEventTest::testNamedEvent()
 }
 
 
+void NamedEventTest::testCreateManyNamedEvents()
+{
+	std::string name;
+	try
+	{
+		int i = 0;
+		for (; i < 40000; i++)
+		{
+			name = std::string("TestEvent ") + std::to_string(i);
+			NamedEvent* ne = new NamedEvent(name);
+			delete ne;
+		}
+		assertEqual(i, 40000);
+	}
+	catch (const Poco::Exception& e)
+	{
+		fail (std::string("Failed creating named event: ").append(name).append(" ").append(e.displayText()));
+	}
+}
+
+
 void NamedEventTest::setUp()
 {
 }
@@ -116,6 +137,7 @@ CppUnit::Test* NamedEventTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("NamedEventTest");
 
 	CppUnit_addTest(pSuite, NamedEventTest, testNamedEvent);
+	CppUnit_addTest(pSuite, NamedEventTest, testCreateManyNamedEvents);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/NamedEventTest.cpp
+++ b/Foundation/testsuite/src/NamedEventTest.cpp
@@ -17,6 +17,8 @@
 #include "Poco/Timestamp.h"
 #include "Poco/Exception.h"
 
+#include <iostream>
+
 using Poco::NamedEvent;
 using Poco::Thread;
 using Poco::Runnable;
@@ -103,7 +105,15 @@ void NamedEventTest::testNamedEvent()
 
 void NamedEventTest::testCreateManyNamedEvents()
 {
+
 	std::string name;
+	for (int i = 0; i < 40000; i++)
+	{
+		name = std::string("TestEvent ") + std::to_string(i);
+		if (sem_unlink(name.c_str()))
+			std::cout << "sem_unlink failed: " << errno << std::endl;
+	}
+
 	try
 	{
 		int i = 0;

--- a/Foundation/testsuite/src/NamedEventTest.h
+++ b/Foundation/testsuite/src/NamedEventTest.h
@@ -25,6 +25,7 @@ public:
 	~NamedEventTest();
 
 	void testNamedEvent();
+	void testCreateManyNamedEvents();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
When a semaphore id is created with semget, it is released in dtor with semctl(..IPC_RMID).