### PR TITLE
Fix Can not resolve "localhost" if not Network adapter exists #4988

### DIFF
--- a/Net/include/Poco/Net/HostEntry.h
+++ b/Net/include/Poco/Net/HostEntry.h
@@ -48,9 +48,9 @@ public:
 		/// Creates the HostEntry from the data in an addrinfo structure.
 #endif
 
-#if defined(POCO_VXWORKS)
 	HostEntry(const std::string& name, const IPAddress& addr);
-#endif
+		/// Creates the HostEntry from pre defined data
+
 
 	HostEntry(const HostEntry& entry);
 		/// Creates the HostEntry by copying another one.

--- a/Net/src/DNS.cpp
+++ b/Net/src/DNS.cpp
@@ -82,7 +82,7 @@ HostEntry DNS::hostByName(const std::string& hostname, unsigned
 		freeaddrinfo(pAI);
 		return result;
 	}
-#if defined(_WIN32)
+#if defined(POCO_OS_FAMILY_WINDOWS)
 	else if(rc == WSANO_DATA && hostname == "localhost") // no data record found and is local host 
 	{
  #if defined(POCO_HAVE_IPv6)
@@ -141,7 +141,7 @@ HostEntry DNS::hostByAddress(const IPAddress& address, unsigned
 			freeaddrinfo(pAI);
 			return result;
 		}
-#if defined(_WIN32)
+#if defined(POCO_OS_FAMILY_WINDOWS)
 		else if(rc == WSANO_DATA && address.isLoopback()) // no data record found and is local host 
 		{
 			return HostEntry("localhost", address);

--- a/Net/src/DNS.cpp
+++ b/Net/src/DNS.cpp
@@ -85,11 +85,7 @@ HostEntry DNS::hostByName(const std::string& hostname, unsigned
 #if defined(POCO_OS_FAMILY_WINDOWS)
 	else if(rc == WSANO_DATA && hostname == "localhost") // no data record found and is local host 
 	{
- #if defined(POCO_HAVE_IPv6)
-		return HostEntry("localhost", Poco::Net::IPAddress("::1"));
- #else
 		return HostEntry("localhost",Poco::Net::IPAddress("127.0.0.1"));
-#endif // ipv6
 	}
 #endif // _WIN32
 	else

--- a/Net/src/HostEntry.cpp
+++ b/Net/src/HostEntry.cpp
@@ -103,8 +103,6 @@ HostEntry::HostEntry(struct addrinfo* ainfo)
 #endif // POCO_HAVE_IPv6
 
 
-#if defined(POCO_VXWORKS)
-
 
 HostEntry::HostEntry(const std::string& name, const IPAddress& addr):
 	_name(name)
@@ -112,8 +110,6 @@ HostEntry::HostEntry(const std::string& name, const IPAddress& addr):
 	_addresses.push_back(addr);
 }
 
-
-#endif // POCO_VXWORKS
 
 
 HostEntry::HostEntry(const HostEntry& entry):


### PR DESCRIPTION
Fill HostEntry with localhost and a default loopback address if 'getaddrinfo' returns 'WSANO_DATA'