### PR TITLE
[RFC, not for merge] Net: Websocket: introduce non-blocking receive frame API

### DIFF
--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -195,6 +195,8 @@ public:
 		///
 		/// Always returns zero for platforms where not implemented.
 
+	virtual int receiveBytesNoBlock(void* buffer, int length, bool &shouldRetry, int flags = 0);
+
 	virtual int receiveBytes(void* buffer, int length, int flags = 0);
 		/// Receives data from the socket and stores it
 		/// in buffer. Up to length bytes are received.

--- a/Net/include/Poco/Net/StreamSocket.h
+++ b/Net/include/Poco/Net/StreamSocket.h
@@ -203,6 +203,8 @@ public:
 		/// The flags parameter can be used to pass system-defined flags
 		/// for send() like MSG_OOB.
 
+	int receiveBytesNoBlock(void* buffer, int length, bool &shouldRetry, int flags = 0);
+
 	int receiveBytes(void* buffer, int length, int flags = 0);
 		/// Receives data from the socket and stores it
 		/// in buffer. Up to length bytes are received.

--- a/Net/include/Poco/Net/WebSocket.h
+++ b/Net/include/Poco/Net/WebSocket.h
@@ -315,6 +315,8 @@ public:
 		/// the received data is stored starting at the beginning of the
 		/// buffer.
 
+	int receiveFrameNoBlock(Poco::Buffer<char>& buffer, int& flags, bool &shouldRetry);
+
 	Mode mode() const;
 		/// Returns WS_SERVER if the WebSocket is a server-side
 		/// WebSocket, or WS_CLIENT otherwise.

--- a/Net/include/Poco/Net/WebSocketImpl.h
+++ b/Net/include/Poco/Net/WebSocketImpl.h
@@ -46,6 +46,9 @@ public:
 	virtual int receiveBytes(void* buffer, int length, int flags);
 		/// Receives a WebSocket protocol frame.
 
+	int receiveFrameNoBlock(Poco::Buffer<char>& buffer, int& flags, bool &shouldRetry);
+		/// Receives a WebSocket protocol frame in a non-blocking fashion.
+
 	virtual int receiveBytes(Poco::Buffer<char>& buffer, int flags = 0, const Poco::Timespan& span = 0);
 		/// Receives a WebSocket protocol frame.
 
@@ -100,6 +103,12 @@ protected:
 	int receivePayload(char *buffer, int payloadLength, char mask[4], bool useMask);
 	int receiveNBytes(void* buffer, int bytes);
 	int receiveSomeBytes(char* buffer, int bytes);
+
+	int receiveHeaderNoBlock(char mask[4], bool& useMask, size_t &totalRewind, bool &shouldRetry);
+	int receivePayloadNoBlock(char *buffer, int payloadLength, char mask[4], bool useMask, bool &shouldRetry);
+	int receiveNBytesNoBlock(void* buffer, int bytes, bool &shouldRetry);
+	int receiveSomeBytesNoBlock(char* buffer, int bytes, bool &shouldRetry);
+
 	virtual ~WebSocketImpl();
 
 private:

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -400,6 +400,18 @@ int SocketImpl::sendBytes(const SocketBufVec& buffers, int flags)
 }
 
 
+int SocketImpl::receiveBytesNoBlock(void* buffer, int length, bool &shouldRetry, int flags)
+{
+	shouldRetry = true;
+	int ret = 0;
+
+	ret = receiveBytes(buffer, length, flags);
+	if (ret == 0)
+		shouldRetry = false;
+
+	return ret;
+}
+
 int SocketImpl::receiveBytes(void* buffer, int length, int flags)
 {
 	checkBrokenTimeout(SELECT_READ);

--- a/Net/src/StreamSocket.cpp
+++ b/Net/src/StreamSocket.cpp
@@ -179,6 +179,10 @@ int StreamSocket::sendBytes(FIFOBuffer& fifoBuf)
 	return ret;
 }
 
+int StreamSocket::receiveBytesNoBlock(void* buffer, int length, bool &shouldRetry, int flags)
+{
+	return impl()->receiveBytesNoBlock(buffer, length, shouldRetry, flags);
+}
 
 int StreamSocket::receiveBytes(void* buffer, int length, int flags)
 {

--- a/Net/src/WebSocket.cpp
+++ b/Net/src/WebSocket.cpp
@@ -174,6 +174,12 @@ int WebSocket::receiveFrame(Poco::Buffer<char>& buffer, int& flags)
 	return n;
 }
 
+int WebSocket::receiveFrameNoBlock(Poco::Buffer<char>& buffer, int& flags, bool &shouldRetry)
+{
+	int n = static_cast<WebSocketImpl*>(impl())->receiveFrameNoBlock(buffer, flags, shouldRetry);
+	flags = static_cast<WebSocketImpl*>(impl())->frameFlags();
+	return n;
+}
 
 WebSocket::Mode WebSocket::mode() const
 {

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -177,6 +177,8 @@ public:
 		/// Returns the number of bytes sent, which may be
 		/// less than the number of bytes specified.
 
+	int receiveBytesNoBlock(void* buffer, int length, bool &shouldRetry, int flags = 0);
+
 	int receiveBytes(void* buffer, int length, int flags = 0);
 		/// Receives data from the socket and stores it
 		/// in buffer. Up to length bytes are received.


### PR DESCRIPTION
_First of all, I'd like to emphasize that it's an Request For Comments PR, as I would love to hear your opinion on the changes as a whole, to make sure it's an community approved / way-to-go approach / changes._

**Changes description**:
Currently, the Receive Frame of WebsocketImpl is implemented in a way, that it expects for a single websocket frame to be received in a blocking fashion: untill frame gets received, context is blocked till completion.

This is an issue with poor-network-connection clients that connect to server in a way, that clients with high packet loss / clients that send only part of a WSS frame could potentially lock-up processing thread for a very long time.

This fix implements a new set of coroutines, that mimic the behavior of previous implementation, however are aimed to use internal buffer for caching partially received frame, and return one whenever frame assembly is completed.
This proves to unblock the caller thread from any hussle with bad connections, and enables the true async
implementation of socket processing.

**Real life use case / why I made the changes**:
The reason why I did these changes in the first place, is to address an issue we've had with a SW that we were using: Poco library is the backbone of the OpenWiFi uCentral Gateway (later on referrenced as 'GW') software ([link](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/tree/master) that is used as a Cloud controller for uCentral / OpenWifi capable and compatible Access Point devices.
The GW itself is built on top of Poco in the Async-programming fashion.

The part of the GW where we had an issue, is the Observer / Reactor part, that get's triggered upon EPOLLIN events arriving at the underlying websocket FD, which later on makes a call to a **blocking** receiveFrame call - [link 2](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/src/AP_WS_Connection.cpp#L608).
After thorough investigation, we found out, that underlying _receiveFrame_ calls _receiveBytes_->_receiveHeader_ / _receiveMask_ / _receivePayload_ and finally [WebSocketImpl::receiveNBytes](https://github.com/pocoproject/poco/blob/main/Net/src/WebSocketImpl.cpp#L231).
The problem with _receiveNBytes_ function, is that it's a loop-based function, that tries to _receiveSomeBytes_ up untill the size of received data is not satisfied with _payloadSize_ of websocket frame.

E.g. this function expects the underlying socket to return **complete** websocket frame / payload in a loop. Untill exact number of requested bytes of data is not being read the function does not return control to the caller.

A different approach - proposed with this RFC / PR - would be to expose a new API call, that would utilize internal buffering on each _recv()_ call, and in case if bufferized data is sufficient to compose a single WSS frame, it would then return complete frame back to the caller.

**Final words**:
While these changes address specific issue we've had in our production deployments - APs with bad internet connection caused control / websocket processing threads to hang - the use case does not explicitly limits changes usage to **just** better handling of connections with bad internet whatsoever.
These changes fundamentally challenge the synchronous base nature of the underlying receiveFrame function.

CC: @phwhite @stephb9959 @i-chvets @SviatoslavBoichuk @serhiy-p @taraschornyiplv