### PR TITLE
Tune Linux ASLR when running sanitizer, use macOS 14 with some jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      # ASLR (https://en.wikipedia.org/wiki/Address_space_layout_randomization)
+      # causes sanitizer to fail.
+      # vm.mmap_rnd_bits needs to be set to 28 to make it work.
+      # (https://github.com/google/sanitizers/issues/1716)
+      - run: sysctl vm.legacy_va_layout
+      - run: sysctl kernel.randomize_va_space
+      - run: sudo sysctl vm.mmap_rnd_bits
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
       - run: ./configure --everything --no-samples --omit=PDF && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
       - uses: ./.github/actions/retry-action
@@ -103,6 +111,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      # ASLR (https://en.wikipedia.org/wiki/Address_space_layout_randomization)
+      # causes sanitizer to fail.
+      # vm.mmap_rnd_bits needs to be set to 28 to make it work.
+      # (https://github.com/google/sanitizers/issues/1716)
+      - run: sysctl vm.legacy_va_layout
+      - run: sysctl kernel.randomize_va_space
+      - run: sudo sysctl vm.mmap_rnd_bits
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
       - run: ./configure --everything --no-samples --omit=PDF --no-soo && make all -s -j4 SANITIZEFLAGS=-fsanitize=address && sudo make install
       - uses: ./.github/actions/retry-action
@@ -135,6 +151,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      # ASLR (https://en.wikipedia.org/wiki/Address_space_layout_randomization)
+      # causes sanitizer to fail.
+      # vm.mmap_rnd_bits needs to be set to 28 to make it work.
+      # (https://github.com/google/sanitizers/issues/1716)
+      - run: sysctl vm.legacy_va_layout
+      - run: sysctl kernel.randomize_va_space
+      - run: sudo sysctl vm.mmap_rnd_bits
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - run: sudo apt -y update && sudo apt -y install libssl-dev unixodbc-dev libmysqlclient-dev redis-server
       - run: ./configure --everything --no-samples --omit=CppParser,Encodings,Data/MySQL,Data/ODBC,Data/PostgreSQL,MongoDB,PageCompiler,PDF,PocoDoc,ProGen,Redis,SevenZip && make all -s -j4 SANITIZEFLAGS=-fsanitize=thread && sudo make install
       - uses: ./.github/actions/retry-action
@@ -143,8 +167,7 @@ jobs:
           max_attempts: 3
           retry_on: any
           command: >-
-            sudo -s
-            ./ci/runtests.sh TSAN
+            sudo -s ./ci/runtests.sh TSAN
 
   linux-gcc-cmake:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
             ./ci/runtests.sh
 
   macos-clang-make-visibility-hidden:
+    # macos-12 runs on Intel CPU
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
@@ -258,7 +259,8 @@ jobs:
             ./ci/runtests.sh
 
   macos-clang-cmake-openssl:
-    runs-on: macos-12
+    # macos-14 runs on Apple Silicon
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@1.1 mysql-client unixodbc libpq
@@ -283,7 +285,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
   macos-clang-cmake-openssl3:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3 mysql-client unixodbc libpq
@@ -308,7 +310,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
   macos-clang-cmake-openssl3-visibility-hidden:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3 mysql-client unixodbc libpq
@@ -333,7 +335,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
   macos-clang-make-openssl3-tsan:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3


### PR DESCRIPTION
Fixes #4503 and changes macos-12 (Intel) to macos-14 (Apple Silicon) for some jobs.