### PR TITLE
fix(HelpFormatter): lost one space between key and value

### DIFF
--- a/Util/src/HelpFormatter.cpp
+++ b/Util/src/HelpFormatter.cpp
@@ -180,6 +180,7 @@ void HelpFormatter::formatOption(std::ostream& ostr, const Option& option, int w
 		n += (int) shortPrefix().length() + (int) option.shortName().length();
 		if (option.takesArgument())
 		{
+			ostr << ' ';
 			if (!option.argumentRequired()) { ostr << '['; ++n; }
 			ostr << option.argumentName();
 			n += (int) option.argumentName().length();


### PR DESCRIPTION
If the application command line is
```
test.exe --file=filepath
test.exe -f filepath
```
`Poco::Util::HelpFormatter::format()` output is
```
-ffilepath, --file=filepath
```
Lost one space between the key and value, It should be
```
-f filepath, --file=filepath
```