### PR TITLE
Allow set enum as json value

### DIFF
--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -88,11 +88,18 @@ public:
 	Var();
 		/// Creates an empty Var.
 
-	template <typename T>
+	template <typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
 	Var(const T& val)
 		/// Creates the Var from the given value.
 	{
 		construct(val);
+	}
+	
+	template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+	Var(const T& val)
+		/// Creates the Var from the given enum value trough cast to int
+	{
+		construct(static_cast<int>(val));
 	}
 
 	Var(const char* pVal);

--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -88,18 +88,11 @@ public:
 	Var();
 		/// Creates an empty Var.
 
-	template <typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+	template <typename T>
 	Var(const T& val)
 		/// Creates the Var from the given value.
 	{
 		construct(val);
-	}
-	
-	template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
-	Var(const T& val)
-		/// Creates the Var from the given enum value trough cast to int
-	{
-		construct(static_cast<int>(val));
 	}
 
 	Var(const char* pVal);

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -773,7 +773,8 @@ public:
 		{
 			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -784,7 +785,8 @@ public:
 		{
 			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -795,7 +797,8 @@ public:
 		{
 			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -806,7 +809,8 @@ public:
 		{
 			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -817,7 +821,8 @@ public:
 		{
 			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -828,7 +833,8 @@ public:
 		{
 			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -839,7 +845,8 @@ public:
 		{
 			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -850,7 +857,8 @@ public:
 		{
 			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -863,7 +871,8 @@ public:
 		{
 			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -874,7 +883,8 @@ public:
 		{
 			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -887,7 +897,8 @@ public:
 		{
 			val = (std::underlying_type_t<T>(_val) != 0);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -898,7 +909,8 @@ public:
 		{
 			val = static_cast<float>(_val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -909,7 +921,8 @@ public:
 		{
 			val = static_cast<double>(_val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -920,7 +933,8 @@ public:
 		{
 			val = static_cast<char>(_val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -931,7 +945,8 @@ public:
 		{
 			val = NumberFormatter::format(std::underlying_type_t<T>(_val));
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -943,7 +958,8 @@ public:
 			std::string str = NumberFormatter::format(std::underlying_type_t<T>(_val));
 			Poco::UnicodeConverter::convert(str, val);
 		}
-		else {
+		else
+		{
 			VarHolder::convert(val);
 		}
 	}
@@ -954,7 +970,8 @@ public:
 		{
 			return false;
 		}
-		else {
+		else
+		{
 			return VarHolder::isArray();
 		}
 	}
@@ -965,7 +982,8 @@ public:
 		{
 			return false;
 		}
-		else {
+		else
+		{
 			return VarHolder::isStruct();
 		}
 	}
@@ -976,7 +994,8 @@ public:
 		{
 			return std::numeric_limits<std::underlying_type_t<T>>::is_integer;
 		}
-		else {
+		else
+		{
 			return VarHolder::isInteger();
 		}
 	}
@@ -987,7 +1006,8 @@ public:
 		{
 			return std::numeric_limits<std::underlying_type_t<T>>::is_signed;
 		}
-		else {
+		else
+		{
 			return VarHolder::isSigned();
 		}
 	}
@@ -998,7 +1018,8 @@ public:
 		{
 			return std::numeric_limits<std::underlying_type_t<T>>::is_specialized;
 		}
-		else {
+		else
+		{
 			return VarHolder::isNumeric();
 		}
 	}
@@ -1009,7 +1030,8 @@ public:
 		{
 			return false;
 		}
-		else {
+		else
+		{
 			return VarHolder::isBoolean();
 		}
 	}
@@ -1020,7 +1042,8 @@ public:
 		{
 			return false;
 		}
-		else {
+		else
+		{
 			return VarHolder::isString();
 		}
 	}

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -731,6 +731,264 @@ public:
 		return typeid(T);
 	}
 
+	void convert(Int8& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<Int8>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(Int16& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<Int16>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(Int32& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<Int32>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(Int64& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<Int64>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(UInt8& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<UInt8>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(UInt16& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<UInt16>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(UInt32& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<UInt32>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(UInt64& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<UInt64>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+#ifdef POCO_INT64_IS_LONG
+
+	convert(long long& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<long long>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	convert(unsigned long long& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<unsigned long  long>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+#endif
+
+	void convert(bool& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = (std::underlying_type_t<T>(_val) != 0);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(float& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<float>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(double& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<double>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(char& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = static_cast<char>(_val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(std::string& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			val = NumberFormatter::format(std::underlying_type_t<T>(_val));
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	void convert(Poco::UTF16String& val) const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			std::string str = NumberFormatter::format(std::underlying_type_t<T>(_val));
+			Poco::UnicodeConverter::convert(str, val);
+		}
+		else {
+			VarHolder::convert(val);
+		}
+	}
+
+	bool isArray() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return false;
+		}
+		else {
+			return VarHolder::isArray();
+		}
+	}
+
+	bool isStruct() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return false;
+		}
+		else {
+			return VarHolder::isStruct();
+		}
+	}
+
+	bool isInteger() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return std::numeric_limits<std::underlying_type_t<T>>::is_integer;
+		}
+		else {
+			return VarHolder::isInteger();
+		}
+	}
+
+	bool isSigned() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return std::numeric_limits<std::underlying_type_t<T>>::is_signed;
+		}
+		else {
+			return VarHolder::isSigned();
+		}
+	}
+
+	bool isNumeric() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return std::numeric_limits<std::underlying_type_t<T>>::is_specialized;
+		}
+		else {
+			return VarHolder::isNumeric();
+		}
+	}
+
+	bool isBoolean() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return false;
+		}
+		else {
+			return VarHolder::isBoolean();
+		}
+	}
+
+	bool isString() const
+	{
+		if constexpr (std::is_enum<T>::value)
+		{
+			return false;
+		}
+		else {
+			return VarHolder::isString();
+		}
+	}
+	
 	VarHolder* clone(Placeholder<VarHolder>* pVarHolder = 0) const
 	{
 		return cloneHolder(pVarHolder, _val);

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -857,7 +857,7 @@ public:
 
 #ifdef POCO_INT64_IS_LONG
 
-	convert(long long& val) const
+	void convert(long long& val) const
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
@@ -868,7 +868,7 @@ public:
 		}
 	}
 
-	convert(unsigned long long& val) const
+	void convert(unsigned long long& val) const
 	{
 		if constexpr (std::is_enum<T>::value)
 		{

--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -399,6 +399,42 @@ protected:
 		checkUpperLimit<F,T>(from);
 		to = static_cast<T>(from);
 	}
+	
+	template <typename F, typename T, std::enable_if_t<std::is_signed<F>::value && std::is_signed<T>::value && (sizeof(F) <= sizeof(T))>* = nullptr>
+	void convertToSigned(const F& from, T& to) const
+	{
+		to = static_cast<T>(from);
+	}
+	
+	template <typename F, typename T, std::enable_if_t<std::is_signed<F>::value && std::is_signed<T>::value && (sizeof(F) > sizeof(T))>* = nullptr>
+	void convertToSigned(const F& from, T& to) const
+	{
+		convertToSmaller(from, to);
+	}
+	
+	template <typename F, typename T, std::enable_if_t<!std::is_signed<F>::value && std::is_signed<T>::value>* = nullptr>
+	void convertToSigned(const F& from, T& to) const
+	{
+		convertUnsignedToSigned(from, to);
+	}
+	
+	template <typename F, typename T, std::enable_if_t<!std::is_signed<F>::value && !std::is_signed<T>::value && (sizeof(F) <= sizeof(T))>* = nullptr>
+	void convertToUnsigned(const F& from, T& to) const
+	{
+		to = static_cast<T>(from);
+	}
+	
+	template <typename F, typename T, std::enable_if_t<!std::is_signed<F>::value && !std::is_signed<T>::value && (sizeof(F) > sizeof(T))>* = nullptr>
+	void convertToUnsigned(const F& from, T& to) const
+	{
+		convertToSmallerUnsigned(from, to);
+	}
+	
+	template <typename F, typename T, std::enable_if_t<std::is_signed<F>::value && !std::is_signed<T>::value>* = nullptr>
+	void convertToUnsigned(const F& from, T& to) const
+	{
+		convertSignedToUnsigned(from, to);
+	}
 
 private:
 
@@ -735,7 +771,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<Int8>(_val);
+			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -746,7 +782,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<Int16>(_val);
+			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -757,7 +793,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<Int32>(_val);
+			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -768,7 +804,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<Int64>(_val);
+			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -779,7 +815,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<UInt8>(_val);
+			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -790,7 +826,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<UInt16>(_val);
+			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -801,7 +837,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<UInt32>(_val);
+			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -812,7 +848,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<UInt64>(_val);
+			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -825,7 +861,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<long long>(_val);
+			convertToSigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);
@@ -836,7 +872,7 @@ public:
 	{
 		if constexpr (std::is_enum<T>::value)
 		{
-			val = static_cast<unsigned long  long>(_val);
+			convertToUnsigned(std::underlying_type_t<T>(_val), val);
 		}
 		else {
 			VarHolder::convert(val);

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -1644,6 +1644,103 @@ void VarTest::testULongLong()
 }
 
 
+void VarTest::testEnumType()
+{
+	enum class src {
+		value = 32
+	};
+
+	Var a1 = src::value;
+
+	assertTrue (a1.type() == typeid(src));
+
+	std::string s1;
+	Poco::Int8 s2;
+	Poco::Int16 s3;
+	Poco::Int32 s4;
+	Poco::Int64 s5;
+	Poco::UInt8 s6;
+	Poco::UInt16 s7;
+	Poco::UInt32 s8;
+	Poco::UInt64 s9;
+	float s10;
+	double s11;
+	bool s12;
+	char s13;
+	a1.convert(s1);
+	a1.convert(s2);
+	a1.convert(s3);
+	a1.convert(s4);
+	a1.convert(s5);
+	a1.convert(s6);
+	a1.convert(s7);
+	a1.convert(s8);
+	a1.convert(s9);
+	a1.convert(s10);
+	a1.convert(s11);
+	a1.convert(s12);
+	a1.convert(s13);
+	long s14;
+	unsigned long s15;
+	long long s16;
+	unsigned long long s17;
+	a1.convert(s14);
+	a1.convert(s15);
+	a1.convert(s16);
+	a1.convert(s17);
+	assertTrue (s14 == 32);
+	assertTrue (s15 == 32);
+	assertTrue (s16 == 32);
+	assertTrue (s17 == 32);
+	assertTrue (s1 == "32");
+	assertTrue (s2 == 32);
+	assertTrue (s3 == 32);
+	assertTrue (s4 == 32);
+	assertTrue (s5 == 32);
+	assertTrue (s6 == 32);
+	assertTrue (s7 == 32);
+	assertTrue (s8 == 32);
+	assertTrue (s9 == 32);
+	assertTrue (s10 == 32.0f);
+	assertTrue (s11 == 32.0);
+	assertTrue (s12);
+	assertTrue (s13 == ' ');
+	Var a2(a1);
+	std::string t2;
+	a2.convert(t2);
+	assertTrue (s1 == t2);
+
+	src value = a1.extract<src>();
+	assertTrue (value == src::value);
+
+	try
+	{
+		POCO_UNUSED Int16 value2; value2 = a1.extract<Int16>();
+		fail("bad cast - must throw");
+	}
+	catch (Poco::BadCastException&)
+	{
+	}
+
+	Var a3 = a1 + 1;
+	assertTrue (a3 == 33);
+	a3 = a1 - 1;
+	assertTrue (a3 == 31);
+	a3 += 1;
+	assertTrue (a3 == 32);
+	a3 -= 1;
+	assertTrue (a3 == 31);
+	a3 = a1 / 2;
+	assertTrue (a3 == 16);
+	a3 = a1 * 2;
+	assertTrue (a3 == 64);
+	a3 /= 2;
+	assertTrue (a3 == 32);
+	a3 *= 2;
+	assertTrue (a3 == 64);
+}
+
+
 void VarTest::testUDT()
 {
 	Dummy d0;
@@ -3344,6 +3441,7 @@ CppUnit::Test* VarTest::suite()
 	CppUnit_addTest(pSuite, VarTest, testEmpty);
 	CppUnit_addTest(pSuite, VarTest, testIterator);
 	CppUnit_addTest(pSuite, VarTest, testVarVisitor);
+	CppUnit_addTest(pSuite, VarTest, testEnumType);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/VarTest.h
+++ b/Foundation/testsuite/src/VarTest.h
@@ -42,6 +42,7 @@ public:
 	void testULong();
 	void testLongLong();
 	void testULongLong();
+	void testEnumType();
 	void testString();
 	void testUDT();
 	void testConversionOperator();

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -2369,7 +2369,23 @@ void JSONTest::testRemove()
 	assertTrue(nl[1] == "baz");
 
 }
-
+void JSONTest::testEnum()
+{
+	enum SAMPLE_ENUM
+	{
+		SOME_ENUM_VALUE = 42
+	};
+	
+	Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+	
+	obj->set("taskType", SOME_ENUM_VALUE);
+	
+	Poco::Dynamic::Var var(obj);
+	std::string expected = "{\"taskType\":42}";
+	std::string result = var.convert<std::string>();
+	
+	assertEquals(expected, result);
+}
 
 CppUnit::Test* JSONTest::suite()
 {
@@ -2424,6 +2440,7 @@ CppUnit::Test* JSONTest::suite()
 	CppUnit_addTest(pSuite, JSONTest, testCopy);
 	CppUnit_addTest(pSuite, JSONTest, testMove);
 	CppUnit_addTest(pSuite, JSONTest, testRemove);
+	CppUnit_addTest(pSuite, JSONTest, testEnum);
 
 	return pSuite;
 }

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -2373,18 +2373,173 @@ void JSONTest::testEnum()
 {
 	enum SAMPLE_ENUM
 	{
-		SOME_ENUM_VALUE = 42
+		SE_VALUE = 42
 	};
 	
-	Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+	enum class SAMPLE_ENUM_CLASS
+	{
+		VALUE = 42
+	};
 	
-	obj->set("taskType", SOME_ENUM_VALUE);
+	enum class SAMPLE_ENUM_CLASS_I8: Poco::Int8
+	{
+		VALUE = 42
+	};
 	
-	Poco::Dynamic::Var var(obj);
-	std::string expected = "{\"taskType\":42}";
-	std::string result = var.convert<std::string>();
+	enum class SAMPLE_ENUM_CLASS_I16: Poco::Int16
+	{
+		VALUE = 42
+	};
 	
-	assertEquals(expected, result);
+	enum class SAMPLE_ENUM_CLASS_I32: Poco::Int32
+	{
+		VALUE = 42
+	};
+	
+	enum class SAMPLE_ENUM_CLASS_I64: Poco::Int64
+	{
+		VALUE = 42
+	};
+	
+	enum class SAMPLE_ENUM_CLASS_UI8: Poco::UInt8
+	{
+		VALUE = 42
+	};
+	
+	enum class SAMPLE_ENUM_CLASS_UI16: Poco::UInt16
+	{
+		VALUE = 42
+	};
+	
+	enum class SAMPLE_ENUM_CLASS_UI32: Poco::UInt32
+	{
+		VALUE = 42
+	};
+	
+	enum class SAMPLE_ENUM_CLASS_UI64: Poco::UInt64
+	{
+		VALUE = 42
+	};
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("simple_enum", SE_VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"simple_enum\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM se = obj->get("simple_enum").extract<SAMPLE_ENUM>();
+		assertTrue(se == SE_VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class", SAMPLE_ENUM_CLASS::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS se = obj->get("enum_class").extract<SAMPLE_ENUM_CLASS>();
+		assertTrue(se == SAMPLE_ENUM_CLASS::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_i8", SAMPLE_ENUM_CLASS_I8::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_i8\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_I8 se = obj->get("enum_class_i8").extract<SAMPLE_ENUM_CLASS_I8>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_I8::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_i16", SAMPLE_ENUM_CLASS_I16::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_i16\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_I16 se = obj->get("enum_class_i16").extract<SAMPLE_ENUM_CLASS_I16>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_I16::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_i32", SAMPLE_ENUM_CLASS_I32::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_i32\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_I32 se = obj->get("enum_class_i32").extract<SAMPLE_ENUM_CLASS_I32>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_I32::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_i64", SAMPLE_ENUM_CLASS_I64::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_i64\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_I64 se = obj->get("enum_class_i64").extract<SAMPLE_ENUM_CLASS_I64>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_I64::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_ui8", SAMPLE_ENUM_CLASS_UI8::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_ui8\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_UI8 se = obj->get("enum_class_ui8").extract<SAMPLE_ENUM_CLASS_UI8>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_UI8::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_ui16", SAMPLE_ENUM_CLASS_UI16::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_ui16\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_UI16 se = obj->get("enum_class_ui16").extract<SAMPLE_ENUM_CLASS_UI16>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_UI16::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_ui32", SAMPLE_ENUM_CLASS_UI32::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_ui32\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_UI32 se = obj->get("enum_class_ui32").extract<SAMPLE_ENUM_CLASS_UI32>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_UI32::VALUE);
+	}
+	
+	{
+		Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+		obj->set("enum_class_ui64", SAMPLE_ENUM_CLASS_UI64::VALUE);
+		Poco::Dynamic::Var var(obj);
+		std::string expected = "{\"enum_class_ui64\":42}";
+		std::string result = var.convert<std::string>();
+		assertEquals(expected, result);
+		
+		SAMPLE_ENUM_CLASS_UI64 se = obj->get("enum_class_ui64").extract<SAMPLE_ENUM_CLASS_UI64>();
+		assertTrue(se == SAMPLE_ENUM_CLASS_UI64::VALUE);
+	}
 }
 
 CppUnit::Test* JSONTest::suite()

--- a/JSON/testsuite/src/JSONTest.h
+++ b/JSON/testsuite/src/JSONTest.h
@@ -86,6 +86,8 @@ public:
 	void testMove();
 	void testRemove();
 
+	void testEnum();
+
 	void setUp();
 	void tearDown();
 


### PR DESCRIPTION
fix issue #4341
add testEnum

```cpp
        enum SAMPLE_ENUM
	{
		SE_VALUE = 42
	};
	
	Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
	obj->set("simple_enum", SE_VALUE);
	Poco::Dynamic::Var var(obj);
	std::string expected = "{\"simple_enum\":42}";
	std::string result = var.convert<std::string>();
	assertEquals(expected, result);
		
	SAMPLE_ENUM se = obj->get("simple_enum").extract<SAMPLE_ENUM>();
	assertTrue(se == SE_VALUE);
```
Canges are simple, I've added branch for every default method VarHolderImpl<T>

```cpp
     void convert(Int8& val) const
	{
		if constexpr (std::is_enum<T>::value)
		{
			convertToSigned(std::underlying_type_t<T>(_val), val);
		}
		else
		{
			VarHolder::convert(val);
		}
	}   
```