### PR TITLE
Async notification center (dispatch notifications asynchronously)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
 
   linux-emscripten-cmake:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt -y update && sudo apt -y install cmake ninja-build emscripten
@@ -372,12 +372,12 @@ jobs:
 #            PWD=`pwd`
 #            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
-  macos-clang-cmake-openssl3:
-    runs-on: macos-latest
+  macos-clang-18-cmake-openssl3:
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3 mysql-client unixodbc libpq
-      - run: cmake -S. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
+      - run: CXX=$(brew --prefix llvm@18)/bin/clang++ CC=$(brew --prefix llvm@18)/bin/clang cmake -S. -Bcmake-build -DENABLE_PDF=OFF -DENABLE_TESTS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/usr/local/opt/mysql-client && cmake --build cmake-build --target all
       - uses: ./.github/actions/retry-action
         with:
           timeout_minutes: 90
@@ -398,7 +398,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
   macos-clang-cmake-openssl3-visibility-hidden:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3 mysql-client unixodbc libpq
@@ -423,7 +423,7 @@ jobs:
             ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)|(Redis)"
 
   macos-clang-make-openssl3-tsan:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: brew install openssl@3
@@ -785,7 +785,7 @@ jobs:
             ./ci/runtests.sh
 
   linux-gcc-make-mongodb:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: supercharge/mongodb-github-action@1.10.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,22 +50,6 @@ option(POCO_ENABLE_CPP20 "Build Poco with C++20 standard" ON)
 
 if (EMSCRIPTEN)
 	set(POCO_ENABLE_CPP20 OFF CACHE BOOL "Build Poco with C++20 standard" FORCE)
-else()
-
-	# https://libcxx.llvm.org/Status/Cxx20.html
-	# https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
-
-	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-		if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0)
-			# Does not fully support C++20 yet
-			set(POCO_ENABLE_CPP20 OFF CACHE BOOL "Build Poco with C++20 standard" FORCE)
-		endif ()
-	elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-		if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17.0)
-			# Does not fully support C++20 yet
-			set(POCO_ENABLE_CPP20 OFF CACHE BOOL "Build Poco with C++20 standard" FORCE)
-		endif ()
-	endif()
 endif()
 
 if (POCO_ENABLE_CPP20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,8 @@ if (EMSCRIPTEN)
 	set(POCO_ENABLE_CPP20 OFF CACHE BOOL "Build Poco with C++20 standard" FORCE)
 else()
 
-# https://libcxx.llvm.org/Status/Cxx20.html
-# https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
+	# https://libcxx.llvm.org/Status/Cxx20.html
+	# https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
 
 	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 		if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18.0)

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -40,7 +40,7 @@ public:
 
 	virtual bool equals(const AbstractObserver& observer) const = 0;
 
-	POCO_DEPRECATED("use `Poco::Any accepts(Notification*)` instead")
+	POCO_DEPRECATED("use `bool accepts(Notification::Ptr&)` instead")
 	virtual bool accepts(Notification* pNf, const char* pName) const = 0;
 
 	virtual bool accepts(const Notification::Ptr& pNf) const = 0;

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -32,9 +32,11 @@ class Foundation_API AbstractObserver
 public:
 	AbstractObserver();
 	AbstractObserver(const AbstractObserver& observer);
+	AbstractObserver(AbstractObserver&& observer);
 	virtual ~AbstractObserver();
 
 	AbstractObserver& operator = (const AbstractObserver& observer);
+	AbstractObserver& operator = (AbstractObserver&& observer);
 
 	virtual void notify(Notification* pNf) const = 0;
 

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -41,7 +41,7 @@ public:
 
 	virtual void notify(Notification* pNf) const = 0;
 
-	virtual NotificationResult notifySynchronously(Notification* pNf) const;
+	virtual NotificationResult notifySync(Notification* pNf) const;
 		/// Synchronous notification processing. Blocks and returns a result.
 		/// Default implementation throws NotImplementedException.
 
@@ -52,7 +52,7 @@ public:
 
 	virtual bool accepts(const Notification::Ptr& pNf) const = 0;
 
-	virtual bool acceptsSynchronously() const;
+	virtual bool acceptsSync() const;
 		/// Returns true if this observer supports synchronous notification processing.
 
 	virtual AbstractObserver* clone() const = 0;

--- a/Foundation/include/Poco/AbstractObserver.h
+++ b/Foundation/include/Poco/AbstractObserver.h
@@ -30,6 +30,7 @@ class Foundation_API AbstractObserver
 	/// the Observer and NObserver template classes.
 {
 public:
+
 	AbstractObserver();
 	AbstractObserver(const AbstractObserver& observer);
 	AbstractObserver(AbstractObserver&& observer);
@@ -40,12 +41,19 @@ public:
 
 	virtual void notify(Notification* pNf) const = 0;
 
+	virtual NotificationResult notifySynchronously(Notification* pNf) const;
+		/// Synchronous notification processing. Blocks and returns a result.
+		/// Default implementation throws NotImplementedException.
+
 	virtual bool equals(const AbstractObserver& observer) const = 0;
 
 	POCO_DEPRECATED("use `bool accepts(Notification::Ptr&)` instead")
 	virtual bool accepts(Notification* pNf, const char* pName) const = 0;
 
 	virtual bool accepts(const Notification::Ptr& pNf) const = 0;
+
+	virtual bool acceptsSynchronously() const;
+		/// Returns true if this observer supports synchronous notification processing.
 
 	virtual AbstractObserver* clone() const = 0;
 

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -25,8 +25,8 @@
 #include "Poco/NotificationQueue.h"
 
 #if (POCO_HAVE_CPP20_COMPILER)
-	#if !defined(__cpp_lib_jthread)
-		#error ("std::jthread is expected but is not available. Please check your compiler version and settings.")
+	#if !defined(POCO_HAVE_JTHREAD)
+		#pragma message ("NOTE: std::jthread is expected but is not available. Please check your compiler version and settings.")
 	#endif
 #endif
 
@@ -64,7 +64,7 @@ public:
 		/// BOTH: Notifications are enqueued and dispatched to observers in worker threads.
 		/// NOTIFY and BOTH are only available if the compiler supports C++20.
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	AsyncNotificationCenter(AsyncMode mode = AsyncMode::ENQUEUE, std::size_t workersCount = AsyncNotificationCenter::DEFAULT_WORKERS_COUNT);
 		/// Creates the AsyncNotificationCenter and starts the notifying thread and workers.
@@ -109,7 +109,7 @@ private:
 	std::atomic<bool> _started;
 	std::atomic<bool> _done;
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 	// Async notification dispatching
 
 	using NotificationList = std::list<Notification::Ptr>;

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -23,7 +23,6 @@
 #include "Poco/Thread.h"
 #include "Poco/RunnableAdapter.h"
 #include "Poco/NotificationQueue.h"
-#include <condition_variable>
 
 #if (POCO_HAVE_CPP20_COMPILER)
 	#if !defined(__cpp_lib_jthread)
@@ -32,6 +31,8 @@
 #endif
 
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 #include <vector>
 #include <list>
 #include <map>

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -46,17 +46,22 @@ class Foundation_API AsyncNotificationCenter: public NotificationCenter
 {
 public:
 
-#if (POCO_HAVE_CPP20_COMPILER)
 	enum class AsyncMode { ENQUEUE,	NOTIFY, BOTH };
 		/// ENQUEUE: Notifications are enqueued in a separate thread.
 		/// NOTIFY: Notifications are dispatched to observers from worker threads
 		/// BOTH: Notifications are enqueued and dispatched to observers in worker threads.
-#else
-	enum class AsyncMode { ENQUEUE };
-#endif
+		/// NOTIFY and BOTH are only available if the compiler supports C++20.
+
+#if (POCO_HAVE_CPP20_COMPILER)
 
 	AsyncNotificationCenter(AsyncMode mode = AsyncMode::ENQUEUE, std::size_t workersCount = AsyncNotificationCenter::DEFAULT_WORKERS_COUNT);
+		/// Creates the AsyncNotificationCenter and starts the notifying thread and workers.
+#else
+
+	AsyncNotificationCenter();
 		/// Creates the AsyncNotificationCenter and starts the notifying thread.
+
+#endif
 
 	~AsyncNotificationCenter() override;
 	/// Stops the notifying thread and destroys the AsyncNotificationCenter.

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -90,6 +90,12 @@ public:
 	int backlog() const override;
 		/// Returns the number of notifications in the notification queue.
 
+	std::vector<NotificationResult> synchronousDispatch(Notification::Ptr pNotification);
+		/// Dispatches the notification synchronously to all observers that have a function
+		/// for synchronous notification processing and accept the notification.
+		/// This method blocks until the notification is processed by
+		/// all observers. Returns results from all observers that accepted the notification.
+
 protected:
 
 	void notifyObservers(Notification::Ptr& pNotification) override;

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -46,6 +46,7 @@ class Foundation_API AsyncNotificationCenter: public NotificationCenter
 	/// from notifying subscribers by calling observers' notification
 	/// handler in a dedicated thread.
 	/// It supports multiple modes of operation:
+	///
 	/// - ENQUEUE: Notifications are added to a queue, separate single thread
 	///            asynchronously dispatches them to observers sequentially
 	/// - NOTIFY: Notifications are added to a list for each observer, multiple
@@ -62,7 +63,7 @@ public:
 		/// ENQUEUE: Notifications are enqueued in a separate thread.
 		/// NOTIFY: Notifications are dispatched to observers from worker threads
 		/// BOTH: Notifications are enqueued and dispatched to observers in worker threads.
-		/// NOTIFY and BOTH are only available if the compiler supports C++20.
+		/// NOTIFY and BOTH are only available if the compiler supports C++20 std::jthread.
 
 #if (POCO_HAVE_JTHREAD)
 
@@ -103,11 +104,11 @@ private:
 	const AsyncMode _mode { AsyncMode::ENQUEUE };
 
 	// Async enqueue for notifications
-	Thread _thread;
+	Thread _enqueueThread;
 	NotificationQueue _nq;
 	Adapter _ra;
-	std::atomic<bool> _started;
-	std::atomic<bool> _done;
+	std::atomic<bool> _enqueueThreadStarted;
+	std::atomic<bool> _enqueueThreadDone;
 
 #if (POCO_HAVE_JTHREAD)
 	// Async notification dispatching

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -18,17 +18,23 @@
 #ifndef Foundation_AsyncNotificationCenter_INCLUDED
 #define Foundation_AsyncNotificationCenter_INCLUDED
 
-
 #include "Poco/Foundation.h"
 #include "Poco/NotificationCenter.h"
 #include "Poco/Thread.h"
-#include "Poco/Stopwatch.h"
-#include "Poco/Debugger.h"
-#include "Poco/ErrorHandler.h"
-#include "Poco/Format.h"
 #include "Poco/RunnableAdapter.h"
 #include "Poco/NotificationQueue.h"
+#include <condition_variable>
 
+#if (POCO_HAVE_CPP20_COMPILER)
+	#if !defined(__cpp_lib_jthread)
+		#error ("std::jthread is expected but is not available. Please check your compiler version and settings.")
+	#endif
+#endif
+
+#include <thread>
+#include <vector>
+#include <list>
+#include <map>
 
 namespace Poco {
 
@@ -39,7 +45,17 @@ class Foundation_API AsyncNotificationCenter: public NotificationCenter
 	/// handler in a dedicated thread.
 {
 public:
-	AsyncNotificationCenter();
+
+#if (POCO_HAVE_CPP20_COMPILER)
+	enum class AsyncMode { ENQUEUE,	NOTIFY, BOTH };
+		/// ENQUEUE: Notifications are enqueued in a separate thread.
+		/// NOTIFY: Notifications are dispatched to observers from worker threads
+		/// BOTH: Notifications are enqueued and dispatched to observers in worker threads.
+#else
+	enum class AsyncMode { ENQUEUE };
+#endif
+
+	AsyncNotificationCenter(AsyncMode mode = AsyncMode::ENQUEUE, std::size_t workersCount = AsyncNotificationCenter::DEFAULT_WORKERS_COUNT);
 		/// Creates the AsyncNotificationCenter and starts the notifying thread.
 
 	~AsyncNotificationCenter() override;
@@ -56,6 +72,10 @@ public:
 	int backlog() const override;
 	/// Returns the numbner of notifications in the notification queue.
 
+protected:
+
+	void notifyObservers(Notification::Ptr& pNotification) override;
+
 private:
 	void start();
 	void stop();
@@ -63,11 +83,55 @@ private:
 
 	using Adapter = RunnableAdapter<AsyncNotificationCenter>;
 
+	const AsyncMode _mode { AsyncMode::ENQUEUE };
+
+	// Async enqueue for notifications
 	Thread _thread;
 	NotificationQueue _nq;
 	Adapter _ra;
 	std::atomic<bool> _started;
 	std::atomic<bool> _done;
+
+#if (POCO_HAVE_CPP20_COMPILER)
+	// Async notification dispatching
+
+	using NotificationList = std::list<Notification::Ptr>;
+	using ObserversMap = std::map<AbstractObserverPtr, NotificationList>;
+	using NotificationTuple = std::tuple<AbstractObserverPtr, Notification::Ptr>;
+
+	std::optional<NotificationTuple> nextNotification();
+
+	void dispatchNotifications(std::stop_token& stopToken);
+		/// Dispatching function executed by each worker thread.
+
+	constexpr static std::size_t DEFAULT_WORKERS_COUNT { 5 };
+		/// Default number of worker threads to process notifications.
+		/// This can be configured to a different value if needed.
+
+	const std::size_t _workersCount { DEFAULT_WORKERS_COUNT };
+		/// Number of worker threads to process notifications.
+		/// This can be configured to a different value if needed.
+
+	std::vector<std::jthread> _workers;
+		/// Workers pop notifications from the lists and call the observers' notification handlers.
+		/// If an observer is not registered anymore (hasObserver), it is removed from the map.
+		/// Workers pick observers in a round robin fashion.
+
+	ObserversMap _lists;
+		/// Each observer has its own list of pending notifications.
+		/// Observers are identifed by their pointers.
+		/// When adding to the queue, observersToNotify is used to get the observers
+		/// that are registered for such notification.
+
+	ObserversMap::iterator _workerIterator;
+		/// Iterator to the current observer list being processed by the worker threads.
+		/// It is used to ensure that workers process observers in a round robin fashion.
+
+	std::mutex _listsMutex;
+	std::condition_variable	_listsCondition;
+		// Condition variable to notify workers when new notifications are added to lists.
+
+#endif
 };
 
 

--- a/Foundation/include/Poco/AsyncNotificationCenter.h
+++ b/Foundation/include/Poco/AsyncNotificationCenter.h
@@ -45,17 +45,31 @@ class Foundation_API AsyncNotificationCenter: public NotificationCenter
 	/// AsyncNotificationCenter decouples posting of notifications
 	/// from notifying subscribers by calling observers' notification
 	/// handler in a dedicated thread.
+	///
 	/// It supports multiple modes of operation:
 	///
 	/// - ENQUEUE: Notifications are added to a queue, separate single thread
 	///            asynchronously dispatches them to observers sequentially
+	///
 	/// - NOTIFY: Notifications are added to a list for each observer, multiple
 	///           worker threads process notifications in parallel
+	///
 	/// - BOTH: Combination of both modes, notifications are enqueued and worker
 	///         threads dispatch them to observers in parallel.
 	///
-	/// Note about using AsyncObserver: although it is possible to use them with
-	/// AsyncNotificationCenter, it is more efficient to use NObserver.
+	/// NOTIFY and BOTH mode:
+	///
+	/// These modes are only available if the compiler supports C++20 std::jthread.
+	///
+	/// Notifications can be delivered to observers in a different order than they
+	/// were posted, as they are processed by multiple worker threads. Observer
+	/// handlers must also be thread-safe as multiple notifications can be dispatched
+	/// to the same observer in parallel.
+	///
+	/// Note about using AsyncObserver
+	///
+	/// Although it is possible to use them with AsyncNotificationCenter,
+	/// it is more efficient to use NObserver.
 {
 public:
 
@@ -63,7 +77,6 @@ public:
 		/// ENQUEUE: Notifications are enqueued in a separate thread.
 		/// NOTIFY: Notifications are dispatched to observers from worker threads
 		/// BOTH: Notifications are enqueued and dispatched to observers in worker threads.
-		/// NOTIFY and BOTH are only available if the compiler supports C++20 std::jthread.
 
 #if (POCO_HAVE_JTHREAD)
 

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -189,6 +189,13 @@
 #define POCO_HAVE_CPP20_COMPILER (__cplusplus >= 202002L)
 #define POCO_HAVE_CPP23_COMPILER (__cplusplus >= 202302L)
 
+#if defined(POCO_HAVE_CPP20_COMPILER)
+#include <version>
+#if defined(__cpp_lib_jthread)
+	#define POCO_HAVE_JTHREAD 1
+#endif
+#endif
+
 // Option to silence deprecation warnings.
 #ifndef POCO_SILENCE_DEPRECATED
 	#define POCO_DEPRECATED(reason) [[deprecated(reason)]]

--- a/Foundation/include/Poco/NObserver.h
+++ b/Foundation/include/Poco/NObserver.h
@@ -131,7 +131,7 @@ public:
 		handle(NotificationPtr(static_cast<N*>(pNf), true));
 	}
 
-	NotificationResult notifySynchronously(Notification* pNf) const override
+	NotificationResult notifySync(Notification* pNf) const override
 	{
 		return handleSync(NotificationPtr(static_cast<N*>(pNf), true));
 	}
@@ -156,7 +156,7 @@ public:
 			return pNf.template cast<N>() != nullptr;
 	}
 
-	bool acceptsSynchronously() const override
+	bool acceptsSync() const override
 	{
 		return _pObject != nullptr && _syncHandler != nullptr;
 	}

--- a/Foundation/include/Poco/NObserver.h
+++ b/Foundation/include/Poco/NObserver.h
@@ -20,6 +20,7 @@
 
 #include "Poco/Foundation.h"
 #include "Poco/AbstractObserver.h"
+#include "Poco/AutoPtr.h"
 #include "Poco/Mutex.h"
 
 #include <functional>
@@ -209,6 +210,8 @@ protected:
 
 		if (_matcherFunc)
 			return _matcherFunc(ptr->name());
+
+		return false;
 	}
 
 	Mutex& mutex() const
@@ -217,7 +220,7 @@ protected:
 	}
 
 private:
-	C*       _pObject {nullptr};
+	C* _pObject {nullptr};
 	Handler _handler {nullptr};
 	SyncHandler _syncHandler {nullptr};
 	Matcher _matcher {nullptr};

--- a/Foundation/include/Poco/Notification.h
+++ b/Foundation/include/Poco/Notification.h
@@ -19,14 +19,20 @@
 
 
 #include "Poco/Foundation.h"
-#include "Poco/Mutex.h"
 #include "Poco/RefCountedObject.h"
 #include "Poco/AutoPtr.h"
+#include "Poco/Any.h"
+
 #include <memory>
 
 
 namespace Poco {
 
+using NotificationResult = std::pair<std::string, Poco::Any>;
+	/// Used for synchronous notification processing.
+	/// Observer shall return a pair containing a string identifier
+	/// that is interpreted by the caller and an Any object for
+	/// the payload (result).
 
 class Foundation_API Notification: public RefCountedObject
 	/// The base class for all notification classes used

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -141,7 +141,7 @@ protected:
 	}
 
 	ObserverList observersToNotify(const Notification::Ptr& pNotification) const;
-	void notifyObservers(Notification::Ptr& pNotification);
+	virtual void notifyObservers(Notification::Ptr& pNotification);
 
 private:
 

--- a/Foundation/include/Poco/Observer.h
+++ b/Foundation/include/Poco/Observer.h
@@ -27,7 +27,7 @@ namespace Poco {
 
 
 template <class C, class N>
-class Observer: public AbstractObserver
+class POCO_DEPRECATED("use `NObserver` instead") Observer: public AbstractObserver
 	/// This template class implements an adapter that sits between
 	/// a NotificationCenter and an object receiving notifications
 	/// from it. It is quite similar in concept to the

--- a/Foundation/src/AbstractObserver.cpp
+++ b/Foundation/src/AbstractObserver.cpp
@@ -25,12 +25,12 @@ AbstractObserver::~AbstractObserver() = default;
 AbstractObserver& AbstractObserver::operator = (const AbstractObserver& /*observer*/) = default;
 AbstractObserver& AbstractObserver::operator = (AbstractObserver&& /*observer*/) = default;
 
-NotificationResult AbstractObserver::notifySynchronously(Notification* pNf) const
+NotificationResult AbstractObserver::notifySync(Notification* pNf) const
 {
 	throw Poco::NotImplementedException("Synchronous notification not implemented.");
 }
 
-bool AbstractObserver::acceptsSynchronously() const
+bool AbstractObserver::acceptsSync() const
 {
 	return false;
 }

--- a/Foundation/src/AbstractObserver.cpp
+++ b/Foundation/src/AbstractObserver.cpp
@@ -17,26 +17,12 @@
 
 namespace Poco {
 
-
-AbstractObserver::AbstractObserver()
-{
-}
-
-
-AbstractObserver::AbstractObserver(const AbstractObserver& /*observer*/)
-{
-}
-
-
-AbstractObserver::~AbstractObserver()
-{
-}
-
-
-AbstractObserver& AbstractObserver::operator = (const AbstractObserver& /*observer*/)
-{
-	return *this;
-}
+AbstractObserver::AbstractObserver() = default;
+AbstractObserver::AbstractObserver(const AbstractObserver& /*observer*/) = default;
+AbstractObserver::AbstractObserver(AbstractObserver&& /*observer*/) = default;
+AbstractObserver::~AbstractObserver() = default;
+AbstractObserver& AbstractObserver::operator = (const AbstractObserver& /*observer*/) = default;
+AbstractObserver& AbstractObserver::operator = (AbstractObserver&& /*observer*/) = default;
 
 
 } // namespace Poco

--- a/Foundation/src/AbstractObserver.cpp
+++ b/Foundation/src/AbstractObserver.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/AbstractObserver.h"
+#include "Poco/Exception.h"
 
 
 namespace Poco {
@@ -24,5 +25,14 @@ AbstractObserver::~AbstractObserver() = default;
 AbstractObserver& AbstractObserver::operator = (const AbstractObserver& /*observer*/) = default;
 AbstractObserver& AbstractObserver::operator = (AbstractObserver&& /*observer*/) = default;
 
+NotificationResult AbstractObserver::notifySynchronously(Notification* pNf) const
+{
+	throw Poco::NotImplementedException("Synchronous notification not implemented.");
+}
+
+bool AbstractObserver::acceptsSynchronously() const
+{
+	return false;
+}
 
 } // namespace Poco

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -90,10 +90,10 @@ std::vector<NotificationResult> AsyncNotificationCenter::synchronousDispatch(Not
 	results.reserve(observers.size());
 	for (auto& o : observers)
 	{
-		if (!o->acceptsSynchronously())
+		if (!o->acceptsSync())
 			continue;
 
-		results.push_back(o->notifySynchronously(pNotification));
+		results.push_back(o->notifySync(pNotification));
 	}
 
 	return results;

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -23,7 +23,7 @@
 
 namespace Poco {
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 AsyncNotificationCenter::AsyncNotificationCenter(AsyncMode mode, std::size_t workersCount) :
 	_mode(mode),
@@ -55,7 +55,7 @@ AsyncNotificationCenter::~AsyncNotificationCenter()
 
 void AsyncNotificationCenter::postNotification(Notification::Ptr pNotification)
 {
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 	if (_mode == AsyncMode::ENQUEUE || _mode == AsyncMode::BOTH)
 	{
 		_nq.enqueueNotification(pNotification);
@@ -80,7 +80,7 @@ void AsyncNotificationCenter::notifyObservers(Notification::Ptr& pNotification)
 {
 	poco_check_ptr (pNotification);
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	if (_mode == AsyncMode::NOTIFY || _mode == AsyncMode::BOTH)
 	{
@@ -127,7 +127,7 @@ void AsyncNotificationCenter::start()
 		Thread::sleep(100);
 	}
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 	_workerIterator = _lists.begin();
 
 	auto dispatch = [this](std::stop_token stopToken, int id) {
@@ -150,7 +150,7 @@ void AsyncNotificationCenter::stop()
 	while (!_done) Thread::sleep(100);
 	_thread.join();
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 	for (auto& t: _workers)
 	{
 		t.request_stop();
@@ -187,7 +187,7 @@ void AsyncNotificationCenter::dequeue()
 	_started = false;
 }
 
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 std::optional<AsyncNotificationCenter::NotificationTuple> AsyncNotificationCenter::nextNotification()
 {
@@ -208,7 +208,8 @@ std::optional<AsyncNotificationCenter::NotificationTuple> AsyncNotificationCente
 			++_workerIterator;
 			continue;
 		};
-		if (!hasObserver(*o)) {
+		if (!hasObserver(*o))
+		{
 			// Observer is not registered anymore, remove its list
 			_workerIterator = _lists.erase(_workerIterator);
 			continue;

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -15,13 +15,21 @@
 
 #include "Poco/AsyncNotificationCenter.h"
 
+#include "Poco/AbstractObserver.h"
+#include "Poco/Stopwatch.h"
+#include "Poco/Debugger.h"
+#include "Poco/ErrorHandler.h"
+#include "Poco/Format.h"
 
 namespace Poco {
 
 
-AsyncNotificationCenter::AsyncNotificationCenter(): _ra(*this, &AsyncNotificationCenter::dequeue),
+AsyncNotificationCenter::AsyncNotificationCenter(AsyncMode mode, std::size_t workersCount) :
+	_mode(mode),
+	_ra(*this, &AsyncNotificationCenter::dequeue),
 	_started(false),
-	_done(false)
+	_done(false),
+	_workersCount(workersCount)
 {
 	start();
 }
@@ -35,13 +43,47 @@ AsyncNotificationCenter::~AsyncNotificationCenter()
 
 void AsyncNotificationCenter::postNotification(Notification::Ptr pNotification)
 {
-	_nq.enqueueNotification(pNotification);
+	if (_mode == AsyncMode::ENQUEUE || _mode == AsyncMode::BOTH)
+	{
+		_nq.enqueueNotification(pNotification);
+	}
+	else
+	{
+		// Notification enqueue is synchronous
+		notifyObservers(pNotification);
+	}
 }
 
 
 int AsyncNotificationCenter::backlog() const
 {
 	return _nq.size();
+}
+
+void AsyncNotificationCenter::notifyObservers(Notification::Ptr& pNotification)
+{
+	poco_check_ptr (pNotification);
+
+	if (_mode == AsyncMode::NOTIFY || _mode == AsyncMode::BOTH)
+	{
+		// Notification is asynchronous, add it to the lists
+		// for appropriate observers.
+		std::unique_lock<std::mutex> lock(_listsMutex);
+		auto observers = observersToNotify(pNotification);
+		if (observers.empty())
+			return;
+		for (auto& o : observers)
+		{
+			auto& list = _lists[o];
+			list.push_back(pNotification);
+		}
+		_listsCondition.notify_all();
+	}
+	else
+	{
+		// Notification is synchronous
+		NotificationCenter::notifyObservers(pNotification);
+	}
 }
 
 
@@ -62,6 +104,18 @@ void AsyncNotificationCenter::start()
 			throw Poco::TimeoutException(poco_src_loc);
 		Thread::sleep(100);
 	}
+
+	_workerIterator = _lists.begin();
+
+	auto dispatch = [this](std::stop_token stopToken) {
+		this->dispatchNotifications(stopToken);
+	};
+
+	for (std::size_t i {0}; i < _workersCount; ++i)
+	{
+		auto worker = std::jthread(dispatch);
+		_workers.push_back(std::move(worker));
+	}
 }
 
 
@@ -71,6 +125,11 @@ void AsyncNotificationCenter::stop()
 	_nq.wakeUpAll();
 	while (!_done) Thread::sleep(100);
 	_thread.join();
+
+	for (auto& t: _workers)
+	{
+		t.request_stop();
+	}
 }
 
 
@@ -100,6 +159,60 @@ void AsyncNotificationCenter::dequeue()
 	}
 	_done = true;
 	_started = false;
+}
+
+std::optional<AsyncNotificationCenter::NotificationTuple> AsyncNotificationCenter::nextNotification()
+{
+	std::unique_lock<std::mutex> lock(_listsMutex);
+
+	for (std::size_t i {0}; i < _lists.size(); ++i)
+	{
+		if (_lists.empty())
+			break;
+
+		if (_workerIterator == _lists.end())
+			_workerIterator = _lists.begin();
+
+		auto& o = _workerIterator->first;
+		auto& l = _workerIterator->second;
+		if (l.empty())
+		{
+			++_workerIterator;
+			continue;
+		};
+		if (!hasObserver(*o)) {
+			// Observer is not registered anymore, remove its list
+			_workerIterator = _lists.erase(_workerIterator);
+			continue;
+		}
+		auto n = l.front();
+		l.pop_front();
+		return { {o, n} };
+	}
+	return {};
+}
+
+void AsyncNotificationCenter::dispatchNotifications(std::stop_token& stopToken)
+{
+	while (!stopToken.stop_requested())
+	{
+		// get next observer and notification
+		auto no = nextNotification();
+		if (no.has_value())
+		{
+			auto [a, n] = *no;
+			a->notify(n);
+			continue;
+		}
+		// No notification available, wait for a while
+		std::unique_lock<std::mutex> lock(_listsMutex);
+		_listsCondition.wait_for(
+			lock, 1s,
+			[&stopToken] { return stopToken.stop_requested(); }
+		);
+		if (stopToken.stop_requested())
+			break;
+	}
 }
 
 

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -40,8 +40,8 @@ AsyncNotificationCenter::AsyncNotificationCenter(AsyncMode mode, std::size_t wor
 
 AsyncNotificationCenter::AsyncNotificationCenter() :
 	_ra(*this, &AsyncNotificationCenter::dequeue),
-	_started(false),
-	_done(false)
+	_enqueueThreadStarted(false),
+	_enqueueThreadDone(false)
 {
 	start();
 }

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -20,6 +20,7 @@
 #include "Poco/Debugger.h"
 #include "Poco/ErrorHandler.h"
 #include "Poco/Format.h"
+#include <vector>
 
 namespace Poco {
 
@@ -75,6 +76,29 @@ int AsyncNotificationCenter::backlog() const
 {
 	return _nq.size();
 }
+
+
+std::vector<NotificationResult> AsyncNotificationCenter::synchronousDispatch(Notification::Ptr pNotification)
+{
+	poco_check_ptr (pNotification);
+
+	auto observers = observersToNotify(pNotification);
+	if (observers.empty())
+		return {};
+
+	std::vector<NotificationResult> results;
+	results.reserve(observers.size());
+	for (auto& o : observers)
+	{
+		if (!o->acceptsSynchronously())
+			continue;
+
+		results.push_back(o->notifySynchronously(pNotification));
+	}
+
+	return results;
+}
+
 
 void AsyncNotificationCenter::notifyObservers(Notification::Ptr& pNotification)
 {

--- a/Foundation/src/NotificationCenter.cpp
+++ b/Foundation/src/NotificationCenter.cpp
@@ -54,7 +54,7 @@ void NotificationCenter::addObserver(const AbstractObserver& observer)
 void NotificationCenter::removeObserver(const AbstractObserver& observer)
 {
 	Mutex::ScopedLock lock(_mutex);
-	for (ObserverList::iterator it = _observers.begin(); it != _observers.end(); ++it)
+	for (auto it = _observers.begin(); it != _observers.end(); ++it)
 	{
 		if (observer.equals(**it))
 		{

--- a/Foundation/src/NotificationQueue.cpp
+++ b/Foundation/src/NotificationQueue.cpp
@@ -20,9 +20,7 @@
 namespace Poco {
 
 
-NotificationQueue::NotificationQueue()
-{
-}
+NotificationQueue::NotificationQueue() = default;
 
 
 NotificationQueue::~NotificationQueue()
@@ -84,7 +82,7 @@ Notification* NotificationQueue::dequeueNotification()
 Notification* NotificationQueue::waitDequeueNotification()
 {
 	Notification::Ptr pNf;
-	WaitInfo* pWI = 0;
+	WaitInfo* pWI = nullptr;
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = dequeueOne();
@@ -102,7 +100,7 @@ Notification* NotificationQueue::waitDequeueNotification()
 Notification* NotificationQueue::waitDequeueNotification(long milliseconds)
 {
 	Notification::Ptr pNf;
-	WaitInfo* pWI = 0;
+	WaitInfo* pWI = nullptr;
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = dequeueOne();
@@ -118,7 +116,7 @@ Notification* NotificationQueue::waitDequeueNotification(long milliseconds)
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = pWI->pNf;
-		for (WaitQueue::iterator it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
+		for (auto it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
 		{
 			if (*it == pWI)
 			{
@@ -179,7 +177,7 @@ void NotificationQueue::clear()
 bool NotificationQueue::remove(Notification::Ptr pNotification)
 {
 	FastMutex::ScopedLock lock(_mutex);
-	NfQueue::iterator it = std::find(_nfQueue.begin(), _nfQueue.end(), pNotification);
+	auto it = std::find(_nfQueue.begin(), _nfQueue.end(), pNotification);
 	if (it == _nfQueue.end())
 	{
 		return false;

--- a/Foundation/src/PriorityNotificationQueue.cpp
+++ b/Foundation/src/PriorityNotificationQueue.cpp
@@ -20,9 +20,7 @@
 namespace Poco {
 
 
-PriorityNotificationQueue::PriorityNotificationQueue()
-{
-}
+PriorityNotificationQueue::PriorityNotificationQueue() = default;
 
 
 PriorityNotificationQueue::~PriorityNotificationQueue()
@@ -67,7 +65,7 @@ Notification* PriorityNotificationQueue::dequeueNotification()
 Notification* PriorityNotificationQueue::waitDequeueNotification()
 {
 	Notification::Ptr pNf;
-	WaitInfo* pWI = 0;
+	WaitInfo* pWI = nullptr;
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = dequeueOne();
@@ -85,7 +83,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification()
 Notification* PriorityNotificationQueue::waitDequeueNotification(long milliseconds)
 {
 	Notification::Ptr pNf;
-	WaitInfo* pWI = 0;
+	WaitInfo* pWI = nullptr;
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = dequeueOne();
@@ -101,7 +99,7 @@ Notification* PriorityNotificationQueue::waitDequeueNotification(long millisecon
 	{
 		FastMutex::ScopedLock lock(_mutex);
 		pNf = pWI->pNf;
-		for (WaitQueue::iterator it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
+		for (auto it = _waitQueue.begin(); it != _waitQueue.end(); ++it)
 		{
 			if (*it == pWI)
 			{
@@ -169,7 +167,7 @@ bool PriorityNotificationQueue::hasIdleThreads() const
 Notification::Ptr PriorityNotificationQueue::dequeueOne()
 {
 	Notification::Ptr pNf;
-	NfQueue::iterator it = _nfQueue.begin();
+	auto it = _nfQueue.begin();
 	if (it != _nfQueue.end())
 	{
 		pNf = it->second;

--- a/Foundation/src/TimedNotificationQueue.cpp
+++ b/Foundation/src/TimedNotificationQueue.cpp
@@ -20,9 +20,7 @@
 namespace Poco {
 
 
-TimedNotificationQueue::TimedNotificationQueue()
-{
-}
+TimedNotificationQueue::TimedNotificationQueue() = default;
 
 
 TimedNotificationQueue::~TimedNotificationQueue()
@@ -67,7 +65,7 @@ Notification* TimedNotificationQueue::dequeueNotification()
 {
 	FastMutex::ScopedLock lock(_mutex);
 
-	NfQueue::iterator it = _nfQueue.begin();
+	auto it = _nfQueue.begin();
 	if (it != _nfQueue.end())
 	{
 		Clock::ClockDiff sleep = -it->first.elapsed();
@@ -78,7 +76,7 @@ Notification* TimedNotificationQueue::dequeueNotification()
 			return pNf.duplicate();
 		}
 	}
-	return 0;
+	return nullptr;
 }
 
 
@@ -86,14 +84,14 @@ Notification* TimedNotificationQueue::dequeueNextNotification()
 {
 	FastMutex::ScopedLock lock(_mutex);
 
-	NfQueue::iterator it = _nfQueue.begin();
+	auto it = _nfQueue.begin();
 	if (it != _nfQueue.end())
 	{
 		Notification::Ptr pNf = it->second;
 		_nfQueue.erase(it);
 		return pNf.duplicate();
 	}
-	return 0;
+	return nullptr;
 }
 
 Notification* TimedNotificationQueue::waitDequeueNotification()
@@ -101,7 +99,7 @@ Notification* TimedNotificationQueue::waitDequeueNotification()
 	for (;;)
 	{
 		_mutex.lock();
-		NfQueue::iterator it = _nfQueue.begin();
+		auto it = _nfQueue.begin();
 		if (it != _nfQueue.end())
 		{
 			_mutex.unlock();
@@ -130,7 +128,7 @@ Notification* TimedNotificationQueue::waitDequeueNotification(long milliseconds)
 	while (milliseconds >= 0)
 	{
 		_mutex.lock();
-		NfQueue::iterator it = _nfQueue.begin();
+		auto it = _nfQueue.begin();
 		if (it != _nfQueue.end())
 		{
 			_mutex.unlock();
@@ -163,9 +161,9 @@ Notification* TimedNotificationQueue::waitDequeueNotification(long milliseconds)
 			_nfAvailable.tryWait(milliseconds);
 			milliseconds -= static_cast<long>((now.elapsed() + 999)/1000);
 		}
-		else return 0;
+		else return nullptr;
 	}
-	return 0;
+	return nullptr;
 }
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -502,7 +502,6 @@ CppUnit::Test* NotificationCenterTest::suite()
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncNotify);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncBoth);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncNotifyStress);
-	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncNotifyStress);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncRemoveObserver);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testDefaultNotificationCenter);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testMixedObservers);

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -215,6 +215,8 @@ void NotificationCenterTest::testAsyncNotificationCenter()
 
 void NotificationCenterTest::testAsyncNotificationCenterAsyncNotify()
 {
+#if (POCO_HAVE_CPP20_COMPILER)
+
 	using ObserverT = AsyncObserver<NotificationCenterTest, TestNotification>::Type;
 
 	AsyncNotificationCenter nc(AsyncNotificationCenter::AsyncMode::NOTIFY);
@@ -236,6 +238,7 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncNotify()
 	assertTrue(_set.size() == 2);
 	assertTrue(_set.find("handleAsync1") != _set.end());
 	assertTrue(_set.find("handleAsync2") != _set.end());
+#endif
 }
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -27,16 +27,13 @@ using Poco::AsyncObserver;
 using Poco::Notification;
 using Poco::AutoPtr;
 
-
-static std::size_t notificationCounter {0};
-
 class TestNotification: public Notification
 {
 public:
 	TestNotification() = default;
 
-	TestNotification(const std::string& name, int num = 0):
-		Notification(name), num(num)
+	TestNotification(const std::string& name, int n = 0):
+		Notification(name), num(n)
 	{}
 
 	int num {0};
@@ -219,7 +216,7 @@ void NotificationCenterTest::testAsyncNotificationCenter()
 
 void NotificationCenterTest::testAsyncNotificationCenterAsyncNotify()
 {
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
@@ -254,7 +251,7 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncNotify()
 
 void NotificationCenterTest::testAsyncNotificationCenterAsyncBoth()
 {
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
@@ -289,7 +286,7 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncBoth()
 
 void NotificationCenterTest::testAsyncNotificationCenterAsyncNotifyStress()
 {
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
@@ -331,7 +328,7 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncNotifyStress()
 
 void NotificationCenterTest::testAsyncNotificationCenterAsyncRemoveObserver()
 {
-#if (POCO_HAVE_CPP20_COMPILER)
+#if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -15,7 +15,6 @@
 #include "Poco/Notification.h"
 #include "Poco/NotificationCenter.h"
 #include "Poco/AsyncNotificationCenter.h"
-#include "Poco/Observer.h"
 #include "Poco/NObserver.h"
 #include "Poco/AsyncObserver.h"
 #include "Poco/AutoPtr.h"
@@ -23,7 +22,6 @@
 
 using Poco::NotificationCenter;
 using Poco::AsyncNotificationCenter;
-using Poco::Observer;
 using Poco::NObserver;
 using Poco::AsyncObserver;
 using Poco::Notification;
@@ -61,7 +59,7 @@ void NotificationCenterTest::testNotificationCenter1()
 void NotificationCenterTest::testNotificationCenter2()
 {
 	NotificationCenter nc;
-	Observer<NotificationCenterTest, Notification> o(*this, &NotificationCenterTest::handle1);
+	NObserver<NotificationCenterTest, Notification> o(*this, &NotificationCenterTest::handle1);
 	nc.addObserver(o);
 	assertTrue (nc.hasObserver(o));
 	assertTrue (nc.hasObservers());
@@ -69,7 +67,7 @@ void NotificationCenterTest::testNotificationCenter2()
 	nc.postNotification(new Notification);
 	assertTrue (_set.size() == 1);
 	assertTrue (_set.find("handle1") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	assertTrue (!nc.hasObserver(o));
 	assertTrue (!nc.hasObservers());
 	assertTrue (nc.countObservers() == 0);
@@ -79,8 +77,8 @@ void NotificationCenterTest::testNotificationCenter2()
 void NotificationCenterTest::testNotificationCenter3()
 {
 	NotificationCenter nc;
-	Observer<NotificationCenterTest, Notification> o1(*this, &NotificationCenterTest::handle1);
-	Observer<NotificationCenterTest, Notification> o2(*this, &NotificationCenterTest::handle2);
+	NObserver<NotificationCenterTest, Notification> o1(*this, &NotificationCenterTest::handle1);
+	NObserver<NotificationCenterTest, Notification> o2(*this, &NotificationCenterTest::handle2);
 	nc.addObserver(o1);
 	assertTrue (nc.hasObserver(o1));
 	nc.addObserver(o2);
@@ -91,9 +89,9 @@ void NotificationCenterTest::testNotificationCenter3()
 	assertTrue (_set.size() == 2);
 	assertTrue (_set.find("handle1") != _set.end());
 	assertTrue (_set.find("handle2") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	assertTrue (!nc.hasObserver(o1));
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle2));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle2));
 	assertTrue (!nc.hasObserver(o2));
 	assertTrue (!nc.hasObservers());
 	assertTrue (nc.countObservers() == 0);
@@ -103,8 +101,8 @@ void NotificationCenterTest::testNotificationCenter3()
 void NotificationCenterTest::testNotificationCenter4()
 {
 	NotificationCenter nc;
-	Observer<NotificationCenterTest, Notification> o1(*this, &NotificationCenterTest::handle1);
-	Observer<NotificationCenterTest, Notification> o2(*this, &NotificationCenterTest::handle2);
+	NObserver<NotificationCenterTest, Notification> o1(*this, &NotificationCenterTest::handle1);
+	NObserver<NotificationCenterTest, Notification> o2(*this, &NotificationCenterTest::handle2);
 	nc.addObserver(o1);
 	assertTrue (nc.hasObserver(o1));
 	nc.addObserver(o2);
@@ -113,20 +111,20 @@ void NotificationCenterTest::testNotificationCenter4()
 	assertTrue (_set.size() == 2);
 	assertTrue (_set.find("handle1") != _set.end());
 	assertTrue (_set.find("handle2") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	assertTrue (!nc.hasObserver(o1));
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle2));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle2));
 	assertTrue (!nc.hasObserver(o2));
 	_set.clear();
 	nc.postNotification(new Notification);
 	assertTrue (_set.empty());
-	Observer<NotificationCenterTest, Notification> o3(*this, &NotificationCenterTest::handle3);
+	NObserver<NotificationCenterTest, Notification> o3(*this, &NotificationCenterTest::handle3);
 	nc.addObserver(o3);
 	assertTrue (nc.hasObserver(o3));
 	nc.postNotification(new Notification);
 	assertTrue (_set.size() == 1);
 	assertTrue (_set.find("handle3") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle3));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle3));
 	assertTrue (!nc.hasObserver(o3));
 }
 
@@ -134,8 +132,8 @@ void NotificationCenterTest::testNotificationCenter4()
 void NotificationCenterTest::testNotificationCenter5()
 {
 	NotificationCenter nc;
-	nc.addObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
-	nc.addObserver(Observer<NotificationCenterTest, TestNotification>(*this, &NotificationCenterTest::handleTest));
+	nc.addObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.addObserver(NObserver<NotificationCenterTest, TestNotification>(*this, &NotificationCenterTest::handleTest));
 	nc.postNotification(new Notification);
 	assertTrue (_set.size() == 1);
 	assertTrue (_set.find("handle1") != _set.end());
@@ -144,8 +142,8 @@ void NotificationCenterTest::testNotificationCenter5()
 	assertTrue (_set.size() == 2);
 	assertTrue (_set.find("handle1") != _set.end());
 	assertTrue (_set.find("handleTest") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
-	nc.removeObserver(Observer<NotificationCenterTest, TestNotification>(*this, &NotificationCenterTest::handleTest));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, TestNotification>(*this, &NotificationCenterTest::handleTest));
 }
 
 
@@ -239,7 +237,7 @@ void NotificationCenterTest::testAsyncNotificationCenter2()
 	assertTrue(_set.find("handleAsync2") != _set.end());
 }
 
-void NotificationCenterTest::testAsyncNotificationCenterSyncronousNotify()
+void NotificationCenterTest::testAsyncNotificationCenterSyncNotify()
 {
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
@@ -404,11 +402,11 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncRemoveObserver()
 void NotificationCenterTest::testDefaultNotificationCenter()
 {
 	NotificationCenter& nc = NotificationCenter::defaultCenter();
-	nc.addObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.addObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	nc.postNotification(new Notification);
 	assertTrue (_set.size() == 1);
 	assertTrue (_set.find("handle1") != _set.end());
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 }
 
 
@@ -417,7 +415,7 @@ void NotificationCenterTest::testMixedObservers()
 	using AObserverT = AsyncObserver<NotificationCenterTest, TestNotification>::Type;
 
 	AsyncNotificationCenter nc;
-	nc.addObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.addObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	nc.addObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handleAuto));
 	nc.addObserver(AObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
 	nc.postNotification(new Notification);
@@ -428,7 +426,7 @@ void NotificationCenterTest::testMixedObservers()
 
 	nc.removeObserver(AObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
 	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handleAuto));
-	nc.removeObserver(Observer<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
+	nc.removeObserver(NObserver<NotificationCenterTest, Notification>(*this, &NotificationCenterTest::handle1));
 	Poco::Mutex::ScopedLock l(_mutex);
 	assertTrue (_set.size() == 3);
 	assertTrue (_set.find("handle1") != _set.end());
@@ -437,36 +435,32 @@ void NotificationCenterTest::testMixedObservers()
 }
 
 
-void NotificationCenterTest::handle1(Poco::Notification* pNf)
+void NotificationCenterTest::handle1(const AutoPtr<Notification>& pNf)
 {
 	Poco::Mutex::ScopedLock l(_mutex);
 	poco_check_ptr (pNf);
-	AutoPtr<Notification> nf = pNf;
 	_set.insert("handle1");
 	_handle1Done = true;
 }
 
 
-void NotificationCenterTest::handle2(Poco::Notification* pNf)
+void NotificationCenterTest::handle2(const AutoPtr<Notification>& pNf)
 {
 	poco_check_ptr (pNf);
-	AutoPtr<Notification> nf = pNf;
 	_set.insert("handle2");
 }
 
 
-void NotificationCenterTest::handle3(Poco::Notification* pNf)
+void NotificationCenterTest::handle3(const AutoPtr<Notification>& pNf)
 {
 	poco_check_ptr (pNf);
-	AutoPtr<Notification> nf = pNf;
 	_set.insert("handle3");
 }
 
 
-void NotificationCenterTest::handleTest(TestNotification* pNf)
+void NotificationCenterTest::handleTest(const AutoPtr<TestNotification>& pNf)
 {
 	poco_check_ptr (pNf);
-	AutoPtr<TestNotification> nf = pNf;
 	_set.insert("handleTest");
 }
 
@@ -542,7 +536,7 @@ CppUnit::Test* NotificationCenterTest::suite()
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncObserver);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenter);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenter2);
-	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterSyncronousNotify);
+	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterSyncNotify);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncNotify);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncBoth);
 	CppUnit_addTest(pSuite, NotificationCenterTest, testAsyncNotificationCenterAsyncNotifyStress);

--- a/Foundation/testsuite/src/NotificationCenterTest.cpp
+++ b/Foundation/testsuite/src/NotificationCenterTest.cpp
@@ -43,11 +43,7 @@ public:
 
 
 NotificationCenterTest::NotificationCenterTest(const std::string& name):
-	CppUnit::TestCase(name),
-	_handle1Done(false),
-	_handleAuto1Done(false),
-	_handleAsync1Done(false),
-	_handleAsync2Done(false)
+	CppUnit::TestCase(name)
 {
 }
 
@@ -220,12 +216,6 @@ void NotificationCenterTest::testAsyncNotificationCenter2()
 {
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
-	_set.clear();
-	_handleAsync1Done = false;
-	_handleAsync2Done = false;
-	_handleAsync1Counter  = 0;
-	_handleAsync2Counter  = 0;
-
 	AsyncNotificationCenter nc;
 
 	const auto matchAsync = [](const std::string& s) -> bool
@@ -281,12 +271,6 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncNotify()
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
-	_set.clear();
-	_handleAsync1Done = false;
-	_handleAsync2Done = false;
-	_handleAsync1Counter  = 0;
-	_handleAsync2Counter  = 0;
-
 	AsyncNotificationCenter nc(AsyncNotificationCenter::AsyncMode::NOTIFY);
 
 	nc.addObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
@@ -316,12 +300,6 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncBoth()
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
 
-	_set.clear();
-	_handleAsync1Done = false;
-	_handleAsync2Done = false;
-	_handleAsync1Counter  = 0;
-	_handleAsync2Counter  = 0;
-
 	AsyncNotificationCenter nc(AsyncNotificationCenter::AsyncMode::BOTH);
 
 	nc.addObserver(ObserverT(*this, &NotificationCenterTest::handleAsync1, &NotificationCenterTest::matchAsync));
@@ -350,12 +328,6 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncNotifyStress()
 #if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
-
-	_set.clear();
-	_handleAsync1Done = false;
-	_handleAsync2Done = false;
-	_handleAsync1Counter  = 0;
-	_handleAsync2Counter  = 0;
 
 	AsyncNotificationCenter nc(AsyncNotificationCenter::AsyncMode::NOTIFY);
 
@@ -392,12 +364,6 @@ void NotificationCenterTest::testAsyncNotificationCenterAsyncRemoveObserver()
 #if (POCO_HAVE_JTHREAD)
 
 	using ObserverT = NObserver<NotificationCenterTest, TestNotification>::Type;
-
-	_set.clear();
-	_handleAsync1Done = false;
-	_handleAsync2Done = false;
-	_handleAsync1Counter  = 0;
-	_handleAsync2Counter  = 0;
 
 	AsyncNotificationCenter nc(AsyncNotificationCenter::AsyncMode::NOTIFY);
 
@@ -548,6 +514,13 @@ bool NotificationCenterTest::matchAsync(const std::string& name) const
 void NotificationCenterTest::setUp()
 {
 	_set.clear();
+	_handle1Done = false;
+	_handleAuto1Done = false;
+	_handleAsync1Done = false;
+	_handleAsync2Done = false;
+
+	_handleAsync1Counter  = 0;
+	_handleAsync2Counter  = 0;
 }
 
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -29,7 +29,7 @@ class NotificationCenterTest: public CppUnit::TestCase
 {
 public:
 	NotificationCenterTest(const std::string& name);
-	~NotificationCenterTest();
+	~NotificationCenterTest() override;
 
 	void testNotificationCenter1();
 	void testNotificationCenter2();
@@ -39,11 +39,12 @@ public:
 	void testNotificationCenterAuto();
 	void testAsyncObserver();
 	void testAsyncNotificationCenter();
+	void testAsyncNotificationCenterAsyncNotify();
 	void testDefaultNotificationCenter();
 	void testMixedObservers();
 
-	void setUp();
-	void tearDown();
+	void setUp() override;
+	void tearDown() override;
 
 	static CppUnit::Test* suite();
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -40,6 +40,9 @@ public:
 	void testAsyncObserver();
 	void testAsyncNotificationCenter();
 	void testAsyncNotificationCenterAsyncNotify();
+	void testAsyncNotificationCenterAsyncBoth();
+	void testAsyncNotificationCenterAsyncNotifyStress();
+	void testAsyncNotificationCenterAsyncRemoveObserver();
 	void testDefaultNotificationCenter();
 	void testMixedObservers();
 
@@ -64,6 +67,10 @@ private:
 	std::atomic<bool> _handleAuto1Done;
 	std::atomic<bool> _handleAsync1Done;
 	std::atomic<bool> _handleAsync2Done;
+
+	std::atomic<std::size_t> _handleAsync1Counter {0};
+	std::atomic<std::size_t> _handleAsync2Counter {0};
+
 	Poco::Mutex _mutex;
 };
 

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -66,10 +66,10 @@ protected:
 
 private:
 	std::set<std::string> _set;
-	std::atomic<bool> _handle1Done;
-	std::atomic<bool> _handleAuto1Done;
-	std::atomic<bool> _handleAsync1Done;
-	std::atomic<bool> _handleAsync2Done;
+	std::atomic<bool> _handle1Done {false};
+	std::atomic<bool> _handleAuto1Done {false};
+	std::atomic<bool> _handleAsync1Done {false};
+	std::atomic<bool> _handleAsync2Done {false};
 
 	std::atomic<std::size_t> _handleAsync1Counter {0};
 	std::atomic<std::size_t> _handleAsync2Counter {0};

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -40,7 +40,7 @@ public:
 	void testAsyncObserver();
 	void testAsyncNotificationCenter();
 	void testAsyncNotificationCenter2();
-	void testAsyncNotificationCenterSyncronousNotify();
+	void testAsyncNotificationCenterSyncNotify();
 	void testAsyncNotificationCenterAsyncNotify();
 	void testAsyncNotificationCenterAsyncBoth();
 	void testAsyncNotificationCenterAsyncNotifyStress();
@@ -54,10 +54,10 @@ public:
 	static CppUnit::Test* suite();
 
 protected:
-	void handle1(Poco::Notification* pNf);
-	void handle2(Poco::Notification* pNf);
-	void handle3(Poco::Notification* pNf);
-	void handleTest(TestNotification* pNf);
+	void handle1(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handle2(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handle3(const Poco::AutoPtr<Poco::Notification>& pNf);
+	void handleTest(const Poco::AutoPtr<TestNotification>& pNf);
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleAsync1(const Poco::AutoPtr<TestNotification>& pNf);
 	void handleAsync2(const Poco::AutoPtr<TestNotification>& pNf);

--- a/Foundation/testsuite/src/NotificationCenterTest.h
+++ b/Foundation/testsuite/src/NotificationCenterTest.h
@@ -39,6 +39,8 @@ public:
 	void testNotificationCenterAuto();
 	void testAsyncObserver();
 	void testAsyncNotificationCenter();
+	void testAsyncNotificationCenter2();
+	void testAsyncNotificationCenterSyncronousNotify();
 	void testAsyncNotificationCenterAsyncNotify();
 	void testAsyncNotificationCenterAsyncBoth();
 	void testAsyncNotificationCenterAsyncNotifyStress();
@@ -59,6 +61,7 @@ protected:
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleAsync1(const Poco::AutoPtr<TestNotification>& pNf);
 	void handleAsync2(const Poco::AutoPtr<TestNotification>& pNf);
+	Poco::NotificationResult handleSync(const Poco::AutoPtr<TestNotification>& pNf);
 	bool matchAsync(const std::string& name) const;
 
 private:

--- a/Foundation/testsuite/src/TaskManagerTest.cpp
+++ b/Foundation/testsuite/src/TaskManagerTest.cpp
@@ -19,7 +19,7 @@
 #include "Poco/Thread.h"
 #include "Poco/ThreadPool.h"
 #include "Poco/Event.h"
-#include "Poco/Observer.h"
+#include "Poco/NObserver.h"
 #include "Poco/Exception.h"
 #include "Poco/AutoPtr.h"
 #include <iostream>
@@ -37,7 +37,7 @@ using Poco::TaskCustomNotification;
 using Poco::Thread;
 using Poco::ThreadPool;
 using Poco::Event;
-using Poco::Observer;
+using Poco::NObserver;
 using Poco::Exception;
 using Poco::NoThreadAvailableException;
 using Poco::SystemException;
@@ -57,7 +57,7 @@ namespace
 		{
 		}
 
-		void runTask()
+		void runTask() override
 		{
 			_started = true;
 			_event.wait();
@@ -112,7 +112,7 @@ namespace
 			_started(false),
 			_cancelled(false),
 			_finished(false),
-			_pException(0),
+			_pException(nullptr),
 			_progress(0.0)
 		{
 		}
@@ -122,34 +122,29 @@ namespace
 			delete _pException;
 		}
 
-		void taskStarted(TaskStartedNotification* pNf)
+		void taskStarted(const AutoPtr<TaskStartedNotification>& pNf)
 		{
 			_started = true;
-			pNf->release();
 		}
 
-		void taskCancelled(TaskCancelledNotification* pNf)
+		void taskCancelled(const AutoPtr<TaskCancelledNotification>& pNf)
 		{
 			_cancelled = true;
-			pNf->release();
 		}
 
-		void taskFinished(TaskFinishedNotification* pNf)
+		void taskFinished(const AutoPtr<TaskFinishedNotification>& pNf)
 		{
 			_finished = true;
-			pNf->release();
 		}
 
-		void taskFailed(TaskFailedNotification* pNf)
+		void taskFailed(const AutoPtr<TaskFailedNotification>& pNf)
 		{
 			_pException = pNf->reason().clone();
-			pNf->release();
 		}
 
-		void taskProgress(TaskProgressNotification* pNf)
+		void taskProgress(const AutoPtr<TaskProgressNotification>& pNf)
 		{
 			_progress = pNf->progress();
-			pNf->release();
 		}
 
 		bool started() const
@@ -196,7 +191,7 @@ namespace
 		{
 		}
 
-		void runTask()
+		void runTask() override
 		{
 			sleep(10000);
 		}
@@ -220,14 +215,11 @@ namespace
 		{
 		}
 
-		~CustomTaskObserver()
-		{
-		}
+		~CustomTaskObserver() = default;
 
-		void taskCustom(TaskCustomNotification<C>* pNf)
+		void taskCustom(const AutoPtr<TaskCustomNotification<C>>& pNf)
 		{
 			_custom = pNf->custom();
-			pNf->release();
 		}
 
 		const C& custom() const
@@ -246,20 +238,18 @@ TaskManagerTest::TaskManagerTest(const std::string& name): CppUnit::TestCase(nam
 }
 
 
-TaskManagerTest::~TaskManagerTest()
-{
-}
+TaskManagerTest::~TaskManagerTest() = default;
 
 
 void TaskManagerTest::testFinish()
 {
 	TaskManager tm;
 	TaskObserver to;
-	tm.addObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.addObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.addObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.addObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.addObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.addObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.addObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.addObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.addObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.addObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 	AutoPtr<TestTask> pTT = new TestTask;
 	tm.start(pTT.duplicate());
 	while (pTT->state() < Task::TASK_RUNNING) Thread::sleep(50);
@@ -286,11 +276,11 @@ void TaskManagerTest::testFinish()
 	assertTrue (!to.error());
 	tm.cancelAll();
 	tm.joinAll();
-	tm.removeObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.removeObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.removeObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.removeObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.removeObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.removeObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.removeObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.removeObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.removeObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.removeObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 }
 
 
@@ -298,11 +288,11 @@ void TaskManagerTest::testCancel()
 {
 	TaskManager tm;
 	TaskObserver to;
-	tm.addObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.addObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.addObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.addObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.addObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.addObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.addObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.addObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.addObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.addObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 	AutoPtr<TestTask> pTT = new TestTask;
 	tm.start(pTT.duplicate());
 	while (pTT->state() < Task::TASK_RUNNING) Thread::sleep(50);
@@ -331,11 +321,11 @@ void TaskManagerTest::testCancel()
 	assertTrue (!to.error());
 	tm.cancelAll();
 	tm.joinAll();
-	tm.removeObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.removeObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.removeObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.removeObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.removeObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.removeObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.removeObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.removeObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.removeObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.removeObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 }
 
 
@@ -343,11 +333,11 @@ void TaskManagerTest::testError()
 {
 	TaskManager tm;
 	TaskObserver to;
-	tm.addObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.addObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.addObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.addObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.addObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.addObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.addObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.addObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.addObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.addObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 	AutoPtr<TestTask> pTT = new TestTask;
 	assertTrue (tm.start(pTT.duplicate()));
 	while (pTT->state() < Task::TASK_RUNNING) Thread::sleep(50);
@@ -369,17 +359,17 @@ void TaskManagerTest::testError()
 	assertTrue (pTT->state() == Task::TASK_FINISHED);
 	while (!to.finished()) Thread::sleep(50);
 	assertTrue (to.finished());
-	assertTrue (to.error() != 0);
+	assertTrue (to.error() != nullptr);
 	while (tm.count() == 1) Thread::sleep(50);
 	list = tm.taskList();
 	assertTrue (list.empty());
 	tm.cancelAll();
 	tm.joinAll();
-	tm.removeObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.removeObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.removeObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.removeObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.removeObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.removeObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.removeObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.removeObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.removeObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.removeObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 }
 
 
@@ -389,7 +379,7 @@ void TaskManagerTest::testCustom()
 
 	CustomTaskObserver<int> ti(0);
 	tm.addObserver(
-		Observer<CustomTaskObserver<int>, TaskCustomNotification<int> >
+		NObserver<CustomTaskObserver<int>, TaskCustomNotification<int> >
 			(ti, &CustomTaskObserver<int>::taskCustom));
 
 	AutoPtr<CustomNotificationTask<int> > pCNT1 = new CustomNotificationTask<int>(0);
@@ -404,7 +394,7 @@ void TaskManagerTest::testCustom()
 
 	CustomTaskObserver<std::string> ts("");
 	tm.addObserver(
-		Observer<CustomTaskObserver<std::string>, TaskCustomNotification<std::string> >
+		NObserver<CustomTaskObserver<std::string>, TaskCustomNotification<std::string> >
 			(ts, &CustomTaskObserver<std::string>::taskCustom));
 
 	AutoPtr<CustomNotificationTask<std::string> > pCNT2 = new CustomNotificationTask<std::string>("");
@@ -422,7 +412,7 @@ void TaskManagerTest::testCustom()
 	CustomTaskObserver<S*> ptst(&s);
 
 	tm.addObserver(
-		Observer<CustomTaskObserver<S*>, TaskCustomNotification<S*> >
+		NObserver<CustomTaskObserver<S*>, TaskCustomNotification<S*> >
 			(ptst, &CustomTaskObserver<S*>::taskCustom));
 
 	AutoPtr<CustomNotificationTask<S*> > pCNT3 = new CustomNotificationTask<S*>(&s);
@@ -442,7 +432,7 @@ void TaskManagerTest::testCustom()
 	CustomTaskObserver<S> tst(s);
 
 	tm.addObserver(
-		Observer<CustomTaskObserver<S>, TaskCustomNotification<S> >
+		NObserver<CustomTaskObserver<S>, TaskCustomNotification<S> >
 			(tst, &CustomTaskObserver<S>::taskCustom));
 
 	AutoPtr<CustomNotificationTask<S> > pCNT4 = new CustomNotificationTask<S>(s);
@@ -471,11 +461,11 @@ void TaskManagerTest::testCancelNoStart()
 {
 	TaskManager tm;
 	TaskObserver to;
-	tm.addObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.addObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.addObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.addObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.addObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.addObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.addObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.addObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.addObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.addObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 	AutoPtr<TestTask> pTT = new TestTask;
 	pTT->cancel();
 	assertTrue (pTT->isCancelled());
@@ -483,11 +473,11 @@ void TaskManagerTest::testCancelNoStart()
 	assertTrue (pTT->progress() == 0);
 	assertTrue (pTT->isCancelled());
 	assertFalse (pTT->hasOwner());
-	tm.removeObserver(Observer<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
-	tm.removeObserver(Observer<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
-	tm.removeObserver(Observer<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
-	tm.removeObserver(Observer<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
-	tm.removeObserver(Observer<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
+	tm.removeObserver(NObserver<TaskObserver, TaskStartedNotification>(to, &TaskObserver::taskStarted));
+	tm.removeObserver(NObserver<TaskObserver, TaskCancelledNotification>(to, &TaskObserver::taskCancelled));
+	tm.removeObserver(NObserver<TaskObserver, TaskFailedNotification>(to, &TaskObserver::taskFailed));
+	tm.removeObserver(NObserver<TaskObserver, TaskFinishedNotification>(to, &TaskObserver::taskFinished));
+	tm.removeObserver(NObserver<TaskObserver, TaskProgressNotification>(to, &TaskObserver::taskProgress));
 }
 
 

--- a/Net/include/Poco/Net/ParallelSocketAcceptor.h
+++ b/Net/include/Poco/Net/ParallelSocketAcceptor.h
@@ -45,7 +45,7 @@ class ParallelSocketAcceptor
 {
 public:
 	using ParallelReactor = Poco::Net::ParallelSocketReactor<SR>;
-	using Observer = Poco::Observer<ParallelSocketAcceptor, ReadableNotification>;
+	using Observer = Poco::NObserver<ParallelSocketAcceptor, ReadableNotification>;
 
 	explicit ParallelSocketAcceptor(ServerSocket& socket,
 		unsigned threads = Poco::Environment::processorCount(),
@@ -134,10 +134,9 @@ public:
 		}
 	}
 
-	void onAccept(ReadableNotification* pNotification)
+	void onAccept(const AutoPtr<ReadableNotification>& pNotification)
 		/// Accepts connection and creates event handler.
 	{
-		pNotification->release();
 		StreamSocket sock = _socket.acceptConnection();
 		_pReactor->wakeUp();
 		createServiceHandler(sock);

--- a/Net/include/Poco/Net/SocketAcceptor.h
+++ b/Net/include/Poco/Net/SocketAcceptor.h
@@ -23,7 +23,7 @@
 #include "Poco/Net/SocketReactor.h"
 #include "Poco/Net/ServerSocket.h"
 #include "Poco/Net/StreamSocket.h"
-#include "Poco/Observer.h"
+#include "Poco/NObserver.h"
 
 
 namespace Poco {
@@ -68,7 +68,7 @@ class SocketAcceptor
 	/// if special steps are necessary to create a ServiceHandler object.
 {
 public:
-	using Observer = Poco::Observer<SocketAcceptor, ReadableNotification>;
+	using Observer = Poco::NObserver<SocketAcceptor, ReadableNotification>;
 
 	explicit SocketAcceptor(ServerSocket& socket):
 		_socket(socket),
@@ -146,10 +146,9 @@ public:
 		}
 	}
 
-	void onAccept(ReadableNotification* pNotification)
+	void onAccept(const AutoPtr<ReadableNotification>& pNotification)
 		/// Accepts connection and creates event handler.
 	{
-		pNotification->release();
 		StreamSocket sock = _socket.acceptConnection();
 		_pReactor->wakeUp();
 		createServiceHandler(sock);

--- a/Net/include/Poco/Net/SocketConnector.h
+++ b/Net/include/Poco/Net/SocketConnector.h
@@ -115,9 +115,9 @@ public:
 		/// The overriding method must call the baseclass implementation first.
 	{
 		_pReactor = &reactor;
-		_pReactor->addEventHandler(_socket, Poco::Observer<SocketConnector, ReadableNotification>(*this, &SocketConnector::onReadable));
-		_pReactor->addEventHandler(_socket, Poco::Observer<SocketConnector, WritableNotification>(*this, &SocketConnector::onWritable));
-		_pReactor->addEventHandler(_socket, Poco::Observer<SocketConnector, ErrorNotification>(*this, &SocketConnector::onError));
+		_pReactor->addEventHandler(_socket, Poco::NObserver<SocketConnector, ReadableNotification>(*this, &SocketConnector::onReadable));
+		_pReactor->addEventHandler(_socket, Poco::NObserver<SocketConnector, WritableNotification>(*this, &SocketConnector::onWritable));
+		_pReactor->addEventHandler(_socket, Poco::NObserver<SocketConnector, ErrorNotification>(*this, &SocketConnector::onError));
 	}
 
 	virtual void unregisterConnector()
@@ -130,32 +130,29 @@ public:
 	{
 		if (_pReactor)
 		{
-			_pReactor->removeEventHandler(_socket, Poco::Observer<SocketConnector, ReadableNotification>(*this, &SocketConnector::onReadable));
-			_pReactor->removeEventHandler(_socket, Poco::Observer<SocketConnector, WritableNotification>(*this, &SocketConnector::onWritable));
-			_pReactor->removeEventHandler(_socket, Poco::Observer<SocketConnector, ErrorNotification>(*this, &SocketConnector::onError));
+			_pReactor->removeEventHandler(_socket, Poco::NObserver<SocketConnector, ReadableNotification>(*this, &SocketConnector::onReadable));
+			_pReactor->removeEventHandler(_socket, Poco::NObserver<SocketConnector, WritableNotification>(*this, &SocketConnector::onWritable));
+			_pReactor->removeEventHandler(_socket, Poco::NObserver<SocketConnector, ErrorNotification>(*this, &SocketConnector::onError));
 		}
 	}
 
-	void onReadable(ReadableNotification* pNotification)
+	void onReadable(const AutoPtr<ReadableNotification>& pNotification)
 	{
 		unregisterConnector();
-		pNotification->release();
 		int err = _socket.impl()->socketError(); 
 		if (err) onError(err);
 		else onConnect();
 	}
 
-	void onWritable(WritableNotification* pNotification)
+	void onWritable(const AutoPtr<WritableNotification>& pNotification)
 	{
 		unregisterConnector();
-		pNotification->release();
 		onConnect();
 	}
 
-	void onError(ErrorNotification* pNotification)
+	void onError(const AutoPtr<ErrorNotification>& pNotification)
 	{
 		unregisterConnector();
-		pNotification->release();
 		onError(_socket.impl()->socketError());
 	}
 


### PR DESCRIPTION
Resolves #4851.

- [x] workers that dispatch notifications to observers
- [x] ability for synchronous dispatch of a notification
- [x] more unit tests
- [x] Obsolete Poco::Observer in favour of Poco::NObserver
  - [x] Replace in Poco::Net
  - [x] Replace in Foundation tests
- [x] improve notification matching (avoid dynamic_cast is not necessary, add std::function for matcher)
