### PR TITLE
Exception (VS): static assert to make sure that _HAS_EXCEPTIONS is set

### DIFF
--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -100,9 +100,15 @@ protected:
 private:
 	std::string _msg;
 	Exception*  _pNested;
-	int			_code;
+	int			_code;    
 };
 
+#if defined(_HAS_EXCEPTIONS)
+    // Size of Poco::Exception depends on the exception settings (like _HAS_EXCEPTIONS)
+    // that might influence size of std::exception from which Poco::Exception is derived from.
+    // It is expected that Poco libraries and application using Poco have the same settings.
+    static_assert(_HAS_EXCEPTIONS != 0);
+#endif
 
 //
 // inlines


### PR DESCRIPTION
Resolves #4668.