### PR TITLE
Activity now sets _running flag to false when it finishes or throws.

### DIFF
--- a/Foundation/include/Poco/Activity.h
+++ b/Foundation/include/Poco/Activity.h
@@ -180,9 +180,11 @@ protected:
 		}
 		catch (...)
 		{
+			_running = false;
 			_done.set();
 			throw;
 		}
+		_running = false;
 		_done.set();
 	}
 

--- a/Foundation/testsuite/src/ActivityTest.cpp
+++ b/Foundation/testsuite/src/ActivityTest.cpp
@@ -55,6 +55,44 @@ namespace
 		Activity<ActiveObject> _activity;
 		Poco::UInt64           _count;
 	};
+
+	class BriefActiveObject
+	{
+	public:
+		BriefActiveObject():
+			_activity(this, &BriefActiveObject::run),
+			_count(0)
+		{
+		}
+
+		~BriefActiveObject()
+		{
+		}
+
+		Activity<BriefActiveObject>& activity()
+		{
+			return _activity;
+		}
+
+		Poco::UInt64 count() const
+		{
+			return _count;
+		}
+	protected:
+		void run()
+		{
+			while (!_activity.isStopped())
+			{
+				++_count;
+				if(_count > 2)
+					break;
+
+			}
+		}
+	private:
+		Activity<BriefActiveObject> _activity;
+		Poco::UInt64           _count;
+	};
 }
 
 
@@ -81,6 +119,17 @@ void ActivityTest::testActivity()
 	assertTrue (activeObj.count() > 0);
 }
 
+void ActivityTest::testActivityFinishes()
+{
+	BriefActiveObject briefActiveObj;
+	assertTrue (briefActiveObj.activity().isStopped());
+	briefActiveObj.activity().start();
+	assertTrue (!briefActiveObj.activity().isStopped());
+	Thread::sleep(100);
+	assertTrue (!briefActiveObj.activity().isRunning());
+	assertTrue (briefActiveObj.count() == 3);
+}
+
 
 void ActivityTest::setUp()
 {
@@ -97,6 +146,7 @@ CppUnit::Test* ActivityTest::suite()
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("ActivityTest");
 
 	CppUnit_addTest(pSuite, ActivityTest, testActivity);
+	CppUnit_addTest(pSuite, ActivityTest, testActivityFinishes);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/ActivityTest.h
+++ b/Foundation/testsuite/src/ActivityTest.h
@@ -25,6 +25,7 @@ public:
 	~ActivityTest();
 
 	void testActivity();
+	void testActivityFinishes();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Activity _running flag is now set to false when the activity finishes or throws, previously it was only set if wait had been called. which meant that an activity that had either finished, or thrown would return true from IsRunning function despite not running. Also added a test for this scenario.