### PR TITLE
Implemented automated network library initialization for Windows MinGW targets

### DIFF
--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -101,11 +101,13 @@ std::string htmlize(const std::string& str);
 // Automate network initialization (only relevant on Windows).
 //
 
-#if defined(POCO_OS_FAMILY_WINDOWS) && !defined(POCO_NO_AUTOMATIC_LIB_INIT) && !defined(__GNUC__)
+#if defined(POCO_OS_FAMILY_WINDOWS) && !defined(POCO_NO_AUTOMATIC_LIB_INIT)
 
 extern "C" const struct Net_API NetworkInitializer pocoNetworkInitializer;
 
-#if defined(Net_EXPORTS)
+#if defined(__GNUC__)
+	#define POCO_NET_FORCE_SYMBOL(x) static void *__ ## x ## _fp = (void*)&x;
+#elif defined(Net_EXPORTS)
 	#if defined(_WIN64)
 		#define POCO_NET_FORCE_SYMBOL(s) __pragma(comment (linker, "/export:"#s))
 	#elif defined(_WIN32)

--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -105,7 +105,7 @@ std::string htmlize(const std::string& str);
 
 extern "C" const struct Net_API NetworkInitializer pocoNetworkInitializer;
 
-#if defined(__GNUC__)
+#if defined(POCO_COMPILER_MINGW)
 	#define POCO_NET_FORCE_SYMBOL(x) static void *__ ## x ## _fp = (void*)&x;
 #elif defined(Net_EXPORTS)
 	#if defined(_WIN64)


### PR DESCRIPTION
Fixes issue #661.
Tested working using MinGW gcc 13.2.0 on Windows 10.