### PR TITLE
fix(CMake): Select MSVC runtime library with variable CMAKE_MSVC_RUNTIME_LIBRARY (fixes #4817)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,58 @@ jobs:
             cd cmake-build;
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
 
+  windows-2022-msvc-cmake-static-mt:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: >-
+        class CppUnit::TestCaller<class PathTest>.testFind,
+        class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,
+        class CppUnit::TestCaller<class ICMPClientTest>.testPing,
+        class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,
+        class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,
+        class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,
+        class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy,
+        class CppUnit::TestCaller<class FileTest>.testExists,
+        class CppUnit::TestCaller<class ProcessRunnerTest>.testProcessRunner
+    steps:
+      - uses: actions/checkout@v4
+      - run: cmake -S. -Bcmake-build -DBUILD_SHARED_LIBS=OFF -DPOCO_MT=ON -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+      - run: cmake --build cmake-build --config Release
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build;
+            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+
+  windows-2022-msvc-cmake-static:
+    runs-on: windows-2022
+    env:
+      CPPUNIT_IGNORE: >-
+        class CppUnit::TestCaller<class PathTest>.testFind,
+        class CppUnit::TestCaller<class ICMPSocketTest>.testSendToReceiveFrom,
+        class CppUnit::TestCaller<class ICMPClientTest>.testPing,
+        class CppUnit::TestCaller<class ICMPClientTest>.testBigPing,
+        class CppUnit::TestCaller<class ICMPSocketTest>.testMTU,
+        class CppUnit::TestCaller<class HTTPSClientSessionTest>.testProxy,
+        class CppUnit::TestCaller<class HTTPSStreamFactoryTest>.testProxy,
+        class CppUnit::TestCaller<class FileTest>.testExists,
+        class CppUnit::TestCaller<class ProcessRunnerTest>.testProcessRunner
+    steps:
+      - uses: actions/checkout@v4
+      - run: cmake -S. -Bcmake-build -DBUILD_SHARED_LIBS=OFF -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
+      - run: cmake --build cmake-build --config Release
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build;
+            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+
   # missing asan dll path
   #  windows-2022-msvc-cmake-asan:
   #    runs-on: windows-2022

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include(GNUInstallDirs)
 # Include some common macros to simpilfy the Poco CMake files
 include(PocoMacros)
 
-option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 set(POCO_SANITIZEFLAGS CACHE STRING "Compiler-dependent sanitizer flags (like -fsanitize=address or /fsanitize=address")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 set(POCO_SANITIZEFLAGS CACHE STRING "Compiler-dependent sanitizer flags (like -fsanitize=address or /fsanitize=address")
 
 if(MSVC)
-	option(POCO_MT "Set to OFF|ON (default is OFF) to control build of POCO as /MT instead of /MD" OFF)
+	option(POCO_MT "Set to OFF|ON (default is OFF) to control static build of POCO as /MT instead of /MD" OFF)
 
 	if(BUILD_SHARED_LIBS AND POCO_MT)
 		message(FATAL_ERROR "Cannot have both BUILD_SHARED_LIBS and POCO_MT")

--- a/Foundation/testsuite/CMakeLists.txt
+++ b/Foundation/testsuite/CMakeLists.txt
@@ -59,7 +59,13 @@ target_link_libraries(TestApp PUBLIC Poco::Foundation)
 
 # TestLibrary
 add_library(TestLibrary SHARED src/TestLibrary.cpp src/TestPlugin.cpp src/TestPlugin.h)
-set_target_properties(TestLibrary PROPERTIES PREFIX "" DEBUG_POSTFIX "d") # The test requires the library named TestLibrary. By default it is prefixed with lib.
+set_target_properties(TestLibrary PROPERTIES DEBUG_POSTFIX "d")
+set_target_properties(TestLibrary PROPERTIES RELEASE_POSTFIX "")
+set_target_properties(TestLibrary PROPERTIES CMAKE_MINSIZEREL_POSTFIX "")
+set_target_properties(TestLibrary PROPERTIES CMAKE_RELWITHDEBINFO_POSTFIX "")
+# The test requires the library named TestLibrary. By default it is prefixed with lib.
+set_target_properties(TestLibrary PROPERTIES PREFIX "")
+
 # The test is run in the runtime directory. So the TestLibrary is built there too because it is used by the tests
 set_target_properties(TestLibrary PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 target_link_libraries(TestLibrary PUBLIC Poco::Foundation)

--- a/cmake/DefinePlatformSpecific.cmake
+++ b/cmake/DefinePlatformSpecific.cmake
@@ -9,6 +9,7 @@
 #    * MinSizeRel (CMAKE_C_FLAGS_MINSIZEREL or CMAKE_CXX_FLAGS_MINSIZEREL)
 
 # Setting CXX Flag /MD or /MT and POSTFIX values i.e MDd / MD / MTd / MT / d
+# using CMake variable CMAKE_MSVC_RUNTIME_LIBRARY.
 #
 # For visual studio the library naming is as following:
 #  Dynamic libraries:
@@ -30,24 +31,10 @@ endif()
 
 if(MSVC)
 	if(POCO_MT)
-		set(CompilerFlags
-			CMAKE_CXX_FLAGS
-			CMAKE_CXX_FLAGS_DEBUG
-			CMAKE_CXX_FLAGS_RELEASE
-			CMAKE_CXX_FLAGS_RELWITHDEBINFO
-			CMAKE_CXX_FLAGS_MINSIZEREL
-			CMAKE_C_FLAGS
-			CMAKE_C_FLAGS_DEBUG
-			CMAKE_C_FLAGS_RELEASE
-			CMAKE_C_FLAGS_RELWITHDEBINFO
-			CMAKE_C_FLAGS_MINSIZEREL
-		)
-		foreach(CompilerFlag ${CompilerFlags})
-			string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
-		endforeach()
-
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 		set(STATIC_POSTFIX "mt" CACHE STRING "Set static library postfix" FORCE)
 	else(POCO_MT)
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 		set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
 	endif(POCO_MT)
 

--- a/cmake/DefinePlatformSpecific.cmake
+++ b/cmake/DefinePlatformSpecific.cmake
@@ -38,6 +38,8 @@ if(MSVC)
 		set(STATIC_POSTFIX "md" CACHE STRING "Set static library postfix" FORCE)
 	endif(POCO_MT)
 
+	message(STATUS "MSVC runtime library: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
+
 	if(POCO_SANITIZE_ASAN)
 		message(WARNING "Use POCO_SANITIZEFLAGS instead of POCO_SANITIZE_ASAN")
 		add_compile_options("/fsanitize=address")


### PR DESCRIPTION
Use CMake features to select MSVC runtime library with CMAKE_MSVC_RUNTIME_LIBRARY instead of modifying compiler options.

Resolves #4817 