### PR TITLE
test(ThreadPool): unit test for thread pool shutdown when no worker is running

### DIFF
--- a/Foundation/testsuite/src/ThreadPoolTest.cpp
+++ b/Foundation/testsuite/src/ThreadPoolTest.cpp
@@ -14,6 +14,7 @@
 #include "Poco/ThreadPool.h"
 #include "Poco/RunnableAdapter.h"
 #include "Poco/Exception.h"
+#include "Poco/Timestamp.h"
 #include "Poco/Thread.h"
 
 
@@ -126,6 +127,50 @@ void ThreadPoolTest::testThreadPool()
 	assertTrue (pool.available() == 4);
 }
 
+class Worker : public Poco::Runnable
+{
+	static bool _shutDown;
+public:
+	Worker()
+	{
+	}
+	void run()
+	{
+		while (!_shutDown)
+		{
+			Poco::Thread::sleep(200);
+		}
+	}
+	static void Initialize() {
+		_shutDown = false;
+	}
+	static void Shutdown() {
+		_shutDown = true;
+	}
+};
+
+bool Worker::_shutDown = false;
+
+void ThreadPoolTest::testThreadPoolImmediateShutdown()
+{
+	Worker::Initialize();
+
+	Worker worker1; // create worker threads
+	Worker worker2;
+	Worker::Shutdown();  // workers will come up, and then immediatly be told to go away
+
+	Poco::Timestamp stime;
+
+	Poco::ThreadPool::defaultPool().start(worker1);
+	Poco::ThreadPool::defaultPool().start(worker2);
+
+	Poco::ThreadPool::defaultPool().joinAll();
+	Poco::Timestamp etime;
+
+	Poco::Timestamp::TimeDiff d = etime - stime;
+	assertTrue (d <= 100000);
+
+}
 
 void ThreadPoolTest::setUp()
 {
@@ -156,6 +201,7 @@ CppUnit::Test* ThreadPoolTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("ThreadPoolTest");
 
 	CppUnit_addTest(pSuite, ThreadPoolTest, testThreadPool);
+	CppUnit_addTest(pSuite, ThreadPoolTest, testThreadPoolImmediateShutdown);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/ThreadPoolTest.h
+++ b/Foundation/testsuite/src/ThreadPoolTest.h
@@ -27,6 +27,7 @@ public:
 	~ThreadPoolTest();
 
 	void testThreadPool();
+	void testThreadPoolImmediateShutdown();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Added a unit test to verify if the issue reported in #2450 is present.

