### PR TITLE
Support for RFC 6265 cookies

### DIFF
--- a/Net/include/Poco/Net/HTTPCookie.h
+++ b/Net/include/Poco/Net/HTTPCookie.h
@@ -19,7 +19,6 @@
 
 
 #include "Poco/Net/Net.h"
-#include "Poco/DateTime.h"
 
 
 namespace Poco {
@@ -224,7 +223,6 @@ private:
 	std::string _priority;
 	bool        _secure;
 	int         _maxAge;
-	Poco::DateTime _expires;
 	bool        _httpOnly;
 	SameSite    _sameSite;
 };

--- a/Net/include/Poco/Net/HTTPCookie.h
+++ b/Net/include/Poco/Net/HTTPCookie.h
@@ -19,6 +19,7 @@
 
 
 #include "Poco/Net/Net.h"
+#include "Poco/DateTime.h"
 
 
 namespace Poco {
@@ -40,9 +41,15 @@ class Net_API HTTPCookie
 	/// as a comment, path and domain qualifiers, a maximum age, and a
 	/// version number.
 	///
-	/// This class supports both the Version 0 (by Netscape) and Version 1
-	/// (by RFC 2109) cookie specifications. By default, cookies are created
-	/// using Version 0 to ensure the best interoperability.
+	/// This class supports cookies according to RFC 6265.
+	/// Support for RFC 2109 ("Version 1") has been deprecated.
+	///
+	/// Note: "Version 0" cookies were formerly referred to as "Netscape"
+	/// cookies, but were supposed to be replaced with "Version 1" cookies
+	/// defined in RFC 2109 (and later obsoleted by RFC 2965). However,
+	/// However, as stated in RFC 6265, "none of these documents describe 
+	/// how the Cookie and Set-Cookie headers are actually
+	/// used on the Internet".
 {
 public:
 	enum SameSite
@@ -80,10 +87,11 @@ public:
 	HTTPCookie& operator = (const HTTPCookie& cookie);
 		/// Assigns a cookie.
 
+	POCO_DEPRECATED("Support for RFC 2109 cookies has been deprecated")
 	void setVersion(int version);
 		/// Sets the version of the cookie.
 		///
-		/// Version must be either 0 (denoting a Netscape cookie)
+		/// Version must be either 0 (denoting a RFC6265 cookie)
 		/// or 1 (denoting a RFC 2109 cookie).
 
 	int getVersion() const;
@@ -109,6 +117,7 @@ public:
 	const std::string& getValue() const;
 		/// Returns the value of the cookie.
 
+	POCO_DEPRECATED("Support for RFC 2109 cookies has been deprecated")
 	void setComment(const std::string& comment);
 		/// Sets the comment for the cookie.
 		///
@@ -126,11 +135,13 @@ public:
 	void setPath(const std::string& path);
 		/// Sets the path for the cookie.
 
-	void setPriority(const std::string& priority);
-		/// Sets the priority for the cookie.
-
 	const std::string& getPath() const;
 		/// Returns the path for the cookie.
+
+	void setPriority(const std::string& priority);
+		/// Sets the priority for the cookie.
+		///
+		/// This is a non-standard field.
 
 	const std::string& getPriority() const;
 		/// Returns the priority for the cookie.
@@ -213,6 +224,7 @@ private:
 	std::string _priority;
 	bool        _secure;
 	int         _maxAge;
+	Poco::DateTime _expires;
 	bool        _httpOnly;
 	SameSite    _sameSite;
 };

--- a/Net/src/HTTPCookie.cpp
+++ b/Net/src/HTTPCookie.cpp
@@ -33,6 +33,7 @@ using Poco::DateTimeParser;
 using Poco::NumberFormatter;
 using Poco::NumberParser;
 using Poco::icompare;
+using namespace std::string_literals;
 
 
 namespace Poco {
@@ -71,51 +72,51 @@ HTTPCookie::HTTPCookie(const NameValueCollection& nvc):
 	{
 		const std::string& name  = p.first;
 		const std::string& value = p.second;
-		if (icompare(name, "comment") == 0)
+		if (icompare(name, "Comment"s) == 0)
 		{
-			setComment(value);
+			_comment = value;
 		}
-		else if (icompare(name, "domain") == 0)
+		else if (icompare(name, "Domain"s) == 0)
 		{
 			setDomain(value);
 		}
-		else if (icompare(name, "path") == 0)
+		else if (icompare(name, "Path"s) == 0)
 		{
 			setPath(value);
 		}
-		else if (icompare(name, "priority") == 0)
+		else if (icompare(name, "Priority"s) == 0)
 		{
 			setPriority(value);
 		}
-		else if (icompare(name, "max-age") == 0)
+		else if (icompare(name, "Max-Age"s) == 0)
 		{
 			setMaxAge(NumberParser::parse(value));
 		}
-		else if (icompare(name, "secure") == 0)
-		{
-			setSecure(true);
-		}
-		else if (icompare(name, "expires") == 0)
+		else if (icompare(name, "Expires"s) == 0)
 		{
 			int tzd;
 			DateTime exp = DateTimeParser::parse(value, tzd);
 			Timestamp now;
 			setMaxAge((int) ((exp.timestamp() - now) / Timestamp::resolution()));
 		}
-		else if (icompare(name, "SameSite") == 0)
+		else if (icompare(name, "Secure"s) == 0)
 		{
-			if (icompare(value, "None") == 0)
+			setSecure(true);
+		}
+		else if (icompare(name, "SameSite"s) == 0)
+		{
+			if (icompare(value, "None"s) == 0)
 				_sameSite = SAME_SITE_NONE;
-			else if (icompare(value, "Lax") == 0)
+			else if (icompare(value, "Lax"s) == 0)
 				_sameSite = SAME_SITE_LAX;
-			else if (icompare(value, "Strict") == 0)
+			else if (icompare(value, "Strict"s) == 0)
 				_sameSite = SAME_SITE_STRICT;
 		}
-		else if (icompare(name, "version") == 0)
+		else if (icompare(name, "Version"s) == 0)
 		{
-			setVersion(NumberParser::parse(value));
+			_version = NumberParser::parse(value);
 		}
-		else if (icompare(name, "HttpOnly") == 0)
+		else if (icompare(name, "HttpOnly"s) == 0)
 		{
 			setHttpOnly(true);
 		}
@@ -255,16 +256,16 @@ std::string HTTPCookie::toString() const
 	result.append("=");
 	if (_version == 0)
 	{
-		// Netscape cookie
+		// RFC 6265 (formerly Netscape) cookie
 		result.append(_value);
 		if (!_domain.empty())
 		{
-			result.append("; domain=");
+			result.append("; Domain=");
 			result.append(_domain);
 		}
 		if (!_path.empty())
 		{
-			result.append("; path=");
+			result.append("; Path=");
 			result.append(_path);
 		}
 		if (!_priority.empty())
@@ -276,7 +277,7 @@ std::string HTTPCookie::toString() const
 		{
 			Timestamp ts;
 			ts += _maxAge * Timestamp::resolution();
-			result.append("; expires=");
+			result.append("; Expires=");
 			DateTimeFormatter::append(result, ts, DateTimeFormat::HTTP_FORMAT);
 		}
 		switch (_sameSite)
@@ -295,7 +296,7 @@ std::string HTTPCookie::toString() const
 		}
 		if (_secure)
 		{
-			result.append("; secure");
+			result.append("; Secure");
 		}
 		if (_httpOnly)
 		{
@@ -355,7 +356,7 @@ std::string HTTPCookie::toString() const
 		}
 		if (_secure)
 		{
-			result.append("; secure");
+			result.append("; Secure");
 		}
 		if (_httpOnly)
 		{

--- a/Net/testsuite/src/HTTPCookieTest.cpp
+++ b/Net/testsuite/src/HTTPCookieTest.cpp
@@ -8,6 +8,11 @@
 //
 
 
+#ifndef POCO_SILENCE_DEPRECATED
+#define POCO_SILENCE_DEPRECATED
+#endif
+
+
 #include "HTTPCookieTest.h"
 #include "CppUnit/TestCaller.h"
 #include "CppUnit/TestSuite.h"
@@ -50,26 +55,26 @@ void HTTPCookieTest::testCookie()
 	assertTrue (cookie.getValue() == "value");
 	assertTrue (cookie.toString() == "name=value");
 	cookie.setPath("/");
-	assertTrue (cookie.toString() == "name=value; path=/");
+	assertTrue (cookie.toString() == "name=value; Path=/");
 	cookie.setComment("comment");
-	assertTrue (cookie.toString() == "name=value; path=/");
+	assertTrue (cookie.toString() == "name=value; Path=/");
 	cookie.setDomain("appinf.com");
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/");
 	cookie.setSecure(true);
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/; secure");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/; Secure");
 	cookie.setHttpOnly(true);
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/; secure; HttpOnly");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/; Secure; HttpOnly");
 	cookie.setPriority("Low");
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/; Priority=Low; secure; HttpOnly");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/; Priority=Low; Secure; HttpOnly");
 	cookie.setPriority("Medium");
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/; Priority=Medium; secure; HttpOnly");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/; Priority=Medium; Secure; HttpOnly");
 	cookie.setPriority("High");
-	assertTrue (cookie.toString() == "name=value; domain=appinf.com; path=/; Priority=High; secure; HttpOnly");
+	assertTrue (cookie.toString() == "name=value; Domain=appinf.com; Path=/; Priority=High; Secure; HttpOnly");
 	cookie.setPriority("");
 	cookie.setHttpOnly(false);
 
 	cookie.setVersion(1);
-	assertTrue (cookie.toString() == "name=\"value\"; Comment=\"comment\"; Domain=\"appinf.com\"; Path=\"/\"; secure; Version=\"1\"");
+	assertTrue (cookie.toString() == "name=\"value\"; Comment=\"comment\"; Domain=\"appinf.com\"; Path=\"/\"; Secure; Version=\"1\"");
 
 	cookie.setSecure(false);
 	cookie.setMaxAge(100);
@@ -153,8 +158,8 @@ void HTTPCookieTest::testCookieExpiry(DateTime expiryTime)
 {
 	NameValueCollection nvc;
 	nvc.add("name", "value");
-	std::string expiryString = DateTimeFormatter::format(expiryTime.timestamp(),DateTimeFormat::HTTP_FORMAT);
-	nvc.add("expires", expiryString);
+	std::string expiryString = DateTimeFormatter::format(expiryTime.timestamp(), DateTimeFormat::HTTP_FORMAT);
+	nvc.add("Expires", expiryString);
 
 	Timestamp before; //start of cookie lifetime
 	HTTPCookie cookie(nvc); //cookie created
@@ -170,7 +175,7 @@ void HTTPCookieTest::testCookieExpiry(DateTime expiryTime)
 	Timespan delta = after - before;
 
 	//pull out cookie expire time string
-	size_t startPos = cookieStringV0.find("expires=") + 8;
+	size_t startPos = cookieStringV0.find("Expires=") + 8;
 	std::string cookieExpireTimeStr = cookieStringV0.substr(startPos, cookieStringV0.find(";", startPos));
 	//convert to a DateTime
 	int tzd;


### PR DESCRIPTION
This is mostly a documentation update, stating that "version 1" (RFC 2109) cookies should no longer be used, deprecating some methods related to RFC 2109 and that the former "Netscape" cookies are now "RFC 6265" cookies.