### PR TITLE
fix(Net): Use MessageHeader::quote() for boundary in HTMLForm

### DIFF
--- a/Net/src/HTMLForm.cpp
+++ b/Net/src/HTMLForm.cpp
@@ -18,6 +18,7 @@
 #include "Poco/Net/PartHandler.h"
 #include "Poco/Net/MultipartWriter.h"
 #include "Poco/Net/MultipartReader.h"
+#include "Poco/Net/MessageHeader.h"
 #include "Poco/Net/NullPartHandler.h"
 #include "Poco/Net/NetException.h"
 #include "Poco/NullStream.h"
@@ -219,9 +220,8 @@ void HTMLForm::prepareSubmit(HTTPRequest& request, int options)
 		{
 			_boundary = MultipartWriter::createBoundary();
 			std::string ct(_encoding);
-			ct.append("; boundary=\"");
-			ct.append(_boundary);
-			ct.append("\"");
+			ct.append("; boundary=");
+			MessageHeader::quote(_boundary, ct);
 			request.setContentType(ct);
 		}
 		if (request.getVersion() == HTTPMessage::HTTP_1_0)

--- a/Net/testsuite/src/HTMLFormTest.cpp
+++ b/Net/testsuite/src/HTMLFormTest.cpp
@@ -309,9 +309,8 @@ void HTMLFormTest::testSubmit3()
 	HTTPRequest req("POST", "/form.cgi", HTTPMessage::HTTP_1_1);
 	form.prepareSubmit(req);
 	std::string expCT(HTMLForm::ENCODING_MULTIPART);
-	expCT.append("; boundary=\"");
+	expCT.append("; boundary=");
 	expCT.append(form.boundary());
-	expCT.append("\"");
 	assertTrue (req.getContentType() == expCT);
 	assertTrue (req.getChunkedTransferEncoding());
 }
@@ -343,9 +342,8 @@ void HTMLFormTest::testSubmit5()
 	HTTPRequest req("POST", "/form.cgi", HTTPMessage::HTTP_1_1);
 	form.prepareSubmit(req, HTMLForm::OPT_USE_CONTENT_LENGTH);
 	std::string expCT(HTMLForm::ENCODING_MULTIPART);
-	expCT.append("; boundary=\"");
+	expCT.append("; boundary=");
 	expCT.append(form.boundary());
-	expCT.append("\"");
 	assertTrue (req.getContentType() == expCT);
 	assertTrue (req.getContentLength() == 403);
 }


### PR DESCRIPTION
## Problem

HTMLForm was unconditionally quoting the boundary parameter in Content-Type headers:
```
Content-Type: multipart/form-data; boundary="MIME_boundary_A1B2C3D4"
```

While technically RFC-compliant, this was inconsistent with other parts of the codebase and caused issues with strict parsers like nginx-upload-module.

## Root Cause

Internal inconsistency in Poco:
- `MailMessage` uses `MediaType::toString()` → `MessageHeader::quote()` (conditional quoting)
- `HTMLForm` used manual unconditional quoting

## Solution

Changed HTMLForm to use `MessageHeader::quote()`, which only adds quotes when the value contains special characters. Since `MultipartWriter::createBoundary()` generates boundaries like `MIME_boundary_A1B2C3D4E5F6G7H8` (alphanumeric + underscore only), quotes are no longer added.

## RFC 2046 Compliance

Per RFC 2046 Section 5.1, quotes are only required when boundary contains non-alphanumeric characters other than `.`, `_`, `-`.

## Benefits

1. **Consistency** - HTMLForm now behaves like MailMessage and MediaType
2. **Interoperability** - Works with strict parsers that don't handle unnecessary quotes
3. **Cleaner output** - Generates minimal, RFC-compliant headers

Replaces #4953