### PR TITLE
MongoDB: Mark old wire protocol functions as deprecated

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Cursor.h
+++ b/MongoDB/include/Poco/MongoDB/Cursor.h
@@ -26,8 +26,7 @@
 namespace Poco {
 namespace MongoDB {
 
-//class [[deprecated]] Cursor;
-class Cursor;
+class POCO_DEPRECATED("Use new wire protocol") Cursor;
 
 class MongoDB_API Cursor: public Document
 	/// Cursor is an helper class for querying multiple documents.

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -81,7 +81,7 @@ public:
 		/// Creates a QueryRequest to count the given collection.
 		/// The collectionname must not contain the database name. (old wire protocol)
 
-	//[[deprecated]]
+	POCO_DEPRECATED("Use new wire protocol")
 	Poco::SharedPtr<Poco::MongoDB::DeleteRequest> createDeleteRequest(const std::string& collectionName) const;
 		/// Creates a DeleteRequest to delete documents in the given collection.
 		/// The collectionname must not contain the database name. (old wire protocol)
@@ -96,7 +96,7 @@ public:
 		/// Creates a QueryRequest. (old wire protocol)
 		/// The collectionname must not contain the database name.
 
-	//[[deprecated]]
+	POCO_DEPRECATED("Use new wire protocol")
 	Poco::SharedPtr<Poco::MongoDB::UpdateRequest> createUpdateRequest(const std::string& collectionName) const;
 		/// Creates an UpdateRequest. (old wire protocol)
 		/// The collectionname must not contain the database name.

--- a/MongoDB/include/Poco/MongoDB/DeleteRequest.h
+++ b/MongoDB/include/Poco/MongoDB/DeleteRequest.h
@@ -26,8 +26,7 @@
 namespace Poco {
 namespace MongoDB {
 
-//class [[deprecated]] DeleteRequest;
-class DeleteRequest;
+//class POCO_DEPRECATED("Use new wire protocol") DeleteRequest;
 
 class MongoDB_API DeleteRequest: public RequestMessage
 	/// A DeleteRequest is used to delete one ore more documents from a database.

--- a/MongoDB/include/Poco/MongoDB/UpdateRequest.h
+++ b/MongoDB/include/Poco/MongoDB/UpdateRequest.h
@@ -26,8 +26,7 @@
 namespace Poco {
 namespace MongoDB {
 
-//class [[deprecated]] UpdateRequest;
-class UpdateRequest;
+//class POCO_DEPRECATED("Use new wire protocol") UpdateRequest;
 
 class MongoDB_API UpdateRequest: public RequestMessage
 	/// This request is used to update a document in a database

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -81,7 +81,7 @@ namespace
 	std::string digestToBinaryString(Poco::DigestEngine& engine)
 	{
 		Poco::DigestEngine::Digest d = engine.digest();
-		return std::string(reinterpret_cast<const char*>(&d[0]), d.size());
+		return { reinterpret_cast<const char*>(&d[0]), d.size() };
 	}
 
 	std::string digestToHexString(Poco::DigestEngine& engine)
@@ -116,7 +116,7 @@ namespace
 		}
 		return digestToHexString(md5);
 	}
-}
+} // namespace
 
 
 Database::Database(const std::string& db):
@@ -152,14 +152,16 @@ bool Database::authCR(Connection& connection, const std::string& username, const
 
 	ResponseMessage response;
 	connection.sendRequest(*pCommand, response);
-	if (response.documents().size() > 0)
+	if (response.documents().empty())
+	{
+		throw Poco::ProtocolException("empty response for getnonce");
+	}
 	{
 		Document::Ptr pDoc = response.documents()[0];
 		if (pDoc->getInteger("ok") != 1) return false;
 		nonce = pDoc->get<std::string>("nonce", "");
 		if (nonce.empty()) throw Poco::ProtocolException("no nonce received");
 	}
-	else throw Poco::ProtocolException("empty response for getnonce");
 
 	std::string credsDigest = hashCredentials(username, password);
 
@@ -177,12 +179,12 @@ bool Database::authCR(Connection& connection, const std::string& username, const
 		.add<std::string>("key", key);
 
 	connection.sendRequest(*pCommand, response);
-	if (response.documents().size() > 0)
+	if (!response.documents().empty())
 	{
 		Document::Ptr pDoc = response.documents()[0];
 		return pDoc->getInteger("ok") == 1;
 	}
-	else throw Poco::ProtocolException("empty response for authenticate");
+	throw Poco::ProtocolException("empty response for authenticate");
 }
 
 
@@ -204,7 +206,10 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 	Int32 conversationId = 0;
 	std::string serverFirstMsg;
 
-	if (response.documents().size() > 0)
+	if (response.documents().empty())
+	{
+		throw Poco::ProtocolException("empty response for saslStart");
+	}
 	{
 		Document::Ptr pDoc = response.documents()[0];
 		if (pDoc->getInteger("ok") == 1)
@@ -213,9 +218,11 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 			serverFirstMsg = pPayload->toRawString();
 			conversationId = pDoc->get<Int32>("conversationId");
 		}
-		else return false;
+		else
+		{
+			return false;
+		}
 	}
-	else throw Poco::ProtocolException("empty response for saslStart");
 
 	std::map<std::string, std::string> kvm = parseKeyValueList(serverFirstMsg);
 	const std::string serverNonce = kvm["r"];
@@ -260,7 +267,10 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 
 	std::string serverSecondMsg;
 	connection.sendRequest(*pCommand, response);
-	if (response.documents().size() > 0)
+	if (response.documents().empty())
+	{
+		throw Poco::ProtocolException("empty response for saslContinue");
+	}
 	{
 		Document::Ptr pDoc = response.documents()[0];
 		if (pDoc->getInteger("ok") == 1)
@@ -268,9 +278,11 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 			Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
 			serverSecondMsg = pPayload->toRawString();
 		}
-		else return false;
+		else
+		{
+			return false;
+		}
 	}
-	else throw Poco::ProtocolException("empty response for saslContinue");
 
 	Poco::HMACEngine<Poco::SHA1Engine> hmacSKey(saltedPassword);
 	hmacSKey.update(std::string("Server Key"));
@@ -293,12 +305,12 @@ bool Database::authSCRAM(Connection& connection, const std::string& username, co
 		.add<Binary::Ptr>("payload", new Binary);
 
 	connection.sendRequest(*pCommand, response);
-	if (response.documents().size() > 0)
+	if (!response.documents().empty())
 	{
 		Document::Ptr pDoc = response.documents()[0];
 		return pDoc->getInteger("ok") == 1;
 	}
-	else throw Poco::ProtocolException("empty response for saslContinue");
+	throw Poco::ProtocolException("empty response for saslContinue");
 }
 
 
@@ -312,7 +324,7 @@ Document::Ptr Database::queryBuildInfo(Connection& connection) const
 	connection.sendRequest(*request, response);
 
 	Document::Ptr buildInfo;
-	if ( response.documents().size() > 0 )
+	if ( !response.documents().empty() )
 	{
 		buildInfo = response.documents()[0];
 	}
@@ -353,7 +365,7 @@ Int64 Database::count(Connection& connection, const std::string& collectionName)
 	Poco::MongoDB::ResponseMessage response;
 	connection.sendRequest(*countRequest, response);
 
-	if (response.documents().size() > 0)
+	if (!response.documents().empty())
 	{
 		Poco::MongoDB::Document::Ptr doc = response.documents()[0];
 		return doc->getInteger("n");
@@ -409,7 +421,7 @@ Document::Ptr Database::getLastErrorDoc(Connection& connection) const
 	Poco::MongoDB::ResponseMessage response;
 	connection.sendRequest(*request, response);
 
-	if (response.documents().size() > 0)
+	if (!response.documents().empty())
 	{
 		errorDoc = response.documents()[0];
 	}


### PR DESCRIPTION
Old wire protocol shall be removed from Poco (#4781).

Few often used old-protocol functions are marked as deprecated.