### PR TITLE
Fix dynamic var conversion precision check

### DIFF
--- a/Foundation/include/Poco/Dynamic/VarHolder.h
+++ b/Foundation/include/Poco/Dynamic/VarHolder.h
@@ -475,7 +475,7 @@ private:
 		using U = std::make_unsigned_t<T>;
 		if (value == 0) return 0;
 		int digitCount = 0;
-		U locVal = value; // to prevent sign preservation
+		U locVal = llabs(value); // to prevent sign preservation
 		while (locVal >>= 1) ++digitCount;
 		return digitCount;
 	}


### PR DESCRIPTION
Take the absolute value of the value in numValDigits to fix the precision loss check for negative values. Fixes #4886.