### PR TITLE
Optimize Net module for Android

### DIFF
--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -134,7 +134,7 @@ POCO_NET_FORCE_SYMBOL(pocoNetworkInitializer)
 #endif
 
 
-#if (POCO_OS == POCO_OS_LINUX) || (POCO_OS == POCO_OS_WINDOWS_NT)
+#if (POCO_OS == POCO_OS_LINUX) || (POCO_OS == POCO_OS_WINDOWS_NT) || (POCO_OS == POCO_OS_ANDROID)
 	#define POCO_HAVE_FD_EPOLL 1
 #endif
 

--- a/Net/src/NetworkInterface.cpp
+++ b/Net/src/NetworkInterface.cpp
@@ -1486,7 +1486,7 @@ NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 
 
 #include <sys/types.h>
-#if POCO_OS != POCO_OS_ANDROID // Android doesn't have <ifaddrs.h>
+#if POCO_OS != POCO_OS_ANDROID || __ANDROID_API__ >= 24 // old Android doesn't have <ifaddrs.h>
 #include <ifaddrs.h>
 #endif
 #include <net/if.h>
@@ -1521,7 +1521,7 @@ static NetworkInterface::Type fromNative(unsigned arphrd)
 	}
 }
 
-#if (POCO_OS != POCO_OS_ANDROID) && !defined(POCO_EMSCRIPTEN)
+#if (POCO_OS != POCO_OS_ANDROID || __ANDROID_API__ >= 24) && !defined(POCO_EMSCRIPTEN)
 
 void setInterfaceParams(struct ifaddrs* iface, NetworkInterfaceImpl& impl)
 {
@@ -1580,7 +1580,7 @@ void setInterfaceParams(struct ifaddrs* iface, NetworkInterfaceImpl& impl)
 
 NetworkInterface::Map NetworkInterface::map(bool ipOnly, bool upOnly)
 {
-#if (POCO_OS != POCO_OS_ANDROID) && !defined(POCO_EMSCRIPTEN)
+#if (POCO_OS != POCO_OS_ANDROID || __ANDROID_API__ >= 24) && !defined(POCO_EMSCRIPTEN)
 	FastMutex::ScopedLock lock(_mutex);
 	Map result;
 	unsigned ifIndex = 0;


### PR DESCRIPTION
1. Poco uses `epoll_create`, `epoll_ctl` and `epoll_wait`, and they are always available for NDK. So we can enable epoll for Android platform.
```c
int epoll_create(int __size);

#if __ANDROID_API__ >= 21
int epoll_create1(int __flags) __INTRODUCED_IN(21);
#endif /* __ANDROID_API__ >= 21 */


int epoll_ctl(int __epoll_fd, int __op, int __fd, struct epoll_event* __BIONIC_COMPLICATED_NULLNESS __event);
int epoll_wait(int __epoll_fd, struct epoll_event* _Nonnull __events, int __event_count, int __timeout_ms);

#if __ANDROID_API__ >= 21
int epoll_pwait(int __epoll_fd, struct epoll_event* _Nonnull __events, int __event_count, int __timeout_ms, const sigset_t* _Nullable __mask) __INTRODUCED_IN(21);
#endif /* __ANDROID_API__ >= 21 */


#if __ANDROID_API__ >= 28
int epoll_pwait64(int __epoll_fd, struct epoll_event* _Nonnull __events, int __event_count, int __timeout_ms, const sigset64_t* _Nullable __mask) __INTRODUCED_IN(28);
#endif /* __ANDROID_API__ >= 28 */
```
2. <ifaddr.h>(`getifaddrs` and `freeifaddrs`) was introduced in android-24, so we can use `__ANDROID_API__ >= 24` to check if they are supported
```c
#if __ANDROID_API__ >= 24
int getifaddrs(struct ifaddrs* _Nullable * _Nonnull __list_ptr) __INTRODUCED_IN(24);

/**
 * [freeifaddrs(3)](http://man7.org/linux/man-pages/man3/freeifaddrs.3.html) frees a linked list
 * of `struct ifaddrs` returned by getifaddrs().
 *
 * Available since API level 24.
 */
void freeifaddrs(struct ifaddrs* _Nullable __ptr) __INTRODUCED_IN(24);
#endif /* __ANDROID_API__ >= 24 */
```