### PR TITLE
Use Int64 for TcpServerDispatcher::totalConnections()

### DIFF
--- a/Net/include/Poco/Net/TCPServer.h
+++ b/Net/include/Poco/Net/TCPServer.h
@@ -175,7 +175,7 @@ public:
 	int maxThreads() const;
 		/// Returns the maximum number of threads available.
 
-	int totalConnections() const;
+	Int64 totalConnections() const;
 		/// Returns the total number of handled connections.
 
 	int currentConnections() const;

--- a/Net/include/Poco/Net/TCPServerDispatcher.h
+++ b/Net/include/Poco/Net/TCPServerDispatcher.h
@@ -68,7 +68,7 @@ public:
 	int maxThreads() const;
 		/// Returns the maximum number of threads available.
 
-	int totalConnections() const;
+	Int64 totalConnections() const;
 		/// Returns the total number of handled connections.
 
 	int currentConnections() const;
@@ -103,12 +103,12 @@ private:
 
 	std::atomic<int> _rc;
 	TCPServerParams::Ptr _pParams;
-	std::atomic<int>  _currentThreads;
-	std::atomic<int>  _totalConnections;
-	std::atomic<int>  _currentConnections;
-	std::atomic<int>  _maxConcurrentConnections;
-	std::atomic<int>  _refusedConnections;
-	std::atomic<bool> _stopped;
+	std::atomic<int>   _currentThreads;
+	std::atomic<Int64> _totalConnections;
+	std::atomic<int>   _currentConnections;
+	std::atomic<int>   _maxConcurrentConnections;
+	std::atomic<int>   _refusedConnections;
+	std::atomic<bool>  _stopped;
 	Poco::NotificationQueue         _queue;
 	TCPServerConnectionFactory::Ptr _pConnectionFactory;
 	Poco::ThreadPool&               _threadPool;

--- a/Net/src/TCPServer.cpp
+++ b/Net/src/TCPServer.cpp
@@ -185,7 +185,7 @@ int TCPServer::maxThreads() const
 }
 
 
-int TCPServer::totalConnections() const
+Int64 TCPServer::totalConnections() const
 {
 	return _pDispatcher->totalConnections();
 }

--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -195,7 +195,7 @@ int TCPServerDispatcher::maxThreads() const
 }
 
 
-int TCPServerDispatcher::totalConnections() const
+Int64 TCPServerDispatcher::totalConnections() const
 {
 	return _totalConnections;
 }


### PR DESCRIPTION
Value was previously a 32-bit integer, overflowing after 2 billion connections. Seems a lot, but a 1000 connections/second, it's less than a month.

I did not change `TchServerDispatcher::refusedConnections()`, I do not expect this value to overflow (it if does, well the server is not very useful !).
