### PR TITLE
[JSON] Add more information to unescaped character error message

### DIFF
--- a/JSON/src/pdjson.c
+++ b/JSON/src/pdjson.c
@@ -505,7 +505,15 @@ read_string(json_stream *json)
                 return JSON_ERROR;
         } else {
             if (char_needs_escaping(c)) {
-                json_error(json, "%s", "unescaped control character in string");
+                int length = 0;
+                const char* val = json_get_string(json, &length);
+
+                char msgbuf[1024];
+                int msglen = (length < 1023) ? length : 1023;
+                memcpy(msgbuf, val, msglen);
+                msgbuf[msglen] = '\0';
+
+                json_error(json, "unescaped control character at line %d in input [%s]", json_get_lineno(json), msgbuf);
                 return JSON_ERROR;
             }
 


### PR DESCRIPTION
The JSON parser usually offers little information to help finding errors in the input, I'm trying to make it a little more informative. One mistake I often do is to forget a closing '"' of a string, what causes a parsing error once we reach a newline character. This patch modifies the error message, that ultimately goes inside a thrown exception, to include the line number of the input and print the contents of the string up to the point where the invalid character was found.

I imagine there might be better approaches to this. I wrote this patch just to have something that minimally works for me in my work, and I'm looking forward to better ideas.