### PR TITLE
Throw Error in Socket::available if Socket Error Occurs 

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -653,6 +653,8 @@ int SocketImpl::available()
 	{
 		std::vector<char> buf(result);
 		result = recvfrom(sockfd(), &buf[0], result, MSG_PEEK, nullptr, nullptr);
+
+		if (result < 0) error();
 	}
 #endif
 	return result;

--- a/Net/testsuite/src/DatagramSocketTest.cpp
+++ b/Net/testsuite/src/DatagramSocketTest.cpp
@@ -804,6 +804,32 @@ void DatagramSocketTest::testGatherScatterVariableUNIX()
 }
 
 
+void DatagramSocketTest::testLocalUDPConnectionResetWin()
+{
+#if defined(POCO_OS_FAMILY_WINDOWS)
+	// create a local UDP socket and connect to another local port which doesn't have a UDP socket
+	DatagramSocket socket(SocketAddress("127.0.0.1", 0), true, true);
+
+	socket.connect(SocketAddress("127.0.0.1", 2345));
+
+	// send some data to the socket
+	unsigned char values[5]{};
+	socket.sendBytes(values, 5);
+
+	try
+	{
+		// available calls recvfrom which can cause a "Connection Reset by Peer" error for UDP sockets in Windows due to ICMP packets for remote destination not existing
+		socket.available();
+
+		fail();
+	}
+	catch (const Poco::Net::ConnectionResetException&)
+	{
+	}
+#endif
+}
+
+
 void DatagramSocketTest::setUp()
 {
 }
@@ -831,6 +857,8 @@ CppUnit::Test* DatagramSocketTest::suite()
 #endif
 	CppUnit_addTest(pSuite, DatagramSocketTest, testGatherScatterFixed);
 	CppUnit_addTest(pSuite, DatagramSocketTest, testGatherScatterVariable);
+
+	CppUnit_addTest(pSuite, DatagramSocketTest, testLocalUDPConnectionResetWin);
 
 	return pSuite;
 }

--- a/Net/testsuite/src/DatagramSocketTest.h
+++ b/Net/testsuite/src/DatagramSocketTest.h
@@ -55,6 +55,8 @@ private:
 	void testGatherScatterSTRFFixedUNIX();
 	void testGatherScatterVariableUNIX();
 	void testGatherScatterSTRFVariableUNIX();
+
+	void testLocalUDPConnectionResetWin();
 };
 
 


### PR DESCRIPTION
Changes to help address the issues I was seeing in #4537. This change makes `SocketImpl::available` throw an error exception if the result of `recvfrom` is negative and there was a socket error for UDP sockets. This will correctly inform the calling code that the socket is invalid and needs to be reset. This also fixes the issue with `receiveBytes` throwing `std::bad_array_new_length` because it will instead throw a Poco exception first when calling `available`.