### PR TITLE
Updated CMake to also include the generated pocomessage.rc File

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -15,10 +15,14 @@ POCO_SOURCES_AUTO_PLAT(SRCS WIN32
 	src/EventLogChannel.cpp
 	)
 
+
 # Version Resource
 if(MSVC AND BUILD_SHARED_LIBS)
+	# Empty File needed otherwise cmake does not find it.
+	file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pocomsg.rc CONTENT "")
 	source_group("Resources" FILES ${PROJECT_SOURCE_DIR}/DLLVersion.rc)
 	list(APPEND SRCS ${PROJECT_SOURCE_DIR}/DLLVersion.rc)
+	list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/pocomsg.rc)
 endif()
 
 # Messages


### PR DESCRIPTION
I have added the `pocomessage.rc` in the CMakeLists. Currently it is missing and thats leads to the issue that the `PocoFoundation.dll` does not contains the Message Format for the Eventlog Channel in Windows. So the Eventviewer will show a warning about the missing Information. 
I'm not the CMake Expert so i tried my best to solve it. If there is a better way then please let me know :). 
At the moment i first need to create the File as an empty one because the `custom_command` is first called during the Build. So when running `cmake ..` it is unable to find the file because it is not there. 
This will solve #3304 