### PR TITLE
AsyncObserver

### DIFF
--- a/Foundation/Foundation_vs160.vcxproj
+++ b/Foundation/Foundation_vs160.vcxproj
@@ -1493,6 +1493,7 @@
     <ClInclude Include="include\Poco\AccessExpireStrategy.h" />
     <ClInclude Include="include\Poco\ActiveDispatcher.h" />
     <ClInclude Include="include\Poco\ActiveMethod.h" />
+    <ClInclude Include="include\Poco\AsyncObserver.h" />
     <ClInclude Include="include\Poco\ActiveResult.h" />
     <ClInclude Include="include\Poco\ActiveRunnable.h" />
     <ClInclude Include="include\Poco\ActiveStarter.h" />

--- a/Foundation/Foundation_vs160.vcxproj
+++ b/Foundation/Foundation_vs160.vcxproj
@@ -577,6 +577,7 @@
     <ClCompile Include="src\Ascii.cpp" />
     <ClCompile Include="src\ASCIIEncoding.cpp" />
     <ClCompile Include="src\AsyncChannel.cpp" />
+    <ClCompile Include="src\AsyncNotificationCenter.cpp" />
     <ClCompile Include="src\AtomicCounter.cpp" />
     <ClCompile Include="src\Base32Decoder.cpp" />
     <ClCompile Include="src\Base32Encoder.cpp" />
@@ -1503,6 +1504,8 @@
     <ClInclude Include="include\Poco\Ascii.h" />
     <ClInclude Include="include\Poco\ASCIIEncoding.h" />
     <ClInclude Include="include\Poco\AsyncChannel.h" />
+    <ClInclude Include="include\Poco\AsyncObserver.h" />
+    <ClInclude Include="include\Poco\AsyncNotificationCenter.h" />
     <ClInclude Include="include\Poco\AtomicCounter.h" />
     <ClInclude Include="include\Poco\AutoPtr.h" />
     <ClInclude Include="include\Poco\AutoReleasePool.h" />

--- a/Foundation/Foundation_vs160.vcxproj.filters
+++ b/Foundation/Foundation_vs160.vcxproj.filters
@@ -573,6 +573,9 @@
     <ClCompile Include="src\AbstractObserver.cpp">
       <Filter>Notifications\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\AsyncNotificationCenter.cpp">
+      <Filter>Notifications\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Notification.cpp">
       <Filter>Notifications\Source Files</Filter>
     </ClCompile>
@@ -1449,6 +1452,9 @@
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Poco\AsyncObserver.h">
+      <Filter>Notifications\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Poco\AsyncNotificationCenter.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Poco\Notification.h">

--- a/Foundation/Foundation_vs160.vcxproj.filters
+++ b/Foundation/Foundation_vs160.vcxproj.filters
@@ -1448,6 +1448,9 @@
     <ClInclude Include="include\Poco\NObserver.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\AsyncObserver.h">
+      <Filter>Notifications\Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\Poco\Notification.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>

--- a/Foundation/Foundation_vs170.vcxproj
+++ b/Foundation/Foundation_vs170.vcxproj
@@ -878,6 +878,7 @@
     <ClCompile Include="src\Ascii.cpp" />
     <ClCompile Include="src\ASCIIEncoding.cpp" />
     <ClCompile Include="src\AsyncChannel.cpp" />
+    <ClCompile Include="src\AsyncNotificationCenter.cpp" />
     <ClCompile Include="src\AtomicCounter.cpp" />
     <ClCompile Include="src\Base32Decoder.cpp" />
     <ClCompile Include="src\Base32Encoder.cpp" />
@@ -2110,6 +2111,8 @@
     <ClInclude Include="include\Poco\Ascii.h" />
     <ClInclude Include="include\Poco\ASCIIEncoding.h" />
     <ClInclude Include="include\Poco\AsyncChannel.h" />
+    <ClInclude Include="include\Poco\AsyncObserver.h" />
+    <ClInclude Include="include\Poco\AsyncNotificationCenter.h" />
     <ClInclude Include="include\Poco\AtomicCounter.h" />
     <ClInclude Include="include\Poco\AutoPtr.h" />
     <ClInclude Include="include\Poco\AutoReleasePool.h" />

--- a/Foundation/Foundation_vs170.vcxproj
+++ b/Foundation/Foundation_vs170.vcxproj
@@ -2100,6 +2100,7 @@
     <ClInclude Include="include\Poco\AccessExpireStrategy.h" />
     <ClInclude Include="include\Poco\ActiveDispatcher.h" />
     <ClInclude Include="include\Poco\ActiveMethod.h" />
+    <ClInclude Include="include\Poco\AsyncObserver.h" />
     <ClInclude Include="include\Poco\ActiveResult.h" />
     <ClInclude Include="include\Poco\ActiveRunnable.h" />
     <ClInclude Include="include\Poco\ActiveStarter.h" />

--- a/Foundation/Foundation_vs170.vcxproj
+++ b/Foundation/Foundation_vs170.vcxproj
@@ -2101,7 +2101,6 @@
     <ClInclude Include="include\Poco\AccessExpireStrategy.h" />
     <ClInclude Include="include\Poco\ActiveDispatcher.h" />
     <ClInclude Include="include\Poco\ActiveMethod.h" />
-    <ClInclude Include="include\Poco\AsyncObserver.h" />
     <ClInclude Include="include\Poco\ActiveResult.h" />
     <ClInclude Include="include\Poco\ActiveRunnable.h" />
     <ClInclude Include="include\Poco\ActiveStarter.h" />

--- a/Foundation/Foundation_vs170.vcxproj.filters
+++ b/Foundation/Foundation_vs170.vcxproj.filters
@@ -579,6 +579,9 @@
     <ClCompile Include="src\NotificationCenter.cpp">
       <Filter>Notifications\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\AsyncNotificationCenter.cpp">
+      <Filter>Notifications\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\NotificationQueue.cpp">
       <Filter>Notifications\Source Files</Filter>
     </ClCompile>
@@ -1445,6 +1448,12 @@
       <Filter>Logging\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Poco\AbstractObserver.h">
+      <Filter>Notifications\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Poco\AsyncObserver.h">
+      <Filter>Notifications\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Poco\AsyncNotificationServer.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Poco\NObserver.h">

--- a/Foundation/Foundation_vs170.vcxproj.filters
+++ b/Foundation/Foundation_vs170.vcxproj.filters
@@ -1867,6 +1867,9 @@
     <ClInclude Include="src\pcre2_intmodedep.h">
       <Filter>RegularExpression\PCRE2 Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Poco\AsyncObserver.h">
+      <Filter>Notifications\Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\pocomsg.rc">

--- a/Foundation/Foundation_vs170.vcxproj.filters
+++ b/Foundation/Foundation_vs170.vcxproj.filters
@@ -1453,7 +1453,7 @@
     <ClInclude Include="include\Poco\AsyncObserver.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\Poco\AsyncNotificationServer.h">
+    <ClInclude Include="include\Poco\AsyncNotificationCenter.h">
       <Filter>Notifications\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Poco\NObserver.h">
@@ -1875,9 +1875,6 @@
     </ClInclude>
     <ClInclude Include="src\pcre2_intmodedep.h">
       <Filter>RegularExpression\PCRE2 Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\Poco\AsyncObserver.h">
-      <Filter>Notifications\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Foundation/Makefile
+++ b/Foundation/Makefile
@@ -6,7 +6,7 @@
 
 include $(POCO_BASE)/build/rules/global
 
-objects = ArchiveStrategy Ascii ASCIIEncoding AsyncChannel ActiveThreadPool\
+objects = ArchiveStrategy Ascii ASCIIEncoding AsyncChannel AsyncNotificationCenter ActiveThreadPool\
 	Base32Decoder Base32Encoder Base64Decoder Base64Encoder \
 	BinaryReader BinaryWriter Bugcheck ByteOrder Channel Checksum Clock Configurable ConsoleChannel \
 	Condition CountingStream DateTime LocalDateTime DateTimeFormat DateTimeFormatter DateTimeParser \

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -40,8 +40,32 @@ public:
 	virtual bool equals(const AbstractObserver& observer) const = 0;
 	virtual bool accepts(Notification* pNf, const char* pName = 0) const = 0;
 	virtual AbstractObserver* clone() const = 0;
+
+	virtual void start();
+		/// No-op.
+		/// This method can be implemented by inheriting classes which require
+		/// explicit start in order to begin processing notifications.
+
 	virtual void disable() = 0;
+
+	virtual int backlog() const;
+		/// Returns number of queued messages that this Observer has.
+		/// For non-active (synchronous) observers, always returns zero.
 };
+
+//
+// inlines
+//
+
+inline void AbstractObserver::start()
+{
+}
+
+
+inline int AbstractObserver::backlog() const
+{
+	return 0;
+}
 
 
 } // namespace Poco

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -37,8 +37,14 @@ public:
 	AbstractObserver& operator = (const AbstractObserver& observer);
 
 	virtual void notify(Notification* pNf) const = 0;
+
 	virtual bool equals(const AbstractObserver& observer) const = 0;
-	virtual bool accepts(Notification* pNf, const char* pName = 0) const = 0;
+
+	[[deprecated("use `Poco::Any accepts(Notification*)` instead")]]
+	virtual bool accepts(Notification* pNf, const char* pName) const = 0;
+
+	virtual bool accepts(const Notification::Ptr& pNf) const = 0;
+
 	virtual AbstractObserver* clone() const = 0;
 
 	virtual void start();

--- a/Foundation/include/Poco/Any.h
+++ b/Foundation/include/Poco/Any.h
@@ -24,12 +24,11 @@
 #include <cstddef>
 
 
-#define poco_any_assert(cond) do { if (!(cond)) std::abort(); } while (0)
-
-
 namespace Poco {
 
 class Any;
+
+using namespace std::string_literals;
 
 namespace Dynamic {
 
@@ -407,12 +406,12 @@ ValueType* AnyCast(Any* operand)
 	/// to the stored value.
 	///
 	/// Example Usage:
-	///	 MyType* pTmp = AnyCast<MyType*>(pAny).
-	/// Will return NULL if the cast fails, i.e. types don't match.
+	///	 MyType* pTmp = AnyCast<MyType>(pAny).
+	/// Returns nullptr if the types don't match.
 {
 	return operand && operand->type() == typeid(ValueType)
 				? &static_cast<Any::Holder<ValueType>*>(operand->content())->_held
-				: 0;
+				: nullptr;
 }
 
 
@@ -422,8 +421,8 @@ const ValueType* AnyCast(const Any* operand)
 	/// to the stored value.
 	///
 	/// Example Usage:
-	///	 const MyType* pTmp = AnyCast<MyType*>(pAny).
-	/// Will return NULL if the cast fails, i.e. types don't match.
+	///	 const MyType* pTmp = AnyCast<MyType>(pAny).
+	/// Returns nullptr if the types don't match.
 {
 	return AnyCast<ValueType>(const_cast<Any*>(operand));
 }
@@ -440,18 +439,19 @@ ValueType AnyCast(Any& operand)
 	/// Some compilers will accept this code although a copy is returned. Use the RefAnyCast in
 	/// these cases.
 {
-	typedef typename TypeWrapper<ValueType>::TYPE NonRef;
+	using NonRef = typename TypeWrapper<ValueType>::TYPE;
 
 	NonRef* result = AnyCast<NonRef>(&operand);
 	if (!result)
 	{
-		std::string s = "RefAnyCast: Failed to convert between Any types ";
+		std::string s(__func__);
+		s.append(": Failed to convert between Any types "s);
 		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand.content()->type().name());
+			s.append(Poco::demangle(operand.content()->type().name()));
 			s.append(" => ");
-			s.append(typeid(ValueType).name());
+			s.append(Poco::demangle<ValueType>());
 			s.append(1, ')');
 		}
 		throw BadCastException(s);
@@ -471,7 +471,7 @@ ValueType AnyCast(const Any& operand)
 	/// Some compilers will accept this code although a copy is returned. Use the RefAnyCast in
 	/// these cases.
 {
-	typedef typename TypeWrapper<ValueType>::TYPE NonRef;
+	using NonRef = typename TypeWrapper<ValueType>::TYPE;
 
 	return AnyCast<NonRef&>(const_cast<Any&>(operand));
 }
@@ -487,13 +487,14 @@ const ValueType& RefAnyCast(const Any & operand)
 	ValueType* result = AnyCast<ValueType>(const_cast<Any*>(&operand));
 	if (!result)
 	{
-		std::string s = "RefAnyCast: Failed to convert between Any types ";
+		std::string s(__func__);
+		s.append(": Failed to convert between Any types "s);
 		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand.content()->type().name());
+			s.append(Poco::demangle(operand.content()->type().name()));
 			s.append(" => ");
-			s.append(typeid(ValueType).name());
+			s.append(Poco::demangle<ValueType>());
 			s.append(1, ')');
 		}
 		throw BadCastException(s);
@@ -512,13 +513,14 @@ ValueType& RefAnyCast(Any& operand)
 	ValueType* result = AnyCast<ValueType>(&operand);
 	if (!result)
 	{
-		std::string s = "RefAnyCast: Failed to convert between Any types ";
+		std::string s(__func__);
+		s.append(": Failed to convert between Any types "s);
 		if (operand.content())
 		{
 			s.append(1, '(');
-			s.append(operand.content()->type().name());
+			s.append(Poco::demangle(operand.content()->type().name()));
 			s.append(" => ");
-			s.append(typeid(ValueType).name());
+			s.append(Poco::demangle<ValueType>());
 			s.append(1, ')');
 		}
 		throw BadCastException(s);
@@ -548,6 +550,26 @@ const ValueType* UnsafeAnyCast(const Any* operand)
 	/// different shared libraries.
 {
 	return AnyCast<ValueType>(const_cast<Any*>(operand));
+}
+
+
+template <typename ValueType>
+bool AnyHoldsNullPtr(const Any& any)
+	/// Returns true if any holds a null pointer.
+	/// Fails to compile if `ValueType` is not a pointer.
+{
+	poco_static_assert_ptr(ValueType);
+	return (AnyCast<ValueType>(any) == nullptr);
+}
+
+
+template <typename ValueType>
+bool AnyHoldsNullPtr(const Any* pAny)
+	/// Returns true if the Any pointed to holds a null pointer.
+	/// Returns false if `pAny` is a null pointer.
+{
+	if (!pAny) return false;
+	return (AnyHoldsNullPtr<ValueType>(*pAny));
 }
 
 

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -70,6 +70,9 @@ private:
 	Adapter _ra;
 	std::atomic<bool> _started;
 	std::atomic<bool> _done;
+
+	// TODO: see testDefaultAsyncNotificationCenter for details
+	friend class NotificationCenterTest;
 };
 
 

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -54,12 +54,9 @@ public:
 		/// Enqueues notification into the notification queue.
 
 	virtual int backlog() const;
-		/// Rteurns the numbner of notifications in the notification queue.
+		/// Returns the numbner of notifications in the notification queue.
 
-	static AsyncNotificationCenter& defaultCenter();
-
-// TODO: see testDefaultAsyncNotificationCenter for details
-//private:
+private:
 	void start();
 	void stop();
 	void dequeue();

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -1,0 +1,79 @@
+//
+// AsyncNotificationCenter.h
+//
+// Library: Foundation
+// Package: Notifications
+// Module:  AsyncNotificationCenter
+//
+// Definition of the AsyncNotificationCenter class.
+//
+// Copyright (c) 2006, Applied Informatics Software Engineering GmbH.
+// Aleph ONE Software Engineering d.o.o.,
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Foundation_AsyncNotificationCenter_INCLUDED
+#define Foundation_AsyncNotificationCenter_INCLUDED
+
+
+#include "Poco/Foundation.h"
+#include "Poco/NotificationCenter.h"
+#include "Poco/Thread.h"
+#include "Poco/Stopwatch.h"
+#include "Poco/Debugger.h"
+#include "Poco/ErrorHandler.h"
+#include "Poco/Format.h"
+#include "Poco/RunnableAdapter.h"
+#include "Poco/NotificationQueue.h"
+
+
+namespace Poco {
+
+
+class Foundation_API AsyncNotificationCenter: public NotificationCenter
+	/// AsyncNotificationCenter decouples posting of notifications
+	/// from notifying subscribers by calling observers' notification
+	/// handler in a dedicated thread.
+{
+public:
+	AsyncNotificationCenter();
+		/// Creates the AsyncNotificationCenter and starts the notifying thread.
+
+	~AsyncNotificationCenter();
+		/// Stops the notifying thread and destroys the AsyncNotificationCenter.
+
+	AsyncNotificationCenter& operator = (const AsyncNotificationCenter&) = delete;
+	AsyncNotificationCenter(const AsyncNotificationCenter&) = delete;
+	AsyncNotificationCenter& operator = (AsyncNotificationCenter&&) = delete;
+	AsyncNotificationCenter(AsyncNotificationCenter&&) = delete;
+
+	virtual void postNotification(Notification::Ptr pNotification);
+		/// Enqueues notification into the notification queue.
+
+	virtual int backlog() const;
+		/// Rteurns the numbner of notifications in the notification queue.
+
+	static AsyncNotificationCenter& defaultCenter();
+
+private:
+	void start();
+	void stop();
+	void dequeue();
+
+	using Adapter = RunnableAdapter<AsyncNotificationCenter>;
+
+	Thread _thread;
+	NotificationQueue _nq;
+	Adapter _ra;
+	std::atomic<bool> _started;
+	std::atomic<bool> _done;
+};
+
+
+} // namespace Poco
+
+
+#endif // Foundation_AsyncNotificationCenter_INCLUDED

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -58,7 +58,8 @@ public:
 
 	static AsyncNotificationCenter& defaultCenter();
 
-private:
+// TODO: see testDefaultAsyncNotificationCenter for details
+//private:
 	void start();
 	void stop();
 	void dequeue();
@@ -70,9 +71,6 @@ private:
 	Adapter _ra;
 	std::atomic<bool> _started;
 	std::atomic<bool> _done;
-
-	// TODO: see testDefaultAsyncNotificationCenter for details
-	friend class NotificationCenterTest;
 };
 
 

--- a/Foundation/include/Poco/AsyncObserver.h
+++ b/Foundation/include/Poco/AsyncObserver.h
@@ -38,7 +38,7 @@ class AsyncObserver: public NObserver<C, N>
 	/// to (N)Observer classes, which notify subscribers synchronously).
 	/// In order to become active and process notifications, the start()
 	/// method must be called.
-	/// 
+	///
 	/// This class is meant to be used with the NotificationCenter only.
 	/// Notification processing thread can be started only once, and copying
 	/// should be done before `start()` is called.
@@ -89,7 +89,7 @@ public:
 
 	virtual void notify(Notification* pNf) const
 	{
-		_nq.enqueueNotification(NotificationPtr(pNf, true));
+		_nq.enqueueNotification(NotificationPtr(static_cast<N*>(pNf), true));
 	}
 
 	virtual AbstractObserver* clone() const
@@ -134,14 +134,14 @@ public:
 private:
 	void dequeue()
 	{
-		NotificationPtr pNf;
+		Notification::Ptr pNf;
 		_started = true;
 		_done = false;
 		while ((pNf = _nq.waitDequeueNotification()))
 		{
 			try
 			{
-				this->handle(pNf);
+				this->handle(pNf.unsafeCast<N>());
 			}
 			catch (Poco::Exception& ex)
 			{

--- a/Foundation/include/Poco/AsyncObserver.h
+++ b/Foundation/include/Poco/AsyncObserver.h
@@ -8,14 +8,15 @@
 // Definition of the AsyncObserver class template.
 //
 // Copyright (c) 2006, Applied Informatics Software Engineering GmbH.
+// Aleph ONE Software Engineering d.o.o.,
 // and Contributors.
 //
 // SPDX-License-Identifier:	BSL-1.0
 //
 
 
-#ifndef Foundation_ActiveObserver_INCLUDED
-#define Foundation_ActiveObserver_INCLUDED
+#ifndef Foundation_AsyncObserver_INCLUDED
+#define Foundation_AsyncObserver_INCLUDED
 
 
 #include "Poco/Foundation.h"
@@ -173,4 +174,4 @@ private:
 } // namespace Poco
 
 
-#endif // Foundation_ActiveObserver_INCLUDED
+#endif // Foundation_AsyncObserver_INCLUDED

--- a/Foundation/include/Poco/AsyncObserver.h
+++ b/Foundation/include/Poco/AsyncObserver.h
@@ -137,7 +137,7 @@ private:
 		NotificationPtr pNf;
 		_started = true;
 		_done = false;
-		while (pNf = _nq.waitDequeueNotification())
+		while ((pNf = _nq.waitDequeueNotification()))
 		{
 			try
 			{

--- a/Foundation/include/Poco/AsyncObserver.h
+++ b/Foundation/include/Poco/AsyncObserver.h
@@ -1,0 +1,197 @@
+//
+// AsyncObserver.h
+//
+// Library: Foundation
+// Package: Notifications
+// Module:  AsyncObserver
+//
+// Definition of the AsyncObserver class template.
+//
+// Copyright (c) 2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef Foundation_ActiveObserver_INCLUDED
+#define Foundation_ActiveObserver_INCLUDED
+
+
+#include "Poco/Foundation.h"
+#include "Poco/NObserver.h"
+#include "Poco/Thread.h"
+#include "Poco/Stopwatch.h"
+#include "Poco/Debugger.h"
+#include "Poco/Format.h"
+#include "Poco/RunnableAdapter.h"
+#include "Poco/NotificationQueue.h"
+
+
+namespace Poco {
+
+
+template <class C, class N>
+class AsyncObserver: public NObserver<C, N>
+	/// AsyncObserver notifies subscribers in a dedicated thread (as opposed
+	/// to (N)Observer classes, which notify subscribers synchronously).
+	/// In order to become active and process notifications, the start()
+	/// method must be called.
+	/// 
+	/// This class is meant to be used with the NotificationCenter only.
+	/// Notification processing thread can be started only once, and copying
+	/// should be done before `start()` is called.
+{
+public:
+	using Type = AsyncObserver<C, N>;
+	using Matcher = bool (C::*)(const std::string&);
+
+	AsyncObserver() = delete;
+
+	AsyncObserver(C& object, Handler handler, Matcher matcher = nullptr):
+		NObserver(object, handler),
+		_matcher(matcher),
+		_ra(*this, &AsyncObserver::dequeue),
+		_started(false),
+		_done(false)
+	{
+	}
+
+	AsyncObserver(const AsyncObserver& observer):
+		NObserver(observer),
+		_matcher(observer._matcher),
+		_ra(*this, &AsyncObserver::dequeue),
+		_started(false),
+		_done(false)
+	{
+		poco_assert(observer._nq.size() == 0);
+	}
+
+	~AsyncObserver()
+	{
+		disable();
+	}
+
+	AsyncObserver& operator = (const AsyncObserver& observer)
+	{
+		if (&observer != this)
+		{
+			poco_assert(observer._nq.size() == 0);
+			_pObject = observer._pObject;
+			_handler  = observer._handler;
+			_matcher = observer._matcher;
+			_started = false;
+			_done =false;
+		}
+		return *this;
+	}
+
+	void notify(Notification* pNf) const
+	{
+		Poco::ScopedLockWithUnlock l(_mutex);
+		if (_pObject)
+		{
+			if (!_matcher || (_pObject->*_matcher)(pNf->name()))
+			{
+				l.unlock();
+				N* pCastNf = dynamic_cast<N*>(pNf);
+				if (pCastNf)
+				{
+					NotificationPtr ptr(pCastNf, true);
+					_nq.enqueueNotification(ptr);
+				}
+			}
+		}
+	}
+
+	virtual bool equals(const AbstractObserver& abstractObserver) const
+	{
+		const AsyncObserver* pObs = dynamic_cast<const AsyncObserver*>(&abstractObserver);
+		return pObs && pObs->_pObject == _pObject && pObs->_method == _method && pObs->_matcher == _matcher;
+	}
+
+	virtual bool accepts(Notification* pNf, const char* pName = nullptr) const
+	{
+		if (!dynamic_cast<N*>(pNf)) return false;
+
+		Poco::ScopedLock l(_mutex);
+		return _pObject && _matcher && (_pObject->*_matcher)(pNf->name());
+	}
+
+	virtual AbstractObserver* clone() const
+	{
+		return new AsyncObserver(*this);
+	}
+
+	virtual void start()
+	{
+		Poco::ScopedLock l(_mutex);
+		if (_started)
+		{
+			throw Poco::InvalidAccessException(
+				Poco::format("thread already started %s", poco_src_loc));
+		}
+
+		_thread.start(_ra);
+		Poco::Stopwatch sw;
+		sw.start();
+		while (!_started)
+		{
+			if (sw.elapsedSeconds() > 5)
+				throw Poco::TimeoutException(poco_src_loc);
+			Thread::sleep(100);
+		}
+	}
+
+	virtual void disable()
+	{
+		if (!_started.exchange(false)) return;
+		_nq.wakeUpAll();
+		while (!_done) Thread::sleep(100);
+		_thread.join();
+		NObserver::disable();
+	}
+
+	virtual int backlog() const
+	{
+		return _nq.size();
+	}
+
+private:
+	void dequeue()
+	{
+		NotificationPtr pNf;
+		_started = true;
+		while (pNf = _nq.waitDequeueNotification())
+		{
+			try
+			{
+				_mutex.lock();
+				try
+				{
+					(_pObject->*_method)(pNf);
+					_mutex.unlock();
+				}
+				catch (Poco::SystemException&) { break; }
+				catch (...) { _mutex.unlock(); }
+			} catch (Poco::SystemException&) {}
+		}
+		_done = true;
+		_started = false;
+	}
+
+	using Adapter = RunnableAdapter<AsyncObserver<C, N>>;
+
+	Thread _thread;
+	Matcher _matcher;
+	mutable NotificationQueue _nq;
+	Adapter _ra;
+	std::atomic<bool> _started;
+	std::atomic<bool> _done;
+};
+
+
+} // namespace Poco
+
+
+#endif // Foundation_ActiveObserver_INCLUDED

--- a/Foundation/include/Poco/Bugcheck.h
+++ b/Foundation/include/Poco/Bugcheck.h
@@ -165,42 +165,16 @@ protected:
 #endif
 
 
-//
-// poco_static_assert
-//
-// The following was ported from <boost/static_assert.hpp>
-//
+#define poco_static_assert(B) static_assert(B)
 
 
-template <bool x>
-struct POCO_STATIC_ASSERTION_FAILURE;
-
-
-template <>
-struct POCO_STATIC_ASSERTION_FAILURE<true>
-{
-	enum
-	{
-		value = 1
-	};
-};
-
-
-template <int x>
-struct poco_static_assert_test
-{
-};
-
-
-#if defined(__GNUC__) && (__GNUC__ == 3) && ((__GNUC_MINOR__ == 3) || (__GNUC_MINOR__ == 4))
-#define poco_static_assert(B) \
-	typedef char POCO_JOIN(poco_static_assert_typedef_, __LINE__) \
-        [POCO_STATIC_ASSERTION_FAILURE<(bool) (B)>::value]
-#else
-#define poco_static_assert(B) \
-	typedef poco_static_assert_test<sizeof(POCO_STATIC_ASSERTION_FAILURE<(bool) (B)>)> \
-		POCO_JOIN(poco_static_assert_typedef_, __LINE__) POCO_UNUSED
-#endif
+#define poco_static_assert_ptr(T) \
+	static_assert(std::is_pointer_v<T> || \
+	std::is_same_v<T, nullptr_t> || \
+	std::is_member_pointer_v<T> || \
+	std::is_member_function_pointer_v<T> || \
+	std::is_member_object_pointer_v<T>, \
+	"not a pointer")
 
 
 #endif // Foundation_Bugcheck_INCLUDED

--- a/Foundation/include/Poco/NObserver.h
+++ b/Foundation/include/Poco/NObserver.h
@@ -90,12 +90,7 @@ public:
 
 	virtual void notify(Notification* pNf) const
 	{
-		Poco::Mutex::ScopedLock lock(_mutex);
-		if (_pObject)
-		{
-			NotificationPtr ptr(pNf, true);
-			(_pObject->*_handler)(ptr);
-		}
+		handle(NotificationPtr(static_cast<N*>(pNf), true));
 	}
 
 	virtual bool equals(const AbstractObserver& abstractObserver) const
@@ -112,8 +107,7 @@ public:
 
 	virtual bool accepts(const Notification::Ptr& pNf) const
 	{
-		if(match(pNf)) return pNf.cast<N>() != nullptr;
-		return false;
+		return (match(pNf) && (pNf.template cast<N>() != nullptr));
 	}
 
 	virtual AbstractObserver* clone() const
@@ -130,7 +124,7 @@ public:
 
 protected:
 
-	void handle(const NotificationPtr& ptr)
+	void handle(const NotificationPtr& ptr) const
 	{
 		Mutex::ScopedLock lock(_mutex);
 
@@ -138,7 +132,7 @@ protected:
 			(_pObject->*_handler)(ptr);
 	}
 
-	bool match(const NotificationPtr& ptr) const
+	bool match(const Notification::Ptr& ptr) const
 	{
 		Mutex::ScopedLock l(_mutex);
 

--- a/Foundation/include/Poco/NObserver.h
+++ b/Foundation/include/Poco/NObserver.h
@@ -92,7 +92,10 @@ public:
 	{
 		Poco::Mutex::ScopedLock lock(_mutex);
 		if (_pObject)
-			(_pObject->*_handler)(NotificationPtr(pNf, true));
+		{
+			NotificationPtr ptr(pNf, true);
+			(_pObject->*_handler)(ptr);
+		}
 	}
 
 	virtual bool equals(const AbstractObserver& abstractObserver) const

--- a/Foundation/include/Poco/Notification.h
+++ b/Foundation/include/Poco/Notification.h
@@ -37,7 +37,7 @@ class Foundation_API Notification: public RefCountedObject
 public:
 	using Ptr = AutoPtr<Notification>;
 
-	Notification();
+	Notification(const std::string& name = ""s);
 		/// Creates the notification.
 
 	virtual std::string name() const;
@@ -46,6 +46,7 @@ public:
 
 protected:
 	virtual ~Notification();
+	std::unique_ptr<std::string> _pName;
 };
 
 

--- a/Foundation/include/Poco/Notification.h
+++ b/Foundation/include/Poco/Notification.h
@@ -22,6 +22,7 @@
 #include "Poco/Mutex.h"
 #include "Poco/RefCountedObject.h"
 #include "Poco/AutoPtr.h"
+#include <memory>
 
 
 namespace Poco {

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -132,10 +132,10 @@ public:
 		/// NotificationCenter.
 
 private:
-	typedef SharedPtr<AbstractObserver> AbstractObserverPtr;
-	typedef std::vector<AbstractObserverPtr> ObserverList;
+	using AbstractObserverPtr = SharedPtr<AbstractObserver>;
+	using ObserverList = std::vector<AbstractObserverPtr>;
 
-	ObserverList observersToNotify(Notification::Ptr pNotification) const;
+	ObserverList observersToNotify(const Notification::Ptr& pNotification) const;
 
 	ObserverList  _observers;
 	mutable Mutex _mutex;

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -79,6 +79,7 @@ class Foundation_API NotificationCenter
 	///     }
 {
 public:
+
 	NotificationCenter();
 		/// Creates the NotificationCenter.
 
@@ -120,6 +121,12 @@ public:
 	std::size_t countObservers() const;
 		/// Returns the number of registered observers.
 
+	int backlog() const;
+		/// Returns the sum of queued notifications
+		/// for all observers (applies only to active observers,
+		/// regular observers post notifications syncronously and
+		/// never have a backlog).
+
 	static NotificationCenter& defaultCenter();
 		/// Returns a reference to the default
 		/// NotificationCenter.
@@ -127,6 +134,8 @@ public:
 private:
 	typedef SharedPtr<AbstractObserver> AbstractObserverPtr;
 	typedef std::vector<AbstractObserverPtr> ObserverList;
+
+	ObserverList observersToNotify(Notification::Ptr pNotification) const;
 
 	ObserverList  _observers;
 	mutable Mutex _mutex;

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -83,7 +83,7 @@ public:
 	NotificationCenter();
 		/// Creates the NotificationCenter.
 
-	~NotificationCenter();
+	virtual ~NotificationCenter();
 		/// Destroys the NotificationCenter.
 
 	void addObserver(const AbstractObserver& observer);
@@ -100,7 +100,7 @@ public:
 	bool hasObserver(const AbstractObserver& observer) const;
 		/// Returns true if the observer is registered with this NotificationCenter.
 
-	void postNotification(Notification::Ptr pNotification);
+	virtual void postNotification(Notification::Ptr pNotification);
 		/// Posts a notification to the NotificationCenter.
 		/// The NotificationCenter then delivers the notification
 		/// to all interested observers.
@@ -121,9 +121,9 @@ public:
 	std::size_t countObservers() const;
 		/// Returns the number of registered observers.
 
-	int backlog() const;
+	virtual int backlog() const;
 		/// Returns the sum of queued notifications
-		/// for all observers (applies only to active observers,
+		/// for all observers (applies only to asynchronous observers,
 		/// regular observers post notifications syncronously and
 		/// never have a backlog).
 
@@ -131,11 +131,19 @@ public:
 		/// Returns a reference to the default
 		/// NotificationCenter.
 
-private:
+protected:
 	using AbstractObserverPtr = SharedPtr<AbstractObserver>;
 	using ObserverList = std::vector<AbstractObserverPtr>;
 
+	Mutex& mutex()
+	{
+		return _mutex;
+	}
+
 	ObserverList observersToNotify(const Notification::Ptr& pNotification) const;
+	void notifyObservers(Notification::Ptr& pNotification);
+
+private:
 
 	ObserverList  _observers;
 	mutable Mutex _mutex;

--- a/Foundation/include/Poco/Observer.h
+++ b/Foundation/include/Poco/Observer.h
@@ -74,15 +74,10 @@ public:
 	void notify(Notification* pNf) const
 	{
 		Poco::Mutex::ScopedLock lock(_mutex);
-
 		if (_pObject)
 		{
-			N* pCastNf = dynamic_cast<N*>(pNf);
-			if (pCastNf)
-			{
-				pCastNf->duplicate();
-				(_pObject->*_method)(pCastNf);
-			}
+			pNf->duplicate();
+			(_pObject->*_method)(static_cast<N*>(pNf));
 		}
 	}
 
@@ -92,9 +87,15 @@ public:
 		return pObs && pObs->_pObject == _pObject && pObs->_method == _method;
 	}
 
-	bool accepts(Notification* pNf, const char* pName = 0) const
+	[[deprecated("use `bool accepts(const Notification::Ptr&)` instead")]]
+	bool accepts(Notification* pNf, const char* pName) const
 	{
-		return dynamic_cast<N*>(pNf) && (!pName || pNf->name() == pName);
+		return (!pName || pNf->name() == pName) && (dynamic_cast<N*>(pNf) != nullptr);
+	}
+
+	bool accepts(const Notification::Ptr& pNf) const
+	{
+		return (pNf.cast<N>() != nullptr);
 	}
 
 	AbstractObserver* clone() const

--- a/Foundation/include/Poco/RunnableAdapter.h
+++ b/Foundation/include/Poco/RunnableAdapter.h
@@ -32,7 +32,7 @@ class RunnableAdapter: public Runnable
 	/// Usage:
 	///    RunnableAdapter<MyClass> ra(myObject, &MyObject::doSomething));
 	///    Thread thr;
-	///    thr.Start(ra);
+	///    thr.start(ra);
 	///
 	/// For using a freestanding or static member function as a thread
 	/// target, please see the ThreadTarget class.

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -103,11 +103,4 @@ void AsyncNotificationCenter::dequeue()
 }
 
 
-AsyncNotificationCenter& AsyncNotificationCenter::defaultCenter()
-{
-	static AsyncNotificationCenter nc;
-	return nc;
-}
-
-
 } // namespace Poco

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -1,0 +1,113 @@
+//
+// AsyncNotificationCenter.cpp
+//
+// Library: Foundation
+// Package: Notifications
+// Module:  AsyncNotificationCenter
+//
+// Copyright (c) 2004-2006, Applied Informatics Software Engineering GmbH.
+// Aleph ONE Software Engineering d.o.o.,
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/AsyncNotificationCenter.h"
+
+
+namespace Poco {
+
+
+AsyncNotificationCenter::AsyncNotificationCenter(): _ra(*this, &AsyncNotificationCenter::dequeue),
+	_started(false),
+	_done(false)
+{
+	start();
+}
+
+
+AsyncNotificationCenter::~AsyncNotificationCenter()
+{
+	stop();
+}
+
+
+void AsyncNotificationCenter::postNotification(Notification::Ptr pNotification)
+{
+	_nq.enqueueNotification(pNotification);
+}
+
+
+int AsyncNotificationCenter::backlog() const
+{
+	return _nq.size();
+}
+
+
+void AsyncNotificationCenter::start()
+{
+	Poco::ScopedLock l(mutex());
+	if (_started)
+	{
+		throw Poco::InvalidAccessException(
+			Poco::format("thread already started %s", poco_src_loc));
+	}
+	_thread.start(_ra);
+	Poco::Stopwatch sw;
+	sw.start();
+	while (!_started)
+	{
+		if (sw.elapsedSeconds() > 5)
+			throw Poco::TimeoutException(poco_src_loc);
+		Thread::sleep(100);
+	}
+}
+
+
+void AsyncNotificationCenter::stop()
+{
+	if (!_started.exchange(false)) return;
+	_nq.wakeUpAll();
+	while (!_done) Thread::sleep(100);
+	_thread.join();
+}
+
+
+void AsyncNotificationCenter::dequeue()
+{
+	Notification::Ptr pNf;
+	_started = true;
+	_done = false;
+	while ((pNf = _nq.waitDequeueNotification()))
+	{
+		try
+		{
+			notifyObservers(pNf);
+		}
+		catch (Poco::Exception& ex)
+		{
+			Poco::ErrorHandler::handle(ex);
+		}
+		catch (std::exception& ex)
+		{
+			Poco::ErrorHandler::handle(ex);
+		}
+		catch (...)
+		{
+			Poco::ErrorHandler::handle();
+		}
+	}
+	_done = true;
+	_started = false;
+}
+
+
+AsyncNotificationCenter& AsyncNotificationCenter::defaultCenter()
+{
+	static AsyncNotificationCenter nc;
+	return nc;
+}
+
+
+} // namespace Poco

--- a/Foundation/src/Notification.cpp
+++ b/Foundation/src/Notification.cpp
@@ -19,7 +19,8 @@
 namespace Poco {
 
 
-Notification::Notification()
+Notification::Notification(const std::string& name):
+	_pName(name.empty() ? nullptr : new std::string(name))
 {
 }
 
@@ -31,7 +32,7 @@ Notification::~Notification()
 
 std::string Notification::name() const
 {
-	return typeid(*this).name();
+	return _pName ? *_pName : typeid(*this).name();
 }
 
 

--- a/Foundation/src/NotificationCenter.cpp
+++ b/Foundation/src/NotificationCenter.cpp
@@ -47,6 +47,7 @@ void NotificationCenter::addObserver(const AbstractObserver& observer)
 {
 	Mutex::ScopedLock lock(_mutex);
 	_observers.push_back(observer.clone());
+	_observers.back()->start();
 }
 
 
@@ -75,17 +76,26 @@ bool NotificationCenter::hasObserver(const AbstractObserver& observer) const
 }
 
 
+NotificationCenter::ObserverList NotificationCenter::observersToNotify(Notification::Ptr pNotification) const
+{
+	ObserverList ret;
+	ScopedLock<Mutex> lock(_mutex);
+	for (auto& o : _observers)
+	{
+		if (o->accepts(pNotification))
+			ret.push_back(o);
+	}
+	return ret;
+}
+
+
 void NotificationCenter::postNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
 
-	ScopedLockWithUnlock<Mutex> lock(_mutex);
-	ObserverList observersToNotify(_observers);
-	lock.unlock();
-	for (auto& p: observersToNotify)
-	{
+	ObserverList observers = observersToNotify(pNotification);
+	for (auto& p: observers)
 		p->notify(pNotification);
-	}
 }
 
 
@@ -102,6 +112,20 @@ std::size_t NotificationCenter::countObservers() const
 	Mutex::ScopedLock lock(_mutex);
 
 	return _observers.size();
+}
+
+
+int NotificationCenter::backlog() const
+{
+	int cnt = 0;
+
+	ScopedLockWithUnlock<Mutex> lock(_mutex);
+	ObserverList observersToCount(_observers);
+	lock.unlock();
+	for (auto& p : observersToCount)
+		cnt += p->backlog();
+
+	return cnt;
 }
 
 

--- a/Foundation/src/NotificationCenter.cpp
+++ b/Foundation/src/NotificationCenter.cpp
@@ -93,6 +93,14 @@ void NotificationCenter::postNotification(Notification::Ptr pNotification)
 {
 	poco_check_ptr (pNotification);
 
+	notifyObservers(pNotification);
+}
+
+
+void NotificationCenter::notifyObservers(Notification::Ptr& pNotification)
+{
+	poco_check_ptr (pNotification);
+
 	ObserverList observers = observersToNotify(pNotification);
 	for (auto& p: observers)
 		p->notify(pNotification);

--- a/Foundation/src/NotificationCenter.cpp
+++ b/Foundation/src/NotificationCenter.cpp
@@ -76,7 +76,7 @@ bool NotificationCenter::hasObserver(const AbstractObserver& observer) const
 }
 
 
-NotificationCenter::ObserverList NotificationCenter::observersToNotify(Notification::Ptr pNotification) const
+NotificationCenter::ObserverList NotificationCenter::observersToNotify(const Notification::Ptr& pNotification) const
 {
 	ObserverList ret;
 	ScopedLock<Mutex> lock(_mutex);

--- a/Foundation/testsuite/src/AnyTest.cpp
+++ b/Foundation/testsuite/src/AnyTest.cpp
@@ -334,6 +334,111 @@ void AnyTest::testAnyInt()
 }
 
 
+class A
+{
+public:
+    void f() {}
+	int m;
+};
+
+
+void AnyTest::testAnyPointer()
+{
+	int i = 13;
+
+	Any a = &i;
+	assertTrue (a.type() == typeid(int*));
+	assertFalse (AnyHoldsNullPtr<int*>(a));
+	assertFalse (AnyHoldsNullPtr<int*>(&a));
+	int* p = AnyCast<int*>(&i);
+	assertTrue (*p == 13);
+	Any b = a;
+	assertTrue (b.type() == typeid(int*));
+	int* cpyI = AnyCast<int*>(b);
+	assertTrue (*cpyI == *p);
+	*cpyI = 20;
+	assertTrue (*cpyI == *p);
+	std::string* s = AnyCast<std::string>(&a);
+	assertTrue (s == NULL);
+	assertTrue (AnyCast<nullptr_t>(&a) == nullptr);
+
+	int* POCO_UNUSED tmp = AnyCast<int*>(a);
+	const Any c = a;
+	tmp = AnyCast<int*>(a);
+
+	Any nullPtr(nullptr);
+	assertFalse (AnyHoldsNullPtr<nullptr_t>(nullptr));
+	assertFalse (AnyHoldsNullPtr<void*>(0));
+	assertTrue (AnyHoldsNullPtr<nullptr_t>(nullPtr));
+	assertTrue (AnyHoldsNullPtr<nullptr_t>(&nullPtr));
+	try
+	{
+		AnyHoldsNullPtr<void*>(nullPtr);
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+	nullPtr = &i;
+	try
+	{
+		assertFalse (AnyHoldsNullPtr<nullptr_t>(nullPtr));
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+	assertFalse (AnyHoldsNullPtr<int*>(nullPtr));
+
+	void* voidPtr = nullptr;
+	Any nullVoidPtr(voidPtr);
+	assertTrue (AnyHoldsNullPtr<void*>(nullVoidPtr));
+	try
+	{
+		AnyHoldsNullPtr<nullptr_t>(voidPtr);
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+
+	using FP = void (AnyTest::*)();
+	FP fp = nullptr;
+	Any funcPtr(fp);
+	assertTrue (AnyHoldsNullPtr<FP>(funcPtr));
+	try
+	{
+		AnyHoldsNullPtr<FP>(voidPtr);
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+	funcPtr = &AnyTest::testAnyPointer;
+	assertFalse (AnyHoldsNullPtr<FP>(funcPtr));
+
+	using OP = decltype(&AnyTest::_dummyObject);
+	OP op = nullptr;
+	Any objPtr(op);
+	assertTrue (AnyHoldsNullPtr<OP>(objPtr));
+	objPtr = &AnyTest::_dummyObject;
+	try
+	{
+		AnyHoldsNullPtr<OP>(funcPtr);
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+
+	assertFalse (AnyHoldsNullPtr<OP>(objPtr));
+
+	using MP = decltype(&AnyTest::_dummy);
+	MP mp = nullptr;
+	Any memPtr(mp);
+	assertTrue (AnyHoldsNullPtr<MP>(memPtr));
+	memPtr = &AnyTest::_dummy;
+	try
+	{
+		AnyHoldsNullPtr<MP>(objPtr);
+		fail ("AnyCast must fail", __LINE__, __FILE__);
+	}
+	catch(const Poco::BadCastException&) {}
+
+	assertFalse (AnyHoldsNullPtr<MP>(memPtr));
+}
+
+
 void AnyTest::testAnyComplexType()
 {
 	SomeClass str(13,std::string("hello"));
@@ -456,6 +561,7 @@ CppUnit::Test* AnyTest::suite()
 	CppUnit_addTest(pSuite, AnyTest, testAnySwap);
 	CppUnit_addTest(pSuite, AnyTest, testAnyEmptyCopy);
 	CppUnit_addTest(pSuite, AnyTest, testAnyCastToReference);
+	CppUnit_addTest(pSuite, AnyTest, testAnyPointer);
 	CppUnit_addTest(pSuite, AnyTest, testAnyInt);
 	CppUnit_addTest(pSuite, AnyTest, testAnyComplexType);
 	CppUnit_addTest(pSuite, AnyTest, testAnyVector);

--- a/Foundation/testsuite/src/AnyTest.h
+++ b/Foundation/testsuite/src/AnyTest.h
@@ -20,6 +20,8 @@
 class AnyTest: public CppUnit::TestCase
 {
 public:
+	class Dummy{};
+
 	AnyTest(const std::string& name);
 	~AnyTest();
 
@@ -33,6 +35,7 @@ public:
 	void testAnyEmptyCopy();
 	void testAnyCastToReference();
 
+	void testAnyPointer();
 	void testAnyInt();
 	void testAnyComplexType();
 	void testAnyVector();
@@ -42,6 +45,10 @@ public:
 	void setUp();
 	void tearDown();
 	static CppUnit::Test* suite();
+
+private:
+	int _dummy = 0;
+	Dummy _dummyObject;
 };
 
 

--- a/Foundation/testsuite/src/FIFOEventTest.cpp
+++ b/Foundation/testsuite/src/FIFOEventTest.cpp
@@ -377,7 +377,7 @@ void FIFOEventTest::testAsyncNotifyBenchmark()
 			assertTrue (vresult[i].data() == (i*2));
 		}
 		sw.stop();
-		times.push_back(sw.elapsed()/1000);
+		times.push_back(static_cast<int>(sw.elapsed()/1000));
 		vresult.clear();
 	}
 
@@ -451,7 +451,7 @@ void FIFOEventTest::onAsyncBench(const void* pSender, int& i)
 
 int FIFOEventTest::getCount() const
 {
-	return _count;
+	return static_cast<int>(_count.load());
 }
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -28,6 +28,13 @@ using Poco::AutoPtr;
 
 class TestNotification: public Notification
 {
+public:
+	TestNotification()
+	{}
+
+	TestNotification(const std::string& name):
+		Notification(name)
+	{}
 };
 
 
@@ -155,15 +162,16 @@ void NotificationCenterTest::testNotificationCenterAuto()
 
 void NotificationCenterTest::testNotificationCenterAsync()
 {
-	using ObserverT = AsyncObserver<NotificationCenterTest, Notification>::Type;
+	using ObserverT = AsyncObserver<NotificationCenterTest, TestNotification>::Type;
 
 	NotificationCenter nc;
 
 	nc.addObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
 	nc.addObserver(ObserverT(*this, &NotificationCenterTest::handleAsync2, &NotificationCenterTest::matchAsync));
 
-	nc.postNotification(new Notification("asyncNotification"));
-	nc.postNotification(new Notification("anotherNotification"));
+	nc.postNotification(new TestNotification("asyncNotification"));
+	nc.postNotification(new TestNotification("anotherNotification"));
+	nc.postNotification(new Notification);
 
 	while (!_handle1Done || !_handle2Done)
 		Poco::Thread::sleep(100);
@@ -227,7 +235,7 @@ void NotificationCenterTest::handleAuto(const AutoPtr<Notification>& pNf)
 }
 
 
-void NotificationCenterTest::handleAsync1(const AutoPtr<Notification>& pNf)
+void NotificationCenterTest::handleAsync1(const AutoPtr<TestNotification>& pNf)
 {
 	Poco::Mutex::ScopedLock l(_mutex);
 	_set.insert("handleAsync1");
@@ -235,7 +243,7 @@ void NotificationCenterTest::handleAsync1(const AutoPtr<Notification>& pNf)
 }
 
 
-void NotificationCenterTest::handleAsync2(const AutoPtr<Notification>& pNf)
+void NotificationCenterTest::handleAsync2(const AutoPtr<TestNotification>& pNf)
 {
 	Poco::Mutex::ScopedLock l(_mutex);
 	_set.insert("handleAsync2");

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -180,8 +180,8 @@ void NotificationCenterTest::testAsyncObserver()
 	while (!_handleAsync1Done || !_handleAsync2Done)
 		Poco::Thread::sleep(100);
 
-	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1));
-	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync2));
+	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
+	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync2, &NotificationCenterTest::matchAsync));
 
 	Poco::Mutex::ScopedLock l(_mutex);
 	assertTrue(_set.size() == 2);
@@ -206,8 +206,8 @@ void NotificationCenterTest::testAsyncNotificationCenter()
 	while (!_handleAsync1Done || !_handleAsync2Done)
 		Poco::Thread::sleep(100);
 
-	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1));
-	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync2));
+	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
+	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync2, &NotificationCenterTest::matchAsync));
 
 	Poco::Mutex::ScopedLock l(_mutex);
 	assertTrue(_set.size() == 2);
@@ -241,7 +241,7 @@ void NotificationCenterTest::testDefaultAsyncNotificationCenter()
 	while (!_handle1Done || !_handleAuto1Done || !_handleAsync1Done)
 		Poco::Thread::sleep(100);
 
-	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1));
+	nc.removeObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
 	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handleAuto));
 	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	Poco::Mutex::ScopedLock l(_mutex);
@@ -249,6 +249,10 @@ void NotificationCenterTest::testDefaultAsyncNotificationCenter()
 	assertTrue (_set.find("handle1") != _set.end());
 	assertTrue (_set.find("handleAuto") != _set.end());
 	assertTrue (_set.find("handleAsync1") != _set.end());
+	// TODO: static object thread hangs without this on windows
+	// for explanation/solution, see
+	// https://stackoverflow.com/questions/10441048/exit-thread-upon-deleting-static-object-during-unload-dll-causes-deadlock
+	nc.stop();
 }
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -51,8 +51,8 @@ protected:
 	void handle3(Poco::Notification* pNf);
 	void handleTest(TestNotification* pNf);
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
-	void handleAsync1(const Poco::AutoPtr<Poco::Notification>& pNf);
-	void handleAsync2(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handleAsync1(const Poco::AutoPtr<TestNotification>& pNf);
+	void handleAsync2(const Poco::AutoPtr<TestNotification>& pNf);
 	bool matchAsync(const std::string& name) const;
 
 private:

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -37,8 +37,10 @@ public:
 	void testNotificationCenter4();
 	void testNotificationCenter5();
 	void testNotificationCenterAuto();
-	void testNotificationCenterAsync();
+	void testAsyncObserver();
+	void testAsyncNotificationCenter();
 	void testDefaultNotificationCenter();
+	void testDefaultAsyncNotificationCenter();
 
 	void setUp();
 	void tearDown();

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -60,7 +60,9 @@ protected:
 private:
 	std::set<std::string> _set;
 	std::atomic<bool> _handle1Done;
-	std::atomic<bool> _handle2Done;
+	std::atomic<bool> _handleAuto1Done;
+	std::atomic<bool> _handleAsync1Done;
+	std::atomic<bool> _handleAsync2Done;
 	Poco::Mutex _mutex;
 };
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -18,6 +18,7 @@
 #include "CppUnit/TestCase.h"
 #include "Poco/Notification.h"
 #include "Poco/AutoPtr.h"
+#include "Poco/Mutex.h"
 #include <set>
 
 
@@ -30,13 +31,14 @@ public:
 	NotificationCenterTest(const std::string& name);
 	~NotificationCenterTest();
 
-	void test1();
-	void test2();
-	void test3();
-	void test4();
-	void test5();
-	void testAuto();
-	void testDefaultCenter();
+	void testNotificationCenter1();
+	void testNotificationCenter2();
+	void testNotificationCenter3();
+	void testNotificationCenter4();
+	void testNotificationCenter5();
+	void testNotificationCenterAuto();
+	void testNotificationCenterAsync();
+	void testDefaultNotificationCenter();
 
 	void setUp();
 	void tearDown();
@@ -49,9 +51,13 @@ protected:
 	void handle3(Poco::Notification* pNf);
 	void handleTest(TestNotification* pNf);
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handleAsync1(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handleAsync2(const Poco::AutoPtr<Poco::Notification>& pNf);
+	bool matchAsync(const std::string& name);
 
 private:
 	std::set<std::string> _set;
+	Poco::Mutex _mutex;
 };
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -53,10 +53,12 @@ protected:
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleAsync1(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleAsync2(const Poco::AutoPtr<Poco::Notification>& pNf);
-	bool matchAsync(const std::string& name);
+	bool matchAsync(const std::string& name) const;
 
 private:
 	std::set<std::string> _set;
+	std::atomic<bool> _handle1Done;
+	std::atomic<bool> _handle2Done;
 	Poco::Mutex _mutex;
 };
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -40,7 +40,7 @@ public:
 	void testAsyncObserver();
 	void testAsyncNotificationCenter();
 	void testDefaultNotificationCenter();
-	void testDefaultAsyncNotificationCenter();
+	void testMixedObservers();
 
 	void setUp();
 	void tearDown();

--- a/Foundation/testsuite/src/VarTest.cpp
+++ b/Foundation/testsuite/src/VarTest.cpp
@@ -1997,12 +1997,12 @@ void VarTest::testLimitsFloat()
 {
 	if (std::numeric_limits<double>::max() != std::numeric_limits<float>::max())
 	{
-		double iMin = -1 * std::numeric_limits<float>::max();
+		constexpr double iMin = -1 * std::numeric_limits<float>::max();
 		Var da = iMin * 10;
 		try { float POCO_UNUSED f; f = da; fail("must throw", __LINE__, __FILE__); }
 		catch (RangeException&) {}
 
-		double iMax = std::numeric_limits<float>::max();
+		constexpr double iMax = std::numeric_limits<float>::max();
 		da = iMax * 10;
 		try { float POCO_UNUSED f; f = da; fail("must throw", __LINE__, __FILE__); }
 		catch (RangeException&) {}
@@ -2027,13 +2027,13 @@ void VarTest::testLimitsFloat()
 	float f = 0.f;
 	try { f = anyInt.convert<float>(); fail("must throw", __LINE__, __FILE__); }
 	catch (Poco::RangeException&) {}
-	i = f;
+	i = static_cast<int64_t>(f);
 	assertTrue (0 == i);
 
 	double d = 0.;
 	try { d = anyInt.convert<double>(); fail("must throw", __LINE__, __FILE__); }
 	catch (Poco::RangeException&) {}
-	i = d;
+	i = static_cast<int64_t>(d);
 	assertTrue (0 == i);
 }
 

--- a/Net/include/Poco/Net/ParallelSocketAcceptor.h
+++ b/Net/include/Poco/Net/ParallelSocketAcceptor.h
@@ -22,17 +22,8 @@
 #include "Poco/Net/StreamSocket.h"
 #include "Poco/Net/ServerSocket.h"
 #include "Poco/Environment.h"
-#include "Poco/NObserver.h"
 #include "Poco/SharedPtr.h"
 #include <vector>
-
-
-using Poco::Net::Socket;
-using Poco::Net::SocketReactor;
-using Poco::Net::ServerSocket;
-using Poco::Net::StreamSocket;
-using Poco::NObserver;
-using Poco::AutoPtr;
 
 
 namespace Poco {


### PR DESCRIPTION
#4414 

Summary:

- existing functionality is only broken in the (now deprecated) [AbstractObserver::accepts()](https://github.com/pocoproject/poco/pull/4444/files#diff-c01387ad7bebc0f44dc73dd78c3b81758e087ac8e5c5083d9e359ca9d4c3b313R41-R44)
  This was a "quick and dirty" external path to the goal of filtering notifications by name (in addition to type-filtering)
- optional [_matcher](https://github.com/pocoproject/poco/blob/b6e310fe2ddd13abcfc82c4567c7591c54f7ea3d/Foundation/include/Poco/NObserver.h#L150) is added to `NObserver`
  (defaults to null and does not break existing functionality)
- [NotificationCenter::observersTonotify()](url) filters out the non-interested observers
  - this is the only place where `dynamic_cast` performance hit is taken
  - unnecessary casting is avoided when matcher is present and does not match
  - since observers are filtered, only the ones with matching type are notified, so `notify()` can cast [statically](https://github.com/pocoproject/poco/blob/b6e310fe2ddd13abcfc82c4567c7591c54f7ea3d/Foundation/include/Poco/NObserver.h#L93)
- `AsyncObserver` is child of `NObserver` and runs its own [thread](https://github.com/pocoproject/poco/blob/b6e310fe2ddd13abcfc82c4567c7591c54f7ea3d/Foundation/include/Poco/AsyncObserver.h#L135-L158) to decouple Notification posting from handling
- added`AsyncNotificationCenter`, a child class of the `NotificationCenter`; currently, there is a problem with default static version of this observer on windows:
  https://github.com/pocoproject/poco/blob/71560b0f1c3b68990a554d4aba59759c87590f2e/Foundation/testsuite/src/NotificationCenterTest.cpp#L252-L255