### PR TITLE
Allow ADL for swapping Optional values

### DIFF
--- a/Foundation/include/Poco/Optional.h
+++ b/Foundation/include/Poco/Optional.h
@@ -143,8 +143,9 @@ public:
 
 	void swap(Optional& other) noexcept
 	{
-		std::swap(_value, other._value);
-		std::swap(_isSpecified, other._isSpecified);
+		using std::swap;
+		swap(_value, other._value);
+		swap(_isSpecified, other._isSpecified);
 	}
 
 	const C& value() const


### PR DESCRIPTION
Some types support being swapped but may not have declared their `std::swap` overloads when `Poco/Optional.h` is first included. This is the case for instance with
```C++
    #include <Poco/Optional.h>
    #include <array>

    using Problematic = Poco::Optional<std::array<int, 42> >;
```
With an unqualified call to `swap`, preceded by `using std::swap`, we allow argument-dependent lookup to find suitable implementations of `swap`.