### PR TITLE
fix(Foundation): Fix incorrect bitwise check for newline mode in RegularExpression #4870

### DIFF
--- a/Foundation/src/RegularExpression.cpp
+++ b/Foundation/src/RegularExpression.cpp
@@ -71,13 +71,14 @@ RegularExpression::RegularExpression(const std::string& pattern, int options, bo
 	pcre2_compile_context* context = pcre2_compile_context_create(nullptr);
 	if (!context) throw Poco::RegularExpressionException("cannot create compile context");
 
-	if (options & RE_NEWLINE_LF)
+	const unsigned RE_NEWLINE_MASK = 0x00f00000;
+	if ((options & RE_NEWLINE_MASK) == RE_NEWLINE_LF)
 		pcre2_set_newline(context, PCRE2_NEWLINE_LF);
-	else if (options & RE_NEWLINE_CRLF)
+	else if ((options & RE_NEWLINE_MASK) == RE_NEWLINE_CRLF)
 		pcre2_set_newline(context, PCRE2_NEWLINE_CRLF);
-	else if (options & RE_NEWLINE_ANY)
+	else if ((options & RE_NEWLINE_MASK) == RE_NEWLINE_ANY)
 		pcre2_set_newline(context, PCRE2_NEWLINE_ANY);
-	else if (options & RE_NEWLINE_ANYCRLF)
+	else if ((options & RE_NEWLINE_MASK) == RE_NEWLINE_ANYCRLF)
 		pcre2_set_newline(context, PCRE2_NEWLINE_ANYCRLF);
 	else // default RE_NEWLINE_CR
 		pcre2_set_newline(context, PCRE2_NEWLINE_CR);

--- a/Foundation/testsuite/src/RegularExpressionTest.cpp
+++ b/Foundation/testsuite/src/RegularExpressionTest.cpp
@@ -259,6 +259,15 @@ void RegularExpressionTest::testSubst4()
 }
 
 
+void RegularExpressionTest::testSubst5()
+{
+	RegularExpression re("\\s+$", RegularExpression::RE_MULTILINE | RegularExpression::RE_NEWLINE_ANYCRLF);
+	std::string s = "ABC 123  \n456 789 \nDEF  ";
+	assertTrue (re.subst(s, "", RegularExpression::RE_GLOBAL) == 3);
+	assertTrue (s == "ABC 123\n456 789\nDEF");
+}
+
+
 void RegularExpressionTest::testError()
 {
 	try
@@ -312,6 +321,7 @@ CppUnit::Test* RegularExpressionTest::suite()
 	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst2);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst3);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst4);
+	CppUnit_addTest(pSuite, RegularExpressionTest, testSubst5);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testError);
 	CppUnit_addTest(pSuite, RegularExpressionTest, testGroup);
 

--- a/Foundation/testsuite/src/RegularExpressionTest.h
+++ b/Foundation/testsuite/src/RegularExpressionTest.h
@@ -39,6 +39,7 @@ public:
 	void testSubst2();
 	void testSubst3();
 	void testSubst4();
+	void testSubst5();
 	void testError();
 	void testGroup();
 


### PR DESCRIPTION
## Summary
- Fixed incorrect bitwise checks when determining newline mode in `RegularExpression.cpp`
- The newline mode flags (`RE_NEWLINE_LF`, `RE_NEWLINE_CRLF`, `RE_NEWLINE_ANY`, `RE_NEWLINE_ANYCRLF`) are encoded values in a 4-bit field, not independent bit flags
- The previous code used simple bitwise AND checks which failed when certain flag combinations shared bits (e.g., `RE_NEWLINE_ANYCRLF` (0x00500000) incorrectly matched `RE_NEWLINE_CRLF` (0x00300000) because `0x00500000 & 0x00300000 != 0`)
- Added `testSubst5` test case that reproduces the issue from #4870

## Test plan
- [x] Built Foundation library with minimal build configuration
- [x] Ran `RegularExpressionTest` suite - all 18 tests pass including new `testSubst5`
- [ ] CI should verify on all platforms

Closes #4870