### PR TITLE
Changed target uninstall to be named uninstall-poco

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,7 @@ configure_file(
 	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 	IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
+add_custom_target(uninstall-poco
 	"${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
 )
 


### PR DESCRIPTION
I don't know if I'm doing this right, but I was having pretty much the same issue as [this person](https://github.com/pocoproject/poco/issues/4881) so I changed the name of the target as requested.