### PR TITLE
Update Darwin : change Archflags to POCO_TARGET_OSARCH

### DIFF
--- a/build/config/Darwin-clang-libc++
+++ b/build/config/Darwin-clang-libc++
@@ -11,7 +11,7 @@
 #
 LINKMODE ?= SHARED
 
-ARCHFLAGS          ?= -arch $(POCO_HOST_OSARCH)
+ARCHFLAGS          ?= -arch $(POCO_TARGET_OSARCH)
 SANITIZEFLAGS      ?=
 OSFLAGS            ?= -mmacosx-version-min=10.11 -isysroot $(shell xcrun --show-sdk-path)
 


### PR DESCRIPTION
I was having issues compiling poco for arm64 on an x86 macOS machine, as a static build.  The end result was always x86.  Change is from : 

ARCHFLAGS          ?= -arch $(POCO_HOST_OSARCH)
to
ARCHFLAGS          ?= -arch $(POCO_TARGET_OSARCH)

Otherwise this always compiles to the HOST OS instead of target.  I think this forces you to set POCO_TARGET_OSARCH on the make command, but I'm not sure how to otherwise set a default.

Also OSFLAGS should be able to be something overwritten from the make command, but not sure how to do that.  I was hoping to : 

make install -s -j4 POCO_CONFIG=Darwin64-clang-libc++ MACOSX_DEPLOYMENT_TARGET=10.15 POCO_TARGET_OSARCH=arm64

So 10.15 instead of 10.11.  Also I think the isysroot part of OSFLAGS can be left out, as it should be part of the default path now.