### PR TITLE
LibPNG Unbundled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server libexpat1-dev zlib1g-dev libpcre3-dev
+      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server libexpat1-dev zlib1g-dev libpcre3-dev libpng-dev
       - run: cmake -S. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DPOCO_UNBUNDLED=ON && cmake --build cmake-build --target all
       - uses: ./.github/actions/retry-action
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev unixodbc-dev libmysqlclient-dev redis-server libexpat1-dev zlib1g-dev libpcre3-dev libpng-dev
-      - run: cmake -S. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DPOCO_UNBUNDLED=ON && cmake --build cmake-build --target all
+      - run: cmake -S. -Bcmake-build -GNinja -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DPOCO_UNBUNDLED=ON -DENABLE_PDF=ON && cmake --build cmake-build --target all
       - uses: ./.github/actions/retry-action
         with:
           timeout_minutes: 90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,9 +232,9 @@ else()
 endif()
 
 if(POCO_UNBUNDLED)
-	message(STATUS "Using external sqlite, zlib, pcre2, expat, ...")
+	message(STATUS "Using external sqlite, zlib, pcre2, expat, libpng, ...")
 else()
-	message(STATUS "Using internal sqlite, zlib, pcre2, expat, ...")
+	message(STATUS "Using internal sqlite, zlib, pcre2, expat, libpng, ...")
 endif()
 
 # Disable fork exec

--- a/PDF/CMakeLists.txt
+++ b/PDF/CMakeLists.txt
@@ -90,28 +90,30 @@ POCO_SOURCES(SRCS hpdf
 	src/hpdf_xref.c
 )
 
-# TODO: Currently only bundled is supported, in future this should also be possible
-# with an unbundled version of libpng
-POCO_SOURCES(SRCS libpng
-	src/png.c
-	src/pngerror.c
-	src/pnggccrd.c
-	src/pngget.c
-	src/pngmem.c
-	src/pngpread.c
-	src/pngread.c
-	src/pngrio.c
-	src/pngrtran.c
-	src/pngrutil.c
-	src/pngset.c
-	src/pngtest.c
-	src/pngtrans.c
-	src/pngvcrd.c
-	src/pngwio.c
-	src/pngwrite.c
-	src/pngwtran.c
-	src/pngwutil.c
-)
+if(POCO_UNBUNDLED)
+	find_package(LIBPNG REQUIRED)
+else()
+	POCO_SOURCES(SRCS libpng
+		src/png.c
+		src/pngerror.c
+		src/pnggccrd.c
+		src/pngget.c
+		src/pngmem.c
+		src/pngpread.c
+		src/pngread.c
+		src/pngrio.c
+		src/pngrtran.c
+		src/pngrutil.c
+		src/pngset.c
+		src/pngtest.c
+		src/pngtrans.c
+		src/pngvcrd.c
+		src/pngwio.c
+		src/pngwrite.c
+		src/pngwtran.c
+		src/pngwutil.c
+	)
+endif(POCO_UNBUNDLED)
 
 # Version Resource
 if(MSVC AND BUILD_SHARED_LIBS)
@@ -133,6 +135,7 @@ set_target_properties(PDF
 
 if(POCO_UNBUNDLED)
 	target_link_libraries(PDF PUBLIC ZLIB::ZLIB)
+	target_link_libraries(PDF PUBLIC PNG::PNG)
 	target_compile_definitions(PDF PUBLIC POCO_UNBUNDLED)
 endif(POCO_UNBUNDLED)
 target_link_libraries(PDF PUBLIC Poco::XML Poco::Util)

--- a/PDF/CMakeLists.txt
+++ b/PDF/CMakeLists.txt
@@ -91,7 +91,7 @@ POCO_SOURCES(SRCS hpdf
 )
 
 if(POCO_UNBUNDLED)
-	find_package(LIBPNG REQUIRED)
+	find_package(PNG REQUIRED)
 else()
 	POCO_SOURCES(SRCS libpng
 		src/png.c
@@ -134,10 +134,14 @@ set_target_properties(PDF
 )
 
 if(POCO_UNBUNDLED)
+	include_directories(${PNG_INCLUDE_DIR})
+
 	target_link_libraries(PDF PUBLIC ZLIB::ZLIB)
-	target_link_libraries(PDF PUBLIC PNG::PNG)
+	target_link_libraries(PDF PUBLIC ${PNG_LIBRARY})
 	target_compile_definitions(PDF PUBLIC POCO_UNBUNDLED)
+
 endif(POCO_UNBUNDLED)
+
 target_link_libraries(PDF PUBLIC Poco::XML Poco::Util)
 target_include_directories(PDF
 	PUBLIC

--- a/PDF/cmake/PocoPDFConfig.cmake
+++ b/PDF/cmake/PocoPDFConfig.cmake
@@ -2,7 +2,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(PocoFoundation)
 if(@POCO_UNBUNDLED@)
 	find_dependency(ZLIB REQUIRED)
-	find_dependency(LIBPNG REQUIRED)
+	find_dependency(PNG REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/PocoPDFTargets.cmake")

--- a/PDF/cmake/PocoPDFConfig.cmake
+++ b/PDF/cmake/PocoPDFConfig.cmake
@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(PocoFoundation)
 if(@POCO_UNBUNDLED@)
 	find_dependency(ZLIB REQUIRED)
+	find_dependency(LIBPNG REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/PocoPDFTargets.cmake")


### PR DESCRIPTION
Hey Poco! 

This PR adds the desired "UNBUNDLED=1" LibPNG separation.

Changes to CMakeLists and ci 

As LibPNG is widely used as a dependancy, using both Poco and LibPNG has meant no Poco.
Allow Poco back plz 