### PR TITLE
Fixed incorrect SSL_CTX_set0_tmp_dh_pkey() usage

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -136,9 +136,24 @@ public:
 		SECURITY_LEVEL_256_BITS = 5
 	};
 
+	enum KeyDHGroup
+	{
+		// MODP
+		//KEY_DH_GROUP_768  = 1,  // (768-bit)
+		KEY_DH_GROUP_1024 = 2,  // (1024-bit)
+		//KEY_DH_GROUP_1536 = 5,  // (1536-bit)
+		KEY_DH_GROUP_2048 = 14, // (2048-bit)
+		//KEY_DH_GROUP_3072 = 15, // (3072-bit)
+
+		// ECP
+		//KEY_DH_GROUP_256 = 19, // (256-bit random)
+		//KEY_DH_GROUP_384 = 20, // (384-bit random)
+		//KEY_DH_GROUP_521 = 21  // (521-bit random)
+	};
+
 	struct NetSSL_API Params
 	{
-		Params();
+		Params(KeyDHGroup dhBits = KEY_DH_GROUP_2048);
 			/// Initializes the struct with default values.
 
 		std::string privateKeyFile;
@@ -181,7 +196,7 @@ public:
 			/// Specifies a file containing Diffie-Hellman parameters.
 			/// If empty, the default parameters are used.
 
-		bool dhUse2048Bits;
+		KeyDHGroup dhGroup;
 			/// If set to true, will use 2048-bit MODP Group with 256-bit
 			/// prime order subgroup (RFC5114) instead of 1024-bit for DH.
 
@@ -441,7 +456,7 @@ public:
 
 	void ignoreUnexpectedEof(bool flag = true);
 		/// Enable or disable SSL/TLS SSL_OP_IGNORE_UNEXPECTED_EOF
-		/// 
+		///
 		/// Some TLS implementations do not send the mandatory close_notify alert on shutdown.
 		/// If the application tries to wait for the close_notify alert
 		/// but the peer closes the connection without sending it, an error is generated.
@@ -458,7 +473,7 @@ private:
 	void init(const Params& params);
 		/// Initializes the Context with the given parameters.
 
-	void initDH(bool use2048Bits, const std::string& dhFile);
+	void initDH(KeyDHGroup keyDHGroup, const std::string& dhFile);
 		/// Initializes the Context with Diffie-Hellman parameters.
 
 	void initECDH(const std::string& curve);

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -858,10 +858,13 @@ void Context::initDH(bool use2048Bits, const std::string& dhParamsFile)
 		throw SSLContextException(Poco::format("Context::initDH(%s):EVP_PKEY*", dhParamsFile));
 	}
 
-	SSL_CTX_set0_tmp_dh_pkey(_pSSLContext, pKey);
+	if (!SSL_CTX_set0_tmp_dh_pkey(_pSSLContext, pKey))
+	{
+		if (freeEVPPKey) EVP_PKEY_free(pKey);
+		std::string err = "Context::initDH():SSL_CTX_set0_tmp_dh_pkey()\n";
+		throw SSLContextException(Poco::Crypto::getError(err));
+	}
 	SSL_CTX_set_options(_pSSLContext, SSL_OP_SINGLE_DH_USE);
-
-	if (freeEVPPKey) EVP_PKEY_free(pKey);
 
 #else // OPENSSL_VERSION_NUMBER >= 0x30000000L
 


### PR DESCRIPTION
This simple program crashes POCO (tested under Red Hat Enterprise Linux 9.4):

```c++
#include <Poco/Net/Context.h>

int main()
{
    const Poco::Net::Context context(Poco::Net::Context::CLIENT_USE, "/tmp", Poco::Net::Context::VERIFY_STRICT, 9, false, "ALL");
    return 0;
}
```

The problem is an incorrect usage of SSL_CTX_set0_tmp_dh_pkey() in Context::initDH(). The return value is not evaluated and the key is freed even if it has been successfully transferred to the SSL Context.

The relevant part of the OpenSSL manpage https://docs.openssl.org/3.1/man3/SSL_CTX_set_tmp_dh_callback/:

> Ownership of the dhpkey value is passed to the SSL_CTX or SSL object as a result of this call, and so the caller should not free it if the function call is successful.