### PR TITLE
Remove zero-width space from start of file

### DIFF
--- a/Foundation/src/DataURIStream.cpp
+++ b/Foundation/src/DataURIStream.cpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // DataURIStream.cpp
 //
 // Library: Foundation


### PR DESCRIPTION
There was oddly a zero-width space at the start of DataURIStream.cpp, which seems potentially problematic