### PR TITLE
DateTimeParser Validation and Performance Improvements

### DIFF
--- a/Foundation/include/Poco/DateTimeFormat.h
+++ b/Foundation/include/Poco/DateTimeFormat.h
@@ -128,9 +128,6 @@ public:
 	static bool isValid(const std::string& dateTime);
 		/// Returns true if dateTime validates against at least one supported format.
 
-	typedef std::unordered_set<const std::string*> RegexList;
-	static RegexList REGEX_LIST;
-
 private:
 	typedef std::unordered_set<std::string> Formatlist;
 	static Formatlist FORMAT_LIST;

--- a/Foundation/src/DateTimeFormat.cpp
+++ b/Foundation/src/DateTimeFormat.cpp
@@ -129,19 +129,6 @@ const std::string DateTimeFormat::MONTH_NAMES[] =
 };
 
 
-DateTimeFormat::RegexList DateTimeFormat::REGEX_LIST =
-{
-	&DateTimeFormat::ISO8601_REGEX,
-	&DateTimeFormat::RFC822_REGEX,
-	&DateTimeFormat::RFC1123_REGEX,
-	&DateTimeFormat::HTTP_REGEX,
-	&DateTimeFormat::RFC850_REGEX,
-	&DateTimeFormat::RFC1036_REGEX,
-	&DateTimeFormat::ASCTIME_REGEX,
-	&DateTimeFormat::SORTABLE_REGEX
-};
-
-
 bool DateTimeFormat::hasFormat(const std::string& fmt)
 {
 	return FORMAT_LIST.find(fmt) != FORMAT_LIST.end();
@@ -150,8 +137,7 @@ bool DateTimeFormat::hasFormat(const std::string& fmt)
 
 bool DateTimeFormat::isValid(const std::string& dateTime)
 {
-
-        static const RegularExpression regs[] = {
+        static const RegularExpression regexList[] = {
                 RegularExpression(DateTimeFormat::ISO8601_REGEX),
                 RegularExpression(DateTimeFormat::RFC822_REGEX),
                 RegularExpression(DateTimeFormat::RFC1123_REGEX),
@@ -161,10 +147,8 @@ bool DateTimeFormat::isValid(const std::string& dateTime)
                 RegularExpression(DateTimeFormat::ASCTIME_REGEX),
                 RegularExpression(DateTimeFormat::SORTABLE_REGEX)
         };
-		// make sure the regex list and the array of regexes are in sync
-		poco_assert((sizeof(regs) / sizeof(regs[0])) == REGEX_LIST.size());
-
-        for (const auto& f : regs)
+		
+        for (const auto& f : regexList)
         {
             if (f.match(dateTime)) return true;
         }

--- a/Foundation/src/DateTimeFormat.cpp
+++ b/Foundation/src/DateTimeFormat.cpp
@@ -150,11 +150,25 @@ bool DateTimeFormat::hasFormat(const std::string& fmt)
 
 bool DateTimeFormat::isValid(const std::string& dateTime)
 {
-	for (const auto& f : REGEX_LIST)
-	{
-		if (RegularExpression(*f).match(dateTime)) return true;
-	}
-	return false;
+
+        static const RegularExpression regs[] = {
+                RegularExpression(DateTimeFormat::ISO8601_REGEX),
+                RegularExpression(DateTimeFormat::RFC822_REGEX),
+                RegularExpression(DateTimeFormat::RFC1123_REGEX),
+                RegularExpression(DateTimeFormat::HTTP_REGEX),
+                RegularExpression(DateTimeFormat::RFC850_REGEX),
+                RegularExpression(DateTimeFormat::RFC1036_REGEX),
+                RegularExpression(DateTimeFormat::ASCTIME_REGEX),
+                RegularExpression(DateTimeFormat::SORTABLE_REGEX)
+        };
+		// make sure the regex list and the array of regexes are in sync
+		poco_assert((sizeof(regs) / sizeof(regs[0])) == REGEX_LIST.size());
+
+        for (const auto& f : regs)
+        {
+            if (f.match(dateTime)) return true;
+        }
+        return false;
 }
 
 

--- a/Foundation/src/DateTimeParser.cpp
+++ b/Foundation/src/DateTimeParser.cpp
@@ -21,9 +21,9 @@
 #include <iostream>
 
 namespace {
-	using parse_iter = std::string::const_iterator;
+	using ParseIter = std::string::const_iterator;
 
-	[[nodiscard]] parse_iter skip_non_digits(parse_iter it, parse_iter end)
+	[[nodiscard]] ParseIter skipNonDigits(ParseIter it, ParseIter end)
 	{
 		while (it != end && !Poco::Ascii::isDigit(*it))
 		{
@@ -33,7 +33,7 @@ namespace {
 	}
 
 
-	[[nodiscard]] parse_iter skip_digits(parse_iter it, parse_iter end)
+	[[nodiscard]] ParseIter skipDigits(ParseIter it, ParseIter end)
 	{
 		while (it != end && Poco::Ascii::isDigit(*it))
 		{
@@ -43,25 +43,25 @@ namespace {
 	}
 
 
-	int parse_number_n(const std::string& dtStr, parse_iter& it, parse_iter end, int n)
+	int parseNumberN(const std::string& dtStr, ParseIter& it, ParseIter end, int n)
 	{
-		parse_iter num_start = end;
+		ParseIter numStart = end;
 		int i = 0;
 
 		for (; it != end && i < n && Poco::Ascii::isDigit(*it); ++it, ++i)
 		{
-			if (num_start == end)
+			if (numStart == end)
 			{
-				num_start = it;
+				numStart = it;
 			}
 		}
 
-		if (num_start == end)
+		if (numStart == end)
 		{
 			throw Poco::SyntaxException("Invalid DateTimeString: " + dtStr + ", No number found to parse");
 		}
 
-		std::string number(num_start, it);
+		std::string number(numStart, it);
 		try
 		{
 			return std::stoi(number);
@@ -89,24 +89,24 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 		throw SyntaxException("Invalid DateTimeString: " + dtStr);
 	}
 	
-	const auto parse_number = [&dtStr](parse_iter& it, parse_iter end)
+	const auto parse_number = [&dtStr](ParseIter& it, ParseIter end)
 	{
-		parse_iter num_start = end;
+		ParseIter numStart = end;
 
 		for (; it != end && Poco::Ascii::isDigit(*it); ++it)
 		{
-			if (num_start == end)
+			if (numStart == end)
 			{
-				num_start = it;
+				numStart = it;
 			}
 		}
 
-		if (num_start == end)
+		if (numStart == end)
 		{
 			throw Poco::SyntaxException("Invalid DateTimeString: " + dtStr + ", No number found to parse");
 		}
 
-		std::string number(num_start, it);
+		std::string number(numStart, it);
 		try
 		{
 			return std::stoi(number);
@@ -119,25 +119,25 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 
 	
 
-	const auto parse_fractional_n = [dtStr](parse_iter& it, parse_iter end, int n)
+	const auto parseFractionalN = [dtStr](ParseIter& it, ParseIter end, int n)
 	{
-		parse_iter num_start = end;
+		ParseIter numStart = end;
 		int i = 0;
 
 		for (; it != end && i < n && Poco::Ascii::isDigit(*it); ++it, ++i)
 		{
-			if (num_start == end)
+			if (numStart == end)
 			{
-				num_start = it;
+				numStart = it;
 			}
 		}
 
-		if (num_start == end)
+		if (numStart == end)
 		{
 			return 0;
 		}
 
-		std::string number(num_start, it);
+		std::string number(numStart, it);
 		int result = 0;
 		try
 		{
@@ -192,31 +192,31 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 				case 'd':
 				case 'e':
 				case 'f':
-					it = skip_non_digits(it, end);
-					day = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					day = parseNumberN(dtStr, it, end, 2);
 					dayParsed = true;
 					break;
 				case 'm':
 				case 'n':
 				case 'o':
-					it = skip_non_digits(it, end);
-					month = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					month = parseNumberN(dtStr, it, end, 2);
 					monthParsed = true;
 					break;
 				case 'y':
-					it = skip_non_digits(it, end);
-					year = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					year = parseNumberN(dtStr, it, end, 2);
 					if (year >= 69)
 						year += 1900;
 					else
 						year += 2000;
 					break;
 				case 'Y':
-					it = skip_non_digits(it, end);
-					year = parse_number_n(dtStr, it, end, 4);
+					it = skipNonDigits(it, end);
+					year = parseNumberN(dtStr, it, end, 4);
 					break;
 				case 'r':
-					it = skip_non_digits(it, end);
+					it = skipNonDigits(it, end);
 					year = parse_number(it, end);
 
 					if (year < 1000)
@@ -229,24 +229,24 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 					break;
 				case 'H':
 				case 'h':
-					it = skip_non_digits(it, end);
-					hour = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					hour = parseNumberN(dtStr, it, end, 2);
 					break;
 				case 'a':
 				case 'A':
 					hour = parseAMPM(it, end, hour);
 					break;
 				case 'M':
-					it = skip_non_digits(it, end);
-					minute = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					minute = parseNumberN(dtStr, it, end, 2);
 					break;
 				case 'S':
-					it = skip_non_digits(it, end);
-					second = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					second = parseNumberN(dtStr, it, end, 2);
 					break;
 				case 's':
-					it = skip_non_digits(it, end);
-					second = parse_number_n(dtStr, it, end, 2);
+					it = skipNonDigits(it, end);
+					second = parseNumberN(dtStr, it, end, 2);
 
 					if (it != end && (*it == '.' || *it == ','))
 					{
@@ -257,25 +257,25 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 							throw SyntaxException("Invalid DateTimeString: " + dtStr + ", missing millisecond");
 						}
 						
-						millis = parse_fractional_n(it, end, 3);
-						micros = parse_fractional_n(it, end, 3);
-						it = skip_digits(it, end);
+						millis = parseFractionalN(it, end, 3);
+						micros = parseFractionalN(it, end, 3);
+						it = skipDigits(it, end);
 					}
 					break;
 				case 'i':
-					it = skip_non_digits(it, end);
-					millis = parse_number_n(dtStr, it, end, 3);
+					it = skipNonDigits(it, end);
+					millis = parseNumberN(dtStr, it, end, 3);
 					break;
 				case 'c':
-					it = skip_non_digits(it, end);
-					millis = parse_number_n(dtStr, it, end, 1);
+					it = skipNonDigits(it, end);
+					millis = parseNumberN(dtStr, it, end, 1);
 					millis *= 100;
 					break;
 				case 'F':
-					it = skip_non_digits(it, end);
-					millis = parse_number_n(dtStr, it, end, 3);
-					micros = parse_number_n(dtStr, it, end, 3);
-					it = skip_digits(it, end);
+					it = skipNonDigits(it, end);
+					millis = parseNumberN(dtStr, it, end, 3);
+					micros = parseNumberN(dtStr, it, end, 3);
+					it = skipDigits(it, end);
 					break;
 				case 'z':
 				case 'Z':
@@ -446,7 +446,7 @@ int DateTimeParser::parseTZD(std::string::const_iterator& it, const std::string:
 			int hours = 0;
 			try
 			{
-				hours = parse_number_n("", it, end, 2);
+				hours = parseNumberN("", it, end, 2);
 			}
 			catch(const SyntaxException& e)
 			{
@@ -459,7 +459,7 @@ int DateTimeParser::parseTZD(std::string::const_iterator& it, const std::string:
 			int minutes = 0;
 			try
 			{
-				minutes = parse_number_n("", it, end, 2);
+				minutes = parseNumberN("", it, end, 2);
 			}
 			catch(const SyntaxException& e)
 			{

--- a/Foundation/src/DateTimeParser.cpp
+++ b/Foundation/src/DateTimeParser.cpp
@@ -62,7 +62,6 @@ namespace {
 		}
 
 		std::string number(num_start, it);
-		int result = 0;
 		try
 		{
 			return std::stoi(number);
@@ -108,7 +107,6 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 		}
 
 		std::string number(num_start, it);
-		int result = 0;
 		try
 		{
 			return std::stoi(number);
@@ -468,7 +466,6 @@ int DateTimeParser::parseTZD(std::string::const_iterator& it, const std::string:
 				throw SyntaxException("Timezone invalid number: minutes");
 			}
 			
-			// PARSE_NUMBER_N(minutes, 2);
 			if (minutes < 0 || minutes > 59)
 				throw SyntaxException("Timezone difference minutes out of range");
 			tzd += sign*(hours*3600 + minutes*60);

--- a/Foundation/src/DateTimeParser.cpp
+++ b/Foundation/src/DateTimeParser.cpp
@@ -253,6 +253,12 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 					if (it != end && (*it == '.' || *it == ','))
 					{
 						++it;
+
+						if (it != end && !Ascii::isDigit(*it))
+						{
+							throw SyntaxException("Invalid DateTimeString: " + dtStr + ", missing millisecond");
+						}
+						
 						millis = parse_fractional_n(it, end, 3);
 						micros = parse_fractional_n(it, end, 3);
 						it = skip_digits(it, end);

--- a/Foundation/testsuite/src/DateTimeParserTest.cpp
+++ b/Foundation/testsuite/src/DateTimeParserTest.cpp
@@ -616,6 +616,12 @@ void DateTimeParserTest::testCustom()
 	catch (SyntaxException&)
 	{
 	}
+
+	// bad year (not a number)
+	testBad("%y", "YY", tzd);
+
+	// bad year (number too big)
+	testBad("%r", "123456789101112131415", tzd);
 }
 
 

--- a/Foundation/testsuite/src/DateTimeParserTest.cpp
+++ b/Foundation/testsuite/src/DateTimeParserTest.cpp
@@ -177,6 +177,7 @@ void DateTimeParserTest::testISO8601Frac()
 	assertTrue (dt.microsecond() == 0);
 	assertTrue (tzd == 0);
 	testBad(DateTimeFormat::ISO8601_FRAC_FORMAT, "2005-01-08T12:30:00.1J", tzd);
+	testBad(DateTimeFormat::ISO8601_FRAC_FORMAT, "2005-01-08T12:30:00.Z", tzd);
 
 	dt = DateTimeParser::parse(DateTimeFormat::ISO8601_FRAC_FORMAT, "2005-01-08T12:30:00.123+01:00", tzd);
 	assertTrue (dt.year() == 2005);
@@ -622,6 +623,9 @@ void DateTimeParserTest::testCustom()
 
 	// bad year (number too big)
 	testBad("%r", "123456789101112131415", tzd);
+
+	// check that an invalid millisecond is detected with a custom format
+	testBad("T%H:%M:%s %z", "T12:30:00.Z", tzd);
 }
 
 


### PR DESCRIPTION
Improvements for #4592.

Improve the validation of `DateTimeParser` by validating the numbers parsed for `day`, `month`, `year`, `hour`, `minute`, `second`, `millis`, and `micros`. The value 0 will be used if no digits were found for `micros`.

These changes create new instances of `SyntaxException` thrown by `DateTimeParser::parse` and `DateTimeParser::parseTZD` when the previously listed fields do not contain the required number of digits or the string of digits is not a valid number.

Improve performance by caching the `RegularExpression`s created in `DateTimeFormat::isValid`.