### PR TITLE
fix #4553

### DIFF
--- a/Foundation/include/Poco/Bugcheck.h
+++ b/Foundation/include/Poco/Bugcheck.h
@@ -39,38 +39,38 @@ class Foundation_API Bugcheck
 	/// automatically provide useful context information.
 {
 public:
-	[[noreturn]] static void assertion(const char* cond, const char* file, int line, const char* text = 0);
+	[[noreturn]] static void assertion(const char* cond, const char* file, LineNumber line, const char* text = 0);
 		/// An assertion failed. Break into the debugger, if
 		/// possible, then throw an AssertionViolationException.
 
-	[[noreturn]] static void nullPointer(const char* ptr, const char* file, int line);
+	[[noreturn]] static void nullPointer(const char* ptr, const char* file, LineNumber line);
 		/// An null pointer was encountered. Break into the debugger, if
 		/// possible, then throw an NullPointerException.
 
-	[[noreturn]] static void bugcheck(const char* file, int line);
+	[[noreturn]] static void bugcheck(const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 
-	[[noreturn]] static void bugcheck(const char* msg, const char* file, int line);
+	[[noreturn]] static void bugcheck(const char* msg, const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 
-	static void unexpected(const char* file, int line);
+	static void unexpected(const char* file, LineNumber line);
 		/// An exception was caught in a destructor. Break into debugger,
 		/// if possible and report exception. Must only be called from
 		/// within a catch () block as it rethrows the exception to
 		/// determine its class.
 
-	static void debugger(const char* file, int line);
+	static void debugger(const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible.
 
-	static void debugger(const char* msg, const char* file, int line);
+	static void debugger(const char* msg, const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible.
 
 protected:
-	static std::string what(const char* msg, const char* file, int line, const char* text = 0);
+	static std::string what(const char* msg, const char* file, LineNumber line, const char* text = 0);
 };
 
 

--- a/Foundation/include/Poco/Debugger.h
+++ b/Foundation/include/Poco/Debugger.h
@@ -45,7 +45,7 @@ public:
 		/// Writes a message to the debugger log, if available, otherwise to
 		/// standard error output.
 
-	static void message(const std::string& msg, const char* file, int line);
+	static void message(const std::string& msg, const char* file, LineNumber line);
 		/// Writes a message to the debugger log, if available, otherwise to
 		/// standard error output.
 
@@ -57,10 +57,10 @@ public:
 	static void enter(const std::string& msg);
 		/// Writes a debug message to the debugger log and breaks into it.
 
-	static void enter(const std::string& msg, const char* file, int line);
+	static void enter(const std::string& msg, const char* file, LineNumber line);
 		/// Writes a debug message to the debugger log and breaks into it.
 
-	static void enter(const char* file, int line);
+	static void enter(const char* file, LineNumber line);
 		/// Writes a debug message to the debugger log and breaks into it.
 
 	static constexpr std::string_view sourceFile(const std::string_view& fileName)

--- a/Foundation/include/Poco/Foundation.h
+++ b/Foundation/include/Poco/Foundation.h
@@ -160,6 +160,16 @@ using namespace std::literals;
 #define POCO_DEPRECATED
 #endif
 
+//
+// MS Visual Studio can use type long for __LINE__ macro
+// when /ZI compilation flag is used - https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170#zi-1
+// This breaks some poco interfaces, for ex. logger
+// We should fix type for line number
+namespace Poco {
+
+using LineNumber = decltype(__LINE__);
+
+}
 
 //
 // Pull in basic definitions

--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -130,7 +130,7 @@ public:
 	void log(const Exception& exc);
 		/// Logs the given exception with priority PRIO_ERROR.
 
-	void log(const Exception& exc, const char* file, int line);
+	void log(const Exception& exc, const char* file, LineNumber line);
 		/// Logs the given exception with priority PRIO_ERROR.
 		///
 		/// File must be a static string, such as the value of
@@ -142,8 +142,8 @@ public:
 		/// creates a Message with priority PRIO_FATAL
 		/// and the given message text and sends it
 		/// to the attached channel.
-
-	void fatal(const std::string& msg, const char* file, int line);
+	
+	void fatal(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_FATAL,
 		/// creates a Message with priority PRIO_FATAL
 		/// and the given message text and sends it
@@ -166,7 +166,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void critical(const std::string& msg, const char* file, int line);
+	void critical(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_CRITICAL,
 		/// creates a Message with priority PRIO_CRITICAL
 		/// and the given message text and sends it
@@ -189,7 +189,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void error(const std::string& msg, const char* file, int line);
+	void error(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_ERROR,
 		/// creates a Message with priority PRIO_ERROR
 		/// and the given message text and sends it
@@ -212,7 +212,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void warning(const std::string& msg, const char* file, int line);
+	void warning(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_WARNING,
 		/// creates a Message with priority PRIO_WARNING
 		/// and the given message text and sends it
@@ -235,7 +235,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void notice(const std::string& msg, const char* file, int line);
+	void notice(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_NOTICE,
 		/// creates a Message with priority PRIO_NOTICE
 		/// and the given message text and sends it
@@ -258,7 +258,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void information(const std::string& msg, const char* file, int line);
+	void information(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_INFORMATION,
 		/// creates a Message with priority PRIO_INFORMATION
 		/// and the given message text and sends it
@@ -281,7 +281,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void debug(const std::string& msg, const char* file, int line);
+	void debug(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_DEBUG,
 		/// creates a Message with priority PRIO_DEBUG
 		/// and the given message text and sends it
@@ -304,7 +304,7 @@ public:
 		/// and the given message text and sends it
 		/// to the attached channel.
 
-	void trace(const std::string& msg, const char* file, int line);
+	void trace(const std::string& msg, const char* file, LineNumber line);
 		/// If the Logger's log level is at least PRIO_TRACE,
 		/// creates a Message with priority PRIO_TRACE
 		/// and the given message text and sends it
@@ -463,7 +463,7 @@ protected:
 
 	void log(const std::string& text, Message::Priority prio);
 	void logNPC(const std::string& text, Message::Priority prio);
-	void log(const std::string& text, Message::Priority prio, const char* file, int line);
+	void log(const std::string& text, Message::Priority prio, const char* file, LineNumber line);
 
 	static std::string format(const std::string& fmt, int argc, std::string argv[]);
 	static Logger& parent(const std::string& name);
@@ -799,7 +799,7 @@ inline void Logger::logNPC(const std::string& text, Message::Priority prio)
 }
 
 
-inline void Logger::log(const std::string& text, Message::Priority prio, const char* file, int line)
+inline void Logger::log(const std::string& text, Message::Priority prio, const char* file, LineNumber line)
 {
 	if (_level >= prio && _pChannel)
 	{
@@ -823,7 +823,7 @@ inline void Logger::fatal(const std::string& msg)
 }
 
 
-inline void Logger::fatal(const std::string& msg, const char* file, int line)
+inline void Logger::fatal(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_FATAL, file, line);
 }
@@ -836,7 +836,7 @@ inline void Logger::critical(const std::string& msg)
 }
 
 
-inline void Logger::critical(const std::string& msg, const char* file, int line)
+inline void Logger::critical(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_CRITICAL, file, line);
 }
@@ -848,7 +848,7 @@ inline void Logger::error(const std::string& msg)
 }
 
 
-inline void Logger::error(const std::string& msg, const char* file, int line)
+inline void Logger::error(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_ERROR, file, line);
 }
@@ -860,7 +860,7 @@ inline void Logger::warning(const std::string& msg)
 }
 
 
-inline void Logger::warning(const std::string& msg, const char* file, int line)
+inline void Logger::warning(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_WARNING, file, line);
 }
@@ -872,7 +872,7 @@ inline void Logger::notice(const std::string& msg)
 }
 
 
-inline void Logger::notice(const std::string& msg, const char* file, int line)
+inline void Logger::notice(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_NOTICE, file, line);
 }
@@ -884,7 +884,7 @@ inline void Logger::information(const std::string& msg)
 }
 
 
-inline void Logger::information(const std::string& msg, const char* file, int line)
+inline void Logger::information(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_INFORMATION, file, line);
 }
@@ -896,7 +896,7 @@ inline void Logger::debug(const std::string& msg)
 }
 
 
-inline void Logger::debug(const std::string& msg, const char* file, int line)
+inline void Logger::debug(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_DEBUG, file, line);
 }
@@ -908,7 +908,7 @@ inline void Logger::trace(const std::string& msg)
 }
 
 
-inline void Logger::trace(const std::string& msg, const char* file, int line)
+inline void Logger::trace(const std::string& msg, const char* file, LineNumber line)
 {
 	log(msg, Message::PRIO_TRACE, file, line);
 }

--- a/Foundation/include/Poco/Message.h
+++ b/Foundation/include/Poco/Message.h
@@ -43,7 +43,7 @@ class Foundation_API Message
 	/// caused the message.
 {
 public:
-	typedef std::map<std::string, std::string> StringMap;
+	using StringMap = std::map<std::string, std::string>;
 
 	enum Priority
 	{
@@ -65,7 +65,7 @@ public:
 		/// Creates a Message with the given source, text and priority.
 		/// The thread and process ids are set.
 
-	Message(const std::string& source, const std::string& text, Priority prio, const char* file, int line);
+	Message(const std::string& source, const std::string& text, Priority prio, const char* file, LineNumber line);
 		/// Creates a Message with the given source, text, priority,
 		/// source file path and line.
 		///
@@ -155,14 +155,14 @@ public:
 		/// Returns the source file path of the code creating
 		/// the message. May be 0 if not set.
 
-	void setSourceLine(int line);
+	void setSourceLine(LineNumber line);
 		/// Sets the source file line of the statement
 		/// generating the log message.
 		///
 		/// This is usually the result of the __LINE__
 		/// macro.
 
-	int getSourceLine() const;
+	LineNumber getSourceLine() const;
 		/// Returns the source file line of the statement
 		/// generating the log message. May be 0
 		/// if not set.
@@ -211,7 +211,7 @@ private:
 	std::string _thread;
 	long        _pid;
 	const char* _file;
-	int         _line;
+	LineNumber _line;
 	StringMap*  _pMap;
 };
 
@@ -271,7 +271,7 @@ inline const char* Message::getSourceFile() const
 }
 
 
-inline int Message::getSourceLine() const
+inline LineNumber Message::getSourceLine() const
 {
 	return _line;
 }

--- a/Foundation/include/Poco/NestedDiagnosticContext.h
+++ b/Foundation/include/Poco/NestedDiagnosticContext.h
@@ -68,7 +68,7 @@ public:
 	void push(const std::string& info);
 		/// Pushes a context (without line number and filename) onto the stack.
 
-	void push(const std::string& info, int line, const char* filename);
+	void push(const std::string& info, LineNumber line, const char* filename);
 		/// Pushes a context (including line number and filename)
 		/// onto the stack. Filename must be a static string, such as the
 		/// one produced by the __FILE__ preprocessor macro.
@@ -104,7 +104,7 @@ private:
 	{
 		std::string info;
 		const char* file;
-		int         line;
+		LineNumber  line;
 	};
 	typedef std::vector<Context> Stack;
 
@@ -124,7 +124,7 @@ public:
 	NDCScope(const std::string& info);
 		/// Pushes a context on the stack.
 
-	NDCScope(const std::string& info, int line, const char* filename);
+	NDCScope(const std::string& info, LineNumber line, const char* filename);
 		/// Pushes a context on the stack.
 
 	~NDCScope();
@@ -141,7 +141,7 @@ inline NDCScope::NDCScope(const std::string& info)
 }
 
 
-inline NDCScope::NDCScope(const std::string& info, int line, const char* filename)
+inline NDCScope::NDCScope(const std::string& info, LineNumber line, const char* filename)
 {
 	NestedDiagnosticContext::current().push(info, line, filename);
 }

--- a/Foundation/src/Bugcheck.cpp
+++ b/Foundation/src/Bugcheck.cpp
@@ -21,7 +21,7 @@
 namespace Poco {
 
 
-void Bugcheck::assertion(const char* cond, const char* file, int line, const char* text)
+void Bugcheck::assertion(const char* cond, const char* file, LineNumber line, const char* text)
 {
 	std::string message("Assertion violation: ");
 	message += cond;
@@ -36,21 +36,21 @@ void Bugcheck::assertion(const char* cond, const char* file, int line, const cha
 }
 
 
-void Bugcheck::nullPointer(const char* ptr, const char* file, int line)
+void Bugcheck::nullPointer(const char* ptr, const char* file, LineNumber line)
 {
 	Debugger::enter(std::string("NULL pointer: ") + ptr, file, line);
 	throw NullPointerException(what(ptr, file, line));
 }
 
 
-void Bugcheck::bugcheck(const char* file, int line)
+void Bugcheck::bugcheck(const char* file, LineNumber line)
 {
 	Debugger::enter("Bugcheck", file, line);
 	throw BugcheckException(what(0, file, line));
 }
 
 
-void Bugcheck::bugcheck(const char* msg, const char* file, int line)
+void Bugcheck::bugcheck(const char* msg, const char* file, LineNumber line)
 {
 	std::string m("Bugcheck");
 	if (msg)
@@ -63,7 +63,7 @@ void Bugcheck::bugcheck(const char* msg, const char* file, int line)
 }
 
 
-void Bugcheck::unexpected(const char* file, int line)
+void Bugcheck::unexpected(const char* file, LineNumber line)
 {
 #ifdef _DEBUG
 	try
@@ -94,19 +94,19 @@ void Bugcheck::unexpected(const char* file, int line)
 }
 
 
-void Bugcheck::debugger(const char* file, int line)
+void Bugcheck::debugger(const char* file, LineNumber line)
 {
 	Debugger::enter(file, line);
 }
 
 
-void Bugcheck::debugger(const char* msg, const char* file, int line)
+void Bugcheck::debugger(const char* msg, const char* file, LineNumber line)
 {
 	Debugger::enter(msg, file, line);
 }
 
 
-std::string Bugcheck::what(const char* msg, const char* file, int line, const char* text)
+std::string Bugcheck::what(const char* msg, const char* file, LineNumber line, const char* text)
 {
 	std::ostringstream str;
 	if (msg) str << msg << " ";

--- a/Foundation/src/Debugger.cpp
+++ b/Foundation/src/Debugger.cpp
@@ -68,7 +68,7 @@ void Debugger::message(const std::string& msg)
 }
 
 
-void Debugger::message(const std::string& msg, const char* file, int line)
+void Debugger::message(const std::string& msg, const char* file, LineNumber line)
 {
 #if defined(_DEBUG)
 	std::ostringstream str;
@@ -109,7 +109,7 @@ void Debugger::enter(const std::string& msg)
 }
 
 
-void Debugger::enter(const std::string& msg, const char* file, int line)
+void Debugger::enter(const std::string& msg, const char* file, LineNumber line)
 {
 #if defined(_DEBUG)
 	message(msg, file, line);
@@ -118,7 +118,7 @@ void Debugger::enter(const std::string& msg, const char* file, int line)
 }
 
 
-void Debugger::enter(const char* file, int line)
+void Debugger::enter(const char* file, LineNumber line)
 {
 #if defined(_DEBUG)
 	message("BREAK", file, line);

--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -89,7 +89,7 @@ void Logger::log(const Exception& exc)
 }
 
 
-void Logger::log(const Exception& exc, const char* file, int line)
+void Logger::log(const Exception& exc, const char* file, LineNumber line)
 {
 	error(exc.displayText(), file, line);
 }

--- a/Foundation/src/Message.cpp
+++ b/Foundation/src/Message.cpp
@@ -52,7 +52,7 @@ Message::Message(const std::string& source, const std::string& text, Priority pr
 }
 
 
-Message::Message(const std::string& source, const std::string& text, Priority prio, const char* file, int line):
+Message::Message(const std::string& source, const std::string& text, Priority prio, const char* file, LineNumber line):
 	_source(source),
 	_text(text),
 	_prio(prio),
@@ -238,7 +238,7 @@ void Message::setSourceFile(const char* file)
 }
 
 
-void Message::setSourceLine(int line)
+void Message::setSourceLine(LineNumber line)
 {
 	_line = line;
 }

--- a/Foundation/src/NestedDiagnosticContext.cpp
+++ b/Foundation/src/NestedDiagnosticContext.cpp
@@ -53,7 +53,7 @@ void NestedDiagnosticContext::push(const std::string& info)
 }
 
 
-void NestedDiagnosticContext::push(const std::string& info, int line, const char* filename)
+void NestedDiagnosticContext::push(const std::string& info, LineNumber line, const char* filename)
 {
 	Context ctx;
 	ctx.info = info;

--- a/Foundation/testsuite/src/DateTimeTest.cpp
+++ b/Foundation/testsuite/src/DateTimeTest.cpp
@@ -404,14 +404,14 @@ void DateTimeTest::testArithmetics()
 
 	static const struct
 	{
-		int lineNum;		// source line number
-		int year1;			// operand/result date1 year
-		int month1;			// operand/result date1 month
-		unsigned int day1;	// operand/result date1 day
-		int numDays;		// operand/result 'int' number of days
-		int year2;			// operand/result date2 year
-		int month2;			// operand/result date2 month
-		unsigned int day2;	// operand/result date2 day
+		Poco::LineNumber lineNum;		// source line number
+		int year1;						// operand/result date1 year
+		int month1;						// operand/result date1 month
+		unsigned int day1;				// operand/result date1 day
+		int numDays;					// operand/result 'int' number of days
+		int year2;						// operand/result date2 year
+		int month2;						// operand/result date2 month
+		unsigned int day2;				// operand/result date2 day
 	} data[] =
 	{
 		//          - - - -first- - - -           - - - second - - -
@@ -436,7 +436,7 @@ void DateTimeTest::testArithmetics()
 	const int num_data = sizeof data / sizeof *data;
 	for (int di = 0; di < num_data; ++di)
 	{
-		const int line	 = data[di].lineNum;
+		const Poco::LineNumber line	 = data[di].lineNum;
 		const int num_days = data[di].numDays;
 		DateTime x = DateTime(data[di].year1, data[di].month1, data[di].day1);
 		const DateTime& X = x;
@@ -513,7 +513,7 @@ void DateTimeTest::testIncrementDecrement()
 
 	for (di = 0; di < num_data; ++di)
 	{
-		const int line = data[di].lineNum;
+		const Poco::LineNumber line = data[di].lineNum;
 		DateTime x = DateTime(data[di].year1, data[di].month1,
 							  data[di].day1);
 		// Would do pre-increment of x here.
@@ -532,7 +532,7 @@ void DateTimeTest::testIncrementDecrement()
 
 	for (di = 0; di < num_data; ++di)
 	{
-		const int line = data[di].lineNum;
+		const Poco::LineNumber line = data[di].lineNum;
 		DateTime x = DateTime(data[di].year1, data[di].month1, data[di].day1);
 		DateTime x1 = DateTime(data[di].year1, data[di].month1, data[di].day1);
 		DateTime x2 = DateTime(data[di].year2, data[di].month2, data[di].day2);
@@ -552,7 +552,7 @@ void DateTimeTest::testIncrementDecrement()
 
 	for (di = 0; di < num_data; ++di)
 	{
-		const int line = data[di].lineNum;
+		const Poco::LineNumber line = data[di].lineNum;
 		DateTime x = DateTime(data[di].year2, data[di].month2, data[di].day2);
 		const DateTime& X = x;
 		x = x - Timespan(1,0,0,0,0);
@@ -569,7 +569,7 @@ void DateTimeTest::testIncrementDecrement()
 
 	for (di = 0; di < num_data; ++di)
 	{
-		const int line = data[di].lineNum;
+		const Poco::LineNumber line = data[di].lineNum;
 		DateTime x1 = DateTime(data[di].year1, data[di].month1, data[di].day1);
 		DateTime x = DateTime(data[di].year2, data[di].month2, data[di].day2);
 		DateTime y = x; DateTime Y = y;
@@ -830,7 +830,7 @@ void DateTimeTest::testDayOfWeek()
 	const int num_data = sizeof data / sizeof *data;
 	for (int di = 0; di < num_data ; ++di)
 	{
-		const int line = data[di].d_lineNum;
+		const Poco::LineNumber line = data[di].d_lineNum;
 		DateTime x = DateTime(data[di].d_year, data[di].d_month, data[di].d_day);
 		const DateTime& X = x;
 		loop_1_assert (line, data[di].d_expDay == X.dayOfWeek());

--- a/Foundation/testsuite/src/ProcessRunnerTest.cpp
+++ b/Foundation/testsuite/src/ProcessRunnerTest.cpp
@@ -312,7 +312,7 @@ std::string ProcessRunnerTest::cmdLine(const std::string& cmd, const ProcessRunn
 }
 
 
-void ProcessRunnerTest::checkTimeout(const Stopwatch& sw, const std::string& msg, int timeoutMS, int line)
+void ProcessRunnerTest::checkTimeout(const Stopwatch& sw, const std::string& msg, int timeoutMS, LineNumber line)
 {
 	if (sw.elapsedSeconds()*1000 > timeoutMS)
 	{

--- a/Foundation/testsuite/src/ProcessRunnerTest.h
+++ b/Foundation/testsuite/src/ProcessRunnerTest.h
@@ -37,7 +37,7 @@ public:
 
 private:
 	std::string cmdLine(const std::string& cmd, const Poco::ProcessRunner::Args& args);
-	void checkTimeout(const Poco::Stopwatch& sw, const std::string& msg, int timeoutMS, int line);
+	void checkTimeout(const Poco::Stopwatch& sw, const std::string& msg, int timeoutMS, Poco::LineNumber line);
 };
 
 


### PR DESCRIPTION
fix #4553
MS Visual Studio can use type long for __LINE__ macro when /ZI compilation flag is used - https://learn.microsoft.com/en-us/cpp/build/ reference/z7-zi-zi-debug-information-format?view=msvc-170#zi-1 This breaks some poco interfaces, for ex. logger
We should fix type for line number