### PR TITLE
fix(Net) Use of Uninitialized value in NTLMCredentials::parseChallengeMessage

### DIFF
--- a/Net/src/NTLMCredentials.cpp
+++ b/Net/src/NTLMCredentials.cpp
@@ -213,7 +213,7 @@ bool NTLMCredentials::parseChallengeMessage(const unsigned char* buffer, std::si
 	reader >> zero;
 	if (zero != 0) return false;
 
-	Poco::UInt32 type;
+	Poco::UInt32 type = 0;
 	reader >> type;
 	if (type != NTLM_MESSAGE_TYPE_CHALLENGE) return false;
 


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/372764172

```
==8==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55e265fb8c8d in Poco::Net::NTLMCredentials::parseChallengeMessage(unsigned char const*, unsigned long, Poco::Net::NTLMCredentials::ChallengeMessage&) /src/poco/Net/src/NTLMCredentials.cpp:218:6
    #1 0x55e265f5254f in Poco::Net::HTTPNTLMCredentials::createNTLMMessage(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) /src/poco/Net/src/HTTPNTLMCredentials.cpp:154:8
    #2 0x55e265f515d0 in Poco::Net::HTTPNTLMCredentials::authenticate(Poco::Net::HTTPRequest&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) /src/poco/Net/src/HTTPNTLMCredentials.cpp:92:28
    #3 0x55e265f32069 in Poco::Net::HTTPCredentials::authenticate(Poco::Net::HTTPRequest&, Poco::Net::HTTPResponse const&) /src/poco/Net/src/HTTPCredentials.cpp:104:10
    #4 0x55e265f159b0 in LLVMFuzzerTestOneInput::$_1::operator()() const /src/poco/Net/fuzzing/HTTPParse.cpp:59:10
    #5 0x55e265f159b0 in void catchExceptions<LLVMFuzzerTestOneInput::$_1>(LLVMFuzzerTestOneInput::$_1 const&) /src/poco/Net/fuzzing/HTTPParse.cpp:20:3
    #6 0x55e265f159b0 in LLVMFuzzerTestOneInput /src/poco/Net/fuzzing/HTTPParse.cpp:47:2
    #7 0x55e265e0b0f0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:614:13
    #8 0x55e265df6365 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:327:6
    #9 0x55e265dfbdff in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:862:9
    #10 0x55e265e270a2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #11 0x7f13b90d7082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #12 0x55e265dee54d in _start (/out/http_message_fuzzer+0x14054d)

DEDUP_TOKEN: Poco::Net::NTLMCredentials::parseChallengeMessage(unsigned char const*, unsigned long, Poco::Net::NTLMCredentials::ChallengeMessage&)--Poco::Net::HTTPNTLMCredentials::createNTLMMessage(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)--Poco::Net::HTTPNTLMCredentials::authenticate(Poco::Net::HTTPRequest&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)
  Uninitialized value was created by an allocation of 'type' in the stack frame
    #0 0x55e265fb812d in Poco::Net::NTLMCredentials::parseChallengeMessage(unsigned char const*, unsigned long, Poco::Net::NTLMCredentials::ChallengeMessage&) /src/poco/Net/src/NTLMCredentials.cpp:216:2

DEDUP_TOKEN: Poco::Net::NTLMCredentials::parseChallengeMessage(unsigned char const*, unsigned long, Poco::Net::NTLMCredentials::ChallengeMessage&)
SUMMARY: MemorySanitizer: use-of-uninitialized-value /src/poco/Net/src/NTLMCredentials.cpp:218:6 in Poco::Net::NTLMCredentials::parseChallengeMessage(unsigned char const*, unsigned long, Poco::Net::NTLMCredentials::ChallengeMessage&)
Unique heap origins: 369
Stack depot allocated bytes: 9764880
Unique origin histories: 13
History depot allocated bytes: 196608
```