### PR TITLE
Fix building of FileStreamTest.cpp on FreeBSD

### DIFF
--- a/Foundation/testsuite/src/FileStreamTest.cpp
+++ b/Foundation/testsuite/src/FileStreamTest.cpp
@@ -56,6 +56,7 @@ void FileStreamTest::testRead()
 #if defined(POCO_OS_FAMILY_WINDOWS)
 #include "Poco/UnicodeConverter.h"
 #else
+#include <sys/stat.h>
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
According to POSIX, S_IRGRP et all are defined in sys/stat.h, so the code that uses these defines should include that header