### PR TITLE
fix(Net): Add POCO_HAS_UNIX_SOCKET guards to fix build without Unix sockets #5064

### DIFF
--- a/Data/ODBC/include/Poco/Data/ODBC/ODBC.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBC.h
@@ -54,7 +54,7 @@
 
 #include "Poco/Data/ODBC/Unicode.h"
 
-#if (__cplusplus >= 201703L)
+#if POCO_HAVE_CPP17_COMPILER
 	#if __has_include(<msodbcsql.h>)
 		#include <msodbcsql.h>
 		#define POCO_DATA_ODBC_HAVE_SQL_SERVER_EXT

--- a/Foundation/include/Poco/Platform_POSIX.h
+++ b/Foundation/include/Poco/Platform_POSIX.h
@@ -33,16 +33,6 @@
 
 
 //
-// Thread-safety of local static initialization
-//
-#if __cplusplus >= 201103L || __GNUC__ >= 4 || defined(__clang__)
-	#ifndef POCO_LOCAL_STATIC_INIT_IS_THREADSAFE
-		#define POCO_LOCAL_STATIC_INIT_IS_THREADSAFE 1
-	#endif
-#endif
-
-
-//
 // No syslog.h on QNX/BB10
 //
 #if defined(__QNXNTO__)

--- a/Net/include/Poco/Net/SocketDefs.h
+++ b/Net/include/Poco/Net/SocketDefs.h
@@ -18,6 +18,7 @@
 #define Net_SocketDefs_INCLUDED
 
 
+#include "Poco/Config.h"
 #include <vector>
 
 
@@ -33,7 +34,7 @@
 	#include <ws2tcpip.h>
 	#include <ws2def.h>
 	#if !defined (POCO_NET_NO_UNIX_SOCKET)
-		#if (__cplusplus >= 201703L)
+		#if POCO_HAVE_CPP17_COMPILER
 			#if __has_include(<afunix.h>)
 				#include <afunix.h>
 				#define POCO_HAS_UNIX_SOCKET

--- a/Net/src/HTTPSession.cpp
+++ b/Net/src/HTTPSession.cpp
@@ -196,7 +196,9 @@ void HTTPSession::connect(const SocketAddress& address)
 	_socket.connect(address, _connectionTimeout);
 	_socket.setReceiveTimeout(_receiveTimeout);
 	_socket.setSendTimeout(_sendTimeout);
+#if defined(POCO_HAS_UNIX_SOCKET)
 	if (address.family() != SocketAddress::UNIX_LOCAL)
+#endif
 		_socket.setNoDelay(true);
 	// There may be leftover data from a previous (failed) request in the buffer,
 	// so we clear it.

--- a/Net/src/SocketAddress.cpp
+++ b/Net/src/SocketAddress.cpp
@@ -380,11 +380,13 @@ void SocketAddress::init(const std::string& hostAndPort)
 {
 	poco_assert (!hostAndPort.empty());
 
+#if defined(POCO_HAS_UNIX_SOCKET)
 	if (isUnixLocal(hostAndPort))
 	{
 		newLocal(hostAndPort);
 		return;
 	}
+#endif
 
 	std::string host;
 	std::string port;

--- a/Net/src/WebSocketImpl.cpp
+++ b/Net/src/WebSocketImpl.cpp
@@ -47,7 +47,9 @@ WebSocketImpl::WebSocketImpl(StreamSocketImpl* pStreamSocketImpl, HTTPSession& s
 	// for small WebSocket frames. Skip for Unix domain sockets.
 	try
 	{
+#if defined(POCO_HAS_UNIX_SOCKET)
 		if (_pStreamSocketImpl->address().family() != SocketAddress::UNIX_LOCAL)
+#endif
 			_pStreamSocketImpl->setNoDelay(true);
 	}
 	catch (NetException&)


### PR DESCRIPTION
## Summary

When `POCO_HAS_UNIX_SOCKET` is not defined (e.g., older Windows SDKs lacking `afunix.h`, or when `POCO_NET_NO_UNIX_SOCKET` is explicitly defined), the build failed because:

- `HTTPSession::connect()` referenced `SocketAddress::UNIX_LOCAL`
- `SocketAddress::init()` called `newLocal()` which is only declared when `POCO_HAS_UNIX_SOCKET` is defined
- `WebSocketImpl` constructor referenced `SocketAddress::UNIX_LOCAL`

## Changes

1. **Net/src/HTTPSession.cpp** - Added `#if defined(POCO_HAS_UNIX_SOCKET)` guard around `UNIX_LOCAL` check
2. **Net/src/SocketAddress.cpp** - Added guard around `isUnixLocal()` and `newLocal()` call
3. **Net/src/WebSocketImpl.cpp** - Added guard around `UNIX_LOCAL` check
4. **Net/include/Poco/Net/SocketDefs.h** - Use `POCO_HAVE_CPP17_COMPILER` macro instead of direct `__cplusplus >= 201703L` check for consistency
5. **Data/ODBC/include/Poco/Data/ODBC/ODBC.h** - Same consistency improvement
6. **Foundation/include/Poco/Platform_POSIX.h** - Simplified thread-safe local static init check since POCO requires C++17 (which guarantees this since C++11)

Closes #5064