### PR TITLE
gcc/clang (-fvisibility=hidden): corrections to compile and work properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,36 @@ jobs:
             EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
             ./ci/runtests.sh
 
+  macos-clang-make-visibility-hidden:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - run: brew install openssl@1.1 mysql-client unixodbc libpq
+      - run: >-
+          ./configure --everything --no-prefix --cflags="-fvisibility=hidden" --omit=PDF
+          --odbc-include=/usr/local/opt/unixodbc/include --odbc-lib=/usr/local/opt/unixodbc/lib
+          --mysql-include=/usr/local/opt/mysql-client/include --mysql-lib=/usr/local/opt/mysql-client/lib
+          --include-path="/usr/local/opt/openssl@1.1/include" --library-path="/usr/local/opt/openssl@1.1/lib" &&
+          make all -s -j4
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            sudo -s
+            CPPUNIT_IGNORE="
+            CppUnit::TestCaller<ThreadTest>.testTrySleep,
+            CppUnit::TestCaller<TimestampTest>.testTimestamp,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testExpireN,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testAccessExpireN,
+            CppUnit::TestCaller<UniqueExpireLRUCacheTest>.testExpireN,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testAccessExpireN,
+            CppUnit::TestCaller<SyslogTest>.testOldBSD,
+            CppUnit::TestCaller<PollSetTest>.testPollClosedServer"
+            EXCLUDE_TESTS="Redis Data/MySQL Data/ODBC Data/PostgreSQL MongoDB PDF"
+            ./ci/runtests.sh
+
   macos-clang-cmake-openssl:
     runs-on: macos-12
     steps:
@@ -251,6 +281,31 @@ jobs:
       - uses: actions/checkout@v3
       - run: brew install openssl@3 mysql-client unixodbc libpq
       - run: cmake -S. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build &&
+            sudo -s
+            CPPUNIT_IGNORE="
+            CppUnit::TestCaller<ThreadTest>.testTrySleep,
+            CppUnit::TestCaller<TimestampTest>.testTimestamp,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testExpireN,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testAccessExpireN,
+            CppUnit::TestCaller<UniqueExpireLRUCacheTest>.testExpireN,
+            CppUnit::TestCaller<ExpireLRUCacheTest>.testAccessExpireN,
+            CppUnit::TestCaller<PollSetTest>.testPollClosedServer"
+            PWD=`pwd`
+            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
+
+  macos-clang-cmake-openssl3-visibility-hidden:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - run: brew install openssl@3 mysql-client unixodbc libpq
+      - run: cmake -S. -Bcmake-build -DCMAKE_CXX_VISIBILITY_PRESET=hidden -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
       - uses: ./.github/actions/retry-action
         with:
           timeout_minutes: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: brew install openssl@3 mysql-client unixodbc libpq
-      - run: cmake -S. -Bcmake-build -DCMAKE_CXX_VISIBILITY_PRESET=hidden -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+      - run: cmake -S. -Bcmake-build -DCMAKE_CXX_VISIBILITY_PRESET=hidden -DENABLE_ENCODINGS_COMPILER=ON -DENABLE_PDF=ON -DENABLE_SEVENZIP=ON -DENABLE_CPPPARSER=ON -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
       - uses: ./.github/actions/retry-action
         with:
           timeout_minutes: 90

--- a/ActiveRecord/include/Poco/ActiveRecord/ActiveRecordLib.h
+++ b/ActiveRecord/include/Poco/ActiveRecord/ActiveRecordLib.h
@@ -41,7 +41,11 @@
 
 
 #if !defined(ActiveRecordLib_API)
-	#define ActiveRecordLib_API
+	#if !defined(POCO_NO_GCC_API_ATTRIBUTE) && defined (__GNUC__) && (__GNUC__ >= 4)
+		#define ActiveRecordLib_API __attribute__ ((visibility ("default")))
+	#else
+		#define ActiveRecordLib_API
+	#endif
 #endif
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ endif()
 include(CXX1x)
 check_for_cxx17_compiler(CXX17_COMPILER)
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-
 # If a C++17 compiler is available, then set the appropriate flags
 if(CXX17_COMPILER)
 	set(CMAKE_CXX_STANDARD 17)
@@ -559,6 +557,7 @@ message(STATUS "[cmake] Build type:             ${CMAKE_BUILD_TYPE}")
 string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
 message(STATUS "[cmake] Build with cxx flags:   ${CMAKE_CXX_FLAGS_${BUILD_TYPE}} ${CMAKE_CXX_FLAGS}")
 message(STATUS "[cmake] Build with c flags:     ${CMAKE_C_FLAGS_${BUILD_TYPE}} ${CMAKE_C_FLAGS}")
+message(STATUS "[cmake] C++ symbol visibility:  ${CMAKE_CXX_VISIBILITY_PRESET}")
 
 foreach(component ${Poco_COMPONENTS})
 	message(STATUS "Building: ${component}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ endif()
 include(CXX1x)
 check_for_cxx17_compiler(CXX17_COMPILER)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
 # If a C++17 compiler is available, then set the appropriate flags
 if(CXX17_COMPILER)
 	set(CMAKE_CXX_STANDARD 17)

--- a/CppParser/include/Poco/CppParser/CppParser.h
+++ b/CppParser/include/Poco/CppParser/CppParser.h
@@ -40,8 +40,12 @@
 #endif
 
 
-#if !defined(CppParser_API)
-	#define CppParser_API
+#if !defined(ActiveRecordLib_API)
+	#if !defined(POCO_NO_GCC_API_ATTRIBUTE) && defined (__GNUC__) && (__GNUC__ >= 4)
+		#define CppParser_API __attribute__ ((visibility ("default")))
+	#else
+		#define CppParser_API
+	#endif
 #endif
 
 

--- a/CppParser/include/Poco/CppParser/CppParser.h
+++ b/CppParser/include/Poco/CppParser/CppParser.h
@@ -40,7 +40,7 @@
 #endif
 
 
-#if !defined(ActiveRecordLib_API)
+#if !defined(CppParser_API)
 	#if !defined(POCO_NO_GCC_API_ATTRIBUTE) && defined (__GNUC__) && (__GNUC__ >= 4)
 		#define CppParser_API __attribute__ ((visibility ("default")))
 	#else

--- a/Crypto/include/Poco/Crypto/CipherKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/CipherKeyImpl.h
@@ -33,7 +33,7 @@ namespace Poco {
 namespace Crypto {
 
 
-class CipherKeyImpl: public RefCountedObject
+class Crypto_API CipherKeyImpl: public RefCountedObject
 	/// An implementation of the CipherKey class for OpenSSL's crypto library.
 {
 public:

--- a/Crypto/include/Poco/Crypto/ECKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/ECKeyImpl.h
@@ -40,7 +40,7 @@ class X509Certificate;
 class PKCS12Container;
 
 
-class ECKeyImpl: public KeyPairImpl
+class Crypto_API ECKeyImpl: public KeyPairImpl
 	/// Elliptic Curve key clas implementation.
 {
 public:

--- a/Crypto/include/Poco/Crypto/KeyPairImpl.h
+++ b/Crypto/include/Poco/Crypto/KeyPairImpl.h
@@ -31,7 +31,7 @@ namespace Poco {
 namespace Crypto {
 
 
-class KeyPairImpl: public Poco::RefCountedObject
+class Crypto_API KeyPairImpl: public Poco::RefCountedObject
 	/// Class KeyPairImpl
 {
 public:

--- a/Crypto/include/Poco/Crypto/RSAKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/RSAKeyImpl.h
@@ -43,7 +43,7 @@ class X509Certificate;
 class PKCS12Container;
 
 
-class RSAKeyImpl: public KeyPairImpl
+class Crypto_API RSAKeyImpl: public KeyPairImpl
 	/// class RSAKeyImpl
 {
 public:

--- a/Data/include/Poco/Data/RecordSet.h
+++ b/Data/include/Poco/Data/RecordSet.h
@@ -20,7 +20,6 @@
 
 #include "Poco/Data/Data.h"
 #include "Poco/Data/Session.h"
-#include "Poco/Data/Extraction.h"
 #include "Poco/Data/BulkExtraction.h"
 #include "Poco/Data/Statement.h"
 #include "Poco/Data/RowIterator.h"
@@ -166,100 +165,23 @@ public:
 		/// Returns the number of columns in the recordset.
 
 	template <class C>
-	const Column<C>& column(const std::string& name) const
+	const Column<C>& column(const std::string& name) const;
 		/// Returns the reference to the first Column with the specified name.
-	{
-		if (isBulkExtraction())
-		{
-			using E = InternalBulkExtraction<C>;
-			return columnImpl<C,E>(name);
-		}
-		else
-		{
-			using E = InternalExtraction<C>;
-			return columnImpl<C,E>(name);
-		}
-	}
 
 	template <class C>
-	const Column<C>& column(std::size_t pos) const
-		/// Returns the reference to column at specified position.
-	{
-		if (isBulkExtraction())
-		{
-			using E = InternalBulkExtraction<C>;
-			return columnImpl<C,E>(pos);
-		}
-		else
-		{
-			using E = InternalExtraction<C>;
-			return columnImpl<C,E>(pos);
-		}
-	}
+	const Column<C>& column(std::size_t pos) const;
 
 	Row& row(std::size_t pos);
 		/// Returns reference to row at position pos.
 		/// Rows are lazy-created and cached.
 
 	template <class T>
-	const T& value(std::size_t col, std::size_t row, bool useFilter = true) const
+	const T& value(std::size_t col, std::size_t row, bool useFilter = true) const;
 		/// Returns the reference to data value at [col, row] location.
-	{
-		if (useFilter && isFiltered() && !isAllowed(row))
-			throw InvalidAccessException("Row not allowed");
-
-		switch (storage())
-		{
-			case STORAGE_VECTOR:
-			{
-				using C = typename std::vector<T>;
-				return column<C>(col).value(row);
-			}
-			case STORAGE_LIST:
-			{
-				using C = typename std::list<T>;
-				return column<C>(col).value(row);
-			}
-			case STORAGE_DEQUE:
-			case STORAGE_UNKNOWN:
-			{
-				using C = typename std::deque<T>;
-				return column<C>(col).value(row);
-			}
-			default:
-				throw IllegalStateException("Invalid storage setting.");
-		}
-	}
 
 	template <class T>
-	const T& value(const std::string& name, std::size_t row, bool useFilter = true) const
+	const T& value(const std::string& name, std::size_t row, bool useFilter = true) const;
 		/// Returns the reference to data value at named column, row location.
-	{
-		if (useFilter && isFiltered() && !isAllowed(row))
-			throw InvalidAccessException("Row not allowed");
-
-		switch (storage())
-		{
-			case STORAGE_VECTOR:
-			{
-				using C = typename std::vector<T>;
-				return column<C>(name).value(row);
-			}
-			case STORAGE_LIST:
-			{
-				using C = typename std::list<T>;
-				return column<C>(name).value(row);
-			}
-			case STORAGE_DEQUE:
-			case STORAGE_UNKNOWN:
-			{
-				using C = typename std::deque<T>;
-				return column<C>(name).value(row);
-			}
-			default:
-				throw IllegalStateException("Invalid storage setting.");
-		}
-	}
 
 	Poco::Dynamic::Var value(std::size_t col, std::size_t row, bool checkFiltering = true) const;
 		/// Returns the data value at column, row location.

--- a/Data/src/RecordSet.cpp
+++ b/Data/src/RecordSet.cpp
@@ -150,62 +150,62 @@ const Column<C>& RecordSet::column(const std::string& name) const
 }
 
 
-template const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(const std::string& name) const;
-template const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(const std::string& name) const;
-template const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(const std::string& name) const;
-template const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(const std::string& name) const;
-template const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(const std::string& name) const;
-template const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(const std::string& name) const;
-template const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(const std::string& name) const;
-template const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(const std::string& name) const;
-template const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(const std::string& name) const;
-template const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(const std::string& name) const;
-template const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(const std::string& name) const;
-template const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(const std::string& name) const;
-template const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(const std::string& name) const;
-template const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(const std::string& name) const;
-template const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(const std::string& name) const;
-template const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(const std::string& name) const;
-template const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(const std::string& name) const;
-template const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(const std::string& name) const;
+template Data_API const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(const std::string& name) const;
+template Data_API const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(const std::string& name) const;
+template Data_API const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(const std::string& name) const;
+template Data_API const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(const std::string& name) const;
+template Data_API const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(const std::string& name) const;
+template Data_API const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(const std::string& name) const;
+template Data_API const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(const std::string& name) const;
+template Data_API const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(const std::string& name) const;
+template Data_API const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(const std::string& name) const;
+template Data_API const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(const std::string& name) const;
+template Data_API const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(const std::string& name) const;
+template Data_API const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(const std::string& name) const;
+template Data_API const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(const std::string& name) const;
+template Data_API const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(const std::string& name) const;
+template Data_API const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(const std::string& name) const;
+template Data_API const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(const std::string& name) const;
+template Data_API const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(const std::string& name) const;
+template Data_API const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(const std::string& name) const;
 
-template const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(const std::string& name) const;
-template const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(const std::string& name) const;
-template const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(const std::string& name) const;
-template const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(const std::string& name) const;
-template const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(const std::string& name) const;
-template const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(const std::string& name) const;
-template const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(const std::string& name) const;
-template const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(const std::string& name) const;
-template const Column<std::list<float>>& RecordSet::column<std::list<float>>(const std::string& name) const;
-template const Column<std::list<double>>& RecordSet::column<std::list<double>>(const std::string& name) const;
-template const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(const std::string& name) const;
-template const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(const std::string& name) const;
-template const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(const std::string& name) const;
-template const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(const std::string& name) const;
-template const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(const std::string& name) const;
-template const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(const std::string& name) const;
-template const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(const std::string& name) const;
-template const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(const std::string& name) const;
+template Data_API const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(const std::string& name) const;
+template Data_API const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(const std::string& name) const;
+template Data_API const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(const std::string& name) const;
+template Data_API const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(const std::string& name) const;
+template Data_API const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(const std::string& name) const;
+template Data_API const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(const std::string& name) const;
+template Data_API const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(const std::string& name) const;
+template Data_API const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(const std::string& name) const;
+template Data_API const Column<std::list<float>>& RecordSet::column<std::list<float>>(const std::string& name) const;
+template Data_API const Column<std::list<double>>& RecordSet::column<std::list<double>>(const std::string& name) const;
+template Data_API const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(const std::string& name) const;
+template Data_API const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(const std::string& name) const;
+template Data_API const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(const std::string& name) const;
+template Data_API const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(const std::string& name) const;
+template Data_API const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(const std::string& name) const;
+template Data_API const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(const std::string& name) const;
+template Data_API const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(const std::string& name) const;
+template Data_API const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(const std::string& name) const;
 
-template const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(const std::string& name) const;
-template const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(const std::string& name) const;
-template const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(const std::string& name) const;
-template const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(const std::string& name) const;
-template const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(const std::string& name) const;
-template const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(const std::string& name) const;
-template const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(const std::string& name) const;
-template const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(const std::string& name) const;
-template const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(const std::string& name) const;
-template const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(const std::string& name) const;
-template const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(const std::string& name) const;
-template const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(const std::string& name) const;
-template const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(const std::string& name) const;
-template const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(const std::string& name) const;
-template const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(const std::string& name) const;
-template const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(const std::string& name) const;
-template const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(const std::string& name) const;
-template const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(const std::string& name) const;
+template Data_API const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(const std::string& name) const;
+template Data_API const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(const std::string& name) const;
+template Data_API const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(const std::string& name) const;
+template Data_API const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(const std::string& name) const;
+template Data_API const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(const std::string& name) const;
+template Data_API const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(const std::string& name) const;
+template Data_API const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(const std::string& name) const;
+template Data_API const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(const std::string& name) const;
+template Data_API const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(const std::string& name) const;
+template Data_API const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(const std::string& name) const;
+template Data_API const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(const std::string& name) const;
+template Data_API const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(const std::string& name) const;
+template Data_API const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(const std::string& name) const;
+template Data_API const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(const std::string& name) const;
+template Data_API const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(const std::string& name) const;
+template Data_API const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(const std::string& name) const;
+template Data_API const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(const std::string& name) const;
+template Data_API const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(const std::string& name) const;
 
 
 template <class C>
@@ -225,62 +225,62 @@ const Column<C>& RecordSet::column(std::size_t pos) const
 }
 
 
-template const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(std::size_t pos) const;
-template const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(std::size_t pos) const;
-template const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(std::size_t pos) const;
-template const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(std::size_t pos) const;
-template const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(std::size_t pos) const;
-template const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(std::size_t pos) const;
-template const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(std::size_t pos) const;
-template const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(std::size_t pos) const;
-template const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(std::size_t pos) const;
-template const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(std::size_t pos) const;
-template const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(std::size_t pos) const;
-template const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(std::size_t pos) const;
-template const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(std::size_t pos) const;
-template const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(std::size_t pos) const;
-template const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(std::size_t pos) const;
-template const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(std::size_t pos) const;
-template const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(std::size_t pos) const;
-template const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(std::size_t pos) const;
+template Data_API const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(std::size_t pos) const;
+template Data_API const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(std::size_t pos) const;
+template Data_API const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(std::size_t pos) const;
+template Data_API const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(std::size_t pos) const;
+template Data_API const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(std::size_t pos) const;
+template Data_API const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(std::size_t pos) const;
+template Data_API const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(std::size_t pos) const;
+template Data_API const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(std::size_t pos) const;
+template Data_API const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(std::size_t pos) const;
+template Data_API const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(std::size_t pos) const;
+template Data_API const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(std::size_t pos) const;
+template Data_API const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(std::size_t pos) const;
+template Data_API const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(std::size_t pos) const;
 
-template const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(std::size_t pos) const;
-template const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(std::size_t pos) const;
-template const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(std::size_t pos) const;
-template const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(std::size_t pos) const;
-template const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(std::size_t pos) const;
-template const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(std::size_t pos) const;
-template const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(std::size_t pos) const;
-template const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(std::size_t pos) const;
-template const Column<std::list<float>>& RecordSet::column<std::list<float>>(std::size_t pos) const;
-template const Column<std::list<double>>& RecordSet::column<std::list<double>>(std::size_t pos) const;
-template const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(std::size_t pos) const;
-template const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(std::size_t pos) const;
-template const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(std::size_t pos) const;
-template const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(std::size_t pos) const;
-template const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(std::size_t pos) const;
-template const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(std::size_t pos) const;
-template const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(std::size_t pos) const;
-template const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(std::size_t pos) const;
+template Data_API const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(std::size_t pos) const;
+template Data_API const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(std::size_t pos) const;
+template Data_API const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(std::size_t pos) const;
+template Data_API const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(std::size_t pos) const;
+template Data_API const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(std::size_t pos) const;
+template Data_API const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(std::size_t pos) const;
+template Data_API const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(std::size_t pos) const;
+template Data_API const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(std::size_t pos) const;
+template Data_API const Column<std::list<float>>& RecordSet::column<std::list<float>>(std::size_t pos) const;
+template Data_API const Column<std::list<double>>& RecordSet::column<std::list<double>>(std::size_t pos) const;
+template Data_API const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(std::size_t pos) const;
+template Data_API const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(std::size_t pos) const;
+template Data_API const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(std::size_t pos) const;
+template Data_API const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(std::size_t pos) const;
+template Data_API const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(std::size_t pos) const;
+template Data_API const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(std::size_t pos) const;
+template Data_API const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(std::size_t pos) const;
+template Data_API const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(std::size_t pos) const;
 
-template const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(std::size_t pos) const;
-template const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(std::size_t pos) const;
-template const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(std::size_t pos) const;
-template const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(std::size_t pos) const;
-template const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(std::size_t pos) const;
-template const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(std::size_t pos) const;
-template const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(std::size_t pos) const;
-template const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(std::size_t pos) const;
-template const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(std::size_t pos) const;
-template const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(std::size_t pos) const;
-template const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(std::size_t pos) const;
-template const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(std::size_t pos) const;
-template const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(std::size_t pos) const;
-template const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(std::size_t pos) const;
-template const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(std::size_t pos) const;
-template const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(std::size_t pos) const;
-template const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(std::size_t pos) const;
-template const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(std::size_t pos) const;
+template Data_API const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(std::size_t pos) const;
+template Data_API const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(std::size_t pos) const;
+template Data_API const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(std::size_t pos) const;
+template Data_API const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(std::size_t pos) const;
+template Data_API const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(std::size_t pos) const;
+template Data_API const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(std::size_t pos) const;
+template Data_API const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(std::size_t pos) const;
+template Data_API const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(std::size_t pos) const;
+template Data_API const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(std::size_t pos) const;
+template Data_API const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(std::size_t pos) const;
+template Data_API const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(std::size_t pos) const;
+template Data_API const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(std::size_t pos) const;
+template Data_API const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(std::size_t pos) const;
 
 
 template <class T>
@@ -314,24 +314,24 @@ const T& RecordSet::value(std::size_t col, std::size_t row, bool useFilter) cons
 }
 
 
-template const bool& RecordSet::value<bool>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UInt8& RecordSet::value<UInt8>(std::size_t col, std::size_t row, bool useFilter) const;
-template const Int16& RecordSet::value<Int16>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UInt16& RecordSet::value<UInt16>(std::size_t col, std::size_t row, bool useFilter) const;
-template const Int32& RecordSet::value<Int32>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UInt32& RecordSet::value<UInt32>(std::size_t col, std::size_t row, bool useFilter) const;
-template const Int64& RecordSet::value<Int64>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UInt64& RecordSet::value<UInt64>(std::size_t col, std::size_t row, bool useFilter) const;
-template const float& RecordSet::value<float>(std::size_t col, std::size_t row, bool useFilter) const;
-template const double& RecordSet::value<double>(std::size_t col, std::size_t row, bool useFilter) const;
-template const std::string& RecordSet::value<std::string>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UTF16String& RecordSet::value<UTF16String>(std::size_t col, std::size_t row, bool useFilter) const;
-template const BLOB& RecordSet::value<BLOB>(std::size_t col, std::size_t row, bool useFilter) const;
-template const CLOB& RecordSet::value<CLOB>(std::size_t col, std::size_t row, bool useFilter) const;
-template const Date& RecordSet::value<Date>(std::size_t col, std::size_t row, bool useFilter) const;
-template const Time& RecordSet::value<Time>(std::size_t col, std::size_t row, bool useFilter) const;
-template const DateTime& RecordSet::value<DateTime>(std::size_t col, std::size_t row, bool useFilter) const;
-template const UUID& RecordSet::value<UUID>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const bool& RecordSet::value<bool>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UInt8& RecordSet::value<UInt8>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const Int16& RecordSet::value<Int16>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UInt16& RecordSet::value<UInt16>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const Int32& RecordSet::value<Int32>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UInt32& RecordSet::value<UInt32>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const Int64& RecordSet::value<Int64>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UInt64& RecordSet::value<UInt64>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const float& RecordSet::value<float>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const double& RecordSet::value<double>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const std::string& RecordSet::value<std::string>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UTF16String& RecordSet::value<UTF16String>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const BLOB& RecordSet::value<BLOB>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const CLOB& RecordSet::value<CLOB>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const Date& RecordSet::value<Date>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const Time& RecordSet::value<Time>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const DateTime& RecordSet::value<DateTime>(std::size_t col, std::size_t row, bool useFilter) const;
+template Data_API const UUID& RecordSet::value<UUID>(std::size_t col, std::size_t row, bool useFilter) const;
 
 
 template <class T>
@@ -365,24 +365,24 @@ const T& RecordSet::value(const std::string& name, std::size_t row, bool useFilt
 }
 
 
-template const bool& RecordSet::value<bool>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UInt8& RecordSet::value<UInt8>(const std::string& name, std::size_t row, bool useFilter) const;
-template const Int16& RecordSet::value<Int16>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UInt16& RecordSet::value<UInt16>(const std::string& name, std::size_t row, bool useFilter) const;
-template const Int32& RecordSet::value<Int32>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UInt32& RecordSet::value<UInt32>(const std::string& name, std::size_t row, bool useFilter) const;
-template const Int64& RecordSet::value<Int64>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UInt64& RecordSet::value<UInt64>(const std::string& name, std::size_t row, bool useFilter) const;
-template const float& RecordSet::value<float>(const std::string& name, std::size_t row, bool useFilter) const;
-template const double& RecordSet::value<double>(const std::string& name, std::size_t row, bool useFilter) const;
-template const std::string& RecordSet::value<std::string>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UTF16String& RecordSet::value<UTF16String>(const std::string& name, std::size_t row, bool useFilter) const;
-template const BLOB& RecordSet::value<BLOB>(const std::string& name, std::size_t row, bool useFilter) const;
-template const CLOB& RecordSet::value<CLOB>(const std::string& name, std::size_t row, bool useFilter) const;
-template const Date& RecordSet::value<Date>(const std::string& name, std::size_t row, bool useFilter) const;
-template const Time& RecordSet::value<Time>(const std::string& name, std::size_t row, bool useFilter) const;
-template const DateTime& RecordSet::value<DateTime>(const std::string& name, std::size_t row, bool useFilter) const;
-template const UUID& RecordSet::value<UUID>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const bool& RecordSet::value<bool>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UInt8& RecordSet::value<UInt8>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const Int16& RecordSet::value<Int16>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UInt16& RecordSet::value<UInt16>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const Int32& RecordSet::value<Int32>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UInt32& RecordSet::value<UInt32>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const Int64& RecordSet::value<Int64>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UInt64& RecordSet::value<UInt64>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const float& RecordSet::value<float>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const double& RecordSet::value<double>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const std::string& RecordSet::value<std::string>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UTF16String& RecordSet::value<UTF16String>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const BLOB& RecordSet::value<BLOB>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const CLOB& RecordSet::value<CLOB>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const Date& RecordSet::value<Date>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const Time& RecordSet::value<Time>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const DateTime& RecordSet::value<DateTime>(const std::string& name, std::size_t row, bool useFilter) const;
+template Data_API const UUID& RecordSet::value<UUID>(const std::string& name, std::size_t row, bool useFilter) const;
 
 
 Poco::Dynamic::Var RecordSet::value(std::size_t col, std::size_t row, bool useFilter) const

--- a/Data/src/RecordSet.cpp
+++ b/Data/src/RecordSet.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/Data/RecordSet.h"
+#include "Poco/Data/Extraction.h"
 #include "Poco/Data/RowFilter.h"
 #include "Poco/Data/Date.h"
 #include "Poco/Data/Time.h"
@@ -130,6 +131,258 @@ void RecordSet::reset(const Statement& stmt)
 	_pBegin = new RowIterator(this, 0 == rowsExtracted());
 	_pEnd = new RowIterator(this, true);
 }
+
+
+template <class C>
+const Column<C>& RecordSet::column(const std::string& name) const
+	/// Returns the reference to the first Column with the specified name.
+{
+	if (isBulkExtraction())
+	{
+		using E = InternalBulkExtraction<C>;
+		return columnImpl<C,E>(name);
+	}
+	else
+	{
+		using E = InternalExtraction<C>;
+		return columnImpl<C,E>(name);
+	}
+}
+
+
+template const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(const std::string& name) const;
+template const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(const std::string& name) const;
+template const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(const std::string& name) const;
+template const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(const std::string& name) const;
+template const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(const std::string& name) const;
+template const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(const std::string& name) const;
+template const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(const std::string& name) const;
+template const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(const std::string& name) const;
+template const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(const std::string& name) const;
+template const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(const std::string& name) const;
+template const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(const std::string& name) const;
+template const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(const std::string& name) const;
+template const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(const std::string& name) const;
+template const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(const std::string& name) const;
+template const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(const std::string& name) const;
+template const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(const std::string& name) const;
+template const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(const std::string& name) const;
+template const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(const std::string& name) const;
+
+template const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(const std::string& name) const;
+template const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(const std::string& name) const;
+template const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(const std::string& name) const;
+template const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(const std::string& name) const;
+template const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(const std::string& name) const;
+template const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(const std::string& name) const;
+template const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(const std::string& name) const;
+template const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(const std::string& name) const;
+template const Column<std::list<float>>& RecordSet::column<std::list<float>>(const std::string& name) const;
+template const Column<std::list<double>>& RecordSet::column<std::list<double>>(const std::string& name) const;
+template const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(const std::string& name) const;
+template const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(const std::string& name) const;
+template const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(const std::string& name) const;
+template const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(const std::string& name) const;
+template const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(const std::string& name) const;
+template const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(const std::string& name) const;
+template const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(const std::string& name) const;
+template const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(const std::string& name) const;
+
+template const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(const std::string& name) const;
+template const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(const std::string& name) const;
+template const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(const std::string& name) const;
+template const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(const std::string& name) const;
+template const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(const std::string& name) const;
+template const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(const std::string& name) const;
+template const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(const std::string& name) const;
+template const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(const std::string& name) const;
+template const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(const std::string& name) const;
+template const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(const std::string& name) const;
+template const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(const std::string& name) const;
+template const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(const std::string& name) const;
+template const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(const std::string& name) const;
+template const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(const std::string& name) const;
+template const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(const std::string& name) const;
+template const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(const std::string& name) const;
+template const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(const std::string& name) const;
+template const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(const std::string& name) const;
+
+
+template <class C>
+const Column<C>& RecordSet::column(std::size_t pos) const
+	/// Returns the reference to column at specified position.
+{
+	if (isBulkExtraction())
+	{
+		using E = InternalBulkExtraction<C>;
+		return columnImpl<C,E>(pos);
+	}
+	else
+	{
+		using E = InternalExtraction<C>;
+		return columnImpl<C,E>(pos);
+	}
+}
+
+
+template const Column<std::vector<bool>>& RecordSet::column<std::vector<bool>>(std::size_t pos) const;
+template const Column<std::vector<UInt8>>& RecordSet::column<std::vector<UInt8>>(std::size_t pos) const;
+template const Column<std::vector<Int16>>& RecordSet::column<std::vector<Int16>>(std::size_t pos) const;
+template const Column<std::vector<UInt16>>& RecordSet::column<std::vector<UInt16>>(std::size_t pos) const;
+template const Column<std::vector<Int32>>& RecordSet::column<std::vector<Int32>>(std::size_t pos) const;
+template const Column<std::vector<UInt32>>& RecordSet::column<std::vector<UInt32>>(std::size_t pos) const;
+template const Column<std::vector<Int64>>& RecordSet::column<std::vector<Int64>>(std::size_t pos) const;
+template const Column<std::vector<UInt64>>& RecordSet::column<std::vector<UInt64>>(std::size_t pos) const;
+template const Column<std::vector<float>>& RecordSet::column<std::vector<float>>(std::size_t pos) const;
+template const Column<std::vector<double>>& RecordSet::column<std::vector<double>>(std::size_t pos) const;
+template const Column<std::vector<std::string>>& RecordSet::column<std::vector<std::string>>(std::size_t pos) const;
+template const Column<std::vector<UTF16String>>& RecordSet::column<std::vector<UTF16String>>(std::size_t pos) const;
+template const Column<std::vector<BLOB>>& RecordSet::column<std::vector<BLOB>>(std::size_t pos) const;
+template const Column<std::vector<CLOB>>& RecordSet::column<std::vector<CLOB>>(std::size_t pos) const;
+template const Column<std::vector<Date>>& RecordSet::column<std::vector<Date>>(std::size_t pos) const;
+template const Column<std::vector<Time>>& RecordSet::column<std::vector<Time>>(std::size_t pos) const;
+template const Column<std::vector<DateTime>>& RecordSet::column<std::vector<DateTime>>(std::size_t pos) const;
+template const Column<std::vector<UUID>>& RecordSet::column<std::vector<UUID>>(std::size_t pos) const;
+
+template const Column<std::list<bool>>& RecordSet::column<std::list<bool>>(std::size_t pos) const;
+template const Column<std::list<UInt8>>& RecordSet::column<std::list<UInt8>>(std::size_t pos) const;
+template const Column<std::list<Int16>>& RecordSet::column<std::list<Int16>>(std::size_t pos) const;
+template const Column<std::list<UInt16>>& RecordSet::column<std::list<UInt16>>(std::size_t pos) const;
+template const Column<std::list<Int32>>& RecordSet::column<std::list<Int32>>(std::size_t pos) const;
+template const Column<std::list<UInt32>>& RecordSet::column<std::list<UInt32>>(std::size_t pos) const;
+template const Column<std::list<Int64>>& RecordSet::column<std::list<Int64>>(std::size_t pos) const;
+template const Column<std::list<UInt64>>& RecordSet::column<std::list<UInt64>>(std::size_t pos) const;
+template const Column<std::list<float>>& RecordSet::column<std::list<float>>(std::size_t pos) const;
+template const Column<std::list<double>>& RecordSet::column<std::list<double>>(std::size_t pos) const;
+template const Column<std::list<std::string>>& RecordSet::column<std::list<std::string>>(std::size_t pos) const;
+template const Column<std::list<UTF16String>>& RecordSet::column<std::list<UTF16String>>(std::size_t pos) const;
+template const Column<std::list<BLOB>>& RecordSet::column<std::list<BLOB>>(std::size_t pos) const;
+template const Column<std::list<CLOB>>& RecordSet::column<std::list<CLOB>>(std::size_t pos) const;
+template const Column<std::list<Date>>& RecordSet::column<std::list<Date>>(std::size_t pos) const;
+template const Column<std::list<Time>>& RecordSet::column<std::list<Time>>(std::size_t pos) const;
+template const Column<std::list<DateTime>>& RecordSet::column<std::list<DateTime>>(std::size_t pos) const;
+template const Column<std::list<UUID>>& RecordSet::column<std::list<UUID>>(std::size_t pos) const;
+
+template const Column<std::deque<bool>>& RecordSet::column<std::deque<bool>>(std::size_t pos) const;
+template const Column<std::deque<UInt8>>& RecordSet::column<std::deque<UInt8>>(std::size_t pos) const;
+template const Column<std::deque<Int16>>& RecordSet::column<std::deque<Int16>>(std::size_t pos) const;
+template const Column<std::deque<UInt16>>& RecordSet::column<std::deque<UInt16>>(std::size_t pos) const;
+template const Column<std::deque<Int32>>& RecordSet::column<std::deque<Int32>>(std::size_t pos) const;
+template const Column<std::deque<UInt32>>& RecordSet::column<std::deque<UInt32>>(std::size_t pos) const;
+template const Column<std::deque<Int64>>& RecordSet::column<std::deque<Int64>>(std::size_t pos) const;
+template const Column<std::deque<UInt64>>& RecordSet::column<std::deque<UInt64>>(std::size_t pos) const;
+template const Column<std::deque<float>>& RecordSet::column<std::deque<float>>(std::size_t pos) const;
+template const Column<std::deque<double>>& RecordSet::column<std::deque<double>>(std::size_t pos) const;
+template const Column<std::deque<std::string>>& RecordSet::column<std::deque<std::string>>(std::size_t pos) const;
+template const Column<std::deque<UTF16String>>& RecordSet::column<std::deque<UTF16String>>(std::size_t pos) const;
+template const Column<std::deque<BLOB>>& RecordSet::column<std::deque<BLOB>>(std::size_t pos) const;
+template const Column<std::deque<CLOB>>& RecordSet::column<std::deque<CLOB>>(std::size_t pos) const;
+template const Column<std::deque<Date>>& RecordSet::column<std::deque<Date>>(std::size_t pos) const;
+template const Column<std::deque<Time>>& RecordSet::column<std::deque<Time>>(std::size_t pos) const;
+template const Column<std::deque<DateTime>>& RecordSet::column<std::deque<DateTime>>(std::size_t pos) const;
+template const Column<std::deque<UUID>>& RecordSet::column<std::deque<UUID>>(std::size_t pos) const;
+
+
+template <class T>
+const T& RecordSet::value(std::size_t col, std::size_t row, bool useFilter) const
+	/// Returns the reference to data value at [col, row] location.
+{
+	if (useFilter && isFiltered() && !isAllowed(row))
+		throw InvalidAccessException("Row not allowed");
+
+	switch (storage())
+	{
+		case STORAGE_VECTOR:
+		{
+			using C = typename std::vector<T>;
+			return column<C>(col).value(row);
+		}
+		case STORAGE_LIST:
+		{
+			using C = typename std::list<T>;
+			return column<C>(col).value(row);
+		}
+		case STORAGE_DEQUE:
+		case STORAGE_UNKNOWN:
+		{
+			using C = typename std::deque<T>;
+			return column<C>(col).value(row);
+		}
+		default:
+			throw IllegalStateException("Invalid storage setting.");
+	}
+}
+
+
+template const bool& RecordSet::value<bool>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UInt8& RecordSet::value<UInt8>(std::size_t col, std::size_t row, bool useFilter) const;
+template const Int16& RecordSet::value<Int16>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UInt16& RecordSet::value<UInt16>(std::size_t col, std::size_t row, bool useFilter) const;
+template const Int32& RecordSet::value<Int32>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UInt32& RecordSet::value<UInt32>(std::size_t col, std::size_t row, bool useFilter) const;
+template const Int64& RecordSet::value<Int64>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UInt64& RecordSet::value<UInt64>(std::size_t col, std::size_t row, bool useFilter) const;
+template const float& RecordSet::value<float>(std::size_t col, std::size_t row, bool useFilter) const;
+template const double& RecordSet::value<double>(std::size_t col, std::size_t row, bool useFilter) const;
+template const std::string& RecordSet::value<std::string>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UTF16String& RecordSet::value<UTF16String>(std::size_t col, std::size_t row, bool useFilter) const;
+template const BLOB& RecordSet::value<BLOB>(std::size_t col, std::size_t row, bool useFilter) const;
+template const CLOB& RecordSet::value<CLOB>(std::size_t col, std::size_t row, bool useFilter) const;
+template const Date& RecordSet::value<Date>(std::size_t col, std::size_t row, bool useFilter) const;
+template const Time& RecordSet::value<Time>(std::size_t col, std::size_t row, bool useFilter) const;
+template const DateTime& RecordSet::value<DateTime>(std::size_t col, std::size_t row, bool useFilter) const;
+template const UUID& RecordSet::value<UUID>(std::size_t col, std::size_t row, bool useFilter) const;
+
+
+template <class T>
+const T& RecordSet::value(const std::string& name, std::size_t row, bool useFilter) const
+	/// Returns the reference to data value at named column, row location.
+{
+	if (useFilter && isFiltered() && !isAllowed(row))
+		throw InvalidAccessException("Row not allowed");
+
+	switch (storage())
+	{
+		case STORAGE_VECTOR:
+		{
+			using C = typename std::vector<T>;
+			return column<C>(name).value(row);
+		}
+		case STORAGE_LIST:
+		{
+			using C = typename std::list<T>;
+			return column<C>(name).value(row);
+		}
+		case STORAGE_DEQUE:
+		case STORAGE_UNKNOWN:
+		{
+			using C = typename std::deque<T>;
+			return column<C>(name).value(row);
+		}
+		default:
+			throw IllegalStateException("Invalid storage setting.");
+	}
+}
+
+
+template const bool& RecordSet::value<bool>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UInt8& RecordSet::value<UInt8>(const std::string& name, std::size_t row, bool useFilter) const;
+template const Int16& RecordSet::value<Int16>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UInt16& RecordSet::value<UInt16>(const std::string& name, std::size_t row, bool useFilter) const;
+template const Int32& RecordSet::value<Int32>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UInt32& RecordSet::value<UInt32>(const std::string& name, std::size_t row, bool useFilter) const;
+template const Int64& RecordSet::value<Int64>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UInt64& RecordSet::value<UInt64>(const std::string& name, std::size_t row, bool useFilter) const;
+template const float& RecordSet::value<float>(const std::string& name, std::size_t row, bool useFilter) const;
+template const double& RecordSet::value<double>(const std::string& name, std::size_t row, bool useFilter) const;
+template const std::string& RecordSet::value<std::string>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UTF16String& RecordSet::value<UTF16String>(const std::string& name, std::size_t row, bool useFilter) const;
+template const BLOB& RecordSet::value<BLOB>(const std::string& name, std::size_t row, bool useFilter) const;
+template const CLOB& RecordSet::value<CLOB>(const std::string& name, std::size_t row, bool useFilter) const;
+template const Date& RecordSet::value<Date>(const std::string& name, std::size_t row, bool useFilter) const;
+template const Time& RecordSet::value<Time>(const std::string& name, std::size_t row, bool useFilter) const;
+template const DateTime& RecordSet::value<DateTime>(const std::string& name, std::size_t row, bool useFilter) const;
+template const UUID& RecordSet::value<UUID>(const std::string& name, std::size_t row, bool useFilter) const;
 
 
 Poco::Dynamic::Var RecordSet::value(std::size_t col, std::size_t row, bool useFilter) const

--- a/Foundation/include/Poco/Dynamic/Struct.h
+++ b/Foundation/include/Poco/Dynamic/Struct.h
@@ -288,6 +288,13 @@ private:
 };
 
 
+extern template class Foundation_API Struct<std::string>;
+extern template class Foundation_API Struct<int>;
+
+extern template class Foundation_API Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
+extern template class Foundation_API Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
+
+
 template <>
 class VarHolderImpl<Struct<std::string, std::map<std::string, Var>, std::set<std::string>>>: public VarHolder
 {
@@ -959,8 +966,8 @@ private:
 } // namespace Dynamic
 
 
-typedef Dynamic::Struct<std::string> DynamicStruct;
-typedef Dynamic::Struct<std::string, Poco::OrderedMap<std::string, Dynamic::Var>, Poco::OrderedSet<std::string>> OrderedDynamicStruct;
+using DynamicStruct = Dynamic::Struct<std::string>;
+using OrderedDynamicStruct = Dynamic::Struct<std::string, Poco::OrderedMap<std::string, Dynamic::Var>, Poco::OrderedSet<std::string>>;
 
 
 } // namespace Poco

--- a/Foundation/include/Poco/Dynamic/Struct.h
+++ b/Foundation/include/Poco/Dynamic/Struct.h
@@ -288,11 +288,23 @@ private:
 };
 
 
+#if defined(POCO_OS_FAMILY_WINDOWS)
+
+extern template class Struct<std::string>;
+extern template class Struct<int>;
+
+extern template class Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
+extern template class Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
+
+#else
+
 extern template class Foundation_API Struct<std::string>;
 extern template class Foundation_API Struct<int>;
 
 extern template class Foundation_API Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
 extern template class Foundation_API Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
+
+#endif
 
 
 template <>

--- a/Foundation/include/Poco/FPEnvironment_C99.h
+++ b/Foundation/include/Poco/FPEnvironment_C99.h
@@ -26,7 +26,7 @@
 namespace Poco {
 
 
-class FPEnvironmentImpl
+class Foundation_API FPEnvironmentImpl
 {
 protected:
 	enum RoundingModeImpl

--- a/Foundation/include/Poco/FPEnvironment_DEC.h
+++ b/Foundation/include/Poco/FPEnvironment_DEC.h
@@ -29,7 +29,7 @@
 namespace Poco {
 
 
-class FPEnvironmentImpl
+class Foundation_API FPEnvironmentImpl
 {
 protected:
 	enum RoundingModeImpl

--- a/Foundation/include/Poco/FPEnvironment_QNX.h
+++ b/Foundation/include/Poco/FPEnvironment_QNX.h
@@ -26,7 +26,7 @@
 namespace Poco {
 
 
-class FPEnvironmentImpl
+class Foundation_API FPEnvironmentImpl
 {
 protected:
 	enum RoundingModeImpl

--- a/Foundation/include/Poco/FPEnvironment_SUN.h
+++ b/Foundation/include/Poco/FPEnvironment_SUN.h
@@ -25,7 +25,7 @@
 namespace Poco {
 
 
-class FPEnvironmentImpl
+class Foundation_API FPEnvironmentImpl
 {
 protected:
 	enum RoundingModeImpl

--- a/Foundation/include/Poco/UTFString.h
+++ b/Foundation/include/Poco/UTFString.h
@@ -271,29 +271,35 @@ struct UTF32CharTraits
 		typedef std::basic_string<UTF16Char, UTF16CharTraits> UTF16String;
 		typedef UInt32                                        UTF32Char;
 		typedef std::basic_string<UTF32Char, UTF32CharTraits> UTF32String;
+		#define POCO_USE_STRING16
+		#define POCO_USE_STRING32
 	#else // POCO_NO_WSTRING
 		#if defined(POCO_OS_FAMILY_WINDOWS)
 			typedef wchar_t                                       UTF16Char;
 			typedef std::wstring                                  UTF16String;
 			typedef UInt32                                        UTF32Char;
 			typedef std::basic_string<UTF32Char, UTF32CharTraits> UTF32String;
+			#define POCO_USE_STRING32
 		#elif defined(__SIZEOF_WCHAR_T__) //gcc
 			#if (__SIZEOF_WCHAR_T__ == 2)
 				typedef wchar_t                                       UTF16Char;
 				typedef std::wstring                                  UTF16String;
 				typedef UInt32                                        UTF32Char;
 				typedef std::basic_string<UTF32Char, UTF32CharTraits> UTF32String;
+				#define POCO_USE_STRING32
 			#elif (__SIZEOF_WCHAR_T__ == 4)
 				typedef Poco::UInt16                                  UTF16Char;
 				typedef std::basic_string<UTF16Char, UTF16CharTraits> UTF16String;
 				typedef wchar_t                                       UTF32Char;
 				typedef std::wstring                                  UTF32String;
+				#define POCO_USE_STRING16
 			#endif
 		#else // default to 32-bit wchar_t
 			typedef Poco::UInt16                                  UTF16Char;
 			typedef std::basic_string<UTF16Char, UTF16CharTraits> UTF16String;
 			typedef wchar_t                                       UTF32Char;
 			typedef std::wstring                                  UTF32String;
+			#define POCO_USE_STRING16
 		#endif //POCO_OS_FAMILY_WINDOWS
 	#endif //POCO_NO_WSTRING
 //#endif // POCO_ENABLE_CPP11
@@ -301,5 +307,16 @@ struct UTF32CharTraits
 
 } // namespace Poco
 
+namespace std {
+
+#if defined(POCO_USE_STRING16)
+extern template class Foundation_API std::basic_string<Poco::UTF16Char, Poco::UTF16CharTraits>;
+#endif
+
+#if defined(POCO_USE_STRING32)
+extern template class Foundation_API std::basic_string<Poco::UTF32Char, Poco::UTF32CharTraits>;
+#endif
+
+}
 
 #endif // Foundation_UTFString_INCLUDED

--- a/Foundation/include/Poco/UTFString.h
+++ b/Foundation/include/Poco/UTFString.h
@@ -279,7 +279,6 @@ struct UTF32CharTraits
 			typedef std::wstring                                  UTF16String;
 			typedef UInt32                                        UTF32Char;
 			typedef std::basic_string<UTF32Char, UTF32CharTraits> UTF32String;
-			#define POCO_USE_STRING32
 		#elif defined(__SIZEOF_WCHAR_T__) //gcc
 			#if (__SIZEOF_WCHAR_T__ == 2)
 				typedef wchar_t                                       UTF16Char;
@@ -307,7 +306,6 @@ struct UTF32CharTraits
 
 } // namespace Poco
 
-namespace std {
 
 #if defined(POCO_USE_STRING16)
 extern template class Foundation_API std::basic_string<Poco::UTF16Char, Poco::UTF16CharTraits>;
@@ -317,6 +315,5 @@ extern template class Foundation_API std::basic_string<Poco::UTF16Char, Poco::UT
 extern template class Foundation_API std::basic_string<Poco::UTF32Char, Poco::UTF32CharTraits>;
 #endif
 
-}
 
 #endif // Foundation_UTFString_INCLUDED

--- a/Foundation/src/UTF8String.cpp
+++ b/Foundation/src/UTF8String.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/UTF8String.h"
+#include "Poco/UTFString.h"
 #include "Poco/Unicode.h"
 #include "Poco/TextIterator.h"
 #include "Poco/TextConverter.h"
@@ -21,6 +22,18 @@
 #include "Poco/Ascii.h"
 #include <algorithm>
 
+
+namespace std {
+
+#if defined(POCO_USE_STRING16)
+template class std::basic_string<Poco::UTF16Char, Poco::UTF16CharTraits>;
+#endif
+
+#if defined(POCO_USE_STRING32)
+template class std::basic_string<Poco::UTF32Char, Poco::UTF32CharTraits>;
+#endif
+	
+}
 
 namespace Poco {
 

--- a/Foundation/src/UTF8String.cpp
+++ b/Foundation/src/UTF8String.cpp
@@ -23,7 +23,7 @@
 #include <algorithm>
 
 
-namespace std {
+#if !defined(POCO_OS_FAMILY_WINDOWS)
 
 #if defined(POCO_USE_STRING16)
 template class std::basic_string<Poco::UTF16Char, Poco::UTF16CharTraits>;
@@ -32,8 +32,8 @@ template class std::basic_string<Poco::UTF16Char, Poco::UTF16CharTraits>;
 #if defined(POCO_USE_STRING32)
 template class std::basic_string<Poco::UTF32Char, Poco::UTF32CharTraits>;
 #endif
-	
-}
+
+#endif
 
 namespace Poco {
 

--- a/Foundation/src/VarHolder.cpp
+++ b/Foundation/src/VarHolder.cpp
@@ -22,11 +22,23 @@ namespace Poco {
 namespace Dynamic {
 
 
+#if defined(POCO_OS_FAMILY_WINDOWS)
+
+template class Foundation_API Struct<std::string>;
+template class Foundation_API Struct<int>;
+
+template class Foundation_API Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
+template class Foundation_API Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
+
+#else
+
 template class Struct<std::string>;
 template class Struct<int>;
 
 template class Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
 template class Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
+
+#endif
 
 
 VarHolder::VarHolder()

--- a/Foundation/src/VarHolder.cpp
+++ b/Foundation/src/VarHolder.cpp
@@ -14,11 +14,19 @@
 
 #include "Poco/Dynamic/VarHolder.h"
 #include "Poco/Dynamic/Var.h"
+#include "Poco/Dynamic/Struct.h"
 #include "Poco/JSONString.h"
 
 
 namespace Poco {
 namespace Dynamic {
+
+
+template class Struct<std::string>;
+template class Struct<int>;
+
+template class Struct<std::string, Poco::OrderedMap<std::string, Var>, Poco::OrderedSet<std::string>>;
+template class Struct<int, OrderedMap<int, Var>, OrderedSet<int>>;
 
 
 VarHolder::VarHolder()

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -2356,7 +2356,7 @@ void VarTest::testOrderedDynamicStructString()
 	assertTrue(a1["First Name"] == "Senior");
 	testGetIdxMustThrow(a1, 0);
 
-	typedef Struct<std::string, OrderedMap<std::string, Var>, OrderedSet<std::string> > OrderedStruct;
+	using OrderedStruct = OrderedDynamicStruct;
 	OrderedStruct s1;
 	s1["1"] = 1;
 	s1["2"] = 2;

--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -33,8 +33,14 @@ class JSON_API Array;
 
 }
 
+
+#if defined(POCO_OS_FAMILY_WINDOWS)
+// Explicitly instantiated shared pointer in JSON library
+extern template class Poco::SharedPtr<Poco::JSON::Array>;
+#else
 // Explicitly instantiated shared pointer in JSON library
 extern template class JSON_API Poco::SharedPtr<Poco::JSON::Array>;
+#endif
 
 namespace JSON {
 

--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -26,8 +26,17 @@
 
 
 namespace Poco {
+
 namespace JSON {
 
+class JSON_API Array;
+
+}
+
+// Explicitly instantiated shared pointer in JSON library
+extern template class JSON_API Poco::SharedPtr<Poco::JSON::Array>;
+
+namespace JSON {
 
 class Object;
 

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -34,8 +34,17 @@
 
 
 namespace Poco {
+
 namespace JSON {
 
+class JSON_API Object;
+
+}
+
+// Explicitly instatiated shared pointer in JSON library
+extern template class JSON_API Poco::SharedPtr<Poco::JSON::Object>;
+
+namespace JSON {
 
 class JSON_API Object
 	/// Represents a JSON object. Object provides a representation based on

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -41,8 +41,13 @@ class JSON_API Object;
 
 }
 
+#if defined(POCO_OS_FAMILY_WINDOWS)
+// Explicitly instatiated shared pointer in JSON library
+extern template class Poco::SharedPtr<Poco::JSON::Object>;
+#else
 // Explicitly instatiated shared pointer in JSON library
 extern template class JSON_API Poco::SharedPtr<Poco::JSON::Object>;
+#endif
 
 namespace JSON {
 

--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -20,6 +20,10 @@
 
 using Poco::Dynamic::Var;
 
+// Explicitly instatiated shared pointer in JSON library is required to
+// have known instance of the pointer to be used with VarHolder when
+// compiling with -fvisibility=hidden
+template class Poco::SharedPtr<Poco::JSON::Array>;
 
 namespace Poco {
 namespace JSON {

--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -23,7 +23,12 @@ using Poco::Dynamic::Var;
 // Explicitly instatiated shared pointer in JSON library is required to
 // have known instance of the pointer to be used with VarHolder when
 // compiling with -fvisibility=hidden
+#if defined(POCO_OS_FAMILY_WINDOWS)
+template class JSON_API Poco::SharedPtr<Poco::JSON::Array>;
+#else
 template class Poco::SharedPtr<Poco::JSON::Array>;
+#endif
+
 
 namespace Poco {
 namespace JSON {

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -19,8 +19,13 @@
 
 using Poco::Dynamic::Var;
 
+// Explicitly instatiated shared pointer in JSON library is required to
+// have known instance of the pointer to be used with VarHolder when
+// compiling with -fvisibility=hidden
+template class Poco::SharedPtr<Poco::JSON::Object>;
 
 namespace Poco {
+
 namespace JSON {
 
 

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -22,7 +22,12 @@ using Poco::Dynamic::Var;
 // Explicitly instatiated shared pointer in JSON library is required to
 // have known instance of the pointer to be used with VarHolder when
 // compiling with -fvisibility=hidden
+
+#if defined(POCO_OS_FAMILY_WINDOWS)
+template class JSON_API Poco::SharedPtr<Poco::JSON::Object>;
+#else
 template class Poco::SharedPtr<Poco::JSON::Object>;
+#endif
 
 namespace Poco {
 

--- a/MongoDB/include/Poco/MongoDB/Document.h
+++ b/MongoDB/include/Poco/MongoDB/Document.h
@@ -31,7 +31,7 @@ namespace MongoDB {
 
 class Array;
 
-class ElementFindByName
+class MongoDB_API ElementFindByName
 {
 public:
 	ElementFindByName(const std::string& name):

--- a/MongoDB/include/Poco/MongoDB/UpdateRequest.h
+++ b/MongoDB/include/Poco/MongoDB/UpdateRequest.h
@@ -27,7 +27,7 @@ namespace Poco {
 namespace MongoDB {
 
 
-class UpdateRequest: public RequestMessage
+class MongoDB_API UpdateRequest: public RequestMessage
 	/// This request is used to update a document in a database
 	/// using the OP_UPDATE client request.
 {

--- a/build/config/ARM-Linux
+++ b/build/config/ARM-Linux
@@ -43,7 +43,7 @@ SHAREDLIBLINKEXT = .so
 CFLAGS          = -std=c11 $(ARCHFLAGS)
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = -std=c++14 -Wall -Wno-sign-compare -Wno-psabi $(ARCHFLAGS)
+CXXFLAGS        = -std=c++17 -Wall -Wno-sign-compare -Wno-psabi $(ARCHFLAGS)
 CXXFLAGS32      =
 CXXFLAGS64      =
 LINKFLAGS       =

--- a/build/config/Darwin-clang-libc++
+++ b/build/config/Darwin-clang-libc++
@@ -49,7 +49,7 @@ SHAREDLIBLINKEXT = .dylib
 # Compiler and Linker Flags
 #
 CFLAGS          = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -std=c11
-CXXFLAGS        = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -std=c++14 -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
+CXXFLAGS        = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -std=c++17 -stdlib=libc++ -Wall -Wno-sign-compare -Wno-unused-variable -Wno-unused-function -Wno-unneeded-internal-declaration
 LINKFLAGS       = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -stdlib=libc++
 SHLIBFLAGS      = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -stdlib=libc++
 DYLIBFLAGS      = $(ARCHFLAGS) $(OSFLAGS) $(SANITIZEFLAGS) -stdlib=libc++

--- a/build/config/iPhone
+++ b/build/config/iPhone
@@ -66,7 +66,7 @@ SHAREDLIBLINKEXT = .dylib
 CFLAGS          = $(OSFLAGS) -std=gnu99
 CFLAGS32        =
 CFLAGS64        =
-CXXFLAGS        = $(OSFLAGS) -std=gnu++14 -stdlib=libc++ -Wall -Wno-sign-compare
+CXXFLAGS        = $(OSFLAGS) -std=c++17 -stdlib=libc++ -Wall -Wno-sign-compare
 CXXFLAGS32      =
 CXXFLAGS64      =
 LINKFLAGS       = $(OSFLAGS) -stdlib=libc++


### PR DESCRIPTION
When using option `-fvisibility=hidden` (or `set(CMAKE_CXX_VISIBILITY_PRESET hidden)`) some of the symbols are not exported from libraries and some templates used in `Poco::Dynamic` are instantiated multiple times in different compilation units and therefore type comparison in `VarHolder` fails.

This PR resolves these issues and other problems related to hidden visibility.

Visibility is also changed to hidden when compiling with CMake.

Fixes #3331, fixes #4393.