### PR TITLE
Fix issue with nested `Net::MultipartReader`s

### DIFF
--- a/Net/src/MultipartReader.cpp
+++ b/Net/src/MultipartReader.cpp
@@ -64,7 +64,7 @@ int MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 			*buffer++ = (char) ch; ++n;
 		}
 		ch = buf.sgetc();
-		if (ch == '\r' || ch == '\n') return n;
+		if (ch == eof || ch == '\r' || ch == '\n') return n;
 		*buffer++ = (char) buf.sbumpc(); ++n;
 		if (ch == '-' && buf.sgetc() == '-')
 		{


### PR DESCRIPTION
When using nested `Net::MultipartReader`s I sometimes ended up with some Parts being skipped.

The fundamental problem is that `Net::MultipartStreamBuf` will gladly continue reading even once it has already Returned an EOF. So it will start reading the next Parts Headers

It would probably be better to actually add a `MultipartReader::_reached_end` property. But since the Class is probably only used internally, this small fix might be enough.

### Issue:
The place where the problem pops up is in `readFromDevice` where a possible `EOF` is returned. This will probably also cause a problem with other streambufs.

```cpp
66		ch = buf.sgetc(); // EOF gets returned here by nested MultipartReader
67		if (ch == '\r' || ch == '\n') return n;
68		*buffer++ = (char) buf.sbumpc(); ++n; // MultipartReader starts reading the next part
```

Which is easily fixed by this PR