### PR TITLE
[fix #4576] build for qnx

### DIFF
--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -41,6 +41,9 @@
 #	include <time.h>
 #endif
 
+#if POCO_OS == POCO_OS_QNX
+#	include <sys/neutrino.h>
+#endif
 
 #if POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
 #	include <sys/prctl.h>
@@ -111,18 +114,23 @@ namespace
 
 	std::string getThreadName()
 	{
-		char name[POCO_MAX_THREAD_NAME_LEN + 1]{'\0'};
+	constexpr size_t nameSize =
+#if (POCO_OS == POCO_OS_QNX)
+			_NTO_THREAD_NAME_MAX;
+#else
+			POCO_MAX_THREAD_NAME_LEN;
+#endif
+		char name[nameSize + 1]{'\0'};
 #if (POCO_OS == POCO_OS_FREE_BSD)
-		pthread_getname_np(pthread_self(), name, POCO_MAX_THREAD_NAME_LEN + 1);
+		pthread_getname_np(pthread_self(), name, nameSize + 1);
 #elif (POCO_OS == POCO_OS_MAC_OS_X)
 	#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
 		#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
-			pthread_getname_np(pthread_self(), name, POCO_MAX_THREAD_NAME_LEN + 1);
+			pthread_getname_np(pthread_self(), name, nameSize + 1);
 		#endif
 	#endif // __MAC_OS_X_VERSION_MIN_REQUIRED
 #elif (POCO_OS == POCO_OS_QNX)
-		tName[_NTO_THREAD_NAME_MAX] = {'\0'};
-		pthread_getname_np(pthread_self(), tName, _NTO_THREAD_NAME_MAX);
+		pthread_getname_np(pthread_self(), name, nameSize);
 #else
 		prctl(PR_GET_NAME, name);
 #endif


### PR DESCRIPTION
Resolve unresolved macro _NTO_THREAD_NAME_MAX and undeclared array tName