### PR TITLE
add_subdirectory(tcpclient)

### DIFF
--- a/Net/samples/CMakeLists.txt
+++ b/Net/samples/CMakeLists.txt
@@ -12,4 +12,4 @@ add_subdirectory(download)
 add_subdirectory(httpget)
 add_subdirectory(tcpserver)
 add_subdirectory(ifconfig)
-
+add_subdirectory(tcpclient)


### PR DESCRIPTION
tcpclient missing from Net/samples/CMakeLists.txt 