### PR TITLE
fix(SSLManager): Fixed regression introduced in PR #4103, fixes #4421

### DIFF
--- a/NetSSL_OpenSSL/src/SSLManager.cpp
+++ b/NetSSL_OpenSSL/src/SSLManager.cpp
@@ -76,8 +76,8 @@ const bool        SSLManager::VAL_FIPS_MODE(false);
 
 
 SSLManager::SSLManager():
-	_contextIndex(SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL)),
-	_socketIndex(SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL))
+	_contextIndex(SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr)),
+	_socketIndex(SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr))
 {
 }
 
@@ -100,9 +100,8 @@ void SSLManager::shutdown()
 	PrivateKeyPassphraseRequired.clear();
 	ClientVerificationError.clear();
 	ServerVerificationError.clear();
-	_ptrDefaultServerContext = 0;
-	_ptrDefaultClientContext = 0;
-	_socketIndex = _contextIndex = -1;
+	_ptrDefaultServerContext = nullptr;
+	_ptrDefaultClientContext = nullptr;
 }
 
 
@@ -290,7 +289,7 @@ int SSLManager::verifyOCSPResponseCallback(SSL* pSSL, void* arg)
 		return ocspVerifyFlag ? 0 : 1;
 	}
 
-	OCSP_RESPONSE* pOcspResp = d2i_OCSP_RESPONSE(NULL, &pResp, len);
+	OCSP_RESPONSE* pOcspResp = d2i_OCSP_RESPONSE(nullptr, &pResp, len);
 	if (!pOcspResp) return 0;
 
 	if (OCSP_response_status(pOcspResp) != OCSP_RESPONSE_STATUS_SUCCESSFUL)
@@ -314,7 +313,7 @@ int SSLManager::verifyOCSPResponseCallback(SSL* pSSL, void* arg)
 		return 0;
 	}
 
-	X509* pPeerIssuerCert = NULL;
+	X509* pPeerIssuerCert = nullptr;
 	STACK_OF(X509)* pCertChain = SSL_get_peer_cert_chain(pSSL);
 	unsigned certChainLen = sk_X509_num(pCertChain);
 	for (int i= 0; i < certChainLen ; i++)
@@ -345,7 +344,7 @@ int SSLManager::verifyOCSPResponseCallback(SSL* pSSL, void* arg)
 		{
 			X509_free(pCert);
 			sk_X509_free(pCerts);
-			pCerts = NULL;
+			pCerts = nullptr;
 		}
 	}
 
@@ -363,7 +362,7 @@ int SSLManager::verifyOCSPResponseCallback(SSL* pSSL, void* arg)
 		return 0;
 	}
 
-	OCSP_CERTID* pCertId = OCSP_cert_to_id(NULL, pPeerCert, pPeerIssuerCert);
+	OCSP_CERTID* pCertId = OCSP_cert_to_id(nullptr, pPeerCert, pPeerIssuerCert);
 	if (!pCertId)
 	{
 		X509_free(pPeerCert);

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
@@ -34,6 +34,7 @@ public:
 	void testPostLargeChunkedKeepAlive();
 	void testKeepAlive();
 	void testInterop();
+	void testMultipleSSLInit();
 	void testProxy();
 	void testCachedSession();
 	void testUnknownContentLength();


### PR DESCRIPTION
PR #4103 introduced a bug to improperly set internal indices to -1 in `shutdown()`.

This PR fixes that.