### PR TITLE
Motivated by "The load balancing issue in Poco::ActiveThreadPool" #4544

### DIFF
--- a/Foundation/include/Poco/ActiveThreadPool.h
+++ b/Foundation/include/Poco/ActiveThreadPool.h
@@ -41,16 +41,19 @@ class Foundation_API ActiveThreadPool
 	/// The thread pool always keeps fixed number of threads running.
 	/// Use case for this pool is running many (more than os-max-thread-count) short live tasks
 	/// Round-robin model allow efficiently utilize cpu cores
+	/// Using redistributeTasks option allows optimize reusage of idle threads
 {
 public:
 	ActiveThreadPool(int capacity = static_cast<int>(Environment::processorCount()) + 1,
-		int stackSize = POCO_THREAD_STACK_SIZE);
+		int stackSize = POCO_THREAD_STACK_SIZE,
+		bool redistributeTasks = false);
 		/// Creates a thread pool with fixed capacity threads.
 		/// Threads are created with given stack size.
 
 	ActiveThreadPool(std::string  name,
 		int capacity = static_cast<int>(Environment::processorCount()) + 1,
-		int stackSize = POCO_THREAD_STACK_SIZE);
+		int stackSize = POCO_THREAD_STACK_SIZE,
+		bool redistributeTasks = false);
 		/// Creates a thread pool with the given name and fixed capacity threads.
 		/// Threads are created with given stack size.
 
@@ -124,6 +127,7 @@ private:
 	ThreadVec _threads;
 	mutable FastMutex _mutex;
 	std::atomic<size_t> _lastThreadIndex{0};
+	bool _redistributeTasks;
 };
 
 

--- a/Foundation/testsuite/src/ActiveThreadPoolTest.h
+++ b/Foundation/testsuite/src/ActiveThreadPoolTest.h
@@ -27,6 +27,7 @@ public:
 	~ActiveThreadPoolTest();
 
 	void testActiveThreadPool();
+	void testActiveThreadLoadBalancing();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Optimization allows redistribute tasks to the idle threads
When ActiveThread dequeue next Runnable, it checks is optimization is true and if yes it try to find idle thread and resend task
By default optimization is false