### PR TITLE
fix(Thread): fix Thread reuse error, add thread interrupt feature

### DIFF
--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -230,6 +230,7 @@ POCO_DECLARE_EXCEPTION(Foundation_API, RegularExpressionException, RuntimeExcept
 POCO_DECLARE_EXCEPTION(Foundation_API, LibraryLoadException, RuntimeException)
 POCO_DECLARE_EXCEPTION(Foundation_API, LibraryAlreadyLoadedException, RuntimeException)
 POCO_DECLARE_EXCEPTION(Foundation_API, NoThreadAvailableException, RuntimeException)
+POCO_DECLARE_EXCEPTION(Foundation_API, ThreadInterruptedException, RuntimeException)
 POCO_DECLARE_EXCEPTION(Foundation_API, PropertyNotSupportedException, RuntimeException)
 POCO_DECLARE_EXCEPTION(Foundation_API, PoolOverflowException, RuntimeException)
 POCO_DECLARE_EXCEPTION(Foundation_API, NoPermissionException, RuntimeException)

--- a/Foundation/include/Poco/Thread.h
+++ b/Foundation/include/Poco/Thread.h
@@ -256,6 +256,35 @@ public:
 		/// Negative value means the thread has
 		/// no CPU core affinity.
 
+	bool isInterrupted();
+		/// Tests whether current thread has been interrupted.
+		/// Return true if the task running on this thread should be stopped.
+		/// An interruption can be requested by interrupt().
+		///
+		/// This function can be used to make long running tasks cleanly interruptible.
+		/// Never checking or acting on the value returned by this function is safe,
+		/// however it is advisable do so regularly in long running functions.
+		/// Take care not to call it too often, to keep the overhead low.
+		/// 
+		/// See also checkInterrupted().
+
+	void checkInterrupted();
+		/// Tests whether current thread has been interrupted.
+		/// Throws Poco::ThreadInterruptedException if isInterrupted() return true.
+		///
+		/// Note: The interrupted status of the thread is cleared by this method.
+
+	void interrupt();
+		/// Interrupts this thread.
+		///
+		/// This function does not stop any event loop running on the thread and
+		/// does not terminate it in any way.
+		///
+		/// See also isInterrupted().
+
+	void clearInterrupt();
+		/// Clear the the interrupted status.
+
 protected:
 	ThreadLocalStorage& tls();
 		/// Returns a reference to the thread's local storage.
@@ -301,6 +330,7 @@ private:
 	int                 _id;
 	ThreadLocalStorage* _pTLS;
 	Event               _event;
+	std::atomic_bool    _interruptionRequested;
 
 	friend class ThreadLocalStorage;
 	friend class PooledThread;

--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -176,6 +176,7 @@ POCO_IMPLEMENT_EXCEPTION(RegularExpressionException, RuntimeException, "Error in
 POCO_IMPLEMENT_EXCEPTION(LibraryLoadException, RuntimeException, "Cannot load library")
 POCO_IMPLEMENT_EXCEPTION(LibraryAlreadyLoadedException, RuntimeException, "Library already loaded")
 POCO_IMPLEMENT_EXCEPTION(NoThreadAvailableException, RuntimeException, "No thread available")
+POCO_IMPLEMENT_EXCEPTION(ThreadInterruptedException, RuntimeException, "Thread interrupted")
 POCO_IMPLEMENT_EXCEPTION(PropertyNotSupportedException, RuntimeException, "Property not supported")
 POCO_IMPLEMENT_EXCEPTION(PoolOverflowException, RuntimeException, "Pool overflow")
 POCO_IMPLEMENT_EXCEPTION(NoPermissionException, RuntimeException, "No permission")

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -324,6 +324,7 @@ void ThreadImpl::startImpl(SharedPtr<Runnable> pTarget)
 	{
 		FastMutex::ScopedLock l(_pData->mutex);
 		_pData->pRunnableTarget = pTarget;
+		_pData->done.reset();
 		int errorCode;
 		if ((errorCode = pthread_create(&_pData->thread, &attributes, runnableEntry, this)))
 		{

--- a/Foundation/src/Thread_VX.cpp
+++ b/Foundation/src/Thread_VX.cpp
@@ -123,6 +123,7 @@ void ThreadImpl::startImpl(Runnable& target)
 		throw SystemException("thread already running");
 
 	_pData->pRunnableTarget = &target;
+	_pData->done.reset();
 
 	int stackSize = _pData->stackSize == 0 ? DEFAULT_THREAD_STACK_SIZE : _pData->stackSize;
 	int id = taskSpawn(NULL, _pData->osPrio, VX_FP_TASK, stackSize, reinterpret_cast<FUNCPTR>(runnableEntry), reinterpret_cast<int>(this), 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -143,6 +144,7 @@ void ThreadImpl::startImpl(Callable target, void* pData)
 
 	_pData->pCallbackTarget->callback = target;
 	_pData->pCallbackTarget->pData = pData;
+	_pData->done.reset();
 
 	int stackSize = _pData->stackSize == 0 ? DEFAULT_THREAD_STACK_SIZE : _pData->stackSize;
 	int id = taskSpawn(NULL, _pData->osPrio, VX_FP_TASK, stackSize, reinterpret_cast<FUNCPTR>(callableEntry), reinterpret_cast<int>(this), 0, 0, 0, 0, 0, 0, 0, 0, 0);

--- a/Foundation/testsuite/src/FoundationTestSuite.cpp
+++ b/Foundation/testsuite/src/FoundationTestSuite.cpp
@@ -34,7 +34,25 @@ CppUnit::Test* FoundationTestSuite::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("FoundationTestSuite");
 
+	pSuite->addTest(CoreTestSuite::suite());
+	pSuite->addTest(DateTimeTestSuite::suite());
+	pSuite->addTest(StreamsTestSuite::suite());
+	pSuite->addTest(CryptTestSuite::suite());
+	pSuite->addTest(NotificationsTestSuite::suite());
 	pSuite->addTest(ThreadingTestSuite::suite());
+	pSuite->addTest(SharedLibraryTestSuite::suite());
+	pSuite->addTest(LoggingTestSuite::suite());
+	pSuite->addTest(FilesystemTestSuite::suite());
+	pSuite->addTest(UUIDTestSuite::suite());
+	pSuite->addTest(TextTestSuite::suite());
+	pSuite->addTest(URITestSuite::suite());
+#if !defined(POCO_VXWORKS)
+	pSuite->addTest(ProcessesTestSuite::suite());
+#endif
+	pSuite->addTest(TaskTestSuite::suite());
+	pSuite->addTest(EventTestSuite::suite());
+	pSuite->addTest(CacheTestSuite::suite());
+	pSuite->addTest(HashingTestSuite::suite());
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/FoundationTestSuite.cpp
+++ b/Foundation/testsuite/src/FoundationTestSuite.cpp
@@ -34,25 +34,7 @@ CppUnit::Test* FoundationTestSuite::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("FoundationTestSuite");
 
-	pSuite->addTest(CoreTestSuite::suite());
-	pSuite->addTest(DateTimeTestSuite::suite());
-	pSuite->addTest(StreamsTestSuite::suite());
-	pSuite->addTest(CryptTestSuite::suite());
-	pSuite->addTest(NotificationsTestSuite::suite());
 	pSuite->addTest(ThreadingTestSuite::suite());
-	pSuite->addTest(SharedLibraryTestSuite::suite());
-	pSuite->addTest(LoggingTestSuite::suite());
-	pSuite->addTest(FilesystemTestSuite::suite());
-	pSuite->addTest(UUIDTestSuite::suite());
-	pSuite->addTest(TextTestSuite::suite());
-	pSuite->addTest(URITestSuite::suite());
-#if !defined(POCO_VXWORKS)
-	pSuite->addTest(ProcessesTestSuite::suite());
-#endif
-	pSuite->addTest(TaskTestSuite::suite());
-	pSuite->addTest(EventTestSuite::suite());
-	pSuite->addTest(CacheTestSuite::suite());
-	pSuite->addTest(HashingTestSuite::suite());
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/ThreadTest.cpp
+++ b/Foundation/testsuite/src/ThreadTest.cpp
@@ -619,7 +619,9 @@ void ThreadTest::testInterrupt()
 		InterruptionRunnable r;
 
 		thread.start(r);
-		assertTrue (!thread.tryJoin(2000));
+		Thread::sleep(200);
+		assertTrue (thread.isRunning());
+		assertTrue (!thread.tryJoin(1000));
 
 		// interrupt
 		thread.interrupt();

--- a/Foundation/testsuite/src/ThreadTest.cpp
+++ b/Foundation/testsuite/src/ThreadTest.cpp
@@ -621,7 +621,7 @@ void ThreadTest::testInterrupt()
 		thread.start(r);
 		Thread::sleep(200);
 		assertTrue (thread.isRunning());
-		assertTrue (!thread.tryJoin(1000));
+		assertTrue (!thread.tryJoin(100));
 
 		// interrupt
 		thread.interrupt();

--- a/Foundation/testsuite/src/ThreadTest.h
+++ b/Foundation/testsuite/src/ThreadTest.h
@@ -40,6 +40,7 @@ public:
 	void testThreadStackSize();
 	void testSleep();
 	void testAffinity();
+	void testInterrupt();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
1. fix Thread reuse error
```cpp
Poco::Thread thread;
thread.start(runnable);
thread.join();

// reuse error
thread.start(runable);
thread.join(); // Error !!!
```


2. add thread interrupt feature

See:
  - [java.thread.interrupt](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#isInterrupted--)
  - [boost.thread.interrupt](https://www.boost.org/doc/libs/1_54_0/doc/html/thread/thread_management.html#thread.thread_management.thread.interrupt)
  - [qt.thread.interrupt](https://doc.qt.io/qt-6/qthread.html#requestInterruption)

Poco demo:
```cpp
Poco::Thread thread;
thread.interrupt();

// way-1:
bool ret = Poco::Thread::current()->isInterrupted();

// way-2:
Poco::Thread::current()->checkInterrupted(); // throw Poco::ThreadInterruptedException
```

