### PR TITLE
we should wait result of select before rollback

### DIFF
--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -3284,12 +3284,14 @@ void SQLiteTest::testSessionTransactionReadUncommitted()
 	
 	session << "SELECT COUNT(*) FROM Person", into(count), now;
 	assertTrue (2 == count);
-	assertTrue (session.isTransaction());
-	session.rollback();
-	assertTrue (!session.isTransaction());
-	assertTrue (session.getFeature("autoCommit"));
 	
 	stmt.wait();
+	assertTrue (session.isTransaction());
+	session.rollback();
+	
+	assertTrue (!session.isTransaction());
+	assertTrue (session.getFeature("autoCommit"));
+
 	assertEqual(2, locCount);
 	
 	session << "SELECT count(*) FROM Person", into(count), now;


### PR DESCRIPTION
In previous test-case code I was waiting stmt  after rallback, this is a root couse of bug...
but we saw error only on macos