### PR TITLE
feat(WindowsBuild): customizable path to include for pocoNetworkInitializer #4769

### DIFF
--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -114,11 +114,14 @@ extern "C" const struct Net_API NetworkInitializer pocoNetworkInitializer;
 		#define POCO_NET_FORCE_SYMBOL(s) __pragma(comment (linker, "/export:_"#s))
 	#endif
 #else  // !Net_EXPORTS
-	#if defined(_WIN64)
-		#define POCO_NET_FORCE_SYMBOL(s) __pragma(comment (linker, "/include:"#s))
-	#elif defined(_WIN32)
-		#define POCO_NET_FORCE_SYMBOL(s) __pragma(comment (linker, "/include:_"#s))
+	#if !defined(POCO_NETWORK_INITIALIZER_INCLUDE_PATH)
+		#if defined(_WIN64)
+			#define POCO_NETWORK_INITIALIZER_INCLUDE_PATH "/include:"
+		#elif defined(_WIN32)
+			#define POCO_NETWORK_INITIALIZER_INCLUDE_PATH "/include:_"
+		#endif
 	#endif
+	#define POCO_NET_FORCE_SYMBOL(s) __pragma(comment (linker, POCO_NETWORK_INITIALIZER_INCLUDE_PATH#s))
 #endif // Net_EXPORTS
 
 POCO_NET_FORCE_SYMBOL(pocoNetworkInitializer)


### PR DESCRIPTION
The corrent path to the location of for pocoNetworkInitializer is enhanced to be customizable, so it can be defined from parent project, which uses POCO.

By default, the POCO will use it's default setup, as it was.
If external Project needs specific path (dependent on build output location), it can be done by defining a path as following MACRO:
--> POCO_NETWORK_INITIALIZER_INCLUDE_PATH