### PR TITLE
fix(Foundation): Fix UBSan errors in VarHolder.h

### DIFF
--- a/Foundation/include/Poco/Dynamic/Var.h
+++ b/Foundation/include/Poco/Dynamic/Var.h
@@ -632,7 +632,7 @@ inline void Var::construct(const char* value)
 inline void Var::construct(const Var& other)
 {
 	if (!other.isEmpty())
-		other.content()->clone(&_placeholder);
+		(void) other.content()->clone(&_placeholder);
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #5090 - UndefinedBehaviorSanitizer errors in VarHolder.h

**Fixed issues:**

1. **`numValDigits` for signed integers**: Negating `INT_MIN` caused signed overflow (UB). Now uses safe unsigned arithmetic: `U(0) - static_cast<U>(value)`.

2. **`numValDigits` for floating point**: Casting large floats (e.g., `1e20`) to `int64_t` caused UB. Now uses `std::ilogb()` to get bit count directly from the exponent.

3. **`POCO_VAR_RANGE_EXCEPTION` macro**: Casting out-of-range values to target type was UB. Added `rangeExcCastStr()` helper that safely casts integral sources to `intmax_t`/`uintmax_t`, and returns "?" for floating-point sources.

**C++17 modernization (while fixing the above):**

- Added `[[nodiscard]]` to `clone()`, `type()`, `size()`, and all `is*()` query methods
- Merged multiple SFINAE overloads into single functions using `if constexpr`:
  - `checkUpperLimit`/`checkLowerLimit`: 4 overloads → 2 functions
  - `convertToSmaller`: 3 overloads → 1 function
  - `convertToSigned`/`convertToUnsigned`: 6 overloads → 2 functions
- Removed `unpreserveSign()` function (inlined safe arithmetic into `numValDigits`)
- Fixed `Var.h` to suppress `[[nodiscard]]` warning for intentionally ignored `clone()` return

## Test plan

- [x] Built with UBSan enabled (`-fsanitize=undefined -fno-sanitize=vptr`)
- [x] VarTest passes with no UBSan errors
- [x] All Foundation tests pass