### PR TITLE
Foundation: Add deprecation reasons to APIs

### DIFF
--- a/Foundation/include/Poco/DirectoryIterator.h
+++ b/Foundation/include/Poco/DirectoryIterator.h
@@ -75,7 +75,7 @@ public:
 
 	virtual DirectoryIterator& operator ++ ();   // prefix
 
-	POCO_DEPRECATED("")
+	POCO_DEPRECATED("Please use the prefix increment operator instead")
 	DirectoryIterator operator ++ (int); // postfix
 		/// Please use the prefix increment operator instead.
 

--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -2288,7 +2288,7 @@ inline bool operator >= (const unsigned long& other, const Var& da)
 } // namespace Dynamic
 
 
-using DynamicAny POCO_DEPRECATED("") = Dynamic::Var;
+using DynamicAny POCO_DEPRECATED("Replace with Poco::Dynamic::Var") = Dynamic::Var;
 
 
 } // namespace Poco

--- a/Foundation/include/Poco/Event.h
+++ b/Foundation/include/Poco/Event.h
@@ -55,7 +55,7 @@ public:
 		/// the event is automatically reset after
 		/// a wait() successfully returns.
 
-	POCO_DEPRECATED("")
+	POCO_DEPRECATED("Please use Event::Event(EventType) instead")
 	explicit Event(bool autoReset);
 		/// Please use Event::Event(EventType) instead.
 

--- a/Foundation/include/Poco/FIFOStrategy.h
+++ b/Foundation/include/Poco/FIFOStrategy.h
@@ -25,7 +25,7 @@ namespace Poco {
 
 
 template <class TArgs, class TDelegate>
-class POCO_DEPRECATED("") FIFOStrategy: public DefaultStrategy<TArgs, TDelegate>
+class POCO_DEPRECATED("As of release 1.4.2, DefaultStrategy already implements FIFO behavior, so this class is provided for backwards compatibility only") FIFOStrategy: public DefaultStrategy<TArgs, TDelegate>
 	/// Note: As of release 1.4.2, DefaultStrategy already
 	/// implements FIFO behavior, so this class is provided
 	/// for backwards compatibility only.


### PR DESCRIPTION
Add reasons to some of the deprecations. There are several others without reasons, but I couldn't find a clear answer from the code, so I've left those blank.