### PR TITLE
NetSSL_OpenSSL and NetSSL_Win: non-blocking support, shutdown behavior fix

### DIFF
--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -170,12 +170,22 @@ public:
 	virtual void shutdownReceive();
 		/// Shuts down the receiving part of the socket connection.
 
-	virtual void shutdownSend();
+	virtual int shutdownSend();
 		/// Shuts down the sending part of the socket connection.
+		///
+		/// Returns 0 for a non-blocking socket. May return
+		/// a negative value for a non-blocking socket in case
+		/// of a TLS connection. In that case, the operation should
+		/// be retried once the underlying socket becomes writable.
 
-	virtual void shutdown();
+	virtual int shutdown();
 		/// Shuts down both the receiving and the sending part
 		/// of the socket connection.
+		///
+		/// Returns 0 for a non-blocking socket. May return
+		/// a negative value for a non-blocking socket in case
+		/// of a TLS connection. In that case, the operation should
+		/// be retried once the underlying socket becomes writable.
 
 	virtual int sendBytes(const void* buffer, int length, int flags = 0);
 		/// Sends the contents of the given buffer through

--- a/Net/include/Poco/Net/StreamSocket.h
+++ b/Net/include/Poco/Net/StreamSocket.h
@@ -157,12 +157,22 @@ public:
 	void shutdownReceive();
 		/// Shuts down the receiving part of the socket connection.
 
-	void shutdownSend();
+	int shutdownSend();
 		/// Shuts down the sending part of the socket connection.
+		///
+		/// Returns 0 for a non-blocking socket. May return
+		/// a negative value for a non-blocking socket in case
+		/// of a TLS connection. In that case, the operation should
+		/// be retried once the underlying socket becomes writable.
 
-	void shutdown();
+	int shutdown();
 		/// Shuts down both the receiving and the sending part
 		/// of the socket connection.
+		///
+		/// Returns 0 for a non-blocking socket. May return
+		/// a negative value for a non-blocking socket in case
+		/// of a TLS connection. In that case, the operation should
+		/// be retried once the underlying socket becomes writable.
 
 	int sendBytes(const void* buffer, int length, int flags = 0);
 		/// Sends the contents of the given buffer through

--- a/Net/include/Poco/Net/WebSocketImpl.h
+++ b/Net/include/Poco/Net/WebSocketImpl.h
@@ -69,8 +69,8 @@ public:
 	virtual void listen(int backlog = 64);
 	virtual void close();
 	virtual void shutdownReceive();
-	virtual void shutdownSend();
-	virtual void shutdown();
+	virtual int shutdownSend();
+	virtual int shutdown();
 	virtual int sendTo(const void* buffer, int length, const SocketAddress& address, int flags = 0);
 	virtual int receiveFrom(void* buffer, int length, SocketAddress& address, int flags = 0);
 	virtual void sendUrgent(unsigned char data);

--- a/Net/samples/HTTPTimeServer/src/HTTPTimeServer.cpp
+++ b/Net/samples/HTTPTimeServer/src/HTTPTimeServer.cpp
@@ -67,10 +67,11 @@ public:
 
 		response.setChunkedTransferEncoding(true);
 		response.setContentType("text/html");
+		response.set("Clear-Site-Data", "\"cookies\"");
 
 		std::ostream& ostr = response.send();
 		ostr << "<html><head><title>HTTPTimeServer powered by POCO C++ Libraries</title>";
-		ostr << "<meta http-equiv=\"refresh\" content=\"1\"></head>";
+		ostr << "</head>";
 		ostr << "<body><p style=\"text-align: center; font-size: 48px;\">";
 		ostr << dt;
 		ostr << "</p></body></html>";

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -327,21 +327,23 @@ void SocketImpl::shutdownReceive()
 }
 
 
-void SocketImpl::shutdownSend()
+int SocketImpl::shutdownSend()
 {
 	if (_sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
 
 	int rc = ::shutdown(_sockfd, 1);
 	if (rc != 0) error();
+	return 0;
 }
 
 
-void SocketImpl::shutdown()
+int SocketImpl::shutdown()
 {
 	if (_sockfd == POCO_INVALID_SOCKET) throw InvalidSocketException();
 
 	int rc = ::shutdown(_sockfd, 2);
 	if (rc != 0) error();
+	return 0;
 }
 
 

--- a/Net/src/StreamSocket.cpp
+++ b/Net/src/StreamSocket.cpp
@@ -146,15 +146,15 @@ void StreamSocket::shutdownReceive()
 }
 
 
-void StreamSocket::shutdownSend()
+int StreamSocket::shutdownSend()
 {
-	impl()->shutdownSend();
+	return impl()->shutdownSend();
 }
 
 
-void StreamSocket::shutdown()
+int StreamSocket::shutdown()
 {
-	impl()->shutdown();
+	return impl()->shutdown();
 }
 
 

--- a/Net/src/WebSocketImpl.cpp
+++ b/Net/src/WebSocketImpl.cpp
@@ -539,15 +539,15 @@ void WebSocketImpl::shutdownReceive()
 }
 
 
-void WebSocketImpl::shutdownSend()
+int WebSocketImpl::shutdownSend()
 {
-	_pStreamSocketImpl->shutdownSend();
+	return _pStreamSocketImpl->shutdownSend();
 }
 
 
-void WebSocketImpl::shutdown()
+int WebSocketImpl::shutdown()
 {
-	_pStreamSocketImpl->shutdown();
+	return _pStreamSocketImpl->shutdown();
 }
 
 

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -148,10 +148,11 @@ public:
 		/// number of connections that can be queued
 		/// for this socket.
 
-	void shutdown();
+	int shutdown();
 		/// Shuts down the connection by attempting
 		/// an orderly SSL shutdown, then actually
-		/// shutting down the TCP connection.
+		/// shutting down the TCP connection in the
+		/// send direction.
 
 	void close();
 		/// Close the socket.
@@ -294,7 +295,6 @@ private:
 	bool _needHandshake;
 	std::string _peerHostName;
 	Session::Ptr _pSession;
-	bool _bidirectShutdown = true;
 	mutable MutexT _mutex;
 
 	friend class SecureStreamSocketImpl;

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocketImpl.h
@@ -116,14 +116,25 @@ public:
 		/// Since SSL does not support a half shutdown, this does
 		/// nothing.
 
-	void shutdownSend() override;
+	int shutdownSend() override;
 		/// Shuts down the receiving part of the socket connection.
 		///
-		/// Since SSL does not support a half shutdown, this does
-		/// nothing.
+		/// Sends a close notify shutdown alert message to the peer
+		/// (if not sent yet), then calls shutdownSend() on the
+		/// underlying socket.
+		///
+		/// Returns 0 if the message has been sent.
+		/// Returns 1 if the message has been sent, but the peer
+		/// has not yet sent its shutdown alert message.
+		/// In case of a non-blocking socket, returns < 0 if the
+		/// message cannot be sent at the moment. In this case,
+		/// the call to shutdownSend() must be retried after the
+		/// underlying socket becomes writable again.
 
-	void shutdown() override;
+	int shutdown() override;
 		/// Shuts down the SSL connection.
+		///
+		/// Same as shutdownSend().
 
 	void abort();
 		/// Aborts the connection by closing the underlying

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -264,7 +264,13 @@ int SecureSocketImpl::shutdown()
 		if (!shutdownSent)
 		{
 			int rc = ::SSL_shutdown(_pSSL);
-			if (rc < 0) rc = handleError(rc);
+			if (rc < 0) 
+			{
+				if (SocketImpl::lastError() == POCO_EWOULDBLOCK)
+					rc = SecureStreamSocket::ERR_SSL_WANT_WRITE;
+				else
+					rc = handleError(rc);
+			}
 
 			l.unlock();
 

--- a/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureStreamSocketImpl.cpp
@@ -156,14 +156,15 @@ void SecureStreamSocketImpl::shutdownReceive()
 }
 
 
-void SecureStreamSocketImpl::shutdownSend()
+int SecureStreamSocketImpl::shutdownSend()
 {
+	return _impl.shutdown();
 }
 
 
-void SecureStreamSocketImpl::shutdown()
+int SecureStreamSocketImpl::shutdown()
 {
-	_impl.shutdown();
+	return _impl.shutdown();
 }
 
 

--- a/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
@@ -281,9 +281,7 @@ protected:
 	void performClientHandshakeSendError();
 	void sendOutSecBufferAndAdvanceState(State state);
 
-	void performClientHandshake();
-	SECURITY_STATUS performClientHandshakeLoop();
-	void performClientHandshakeLoopCondReceive();
+	SECURITY_STATUS performClientHandshake();
 
 	SECURITY_STATUS decodeMessage(BYTE* pBuffer, DWORD bufSize, AutoSecBufferDesc<4>& msg, SecBuffer*& pData, SecBuffer*& pExtra);
 	SECURITY_STATUS decodeBufferFull(BYTE* pBuffer, DWORD bufSize, char* pOutBuffer, int outLength, int& bytesDecoded);
@@ -293,7 +291,7 @@ protected:
 	void connectSSL(bool completeHandshake);
 	void completeHandshake();
 	static int lastError();
-	void stateMachine();
+	bool stateMachine();
 	State getState() const;
 	void setState(State st);
 	static bool isLocalHost(const std::string& hostName);

--- a/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
@@ -236,6 +236,12 @@ protected:
 		ST_ERROR
 	};
 
+	enum TLSShutdown
+	{
+		TLS_SHUTDOWN_SENT = 1,
+		TLS_SHUTDOWN_RECEIVED = 2
+	};
+
 	int sendRawBytes(const void* buffer, int length, int flags = 0);
 	int receiveRawBytes(void* buffer, int length, int flags = 0);
 	void clientConnectVerify();
@@ -245,8 +251,8 @@ protected:
 	void clientVerifyCertificate(const std::string& hostName);
 	void verifyCertificateChainClient(PCCERT_CONTEXT pServerCert);
 	void serverVerifyCertificate();
-	LONG serverDisconnect(PCredHandle phCreds, CtxtHandle* phContext);
-	LONG clientDisconnect(PCredHandle phCreds, CtxtHandle* phContext);
+	int serverShutdown(PCredHandle phCreds, CtxtHandle* phContext);
+	int clientShutdown(PCredHandle phCreds, CtxtHandle* phContext);
 	bool loadSecurityLibrary();
 	void initClientContext();
 	void initServerContext();
@@ -286,6 +292,7 @@ private:
 	Poco::AutoPtr<SocketImpl> _pSocket;
 	Context::Ptr   _pContext;
 	Mode           _mode;
+	int            _shutdownFlags;
 	std::string    _peerHostName;
 	bool           _useMachineStore;
 	bool           _clientAuthRequired;

--- a/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
@@ -154,10 +154,11 @@ public:
 		/// number of connections that can be queued
 		/// for this socket.
 
-	void shutdown();
+	int shutdown();
 		/// Shuts down the connection by attempting
 		/// an orderly SSL shutdown, then actually
-		/// shutting down the TCP connection.
+		/// shutting down the TCP connection in the
+		/// send direction.
 
 	void close();
 		/// Close the socket.

--- a/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
@@ -224,16 +224,23 @@ protected:
 	enum State
 	{
 		ST_INITIAL = 0,
+		// Client
 		ST_CONNECTING,
-		ST_CLIENTHANDSHAKESTART,
-		ST_CLIENTHANDSHAKECONDREAD,
-		ST_CLIENTHANDSHAKEINCOMPLETE,
-		ST_CLIENTHANDSHAKEOK,
-		ST_CLIENTHANDSHAKEEXTERROR,
-		ST_CLIENTHANDSHAKECONTINUE,
-		ST_VERIFY,
+		ST_CLIENT_HSK_START,
+		ST_CLIENT_HSK_SEND_TOKEN,
+		ST_CLIENT_HSK_LOOP_INIT,
+		ST_CLIENT_HSK_LOOP_RECV,
+		ST_CLIENT_HSK_LOOP_PROCESS,
+		ST_CLIENT_HSK_LOOP_CONTINUE,
+		ST_CLIENT_HSK_LOOP_SEND,
+		ST_CLIENT_HSK_LOOP_INCOMPLETE,
+		ST_CLIENT_HSK_LOOP_DONE,
+		ST_CLIENT_HSK_SEND_FINAL,
+		ST_CLIENT_HSK_SEND_ERROR,
+		ST_CLIENT_VERIFY,
 		ST_DONE,
-		ST_ERROR
+		ST_ERROR,
+		ST_MAX
 	};
 
 	enum TLSShutdown
@@ -245,7 +252,6 @@ protected:
 	int sendRawBytes(const void* buffer, int length, int flags = 0);
 	int receiveRawBytes(void* buffer, int length, int flags = 0);
 	void clientConnectVerify();
-	void sendInitialTokenOutBuffer();
 	void performServerHandshake();
 	bool serverHandshakeLoop(PCtxtHandle phContext, PCredHandle phCred, bool requireClientAuth, bool doInitialRead, bool newContext);
 	void clientVerifyCertificate(const std::string& hostName);
@@ -253,25 +259,32 @@ protected:
 	void serverVerifyCertificate();
 	int serverShutdown(PCredHandle phCreds, CtxtHandle* phContext);
 	int clientShutdown(PCredHandle phCreds, CtxtHandle* phContext);
-	bool loadSecurityLibrary();
 	void initClientContext();
 	void initServerContext();
 	PCCERT_CONTEXT loadCertificate(bool mustFindCertificate);
 	void initCommon();
 	void cleanup();
-	void performClientHandshake();
+
+	void performClientHandshakeStart();
 	void performInitialClientHandshake();
-	SECURITY_STATUS performClientHandshakeLoop();
+	void performClientHandshakeSendToken();
 	void performClientHandshakeLoopIncompleteMessage();
-	void performClientHandshakeLoopCondReceive();
-	void performClientHandshakeLoopReceive();
-	void performClientHandshakeLoopOK();
 	void performClientHandshakeLoopInit();
+	void performClientHandshakeLoopRecv();
+	void performClientHandshakeLoopProcess();
+	void performClientHandshakeLoopSend();
+	void performClientHandshakeLoopDone();
+	void performClientHandshakeSendFinal();
 	void performClientHandshakeExtraBuffer();
-	void performClientHandshakeSendOutBuffer();
-	void performClientHandshakeLoopContinueNeeded();
-	void performClientHandshakeLoopError();
-	void performClientHandshakeLoopExtError();
+	void performClientHandshakeLoopContinue();
+	void performClientHandshakeError();
+	void performClientHandshakeSendError();
+	void sendOutSecBufferAndAdvanceState(State state);
+
+	void performClientHandshake();
+	SECURITY_STATUS performClientHandshakeLoop();
+	void performClientHandshakeLoopCondReceive();
+
 	SECURITY_STATUS decodeMessage(BYTE* pBuffer, DWORD bufSize, AutoSecBufferDesc<4>& msg, SecBuffer*& pData, SecBuffer*& pExtra);
 	SECURITY_STATUS decodeBufferFull(BYTE* pBuffer, DWORD bufSize, char* pOutBuffer, int outLength, int& bytesDecoded);
 	void stateIllegal();

--- a/NetSSL_Win/include/Poco/Net/SecureStreamSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureStreamSocketImpl.h
@@ -117,14 +117,25 @@ public:
 		/// Since SSL does not support a half shutdown, this does
 		/// nothing.
 
-	void shutdownSend();
+	int shutdownSend();
 		/// Shuts down the receiving part of the socket connection.
 		///
-		/// Since SSL does not support a half shutdown, this does
-		/// nothing.
+		/// Sends a close notify shutdown alert message to the peer
+		/// (if not sent yet), then calls shutdownSend() on the
+		/// underlying socket.
+		///
+		/// Returns 0 if the message has been sent.
+		/// Returns 1 if the message has been sent, but the peer
+		/// has not yet sent its shutdown alert message.
+		/// In case of a non-blocking socket, returns < 0 if the
+		/// message cannot be sent at the moment. In this case,
+		/// the call to shutdownSend() must be retried after the
+		/// underlying socket becomes writable again.
 
-	void shutdown();
+	int shutdown();
 		/// Shuts down the SSL connection.
+		///
+		/// Same as shutdownSend().
 
 	void abort();
 		/// Aborts the connection by closing the underlying

--- a/NetSSL_Win/include/Poco/Net/Utility.h
+++ b/NetSSL_Win/include/Poco/Net/Utility.h
@@ -35,7 +35,7 @@ public:
 		/// Non-case sensitive conversion of a string to a VerificationMode enum.
 		/// If verMode is illegal an OptionException is thrown.
 
-	static const std::string& formatError(long errCode);
+	static std::string formatError(long errCode);
 		/// Converts an winerror.h code into human readable form.
 
 private:

--- a/NetSSL_Win/src/HTTPSStreamFactory.cpp
+++ b/NetSSL_Win/src/HTTPSStreamFactory.cpp
@@ -138,7 +138,7 @@ std::istream* HTTPSStreamFactory::open(const URI& uri)
 			{
 				return new HTTPResponseStream(rs, pSession);
 			}
-			else if (res.getStatus() == HTTPResponse::HTTP_USEPROXY && !retry)
+			else if (res.getStatus() == HTTPResponse::HTTP_USE_PROXY && !retry)
 			{
 				// The requested resource MUST be accessed through the proxy
 				// given by the Location field. The Location field gives the

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -265,7 +265,7 @@ void SecureSocketImpl::listen(int backlog)
 }
 
 
-void SecureSocketImpl::shutdown()
+int SecureSocketImpl::shutdown()
 {
 	if (_mode == MODE_SERVER)
 		serverDisconnect(&_hCreds, &_hContext);
@@ -273,16 +273,22 @@ void SecureSocketImpl::shutdown()
 		clientDisconnect(&_hCreds, &_hContext);
 
 	_pSocket->shutdown();
+	return 0;
 }
 
 
 void SecureSocketImpl::close()
 {
-	if (_mode == MODE_SERVER)
-		serverDisconnect(&_hCreds, &_hContext);
-	else
-		clientDisconnect(&_hCreds, &_hContext);
-
+	try
+	{
+		if (_mode == MODE_SERVER)
+			serverDisconnect(&_hCreds, &_hContext);
+		else
+			clientDisconnect(&_hCreds, &_hContext);
+	}
+	catch (Poco::Exception&)
+	{
+	}
 	_pSocket->close();
 	cleanup();
 }

--- a/NetSSL_Win/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureStreamSocketImpl.cpp
@@ -151,12 +151,13 @@ void SecureStreamSocketImpl::shutdownReceive()
 
 void SecureStreamSocketImpl::shutdownSend()
 {
+	return _impl.shutdown();
 }
 
 
 void SecureStreamSocketImpl::shutdown()
 {
-	_impl.shutdown();
+	return _impl.shutdown();
 }
 
 

--- a/NetSSL_Win/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureStreamSocketImpl.cpp
@@ -149,13 +149,13 @@ void SecureStreamSocketImpl::shutdownReceive()
 }
 
 
-void SecureStreamSocketImpl::shutdownSend()
+int SecureStreamSocketImpl::shutdownSend()
 {
 	return _impl.shutdown();
 }
 
 
-void SecureStreamSocketImpl::shutdown()
+int SecureStreamSocketImpl::shutdown()
 {
 	return _impl.shutdown();
 }

--- a/NetSSL_Win/src/SecureStreamSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureStreamSocketImpl.cpp
@@ -209,8 +209,7 @@ void SecureStreamSocketImpl::verifyPeerCertificate(const std::string& hostName)
 
 int SecureStreamSocketImpl::completeHandshake()
 {
-	_impl.completeHandshake();
-	return 0;
+	return _impl.completeHandshake();
 }
 
 

--- a/NetSSL_Win/src/Utility.cpp
+++ b/NetSSL_Win/src/Utility.cpp
@@ -24,9 +24,6 @@ namespace Poco {
 namespace Net {
 
 
-Poco::FastMutex Utility::_mutex;
-
-
 Context::VerificationMode Utility::convertVerificationMode(const std::string& vMode)
 {
 	std::string mode = Poco::toLower(vMode);
@@ -54,6 +51,7 @@ inline void add(std::map<long, const std::string>& messageMap, long key, const s
 std::map<long, const std::string> Utility::initSSPIErr()
 {
 	std::map<long, const std::string> messageMap;
+	add(messageMap, SEC_E_OK, "OK");
 	add(messageMap, NTE_BAD_UID, "Bad UID");
 	add(messageMap, NTE_BAD_HASH, "Bad Hash");
 	add(messageMap, NTE_BAD_KEY, "Bad Key");
@@ -185,18 +183,15 @@ std::map<long, const std::string> Utility::initSSPIErr()
 }
 
 
-const std::string& Utility::formatError(long errCode)
+std::string Utility::formatError(long errCode)
 {
-	Poco::FastMutex::ScopedLock lock(_mutex);
-
-	static const std::string def("Internal SSPI error");
 	static const std::map<long, const std::string> errs(initSSPIErr());
 
 	const std::map<long, const std::string>::const_iterator it = errs.find(errCode);
 	if (it != errs.end())
 		return it->second;
 	else
-		return def;
+		return "0x" + Poco::NumberFormatter::formatHex(errCode, 8);
 }
 
 


### PR DESCRIPTION
This fixes a whole lot of issues in NetSSL_OpenSSL and NetSSL_Win.
Specifically:
  - we now have full support for non-blocking TLS sockets in both NetSSL_OpenSSL and NetSSL_Win
  - fixed TLS shutdown behavior, hopefully once and for all in both NetSSL_OpenSSL and NetSSL_Win
  - cleaned up and fixed NetSSL_Win, including workaround for Schannel bugs