### PR TITLE
fix(MailMessage): Compare lowercase content disposition headers when reading parts

### DIFF
--- a/Net/src/MailMessage.cpp
+++ b/Net/src/MailMessage.cpp
@@ -104,9 +104,13 @@ namespace
 				NameValueCollection::ConstIterator it = header.begin();
 				NameValueCollection::ConstIterator end = header.end();
 				bool added = false;
+
+				static const auto lcContentDisposition = Poco::toLower(MailMessage::HEADER_CONTENT_DISPOSITION);
+
 				for (; it != end; ++it)
 				{
-					if (!added && MailMessage::HEADER_CONTENT_DISPOSITION == it->first)
+					const auto lcHdr = Poco::toLower(it->first);
+					if (!added && lcContentDisposition == lcHdr)
 					{
 						if (it->second == "inline")
 							_pMsg->addContent(pPS, cte);

--- a/Net/testsuite/src/MailMessageTest.h
+++ b/Net/testsuite/src/MailMessageTest.h
@@ -32,12 +32,12 @@ public:
 	void testReadWriteMultiPart();
 	void testReadWriteMultiPartStore();
 	void testReadDefaultTransferEncoding();
-	void testContentDisposition();
 	void testReadQP();
 	void testRead8Bit();
 	void testReadMultiPart();
 	void testReadMultiPartWithAttachmentNames();
 	void testReadMultiPartDefaultTransferEncoding();
+	void testReadMultiPartMixedCaseHeaders();
 	void testReadMultiPartNoFinalBoundaryFromFile();
 	void testEncodeWord();
 


### PR DESCRIPTION
Fixes #3650.