### PR TITLE
poco Zip: link ZLIB::ZLIB when unbundled

### DIFF
--- a/Zip/CMakeLists.txt
+++ b/Zip/CMakeLists.txt
@@ -29,6 +29,11 @@ target_include_directories(Zip
 	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+if(POCO_UNBUNDLED)
+	find_package(ZLIB REQUIRED)
+	target_link_libraries(Zip PRIVATE ZLIB::ZLIB)
+endif()
+
 POCO_INSTALL(Zip)
 POCO_GENERATE_PACKAGE(Zip)
 


### PR DESCRIPTION
The `Poco::Zip` library target uses ZLIB in its implementation (not in public headers). 

Since https://github.com/pocoproject/poco/pull/4937, compilation may be broken when `POCO_UNBUNDLED` is True - previously, it was consuming ZLIB transitively via Foundation. Compilation may succeed on systems where zlib.h can be found by the compiler in the default paths, but this may not be the same version located by CMake and may cause linker issues (unlikely, but possible).

This PR adds the missing requirement.

Fixes https://github.com/pocoproject/poco/issues/4980