### PR TITLE
enh(ScopedLockWithUnlock): make it more alike std::unique_lock

### DIFF
--- a/Foundation/include/Poco/Mutex.h
+++ b/Foundation/include/Poco/Mutex.h
@@ -52,6 +52,7 @@ class Foundation_API Mutex: private MutexImpl
 {
 public:
 	using ScopedLock = Poco::ScopedLock<Mutex>;
+	using ScopedLockWithUnlock = Poco::ScopedLockWithUnlock<Mutex>;
 
 	Mutex();
 		/// creates the Mutex.
@@ -107,6 +108,7 @@ class Foundation_API FastMutex: private FastMutexImpl
 {
 public:
 	using ScopedLock = Poco::ScopedLock<FastMutex>;
+	using ScopedLockWithUnlock = Poco::ScopedLockWithUnlock<FastMutex>;
 
 	FastMutex();
 		/// creates the Mutex.
@@ -165,6 +167,7 @@ class Foundation_API SpinlockMutex
 {
 public:
 	using ScopedLock = Poco::ScopedLock<SpinlockMutex>;
+	using ScopedLockWithUnlock = Poco::ScopedLockWithUnlock<SpinlockMutex>;
 
 	SpinlockMutex();
 		/// Creates the SpinlockMutex.
@@ -209,6 +212,7 @@ class Foundation_API NullMutex
 {
 public:
 	using ScopedLock = Poco::ScopedLock<NullMutex>;
+	using ScopedLockWithUnlock = Poco::ScopedLockWithUnlock<NullMutex>;
 
 	NullMutex()
 		/// Creates the NullMutex.

--- a/Foundation/include/Poco/NamedMutex.h
+++ b/Foundation/include/Poco/NamedMutex.h
@@ -54,6 +54,7 @@ class Foundation_API NamedMutex: private NamedMutexImpl
 {
 public:
 	using ScopedLock = Poco::ScopedLock<NamedMutex>;
+	using ScopedLockWithUnlock = Poco::ScopedLockWithUnlock<NamedMutex>;
 
 	NamedMutex(const std::string& name);
 		/// creates the Mutex.

--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -75,14 +75,16 @@ class ScopedLockWithUnlock
 	/// unlocking of the mutex.
 {
 public:
-	explicit ScopedLockWithUnlock(M& mutex): _pMutex(&mutex), _locked(true)
+	explicit ScopedLockWithUnlock(M& mutex): _pMutex(&mutex)
 	{
 		_pMutex->lock();
+		_locked = true;
 	}
 
-	ScopedLockWithUnlock(M& mutex, long milliseconds): _pMutex(&mutex), _locked(true)
+	ScopedLockWithUnlock(M& mutex, long milliseconds): _pMutex(&mutex)
 	{
 		_pMutex->lock(milliseconds);
+		_locked = true;
 	}
 
 	~ScopedLockWithUnlock()
@@ -108,6 +110,7 @@ public:
 	{
 		if (_locked)
 		{
+			poco_assert(_pMutex != nullptr);
 			_pMutex->unlock();
 			_locked = false;
 		}
@@ -115,7 +118,7 @@ public:
 
 private:
 	M* _pMutex;
-	bool _locked;
+	bool _locked = false;
 
 	ScopedLockWithUnlock();
 	ScopedLockWithUnlock(const ScopedLockWithUnlock&);

--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -77,12 +77,16 @@ class ScopedLockWithUnlock
 public:
 	explicit ScopedLockWithUnlock(M& mutex): _pMutex(&mutex)
 	{
+		poco_assert(_pMutex != nullptr);
+
 		_pMutex->lock();
 		_locked = true;
 	}
 
 	ScopedLockWithUnlock(M& mutex, long milliseconds): _pMutex(&mutex)
 	{
+		poco_assert(_pMutex != nullptr);
+
 		_pMutex->lock(milliseconds);
 		_locked = true;
 	}
@@ -102,6 +106,7 @@ public:
 	void lock()
 	{
 		poco_assert(_locked == false);
+
 		_pMutex->lock();
 		_locked = true;
 	}
@@ -110,7 +115,6 @@ public:
 	{
 		if (_locked)
 		{
-			poco_assert(_pMutex != nullptr);
 			_pMutex->unlock();
 			_locked = false;
 		}

--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -75,12 +75,12 @@ class ScopedLockWithUnlock
 	/// unlocking of the mutex.
 {
 public:
-	explicit ScopedLockWithUnlock(M& mutex): _pMutex(&mutex)
+	explicit ScopedLockWithUnlock(M& mutex): _pMutex(&mutex), _locked(true)
 	{
 		_pMutex->lock();
 	}
 
-	ScopedLockWithUnlock(M& mutex, long milliseconds): _pMutex(&mutex)
+	ScopedLockWithUnlock(M& mutex, long milliseconds): _pMutex(&mutex), _locked(true)
 	{
 		_pMutex->lock(milliseconds);
 	}
@@ -97,17 +97,25 @@ public:
 		}
 	}
 
+	void lock()
+	{
+		poco_assert(_locked == false);
+		_pMutex->lock();
+		_locked = true;
+	}
+
 	void unlock()
 	{
-		if (_pMutex)
+		if (_locked)
 		{
 			_pMutex->unlock();
-			_pMutex = 0;
+			_locked = false;
 		}
 	}
 
 private:
 	M* _pMutex;
+	bool _locked;
 
 	ScopedLockWithUnlock();
 	ScopedLockWithUnlock(const ScopedLockWithUnlock&);

--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -105,6 +105,7 @@ public:
 
 	void lock()
 	{
+		poco_assert(_pMutex != nullptr);
 		poco_assert(_locked == false);
 
 		_pMutex->lock();
@@ -115,6 +116,8 @@ public:
 	{
 		if (_locked)
 		{
+			poco_assert(_pMutex != nullptr);
+
 			_pMutex->unlock();
 			_locked = false;
 		}


### PR DESCRIPTION
```cpp
void test_std()
{
    std::mutex m;
    std::unique_lock<std::mutex> guard(m);
    guard.unlock(); // OK
    guard.lock(); // OK
}

void test_poco()
{
    Poco::Mutex m;
    Poco::ScopedLockWithUnlock<Poco::Mutex> guard(m);
    guard.unlock(); // OK
    guard.lock(); // Failed !!!
}
```

This PR is to make `Poco::ScopedLockWithUnlock` can lock/unlock for many time. Just same like `std::unique_lock` do.