### PR TITLE
Moving operator<< and operator>> overloads into the Poco::Net namespace.

### DIFF
--- a/Net/include/Poco/Net/IPAddress.h
+++ b/Net/include/Poco/Net/IPAddress.h
@@ -474,12 +474,11 @@ inline void IPAddress::newIPv6(unsigned prefix)
 #endif // POCO_HAVE_IPv6
 
 
-} } // namespace Poco::Net
-
-
 Net_API Poco::BinaryWriter& operator << (Poco::BinaryWriter& writer, const Poco::Net::IPAddress& value);
 Net_API Poco::BinaryReader& operator >> (Poco::BinaryReader& reader, Poco::Net::IPAddress& value);
 Net_API std::ostream& operator << (std::ostream& ostr, const Poco::Net::IPAddress& addr);
+
+} } // namespace Poco::Net
 
 
 #endif // Net_IPAddress_INCLUDED

--- a/Net/include/Poco/Net/SocketAddress.h
+++ b/Net/include/Poco/Net/SocketAddress.h
@@ -316,12 +316,12 @@ inline bool SocketAddress::operator != (const SocketAddress& socketAddress) cons
 }
 
 
-} } // namespace Poco::Net
-
-
 Net_API Poco::BinaryWriter& operator << (Poco::BinaryWriter& writer, const Poco::Net::SocketAddress& value);
 Net_API Poco::BinaryReader& operator >> (Poco::BinaryReader& reader, Poco::Net::SocketAddress& value);
 Net_API std::ostream& operator << (std::ostream& ostr, const Poco::Net::SocketAddress& address);
+
+
+} } // namespace Poco::Net
 
 
 #endif // Net_SocketAddress_INCLUDED

--- a/Net/src/IPAddress.cpp
+++ b/Net/src/IPAddress.cpp
@@ -674,9 +674,6 @@ std::vector<unsigned char> IPAddress::toBytes() const
 }
 
 
-} } // namespace Poco::Net
-
-
 Poco::BinaryWriter& operator << (Poco::BinaryWriter& writer, const Poco::Net::IPAddress& value)
 {
 	writer << static_cast<Poco::UInt8>(value.length());
@@ -701,3 +698,7 @@ std::ostream& operator << (std::ostream& ostr, const Poco::Net::IPAddress& addr)
 	ostr << addr.toString();
 	return ostr;
 }
+
+
+} } // namespace Poco::Net
+

--- a/Net/src/SocketAddress.cpp
+++ b/Net/src/SocketAddress.cpp
@@ -433,9 +433,6 @@ Poco::UInt16 SocketAddress::resolveService(const std::string& service)
 }
 
 
-} } // namespace Poco::Net
-
-
 Poco::BinaryWriter& operator << (Poco::BinaryWriter& writer, const Poco::Net::SocketAddress& value)
 {
 	writer << value.host();
@@ -460,3 +457,8 @@ std::ostream& operator << (std::ostream& ostr, const Poco::Net::SocketAddress& a
 	ostr << address.toString();
 	return ostr;
 }
+
+
+} } // namespace Poco::Net
+
+


### PR DESCRIPTION
Addresses the issues in #3997.