### PR TITLE
Eliminate extra copies in JSON::Object

### DIFF
--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -278,6 +278,7 @@ Object::operator const Poco::DynamicStruct& () const
 				_pStruct->insert(it->first, it->second);
 			}
 		}
+		_modified = false;
 	}
 
 	return *_pStruct;


### PR DESCRIPTION
I didn't create an associated issue for this. I just discovered this minor problem while reviewing the Poco code. The identical code in JSON::Array sets `_modified` to `false`, so I think it should do the same in JSON::Object.