### PR TITLE
Documentation fix on Building with CMake section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ brew install cmake openssl mysql-client libpq
 building the POCO C++ Libraries.
 
 ```
-$ git clone -b master https://github.com/pocoproject/poco.git
+$ git clone -b main https://github.com/pocoproject/poco.git
 $ cd poco
 $ mkdir cmake-build
 $ cd cmake-build


### PR DESCRIPTION
The 'master' branch has been renamed to the 'main' branch in the project's clone command.