### PR TITLE
Fix typo that leads to the use of freed memory

### DIFF
--- a/Data/SQLParser/src/SQLParserResult.cpp
+++ b/Data/SQLParser/src/SQLParserResult.cpp
@@ -67,7 +67,7 @@ int SQLParserResult::errorColumn() const { return errorColumn_; }
 void SQLParserResult::setIsValid(bool isValid) { isValid_ = isValid; }
 
 void SQLParserResult::setErrorDetails(char* errorMsg, int errorLine, int errorColumn) {
-  if (errorMsg_) free(errorMsg);
+  if (errorMsg_) free(errorMsg_);
   errorMsg_ = errorMsg;
   errorLine_ = errorLine;
   errorColumn_ = errorColumn;


### PR DESCRIPTION
The old message ```errorMsg_``` must be freed before assignment to ```errorMsg_```.
However, due to a typo, ```free()``` was called for the new message ```errorMsg```.