### PR TITLE
4557 ndc thread local

### DIFF
--- a/Foundation/include/Poco/NestedDiagnosticContext.h
+++ b/Foundation/include/Poco/NestedDiagnosticContext.h
@@ -89,9 +89,11 @@ public:
 		/// to the given stream. The entries are delimited by
 		/// a newline.
 
-	void dump(std::ostream& ostr, const std::string& delimiter) const;
+	void dump(std::ostream& ostr, const std::string& delimiter, bool nameOnly = false) const;
 		/// Dumps the stack (including line number and filenames)
 		/// to the given stream.
+		/// If nameOnly is false (default), the whole path to file is printed,
+		/// otherwise only the file name.
 
 	void clear();
 		/// Clears the NDC stack.

--- a/Foundation/src/NestedDiagnosticContext.cpp
+++ b/Foundation/src/NestedDiagnosticContext.cpp
@@ -113,10 +113,14 @@ void NestedDiagnosticContext::clear()
 }
 
 
+namespace {
+	static ThreadLocal<NestedDiagnosticContext> ndc;
+}
+
+
 NestedDiagnosticContext& NestedDiagnosticContext::current()
 {
-	static NestedDiagnosticContext ndc;
-	return ndc;
+	return ndc.get();
 }
 
 

--- a/Foundation/src/NestedDiagnosticContext.cpp
+++ b/Foundation/src/NestedDiagnosticContext.cpp
@@ -13,7 +13,6 @@
 
 
 #include "Poco/NestedDiagnosticContext.h"
-#include "Poco/ThreadLocal.h"
 
 
 namespace Poco {

--- a/Foundation/src/NestedDiagnosticContext.cpp
+++ b/Foundation/src/NestedDiagnosticContext.cpp
@@ -113,14 +113,10 @@ void NestedDiagnosticContext::clear()
 }
 
 
-namespace {
-	static ThreadLocal<NestedDiagnosticContext> ndc;
-}
-
-
 NestedDiagnosticContext& NestedDiagnosticContext::current()
 {
-	return ndc.get();
+	static thread_local NestedDiagnosticContext ndc;
+	return ndc;
 }
 
 

--- a/Foundation/src/NestedDiagnosticContext.cpp
+++ b/Foundation/src/NestedDiagnosticContext.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/NestedDiagnosticContext.h"
+#include "Poco/Path.h"
 
 
 namespace Poco {
@@ -94,14 +95,26 @@ void NestedDiagnosticContext::dump(std::ostream& ostr) const
 }
 
 
-void NestedDiagnosticContext::dump(std::ostream& ostr, const std::string& delimiter) const
+void NestedDiagnosticContext::dump(std::ostream& ostr, const std::string& delimiter, bool nameOnly) const
 {
-	for (const auto& i: _stack)
+	for (auto it = _stack.begin(); it != _stack.end(); ++it)
 	{
-		ostr << i.info;
-		if (i.file)
-			ostr << " (in \"" << i.file << "\", line " << i.line << ")";
-		ostr << delimiter;
+		if (it != _stack.begin())
+		{
+			ostr << delimiter;
+		}
+
+		std::string file = it->file ? it->file : "";
+		if (nameOnly && !file.empty())
+		{
+			file = Path(file).getFileName();
+		}
+
+		ostr << it->info;
+		if (!file.empty())
+		{
+			ostr << " (in \"" << file << "\", line " << it->line << ")";
+		}
 	}
 }
 

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -66,10 +66,12 @@ void NDCTest::testNDCScope()
 			NDC::current().dump(ostr);
 
 			assertEqual(ostr.str(), Poco::format(
-R"("item1" (in "src/NDCTest.cpp", line %d)
-"item2" (in "src/NDCTest.cpp", line %d)
-"item3" (in "src/NDCTest.cpp", line %d)
-)", line1, line2, line3));
+R"("item1" (in "%s", line %d)
+"item2" (in "%s", line %d)
+"item3" (in "%s", line %d)
+)", std::string(__FILE__), line1,
+	std::string(__FILE__), line2,
+	std::string(__FILE__), line3));
 
 		}
 		assertTrue (NDC::current().depth() == 2);

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -56,11 +56,6 @@ void NDCTest::testNDCScope()
 {
 	poco_ndc("item1");
 	auto line1 = __LINE__ - 1;
-	if (NDC::current().depth() != 1)
-	{
-		int y = 10;
-		int x = y;
-	}
 	assertTrue (NDC::current().depth() == 1);
 
 	{

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -12,10 +12,14 @@
 #include "CppUnit/TestCaller.h"
 #include "CppUnit/TestSuite.h"
 #include "Poco/NestedDiagnosticContext.h"
+#include "Poco/ActiveThreadPool.h"
+#include "Poco/RunnableAdapter.h"
 #include <iostream>
 
 
 using Poco::NDC;
+using Poco::ActiveThreadPool;
+using Poco::RunnableAdapter;
 
 
 NDCTest::NDCTest(const std::string& name): CppUnit::TestCase(name)
@@ -64,6 +68,25 @@ void NDCTest::testNDCScope()
 }
 
 
+void NDCTest::testNDCMultiThread()
+{
+	ActiveThreadPool pool;
+	RunnableAdapter<NDCTest> ra(*this, &NDCTest::runInThread);
+	for (int i = 0; i < 1000; i++)
+	{
+		pool.start(ra);
+	}
+	pool.joinAll();
+}
+
+
+void NDCTest::runInThread()
+{
+	testNDC();
+	testNDCScope();
+}
+
+
 void NDCTest::setUp()
 {
 }
@@ -80,6 +103,7 @@ CppUnit::Test* NDCTest::suite()
 
 	CppUnit_addTest(pSuite, NDCTest, testNDC);
 	CppUnit_addTest(pSuite, NDCTest, testNDCScope);
+	CppUnit_addTest(pSuite, NDCTest, testNDCMultiThread);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -14,6 +14,7 @@
 #include "Poco/NestedDiagnosticContext.h"
 #include "Poco/ActiveThreadPool.h"
 #include "Poco/RunnableAdapter.h"
+#include "Poco/Format.h"
 #include <iostream>
 #include <sstream>
 
@@ -53,16 +54,23 @@ void NDCTest::testNDC()
 
 void NDCTest::testNDCScope()
 {
-	poco_ndc("item1");
+	poco_ndc("item1"); int line1 = __LINE__;
 	assertTrue (NDC::current().depth() == 1);
 	{
-		poco_ndc("item2");
+		poco_ndc("item2"); int line2 = __LINE__;
 		assertTrue (NDC::current().depth() == 2);
 		{
-			poco_ndc("item3");
+			poco_ndc("item3"); int line3 = __LINE__;
 			assertTrue (NDC::current().depth() == 3);
 			std::ostringstream ostr;
 			NDC::current().dump(ostr);
+
+			assertEqual(ostr.str(), Poco::format(
+R"("item1" (in "src/NDCTest.cpp", line %d)
+"item2" (in "src/NDCTest.cpp", line %d)
+"item3" (in "src/NDCTest.cpp", line %d)
+)", line1, line2, line3));
+
 		}
 		assertTrue (NDC::current().depth() == 2);
 	}

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -54,14 +54,25 @@ void NDCTest::testNDC()
 
 void NDCTest::testNDCScope()
 {
-	poco_ndc("item1"); int line1 = __LINE__;
-	assertTrue (NDC::current().depth() == 1);
+	poco_ndc("item1");
+	auto line1 = __LINE__ - 1;
+	if (NDC::current().depth() != 1)
 	{
-		poco_ndc("item2"); int line2 = __LINE__;
+		int y = 10;
+		int x = y;
+	}
+	assertTrue (NDC::current().depth() == 1);
+
+	{
+		poco_ndc("item2");
+		auto line2 = __LINE__ - 1;
 		assertTrue (NDC::current().depth() == 2);
+
 		{
-			poco_ndc("item3"); int line3 = __LINE__;
+			poco_ndc("item3");
+			auto line3 = __LINE__ - 1;
 			assertTrue (NDC::current().depth() == 3);
+
 			std::ostringstream ostr;
 			NDC::current().dump(ostr);
 
@@ -72,7 +83,6 @@ R"("item1" (in "%s", line %d)
 )", std::string(__FILE__), line1,
 	std::string(__FILE__), line2,
 	std::string(__FILE__), line3));
-
 		}
 		assertTrue (NDC::current().depth() == 2);
 	}

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -15,6 +15,7 @@
 #include "Poco/ActiveThreadPool.h"
 #include "Poco/RunnableAdapter.h"
 #include <iostream>
+#include <sstream>
 
 
 using Poco::NDC;
@@ -60,7 +61,8 @@ void NDCTest::testNDCScope()
 		{
 			poco_ndc("item3");
 			assertTrue (NDC::current().depth() == 3);
-			NDC::current().dump(std::cout);
+			std::ostringstream ostr;
+			NDC::current().dump(ostr);
 		}
 		assertTrue (NDC::current().depth() == 2);
 	}

--- a/Foundation/testsuite/src/NDCTest.cpp
+++ b/Foundation/testsuite/src/NDCTest.cpp
@@ -15,6 +15,7 @@
 #include "Poco/ActiveThreadPool.h"
 #include "Poco/RunnableAdapter.h"
 #include "Poco/Format.h"
+#include "Poco/Path.h"
 #include <iostream>
 #include <sstream>
 
@@ -22,6 +23,7 @@
 using Poco::NDC;
 using Poco::ActiveThreadPool;
 using Poco::RunnableAdapter;
+using Poco::Path;
 
 
 NDCTest::NDCTest(const std::string& name): CppUnit::TestCase(name)
@@ -68,16 +70,26 @@ void NDCTest::testNDCScope()
 			auto line3 = __LINE__ - 1;
 			assertTrue (NDC::current().depth() == 3);
 
-			std::ostringstream ostr;
-			NDC::current().dump(ostr);
+ 			std::ostringstream ostr1;
+			NDC::current().dump(ostr1);
+			assertEqual (ostr1.str(), Poco::format(
+				"\"item1\" (in \"%s\", line %d)\n"
+				"\"item2\" (in \"%s\", line %d)\n"
+				"\"item3\" (in \"%s\", line %d)",
+				std::string(__FILE__), line1,
+				std::string(__FILE__), line2,
+				std::string(__FILE__), line3));
 
-			assertEqual(ostr.str(), Poco::format(
-R"("item1" (in "%s", line %d)
-"item2" (in "%s", line %d)
-"item3" (in "%s", line %d)
-)", std::string(__FILE__), line1,
-	std::string(__FILE__), line2,
-	std::string(__FILE__), line3));
+			std::ostringstream ostr2;
+			NDC::current().dump(ostr2, "\n", true);
+			std::string fileName = Path(__FILE__).getFileName();
+			assertEqual(ostr2.str(), Poco::format(
+				"\"item1\" (in \"%s\", line %d)\n"
+				"\"item2\" (in \"%s\", line %d)\n"
+				"\"item3\" (in \"%s\", line %d)",
+				fileName, line1,
+				fileName, line2,
+				fileName, line3));
 		}
 		assertTrue (NDC::current().depth() == 2);
 	}

--- a/Foundation/testsuite/src/NDCTest.h
+++ b/Foundation/testsuite/src/NDCTest.h
@@ -26,6 +26,7 @@ public:
 
 	void testNDC();
 	void testNDCScope();
+	void testNDCMultiThread();
 
 	void setUp();
 	void tearDown();
@@ -33,6 +34,7 @@ public:
 	static CppUnit::Test* suite();
 
 private:
+	void runInThread();
 };
 
 


### PR DESCRIPTION
Replacement for PR: https://github.com/pocoproject/poco/pull/4674
1. Fix https://github.com/pocoproject/poco/issues/4557
2. Merged `dump(bool nameOnly)` function from [implemented here](https://github.com/pocoproject/poco/blob/df23923b01437031a96ddf1a69387a5f03feb2e3/Foundation/include/Poco/NestedDiagnosticContext.h#L120-L152)
3. Discard `backtrace` from [implemented here](https://github.com/pocoproject/poco/blob/df23923b01437031a96ddf1a69387a5f03feb2e3/Foundation/include/Poco/NestedDiagnosticContext.h#L120-L152) . Because it can be replaced with a more powerful implementation by [Boost.Stacktrace](https://www.boost.org/doc/libs/1_65_1/doc/html/stacktrace.html)