### PR TITLE
Explicitly define conditional LOB constructors for const (w)string &

### DIFF
--- a/Data/include/Poco/Data/LOB.h
+++ b/Data/include/Poco/Data/LOB.h
@@ -63,7 +63,15 @@ public:
 	{
 	}
 
-	LOB(const std::basic_string<T>& content):
+	template<typename U = T>
+	LOB(const std::enable_if_t<std::is_same_v<T, U> && std::is_same_v<U, char>, std::string>& content):
+		_pContent(new std::vector<T>(content.begin(), content.end()))
+		/// Creates a LOB from a string.
+	{
+	}
+
+	template<typename U = T>
+	LOB(const std::enable_if_t<std::is_same_v<T, U> && std::is_same_v<U, wchar_t>, std::wstring>& content):
 		_pContent(new std::vector<T>(content.begin(), content.end()))
 		/// Creates a LOB from a string.
 	{


### PR DESCRIPTION
This fixes compilation against libcxx 19, which removed the
non-standard specializations for std::char_traits including the one
for unsigned char, which would get instantiated for BLOB.
See https://reviews.llvm.org/D138307 and
https://reviews.llvm.org/D157058.

Closes #4722.