### PR TITLE
fix(LogFile): Unify flushing behaviour of WIN32 and STD implementation

### DIFF
--- a/Foundation/src/LogFile_WIN32U.cpp
+++ b/Foundation/src/LogFile_WIN32U.cpp
@@ -17,6 +17,8 @@
 #include "Poco/Exception.h"
 #include "Poco/UnicodeConverter.h"
 
+// TODO: LogStream shall use FileOutputStream for all implementations (see LogStream_STD)
+// TODO: Implement flushToDisk function in FileOutputStream.
 
 namespace Poco {
 

--- a/Foundation/testsuite/src/FileChannelTest.cpp
+++ b/Foundation/testsuite/src/FileChannelTest.cpp
@@ -86,6 +86,59 @@ void FileChannelTest::testRotateNever()
 }
 
 
+void FileChannelTest::testFlushing()
+{
+	std::string name = filename();
+	try
+	{
+		AutoPtr<FileChannel> pChannel = new FileChannel(name);
+		pChannel->setProperty(FileChannel::PROP_FLUSH, "false");
+		pChannel->open();
+		Message msg("source", "01234567890123456789", Message::PRIO_INFORMATION);
+		pChannel->log(msg);
+
+		// File shall be there and have content after writing first message.
+		File f(name);
+		assertTrue (f.exists());
+		assertTrue (f.getSize() >= 20);
+
+		Timestamp::TimeDiff noFlushTime;
+		{
+			Timestamp start;
+			for (int i = 0; i < 2000; ++i)
+			{
+				pChannel->log(msg);
+			}
+			pChannel->close();
+			Timestamp end;
+			noFlushTime = end-start;
+		}
+		Timestamp::TimeDiff flushTime;
+		{
+			pChannel->setProperty(FileChannel::PROP_FLUSH, "true");
+			pChannel->open();
+			Timestamp start;
+			for (int i = 0; i < 2000; ++i)
+			{
+				pChannel->log(msg);
+			}
+			pChannel->close();
+			Timestamp end;
+			flushTime = end-start;
+		}
+
+		// Writing to channel with flushing is expected to be slower.
+		assertTrue(flushTime > noFlushTime);
+	}
+	catch (...)
+	{
+		remove(name);
+		throw;
+	}
+	remove(name);
+}
+
+
 void FileChannelTest::testRotateBySize()
 {
 	std::string name = filename();
@@ -832,6 +885,7 @@ CppUnit::Test* FileChannelTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("FileChannelTest");
 
 	CppUnit_addTest(pSuite, FileChannelTest, testRotateNever);
+	CppUnit_addTest(pSuite, FileChannelTest, testFlushing);
 	CppUnit_addTest(pSuite, FileChannelTest, testRotateBySize);
 	CppUnit_addTest(pSuite, FileChannelTest, testRotateByAge);
 	CppUnit_addLongTest(pSuite, FileChannelTest, testRotateAtTimeDayUTC);

--- a/Foundation/testsuite/src/FileChannelTest.h
+++ b/Foundation/testsuite/src/FileChannelTest.h
@@ -32,6 +32,7 @@ public:
 	~FileChannelTest();
 
 	void testRotateNever();
+	void testFlushing();
 	void testRotateBySize();
 	void testRotateByAge();
 	void testRotateAtTimeDayUTC();


### PR DESCRIPTION
#2443 

Flush options means flush to disk in all implementations.