### PR TITLE
fix(cmake): correct typo AVHAI -> AVAHI

### DIFF
--- a/DNSSD/CMakeLists.txt
+++ b/DNSSD/CMakeLists.txt
@@ -75,7 +75,7 @@ if(ENABLE_DNSSD_DEFAULT)
 	endif()
 endif()
 
-if(ENABLE_DNSSD_AVHAI)
+if(ENABLE_DNSSD_AVAHI)
 	ADD_AVAHI()
 endif()
 


### PR DESCRIPTION
Small typo. It should be AVAHI instead of AVHAI