### PR TITLE
Make Poco::format() support %g or %G as a format specifier like printf() does

### DIFF
--- a/Foundation/include/Poco/Format.h
+++ b/Foundation/include/Poco/Format.h
@@ -62,6 +62,8 @@ std::string Foundation_API format(const std::string& fmt, const Any& value);
 	///   * e signed floating-point value in the form [-]d.dddde[<sign>]dd[d]
 	///   * E signed floating-point value in the form [-]d.ddddE[<sign>]dd[d]
 	///   * f signed floating-point value in the form [-]dddd.dddd
+	///   * g use the shortest representation: %e or %f
+	///   * G use the shortest representation: %E or %F
 	///   * s std::string
 	///   * v std::string_view
 	///   * z std::size_t

--- a/Foundation/src/Format.cpp
+++ b/Foundation/src/Format.cpp
@@ -128,6 +128,8 @@ namespace
 		case 'e': str << std::scientific; break;
 		case 'E': str << std::scientific << std::uppercase; break;
 		case 'f': str << std::fixed; break;
+		case 'g': str << std::defaultfloat; break;
+		case 'G': str << std::defaultfloat << std::uppercase; break;
 		}
 	}
 
@@ -212,6 +214,8 @@ namespace
 				case 'e':
 				case 'E':
 				case 'f':
+				case 'g': 
+				case 'G': 
 					switch (mod)
 					{
 					case 'l': str << AnyCast<long double>(*itVal++); break;

--- a/Foundation/testsuite/src/FormatTest.cpp
+++ b/Foundation/testsuite/src/FormatTest.cpp
@@ -325,6 +325,80 @@ void FormatTest::testAnyInt()
 	assertTrue (s == "42");
 }
 
+void FormatTest::testShortestRepr()
+{
+	std::string str;
+
+	//
+	// uppercase tests
+	//
+	{
+		str = format("%G", 123.456);
+		assertEquals("123.456", str);
+
+		str = format("%G", 12345.6789);
+		assertEquals("12345.7", str);
+
+		str = format("%G", 0.000123);
+		assertEquals("0.000123", str);
+
+		str = format("%G", 1234567890.123);
+		assertEquals("1.23457E+09", str);
+
+		str = format("%G", 0.0);
+		assertEquals("0", str);
+
+		str = format("%G", -9876.54321);
+		assertEquals("-9876.54", str);
+
+		str = format("%.2G", 123.456);
+		assertEquals("1.2E+02", str);
+
+		str = format("%G", 1.0);
+		assertEquals("1", str);
+
+		str = format("%G", 0.00000000123);
+		assertEquals("1.23E-09", str);
+
+		str = format("%G", 0.00000000000123);
+		assertEquals("1.23E-12", str);
+	}
+
+	//
+	// lowercase tests
+	//
+	{
+		str = format("%g", 123.456);
+		assertEquals("123.456", str);
+
+		str = format("%g", 12345.6789);
+		assertEquals("12345.7", str);
+
+		str = format("%g", 0.000123);
+		assertEquals("0.000123", str);
+
+		str = format("%g", 1234567890.123);
+		assertEquals("1.23457e+09", str);
+
+		str = format("%g", 0.0);
+		assertEquals("0", str);
+
+		str = format("%g", -9876.54321);
+		assertEquals("-9876.54", str);
+
+		str = format("%.2g", 123.456);
+		assertEquals("1.2e+02", str);
+
+		str = format("%g", 1.0);
+		assertEquals("1", str);
+
+		str = format("%g", 0.00000000123);
+		assertEquals("1.23e-09", str);
+
+		str = format("%g", 0.00000000000123);
+		assertEquals("1.23e-12", str);
+	}
+}
 
 void FormatTest::testFloatFix()
 {
@@ -527,6 +601,7 @@ CppUnit::Test* FormatTest::suite()
 	CppUnit_addTest(pSuite, FormatTest, testMultiple);
 	CppUnit_addTest(pSuite, FormatTest, testIndex);
 	CppUnit_addTest(pSuite, FormatTest, testAny);
+	CppUnit_addTest(pSuite, FormatTest, testShortestRepr);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/FormatTest.h
+++ b/Foundation/testsuite/src/FormatTest.h
@@ -29,6 +29,7 @@ public:
 	void testFloatSci();
 	void testString();
 	void testStringView();
+	void testShortestRepr();
 	void testMultiple();
 	void testIndex();
 	void testAny();


### PR DESCRIPTION
Resolves #2731
