### PR TITLE
Silence unnecessary NoCertificateException to  fix #4370

### DIFF
--- a/NetSSL_Win/include/Poco/Net/Context.h
+++ b/NetSSL_Win/include/Poco/Net/Context.h
@@ -201,11 +201,13 @@ public:
 		///
 		///   context.requireMinimumProtocol(PROTO_TLSV1_2);
 
-	Poco::Net::X509Certificate certificate();
+	Poco::Net::X509Certificate certificate(bool mustFindCertificate);
 		/// Loads or imports and returns the certificate specified in the constructor.
 		///
 		/// Throws a NoCertificateException if the certificate cannot
-		/// be found or no certificate name has been provided in the constructor.
+		/// be found or no certificate name has been provided in the constructor
+		/// and mustFindCertificate is true. When mustFindCertificate is false
+		/// it does an empty throw for this case.
 		///
 		/// May also throw a filesystem-related exception if the certificate file
 		/// cannot be found.

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -140,13 +140,18 @@ void Context::addTrustedCert(const Poco::Net::X509Certificate& cert)
 }
 
 
-Poco::Net::X509Certificate Context::certificate()
+Poco::Net::X509Certificate Context::certificate(bool mustFindCertificate)
 {
 	if (_pCert)
 		return Poco::Net::X509Certificate(_pCert, true);
 
 	if (_certNameOrPath.empty())
-		throw NoCertificateException("Certificate requested, but no certificate name or path provided");
+	{
+		if (mustFindCertificate)
+			throw NoCertificateException("Certificate requested, but no certificate name or path provided");
+		else
+			throw;
+	}
 
 	if (_options & OPT_LOAD_CERT_FROM_FILE)
 	{

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -714,7 +714,7 @@ PCCERT_CONTEXT SecureSocketImpl::loadCertificate(bool mustFindCertificate)
 {
 	try
 	{
-		Poco::Net::X509Certificate cert = _pContext->certificate();
+		Poco::Net::X509Certificate cert = _pContext->certificate(mustFindCertificate);
 		PCCERT_CONTEXT pCert = cert.system();
 		CertDuplicateCertificateContext(pCert);
 		return pCert;


### PR DESCRIPTION
Avoid creating log messages for NoCertificateException when that exception should be ignored.
Passing on the mustFindCertificate variable one level deeper so Poco::Net::X509Certificate::certificate  already knows it shouldn't create a message for this case.

No idea if this is the best way to handle this, which is why I only created an issue for this originally, but it's one way to fix it.

Alternative might for example be to always create an NoCertificateException, but only pass a message-string when mustFindCertificate is true (if this is possible with your exceptions, I didn't dig that deep). In which  case the documentation change I made for certificate wouldn't be necessary either.