### PR TITLE
enh(tests): Ability to enable/disable testing of deprecated functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,9 @@ endif()
 option(ENABLE_TESTS
 	"Set to OFF|ON (default is OFF) to control build of POCO tests" OFF)
 
+option(ENABLE_TEST_DEPRECATED
+	"Set to OFF|ON (default is OFF) to enable build of tests for deprecated functionality" OFF)
+
 option(ENABLE_COMPILER_WARNINGS
 	"Set to OFF|ON (default is OFF) to enable additional compiler warnings. Intended primarily for maintainers." OFF)
 
@@ -219,6 +222,9 @@ if(ENABLE_TESTS)
 	include(CTest)
 	enable_testing()
 	message(STATUS "Building with unittests & samples")
+	if(ENABLE_TEST_DEPRECATED)
+		add_compile_definitions(POCO_TEST_DEPRECATED)
+	endif()
 else()
 	message(STATUS "Building without tests & samples")
 endif()

--- a/Foundation/testsuite/src/NumberFormatterTest.cpp
+++ b/Foundation/testsuite/src/NumberFormatterTest.cpp
@@ -173,8 +173,17 @@ void NumberFormatterTest::testFormatHex()
 #endif
 #endif
 
-	// Deprecated function
+#if defined(POCO_TEST_DEPRECATED)
+	// Deprecated functions
 	assertTrue (NumberFormatter::formatHex(0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((unsigned) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((long) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((unsigned long) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((Int64) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((UInt64) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((long long) 0x12, true) == "0x12");
+	assertTrue (NumberFormatter::formatHex((unsigned long long) 0x12, true) == "0x12");
+#endif
 
 	assertTrue (NumberFormatter::formatHex(0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex(0xab, Opt::PREFIX) == "0xAB");
@@ -186,7 +195,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex(0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex(0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
-	assertTrue (NumberFormatter::formatHex((unsigned) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((unsigned) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -197,7 +205,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((unsigned) 0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex((unsigned) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
-	assertTrue (NumberFormatter::formatHex((long) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((long) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((long) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((long) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -208,7 +215,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((long) 0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex((long) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
-	assertTrue (NumberFormatter::formatHex((unsigned long) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned long) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned long) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((unsigned long) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -220,7 +226,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((unsigned long) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
 #if defined(POCO_HAVE_INT64)
-	assertTrue (NumberFormatter::formatHex((Int64) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((Int64) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((Int64) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((Int64) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -231,7 +236,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((Int64) 0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex((Int64) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
-	assertTrue (NumberFormatter::formatHex((UInt64) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((UInt64) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((UInt64) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((UInt64) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -242,7 +246,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((UInt64) 0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex((UInt64) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 #if defined(POCO_LONG_IS_64_BIT)
-	assertTrue (NumberFormatter::formatHex((long long) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((long long) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((long long) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((long long) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");
@@ -253,7 +256,6 @@ void NumberFormatterTest::testFormatHex()
 	assertTrue (NumberFormatter::formatHex((long long) 0xab, 6, Opt::PREFIX) == "0x00AB");
 	assertTrue (NumberFormatter::formatHex((long long) 0xab, 6, Opt::PREFIX | Opt::LOWERCASE) == "0x00ab");
 
-	assertTrue (NumberFormatter::formatHex((unsigned long long) 0x12, true) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned long long) 0x12, Opt::PREFIX) == "0x12");
 	assertTrue (NumberFormatter::formatHex((unsigned long long) 0xab, Opt::PREFIX) == "0xAB");
 	assertTrue (NumberFormatter::formatHex((unsigned long long) 0xab, Opt::PREFIX | Opt::LOWERCASE) == "0xab");


### PR DESCRIPTION
 #4425

Introduced preprocessor define `POCO_TEST_DEPRECATED` to wrap tests of deprecated functionality to be disabled by default.

Added option `ENABLE_TEST_DEPRECATED` to enable deprecated tests when building with CMake.