### PR TITLE
fix(HTTPSClientSession): There is no way to resolve host in advance a…

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
@@ -78,10 +78,12 @@ public:
 	HTTPSClientSession();
 		/// Creates an unconnected HTTPSClientSession.
 
-	explicit HTTPSClientSession(const SecureStreamSocket& socket);
+	explicit HTTPSClientSession(const SecureStreamSocket& socket, const std::string& host, Poco::UInt16 port = HTTPS_PORT);
 		/// Creates a HTTPSClientSession using the given socket.
 		/// The socket must not be connected. The session
 		/// takes ownership of the socket.
+		///
+		/// The given host name is used for certificate verification.
 
 	HTTPSClientSession(const SecureStreamSocket& socket, Session::Ptr pSession);
 		/// Creates a HTTPSClientSession using the given socket.

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocket.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocket.h
@@ -108,10 +108,22 @@ public:
 		///
 		/// The given host name is used for certificate verification.
 
+	SecureStreamSocket(const std::string& hostName);
+		/// Creates a secure stream socket using the default
+		/// client SSL context. The created socket is not connected.
+		///
+		/// The given host name is used for certificate verification.
+
 	SecureStreamSocket(const SocketAddress& address, const std::string& hostName, Context::Ptr pContext);
 		/// Creates a secure stream socket using the given
 		/// client SSL context and connects it to
 		/// the socket specified by address.
+		///
+		/// The given host name is used for certificate verification.
+
+	SecureStreamSocket(const std::string& hostName, Context::Ptr pContext);
+		/// Creates a secure stream socket using the given
+		/// client SSL context. The created socket is not connected.
 		///
 		/// The given host name is used for certificate verification.
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -39,11 +39,12 @@ HTTPSClientSession::HTTPSClientSession():
 }
 
 
-HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket):
+HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, const std::string& host, Poco::UInt16 port):
 	HTTPClientSession(socket),
 	_pContext(socket.context())
 {
-	setPort(HTTPS_PORT);
+	setHost(host);
+	setPort(port);
 }
 
 

--- a/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocket.cpp
@@ -60,6 +60,13 @@ SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, const std::
 }
 
 
+SecureStreamSocket::SecureStreamSocket(const std::string& hostName):
+	StreamSocket(new SecureStreamSocketImpl(SSLManager::instance().defaultClientContext()))
+{
+	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
+}
+
+
 SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, Context::Ptr pContext):
 	StreamSocket(new SecureStreamSocketImpl(pContext))
 {
@@ -80,6 +87,13 @@ SecureStreamSocket::SecureStreamSocket(const SocketAddress& address, const std::
 {
 	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
 	connect(address);
+}
+
+
+SecureStreamSocket::SecureStreamSocket(const std::string& hostName, Context::Ptr pContext):
+	StreamSocket(new SecureStreamSocketImpl(pContext))
+{
+	static_cast<SecureStreamSocketImpl*>(impl())->setPeerHostName(hostName);
 }
 
 

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.cpp
@@ -88,6 +88,23 @@ HTTPSClientSessionTest::~HTTPSClientSessionTest()
 }
 
 
+void HTTPSClientSessionTest::testFromSocket()
+{
+	HTTPSTestServer srv;
+	SecureStreamSocket sss("localhost");
+	HTTPSClientSession s(sss, "127.0.0.1", srv.port());
+	HTTPRequest request(HTTPRequest::HTTP_GET, "/small");
+	s.sendRequest(request);
+	HTTPResponse response;
+	std::istream& rs = s.receiveResponse(response);
+	assertTrue (response.getContentLength() == HTTPSTestServer::SMALL_BODY.length());
+	assertTrue (response.getContentType() == "text/plain");
+	std::ostringstream ostr;
+	StreamCopier::copyStream(rs, ostr);
+	assertTrue (ostr.str() == HTTPSTestServer::SMALL_BODY);
+}
+
+
 void HTTPSClientSessionTest::testGetSmall()
 {
 	HTTPSTestServer srv;
@@ -458,6 +475,7 @@ void HTTPSClientSessionTest::testUnknownContentLength()
 	assertTrue (ostr.str() == HTTPSTestServer::SMALL_BODY);
 }
 
+
 void HTTPSClientSessionTest::testServerAbort()
 {
 	HTTPSTestServer srv;
@@ -471,7 +489,7 @@ void HTTPSClientSessionTest::testServerAbort()
 	std::ostringstream ostr;
 	StreamCopier::copyStream(rs, ostr);
 	assertTrue (ostr.str() == HTTPSTestServer::SMALL_BODY);
-	assertTrue ( dynamic_cast<const Poco::Net::SSLConnectionUnexpectedlyClosedException*>(
+	assertTrue (dynamic_cast<const Poco::Net::SSLConnectionUnexpectedlyClosedException*>(
 	         s.networkException()) != NULL );
 }
 
@@ -490,6 +508,7 @@ CppUnit::Test* HTTPSClientSessionTest::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("HTTPSClientSessionTest");
 
+	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testFromSocket);
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testGetSmall);
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testGetLarge);
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testHead);

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
@@ -24,6 +24,7 @@ public:
 	HTTPSClientSessionTest(const std::string& name);
 	~HTTPSClientSessionTest();
 
+	void testFromSocket();
 	void testGetSmall();
 	void testGetLarge();
 	void testHead();


### PR DESCRIPTION
…nd connect to HTTPS server with SNI. #4395