### PR TITLE
Fix detection of odbc and apache2 for Fedora

### DIFF
--- a/cmake/FindApache2.cmake
+++ b/cmake/FindApache2.cmake
@@ -26,6 +26,7 @@ find_path(APACHE2_INCLUDE_DIR httpd.h
 		${APACHE2_ROOT_INCLUDE_DIRS}
 	PATHS
 		${PC_APACHE2_INCLUDE_DIRS}
+		/usr/include/httpd
 		/usr/local/include/apache2
 		/usr/include/apache2
 )

--- a/cmake/FindODBC.cmake
+++ b/cmake/FindODBC.cmake
@@ -36,6 +36,7 @@ find_path(ODBC_INCLUDE_DIR
 	PATHS
 		${PC_ODBC_INCLUDE_DIRS}
 		/usr/include
+		/usr/include/libiodbc
 		/usr/local/include
 		/usr/local/odbc/include
 		/usr/local/iodbc/include


### PR DESCRIPTION
I used this PR as a patch in https://src.fedoraproject.org/rpms/poco/pull-request/5.
It can help the finding of obdc and apache2 system dependencies on Fedora, without manually defining the location of the `ODBC_INCLUDE_DIRS` and `APACHE2_INCLUDE_DIRS` variables.