### PR TITLE
(fix #4536) SQLite transaction isolation support

### DIFF
--- a/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
@@ -100,11 +100,12 @@ public:
 
 	void setTransactionIsolation(Poco::UInt32 ti);
 		/// Sets the transaction isolation level.
-		/// Warning! If you want to use TRANSACTION_READ_UNCOMMITTED isolation level
-		/// than you shouldn't forget that enableSharedCache() and setThreadMode() will affect connection lock behavior
-		/// For ex. Use TRANSACTION_READ_UNCOMMITTED with enableSharedCache() and setThreadMode(THREAD_MODE_MULTI)
-		/// in cases when you have multiple threads, shared connection and custom code for table-lock exceptions
-		/// For ex. Two connections on the same thread with TRANSACTION_READ_UNCOMMITTED for only for one connection will throw exception "databse is locked"
+		/// Warning! In order to use TRANSACTION_READ_UNCOMMITTED isolation level, it is important
+		/// to keep in mind that enableSharedCache() and setThreadMode() affect connection lock behavior.
+		/// Eg. TRANSACTION_READ_UNCOMMITTED with enableSharedCache() and setThreadMode(THREAD_MODE_MULTI)
+		/// in a multiple thread, shared connection and custom code for table-lock exceptions scenario,
+		/// multiple connections on the same thread with TRANSACTION_READ_UNCOMMITTED will throw
+		/// "database locked" exception.
 
 	Poco::UInt32 getTransactionIsolation() const;
 		/// Returns the transaction isolation level.
@@ -149,7 +150,7 @@ private:
 	Poco::Mutex _mutex;
 	static const std::string DEFERRED_BEGIN_TRANSACTION;
 	static const std::string EXCLUSIVE_BEGIN_TRANSACTION;
-	static const std::string IMMEDIATE_BEGIN_TRANSACTION; 
+	static const std::string IMMEDIATE_BEGIN_TRANSACTION;
 	static const std::string COMMIT_TRANSACTION;
 	static const std::string ABORT_TRANSACTION;
 	static const std::string SQLITE_READ_UNCOMMITTED;

--- a/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/SessionImpl.h
@@ -100,6 +100,11 @@ public:
 
 	void setTransactionIsolation(Poco::UInt32 ti);
 		/// Sets the transaction isolation level.
+		/// Warning! If you want to use TRANSACTION_READ_UNCOMMITTED isolation level
+		/// than you shouldn't forget that enableSharedCache() and setThreadMode() will affect connection lock behavior
+		/// For ex. Use TRANSACTION_READ_UNCOMMITTED with enableSharedCache() and setThreadMode(THREAD_MODE_MULTI)
+		/// in cases when you have multiple threads, shared connection and custom code for table-lock exceptions
+		/// For ex. Two connections on the same thread with TRANSACTION_READ_UNCOMMITTED for only for one connection will throw exception "databse is locked"
 
 	Poco::UInt32 getTransactionIsolation() const;
 		/// Returns the transaction isolation level.
@@ -147,6 +152,9 @@ private:
 	static const std::string IMMEDIATE_BEGIN_TRANSACTION; 
 	static const std::string COMMIT_TRANSACTION;
 	static const std::string ABORT_TRANSACTION;
+	static const std::string SQLITE_READ_UNCOMMITTED;
+	static const std::string SQLITE_READ_COMMITTED;
+	Poco::UInt32 _transactionIsolationLevel;
 };
 
 

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -90,6 +90,7 @@ using Poco::Dynamic::Var;
 using Poco::Data::SQLite::Utility;
 using Poco::delegate;
 using Poco::Stopwatch;
+using Poco::Data::SQLite::Connector;
 
 
 class Person
@@ -3134,7 +3135,7 @@ void SQLiteTest::setTransactionIsolation(Session& session, Poco::UInt32 ti)
 }
 
 
-void SQLiteTest::testSessionTransaction()
+void SQLiteTest::testSessionTransactionReadCommitted()
 {
 	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
 	assertTrue (session.isConnected());
@@ -3212,10 +3213,6 @@ void SQLiteTest::testSessionTransaction()
 	session << "SELECT count(*) FROM Person", into(count), now;
 	assertTrue (2 == count);
 
-	/* TODO: see http://www.sqlite.org/pragma.html#pragma_read_uncommitted
-	setTransactionIsolation(session, Session::TRANSACTION_READ_UNCOMMITTED);
-	*/
-
 	session.close();
 	assertTrue (!session.isConnected());
 
@@ -3223,7 +3220,106 @@ void SQLiteTest::testSessionTransaction()
 	assertTrue (!local.isConnected());
 }
 
+void SQLiteTest::testSessionTransactionSerializable()
+{
+	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
+	assertTrue (session.isConnected());
+	setTransactionIsolation(session, Session::TRANSACTION_SERIALIZABLE);
+}
 
+void SQLiteTest::testSessionTransactionRepeatableRead()
+{
+	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
+	assertTrue (session.isConnected());
+	setTransactionIsolation(session, Session::TRANSACTION_REPEATABLE_READ);
+}
+
+void SQLiteTest::testSessionTransactionReadUncommitted()
+{
+	Connector::enableSharedCache();
+	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
+	assertTrue (session.isConnected());
+	
+	session << "DROP TABLE IF EXISTS Person", now;
+	session << "CREATE TABLE IF NOT EXISTS Person (LastName VARCHAR(30), FirstName VARCHAR, Address VARCHAR, Age INTEGER(3))", now;
+	
+	if (!session.canTransact())
+	{
+		std::cout << "Session not capable of transactions." << std::endl;
+		return;
+	}
+	
+	Session local (Poco::Data::SQLite::Connector::KEY, "dummy.db");
+	assertTrue (local.isConnected());
+	
+	assertTrue (local.getFeature("autoCommit"));
+	
+	std::string funct = "transaction()";
+	std::vector<std::string> lastNames;
+	std::vector<std::string> firstNames;
+	std::vector<std::string> addresses;
+	std::vector<int> ages;
+	std::string tableName("Person");
+	lastNames.push_back("LN1");
+	lastNames.push_back("LN2");
+	firstNames.push_back("FN1");
+	firstNames.push_back("FN2");
+	addresses.push_back("ADDR1");
+	addresses.push_back("ADDR2");
+	ages.push_back(1);
+	ages.push_back(2);
+	int count = 0, locCount = 0;
+	std::string result;
+	
+	setTransactionIsolation(session, Session::TRANSACTION_READ_UNCOMMITTED);
+	setTransactionIsolation(local, Session::TRANSACTION_READ_UNCOMMITTED);
+	
+	session.begin();
+	assertTrue (!session.getFeature("autoCommit"));
+	assertTrue (session.isTransaction());
+	session << "INSERT INTO Person VALUES (?,?,?,?)", use(lastNames), use(firstNames), use(addresses), use(ages), now;
+	assertTrue (session.isTransaction());
+	
+	Statement stmt = (local << "SELECT COUNT(*) FROM Person", into(locCount), async, now);
+	
+	session << "SELECT COUNT(*) FROM Person", into(count), now;
+	assertTrue (2 == count);
+	assertTrue (session.isTransaction());
+	session.rollback();
+	assertTrue (!session.isTransaction());
+	assertTrue (session.getFeature("autoCommit"));
+	
+	stmt.wait();
+	assertTrue (2 == locCount);
+	
+	session << "SELECT count(*) FROM Person", into(count), now;
+	assertTrue (0 == count);
+	assertTrue (!session.isTransaction());
+	
+	session.begin();
+	session << "INSERT INTO Person VALUES (?,?,?,?)", use(lastNames), use(firstNames), use(addresses), use(ages), now;
+	assertTrue (session.isTransaction());
+	assertTrue (!session.getFeature("autoCommit"));
+	
+	Statement stmt1 = (local << "SELECT COUNT(*) FROM Person", into(locCount), now);
+	assertTrue (2 == locCount);
+	
+	session << "SELECT count(*) FROM Person", into(count), now;
+	assertTrue (2 == count);
+	
+	session.commit();
+	assertTrue (!session.isTransaction());
+	assertTrue (session.getFeature("autoCommit"));
+	
+	session << "SELECT count(*) FROM Person", into(count), now;
+	assertTrue (2 == count);
+	
+	session.close();
+	assertTrue (!session.isConnected());
+	
+	local.close();
+	assertTrue (!local.isConnected());
+}
 void SQLiteTest::testTransaction()
 {
 	Session session (Poco::Data::SQLite::Connector::KEY, "dummy.db");
@@ -3627,7 +3723,10 @@ CppUnit::Test* SQLiteTest::suite()
 	CppUnit_addTest(pSuite, SQLiteTest, testCommitCallback);
 	CppUnit_addTest(pSuite, SQLiteTest, testRollbackCallback);
 	CppUnit_addTest(pSuite, SQLiteTest, testNotifier);
-	CppUnit_addTest(pSuite, SQLiteTest, testSessionTransaction);
+	CppUnit_addTest(pSuite, SQLiteTest, testSessionTransactionReadCommitted);
+	CppUnit_addTest(pSuite, SQLiteTest, testSessionTransactionReadUncommitted);
+	CppUnit_addTest(pSuite, SQLiteTest, testSessionTransactionSerializable);
+	CppUnit_addTest(pSuite, SQLiteTest, testSessionTransactionRepeatableRead);
 	CppUnit_addTest(pSuite, SQLiteTest, testTransaction);
 	CppUnit_addTest(pSuite, SQLiteTest, testTransactor);
 	CppUnit_addTest(pSuite, SQLiteTest, testFTS3);

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -3290,7 +3290,7 @@ void SQLiteTest::testSessionTransactionReadUncommitted()
 	assertTrue (session.getFeature("autoCommit"));
 	
 	stmt.wait();
-	assertTrue (2 == locCount);
+	assertEqual(2, locCount);
 	
 	session << "SELECT count(*) FROM Person", into(count), now;
 	assertTrue (0 == count);
@@ -3630,6 +3630,7 @@ void SQLiteTest::setUp()
 
 void SQLiteTest::tearDown()
 {
+	Connector::enableSharedCache(false);
 }
 
 

--- a/Data/SQLite/testsuite/src/SQLiteTest.h
+++ b/Data/SQLite/testsuite/src/SQLiteTest.h
@@ -132,7 +132,10 @@ public:
 	void testRollbackCallback();
 	void testNotifier();
 
-	void testSessionTransaction();
+	void testSessionTransactionReadCommitted();
+	void testSessionTransactionReadUncommitted();
+	void testSessionTransactionSerializable();
+	void testSessionTransactionRepeatableRead();
 	void testTransaction();
 	void testTransactor();
 


### PR DESCRIPTION
I've add transaction isolation support for SQLite
Warning! SQLite transactions are [serializable by design](https:// www.sqlite.org/isolation.html) my implementation retuns ```false``` in function ```hasTransactionIsolation``` and throw an exception in ```setTransactionIsolation```