### PR TITLE
Build Zip library tests without linking unnecessary "Poco::Net"

### DIFF
--- a/Zip/cmake/PocoZipConfig.cmake
+++ b/Zip/cmake/PocoZipConfig.cmake
@@ -1,5 +1,3 @@
 include(CMakeFindDependencyMacro)
 find_dependency(PocoFoundation)
-find_dependency(PocoUtil)
-find_dependency(PocoXML)
 include("${CMAKE_CURRENT_LIST_DIR}/PocoZipTargets.cmake")

--- a/Zip/testsuite/CMakeLists.txt
+++ b/Zip/testsuite/CMakeLists.txt
@@ -29,4 +29,4 @@ else()
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data
 	)
 endif()
-target_link_libraries(Zip-testrunner PUBLIC Poco::Zip Poco::Net CppUnit)
+target_link_libraries(Zip-testrunner PUBLIC Poco::Zip CppUnit)


### PR DESCRIPTION
Fixes #4791

Not mentioned in the issue, but I've also found some unnecessary find_package() calls in PocoZipConfig.cmake file. Not sure why they were there, but tests continue to pass after removing them, so I think they can also be safely removed 