### PR TITLE
Fix Thread_POSIX not compiling with Emscripten

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -241,6 +241,11 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "AIX")
 	target_compile_definitions(Foundation PUBLIC POCO_NO_THREADNAME)
 endif()
 
+# Emscripten currently doesn't support thread names
+if(EMSCRIPTEN)
+	target_compile_definitions(Foundation PUBLIC POCO_NO_THREADNAME)
+endif()
+
 # iOS
 if(IOS)
 	target_compile_definitions(Foundation

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -43,8 +43,10 @@
 #	include <sys/neutrino.h>
 #endif
 
-#if POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
-#	include <sys/prctl.h>
+#ifndef POCO_NO_THREADNAME
+	#if POCO_OS == POCO_OS_LINUX || POCO_OS == POCO_OS_ANDROID
+	#	include <sys/prctl.h>
+	#endif
 #endif
 
 #if POCO_OS == POCO_OS_LINUX


### PR DESCRIPTION
When compiling `Thread_POSIX.cpp` with emscripten on macOS, it fails, as it was trying to include `sys/prctl.h` which is a Linux only header file.

Emscripten currently doesn't have support for getting/setting the thread name, so I decided to use the `POCO_NO_THREADNAME` define to disable the thread name functionality which can't compile.

The current emscripten build on the CI is built with Ubuntu, which is why this issue didn't appear on the CI.

Changes:
- I wrapped the `sys/prctl.h` include in `Thread_POSIX.cpp` to only be included when `POCO_NO_THREADNAME` is not defined.
- Changed Foundation CMakeLists.txt to automatically define `POCO_NO_THREADNAME` for emscripten.