### PR TITLE
UUID parsing

### DIFF
--- a/Foundation/src/UUID.cpp
+++ b/Foundation/src/UUID.cpp
@@ -129,20 +129,21 @@ void UUID::parse(const std::string& uuid)
 
 bool UUID::tryParse(const std::string& uuid)
 {
-	if (uuid.size() < 32)
+	std::string uuidCopy = Poco::trim(uuid);
+	if (uuidCopy.size() < 32)
 		return false;
 
 	bool haveHyphens = false;
-	if (uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-')
+	if (uuidCopy[8] == '-' && uuidCopy[13] == '-' && uuidCopy[18] == '-' && uuidCopy[23] == '-')
 	{
-		if (Poco::trim(uuid).size() == 36)
+		if (uuidCopy.size() == 36)
 			haveHyphens = true;
 		else
 			return false;
 	}
 
 	UUID newUUID;
-	std::string::const_iterator it = uuid.begin();
+	std::string::const_iterator it = uuidCopy.begin();
 	newUUID._timeLow = 0;
 	for (int i = 0; i < 8; ++i)
 	{

--- a/Foundation/src/UUID.cpp
+++ b/Foundation/src/UUID.cpp
@@ -15,6 +15,7 @@
 #include "Poco/UUID.h"
 #include "Poco/ByteOrder.h"
 #include "Poco/Exception.h"
+#include "Poco/String.h"
 #include <algorithm>
 #include <cstring>
 
@@ -134,7 +135,7 @@ bool UUID::tryParse(const std::string& uuid)
 	bool haveHyphens = false;
 	if (uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-')
 	{
-		if (uuid.size() >= 36)
+		if (Poco::trim(uuid).size() == 36)
 			haveHyphens = true;
 		else
 			return false;

--- a/Foundation/testsuite/src/UUIDTest.cpp
+++ b/Foundation/testsuite/src/UUIDTest.cpp
@@ -204,10 +204,18 @@ void UUIDTest::testTryParse()
 	UUID uuid;
 	assertTrue (uuid.tryParse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"));
 	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+	assertTrue (uuid.tryParse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8   "));
+	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
 	UUID notUuid;
 	assertTrue (!notUuid.tryParse("not a uuid"));
 	assertTrue (notUuid.isNull());
+
+	UUID wrongUUID;
+	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b51AA"));
+	assertTrue (wrongUUID.isNull());
+	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b5   "));
+	assertTrue (wrongUUID.isNull());
 }
 
 void UUIDTest::setUp()

--- a/Foundation/testsuite/src/UUIDTest.cpp
+++ b/Foundation/testsuite/src/UUIDTest.cpp
@@ -204,7 +204,7 @@ void UUIDTest::testTryParse()
 	UUID uuid;
 	assertTrue (uuid.tryParse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"));
 	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
-	assertTrue (uuid.tryParse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8   "));
+	assertTrue (uuid.tryParse("  6BA7B810-9DAD-11D1-80B4-00C04FD430C8   "));
 	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
 	UUID notUuid;
@@ -212,9 +212,9 @@ void UUIDTest::testTryParse()
 	assertTrue (notUuid.isNull());
 
 	UUID wrongUUID;
-	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b51AA"));
+	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b51AA")); // too long
 	assertTrue (wrongUUID.isNull());
-	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b5   "));
+	assertFalse (wrongUUID.tryParse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b5   ")); // too short
 	assertTrue (wrongUUID.isNull());
 }
 


### PR DESCRIPTION
Complimentary to #4375
I know that fix already done, but I think that we can do better.
IMHO parsing trimmed uuid string is more careful.

Please look at my approach, may be it usefull 