### PR TITLE
CMake: make utf8proc, PCRE2, zlib and expat private dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,11 +562,6 @@ install(
 		Devel
 )
 
-if(POCO_UNBUNDLED)
-	install(FILES cmake/FindPCRE2.cmake DESTINATION "${PocoConfigPackageLocation}")
-	install(FILES cmake/FindUtf8Proc.cmake DESTINATION "${PocoConfigPackageLocation}")
-endif()
-
 message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
 message(STATUS "${PROJECT_NAME} package version: ${PROJECT_VERSION}")
 if(BUILD_SHARED_LIBS)

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -110,7 +110,7 @@ set_target_properties(Foundation
 )
 
 if(POCO_UNBUNDLED)
-	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
+	target_link_libraries(Foundation PRIVATE Pcre2::Pcre2 ZLIB::ZLIB Utf8Proc::Utf8Proc)
 	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
 else()
 	target_compile_definitions(Foundation PUBLIC UTF8PROC_STATIC)

--- a/Foundation/cmake/PocoFoundationConfig.cmake
+++ b/Foundation/cmake/PocoFoundationConfig.cmake
@@ -1,9 +1,1 @@
-if(@POCO_UNBUNDLED@)
-	include(CMakeFindDependencyMacro)
-	list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-	find_dependency(ZLIB REQUIRED)
-	find_dependency(PCRE2 REQUIRED)
-	find_dependency(Utf8Proc REQUIRED)
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/PocoFoundationTargets.cmake")

--- a/XML/CMakeLists.txt
+++ b/XML/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(XML
 )
 
 if(POCO_UNBUNDLED)
-	target_link_libraries(XML PUBLIC EXPAT::EXPAT)
+	target_link_libraries(XML PRIVATE EXPAT::EXPAT)
 	target_compile_definitions(XML PUBLIC POCO_UNBUNDLED)
 else()
 	if(WIN32)

--- a/XML/cmake/PocoXMLConfig.cmake
+++ b/XML/cmake/PocoXMLConfig.cmake
@@ -1,10 +1,3 @@
 include(CMakeFindDependencyMacro)
 find_dependency(PocoFoundation)
-if(@POCO_UNBUNDLED@)
-	if(CMAKE_VERSION VERSION_LESS "3.10")
-		list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/V39")
-	endif()
-	find_dependency(EXPAT REQUIRED)
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/PocoXMLTargets.cmake")


### PR DESCRIPTION
In the unbundled build, utf8proc, PCRE2, zlib and expat were all included as part of the CMake link interface, and therefore the CMake config file required `find_dependency()` calls for each.

These libraries are internal implementation details of Poco and are not exposed in any public API (as of https://github.com/pocoproject/poco/pull/4724). Therefore, we can make them private dependencies and avoid the find_dependency() calls and their associated find scripts.