### PR TITLE
Prevent hostname being replaced with IP during handshake

### DIFF
--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -835,7 +835,9 @@ void SecureSocketImpl::stateError()
 
 void SecureSocketImpl::stateClientConnected()
 {
-	_peerHostName = _pSocket->peerAddress().host().toString();
+	if (_peerHostName.empty())
+        _peerHostName = _pSocket->peerAddress().host().toString();
+
 	setState(ST_CLIENT_HSK_START);
 }
 


### PR DESCRIPTION
Before the handshake is performed, SecureSocketImpl::stateClientConnected overrides the peer hostname with its IP address, making it impossible to send SNI during the handshake in SecureSocketImpl::stateClientHandshakeStart.

This behavior essentially breaks SNI and prevents the library from being used with load balancers that rely on SNI to determine the destination host.

Everywhere else, the peer hostname is replaced by the IP address only when the peer hostname is empty. That makes total sense; however, it seems like this check was forgotten in SecureSocketImpl::stateClientConnected.

`status.github.com` requires SNI, so this example demonstrates the problem:

```
#include <iostream>
#include <Poco/Net/HTTPSClientSession.h>
#include <Poco/Net/HTTPRequest.h>
#include <Poco/Net/HTTPResponse.h>
#include <Poco/StreamCopier.h>
#include <Poco/Net/SSLManager.h>

int main()
{
    Poco::Net::Context::Ptr context
        = new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "");

    Poco::Net::initializeSSL();
    Poco::Net::SSLManager::instance().initializeClient(nullptr, nullptr, context);

    try {
        static const std::string host = "status.github.com";
        Poco::Net::HTTPSClientSession session(host, 443);
        Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_GET, "/");
        session.sendRequest(req);
        Poco::Net::HTTPResponse res;
        std::istream& rs = session.receiveResponse(res);
        std::cout << res.getStatus() << " " << res.getReason() << "\n";
        Poco::StreamCopier::copyStream(rs, std::cout);
    }
    catch (const Poco::Exception& ex)
    {
        std::cerr << ex.displayText() << "\n";
    }

    return EXIT_SUCCESS;
}
```

The output will be
```
Invalid certficate: Host name verification failed
```

Looking at Wireshark we can see that Client Hello does not contain SNI.
<img width="2371" height="514" alt="image" src="https://github.com/user-attachments/assets/4a54eb22-300d-433a-8af6-0cd52c7507f7" />

With the fix in the PR everything works and we can see SNI in the Client Hello message:
<img width="2367" height="396" alt="image" src="https://github.com/user-attachments/assets/c176fd45-8fc5-496b-b9a3-3fb6e7c3dec7" />
