### PR TITLE
mingw compile and link improvements (#4019)

### DIFF
--- a/Foundation/src/Environment_WIN32U.cpp
+++ b/Foundation/src/Environment_WIN32U.cpp
@@ -18,6 +18,7 @@
 #include "Poco/Buffer.h"
 #include <sstream>
 #include <cstring>
+#include <memory>
 #include "Poco/UnWindows.h"
 #include <winsock2.h>
 #include <wincrypt.h>

--- a/Foundation/testsuite/src/UUIDGeneratorTest.cpp
+++ b/Foundation/testsuite/src/UUIDGeneratorTest.cpp
@@ -18,7 +18,6 @@
 
 
 using Poco::UUIDGenerator;
-using Poco::UUID;
 
 
 UUIDGeneratorTest::UUIDGeneratorTest(const std::string& name): CppUnit::TestCase(name)
@@ -35,11 +34,11 @@ void UUIDGeneratorTest::testTimeBased()
 {
 	UUIDGenerator& gen = UUIDGenerator::defaultGenerator();
 
-	std::set<UUID> uuids;
+    std::set<Poco::UUID> uuids;
 	for (int i = 0; i < 1000; ++i)
 	{
-		UUID uuid = gen.create();
-		assertTrue (uuid.version() == UUID::UUID_TIME_BASED);
+        Poco::UUID uuid = gen.create();
+        assertTrue (uuid.version() == Poco::UUID::UUID_TIME_BASED);
 		assertTrue (uuids.find(uuid) == uuids.end());
 		uuids.insert(uuid);
 	}
@@ -50,11 +49,11 @@ void UUIDGeneratorTest::testRandom()
 {
 	UUIDGenerator& gen = UUIDGenerator::defaultGenerator();
 
-	std::set<UUID> uuids;
+    std::set<Poco::UUID> uuids;
 	for (int i = 0; i < 1000; ++i)
 	{
-		UUID uuid = gen.createRandom();
-		assertTrue (uuid.version() == UUID::UUID_RANDOM);
+        Poco::UUID uuid = gen.createRandom();
+        assertTrue (uuid.version() == Poco::UUID::UUID_RANDOM);
 		assertTrue (uuids.find(uuid) == uuids.end());
 		uuids.insert(uuid);
 	}
@@ -65,28 +64,28 @@ void UUIDGeneratorTest::testNameBased()
 {
 	UUIDGenerator& gen = UUIDGenerator::defaultGenerator();
 
-	UUID uuid1 = gen.createFromName(UUID::uri(), "http://www.appinf.com/uuid");
-	assertTrue (uuid1.version() == UUID::UUID_NAME_BASED);
+    Poco::UUID uuid1 = gen.createFromName(Poco::UUID::uri(), "http://www.appinf.com/uuid");
+    assertTrue (uuid1.version() == Poco::UUID::UUID_NAME_BASED);
 	assertTrue (uuid1.variant() == 2);
 
-	UUID uuid2 = gen.createFromName(UUID::uri(), "http://www.appinf.com/uuid2");
+    Poco::UUID uuid2 = gen.createFromName(Poco::UUID::uri(), "http://www.appinf.com/uuid2");
 	assertTrue (uuid2 != uuid1);
 
-	UUID uuid3 = gen.createFromName(UUID::dns(), "www.appinf.com");
+    Poco::UUID uuid3 = gen.createFromName(Poco::UUID::dns(), "www.appinf.com");
 	assertTrue (uuid3 != uuid1);
 
-	UUID uuid4 = gen.createFromName(UUID::oid(), "1.3.6.1.4.1");
+    Poco::UUID uuid4 = gen.createFromName(Poco::UUID::oid(), "1.3.6.1.4.1");
 	assertTrue (uuid4 != uuid1);
 
-	UUID uuid5 = gen.createFromName(UUID::x500(), "cn=Guenter Obiltschnig, ou=People, o=Applied Informatics, c=at");
+    Poco::UUID uuid5 = gen.createFromName(Poco::UUID::x500(), "cn=Guenter Obiltschnig, ou=People, o=Applied Informatics, c=at");
 	assertTrue (uuid5 != uuid1);
 
-	UUID uuid6 = gen.createFromName(UUID::uri(), "http://www.appinf.com/uuid");
+    Poco::UUID uuid6 = gen.createFromName(Poco::UUID::uri(), "http://www.appinf.com/uuid");
 	assertTrue (uuid6 == uuid1);
 
 	Poco::SHA1Engine sha1;
-	UUID uuid7 = gen.createFromName(UUID::uri(), "http://www.appinf.com/uuid", sha1);
-	assertTrue (uuid7.version() == UUID::UUID_NAME_BASED_SHA1);
+    Poco::UUID uuid7 = gen.createFromName(Poco::UUID::uri(), "http://www.appinf.com/uuid", sha1);
+    assertTrue (uuid7.version() == Poco::UUID::UUID_NAME_BASED_SHA1);
 	assertTrue (uuid7.variant() == 2);
 	assertTrue (uuid7 != uuid1);
 }

--- a/Foundation/testsuite/src/UUIDTest.cpp
+++ b/Foundation/testsuite/src/UUIDTest.cpp
@@ -14,10 +14,6 @@
 #include "Poco/UUID.h"
 #include "Poco/Exception.h"
 
-
-using Poco::UUID;
-
-
 UUIDTest::UUIDTest(const std::string& name): CppUnit::TestCase(name)
 {
 }
@@ -30,7 +26,7 @@ UUIDTest::~UUIDTest()
 
 void UUIDTest::testParse()
 {
-	UUID uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+    Poco::UUID uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
 	uuid.parse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8");
@@ -42,7 +38,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6xA7B8109DAD11D180B400C04FD430C8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -51,7 +47,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6xa7b810-9dad-11d1-80b4-00c04fd430c8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -60,7 +56,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6ba7b810-xdad-11d1-80b4-00c04fd430c8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -69,7 +65,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6ba7b810-9dad-x1d1-80b4-00c04fd430c8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -78,7 +74,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6ba7b810-9dad-11d1-x0b4-00c04fd430c8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -87,7 +83,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("6ba7b810-9dad-11d1-80b4-00x04fd430c8");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -96,7 +92,7 @@ void UUIDTest::testParse()
 	try
 	{
 		uuid.parse("495cff3a-a4b3-11ee-9e54-9cb6d0f68b51AA");
-		fail("invalid UUID - must throw");
+        fail("invalid Poco::UUID - must throw");
 	}
 	catch (Poco::SyntaxException&)
 	{
@@ -106,10 +102,10 @@ void UUIDTest::testParse()
 
 void UUIDTest::testBuffer()
 {
-	UUID uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+    Poco::UUID uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 	char buffer[16];
 	uuid.copyTo(buffer);
-	UUID uuid2;
+    Poco::UUID uuid2;
 	uuid2.copyFrom(buffer);
 	assertTrue (uuid2.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 }
@@ -117,12 +113,12 @@ void UUIDTest::testBuffer()
 
 void UUIDTest::testCompare()
 {
-	UUID null;
+    Poco::UUID null;
 	assertTrue (null.isNull());
-	assertTrue (UUID::null().isNull());
+    assertTrue (Poco::UUID::null().isNull());
 
-	UUID uuid1 = null;
-	UUID uuid2;
+    Poco::UUID uuid1 = null;
+    Poco::UUID uuid2;
 	assertTrue (uuid1.isNull());
 	assertTrue (uuid1 == null);
 	assertTrue (!(uuid1 != null));
@@ -132,7 +128,7 @@ void UUIDTest::testCompare()
 	assertTrue (!(uuid1 < null));
 	assertTrue (uuid1.toString() == "00000000-0000-0000-0000-000000000000");
 
-	uuid1 = UUID::dns();
+    uuid1 = Poco::UUID::dns();
 	assertTrue (!uuid1.isNull());
 	assertTrue (uuid1 != null);
 	assertTrue (!(uuid1 == null));
@@ -161,27 +157,27 @@ void UUIDTest::testCompare()
 
 void UUIDTest::testVersion()
 {
-	UUID uuid("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
-	UUID::Version v = uuid.version();
-	assertTrue (v == UUID::UUID_RANDOM);
+    Poco::UUID uuid("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
+    Poco::UUID::Version v = uuid.version();
+    assertTrue (v == Poco::UUID::UUID_RANDOM);
 
 	uuid.parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 	v = uuid.version();
-	assertTrue (v == UUID::UUID_TIME_BASED);
+    assertTrue (v == Poco::UUID::UUID_TIME_BASED);
 
 	uuid.parse("d2ee4220-3625-11d9-9669-0800200c9a66");
 	v = uuid.version();
-	assertTrue (v == UUID::UUID_TIME_BASED);
+    assertTrue (v == Poco::UUID::UUID_TIME_BASED);
 
 	uuid.parse("360d3652-4411-4786-bbe6-b9675b548559");
 	v = uuid.version();
-	assertTrue (v == UUID::UUID_RANDOM);
+    assertTrue (v == Poco::UUID::UUID_RANDOM);
 }
 
 
 void UUIDTest::testVariant()
 {
-	UUID uuid("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
+    Poco::UUID uuid("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
 	int v = uuid.variant();
 	assertTrue (v == 2);
 
@@ -201,8 +197,8 @@ void UUIDTest::testVariant()
 
 void UUIDTest::testSwap()
 {
-	UUID uuid1("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
-	UUID uuid2("d2ee4220-3625-11d9-9669-0800200c9a66");
+    Poco::UUID uuid1("db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
+    Poco::UUID uuid2("d2ee4220-3625-11d9-9669-0800200c9a66");
 	uuid1.swap(uuid2);
 	assertTrue (uuid1.toString() == "d2ee4220-3625-11d9-9669-0800200c9a66");
 	assertTrue (uuid2.toString() == "db4fa7e9-9e62-4597-99e0-b1ec0b59800e");
@@ -210,11 +206,11 @@ void UUIDTest::testSwap()
 
 void UUIDTest::testTryParse()
 {
-	UUID uuid;
+    Poco::UUID uuid;
 	assertTrue (uuid.tryParse("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"));
 	assertTrue (uuid.toString() == "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
-	UUID notUuid;
+    Poco::UUID notUuid;
 	assertTrue (!notUuid.tryParse("not a uuid"));
 	assertTrue (notUuid.isNull());
 }

--- a/Util/include/Poco/Util/Application.h
+++ b/Util/include/Poco/Util/Application.h
@@ -504,7 +504,8 @@ inline Poco::Timespan Application::uptime() const
 //
 // Macro to implement main()
 //
-#if defined(_WIN32)
+
+#if defined(_WIN32) && !defined(POCO_COMPILER_MINGW)
 	#define POCO_APP_MAIN(App) \
 	int wmain(int argc, wchar_t** argv)		\
 	{										\

--- a/Util/testsuite/src/WinConfigurationTest.cpp
+++ b/Util/testsuite/src/WinConfigurationTest.cpp
@@ -15,7 +15,7 @@
 #include "Poco/Util/WinRegistryKey.h"
 #include "Poco/Environment.h"
 #include "Poco/AutoPtr.h"
-#include "Poco/types.h"
+#include "Poco/Types.h"
 #undef min
 #undef max
 #include <limits>

--- a/cmake/DefinePlatformSpecifc.cmake
+++ b/cmake/DefinePlatformSpecifc.cmake
@@ -49,10 +49,6 @@ else(MSVC)
     set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
 endif(MSVC)
 
-if(MINGW)
-    add_link_options("-municode")
-endif()
-
 if (ENABLE_COMPILER_WARNINGS)
     message(STATUS "Enabling additional compiler warning flags.")
     # Additional compiler-specific warning flags


### PR DESCRIPTION
This PR resolves link errors reported in #4019.

IMO building Poco with MinGW with CMake is in a bad state in general.

Foundation-testrunner, for example doesn't find `Poco::SHA2Engine` and `Data `does not compile at all.

Shall any additional effort be invested in MinGW+CMake?