### PR TITLE
fix: Resolve compiler warnings across multiple modules

### DIFF
--- a/Crypto/include/Poco/Crypto/CryptoStream.h
+++ b/Crypto/include/Poco/Crypto/CryptoStream.h
@@ -48,8 +48,8 @@ public:
 		/// Flushes all buffers and finishes the encryption.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	CryptoTransform::Ptr _pTransform;

--- a/Crypto/src/CipherImpl.cpp
+++ b/Crypto/src/CipherImpl.cpp
@@ -116,7 +116,7 @@ namespace
 		if (rc == 0) throwError();
 
 #if OPENSSL_VERSION_NUMBER >= 0x10001000L
-		if (_iv.size() != EVP_CIPHER_iv_length(_pCipher) && EVP_CIPHER_mode(_pCipher) == EVP_CIPH_GCM_MODE)
+		if (static_cast<int>(_iv.size()) != EVP_CIPHER_iv_length(_pCipher) && EVP_CIPHER_mode(_pCipher) == EVP_CIPH_GCM_MODE)
 		{
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 			int rc = EVP_CIPHER_CTX_ctrl(_pContext, EVP_CTRL_GCM_SET_IVLEN, static_cast<int>(_iv.size()), nullptr);
@@ -196,7 +196,7 @@ namespace
 		unsigned char*       output,
 		std::streamsize      outputLength)
 	{
-		poco_assert (outputLength >= (inputLength + blockSize() - 1));
+		poco_assert (outputLength >= (inputLength + static_cast<std::streamsize>(blockSize()) - 1));
 
 		int outLen = static_cast<int>(outputLength);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
@@ -225,7 +225,7 @@ namespace
 		unsigned char*	output,
 		std::streamsize length)
 	{
-		poco_assert (length >= blockSize());
+		poco_assert (length >= static_cast<std::streamsize>(blockSize()));
 
 		int len = static_cast<int>(length);
 

--- a/Crypto/src/CipherKeyImpl.cpp
+++ b/Crypto/src/CipherKeyImpl.cpp
@@ -168,7 +168,7 @@ void CipherKeyImpl::getRandomBytes(ByteVec& vec, std::size_t count)
 	vec.clear();
 	vec.reserve(count);
 
-	for (int i = 0; i < count; ++i)
+	for (std::size_t i = 0; i < count; ++i)
 		vec.push_back(static_cast<unsigned char>(random.get()));
 }
 

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -19,6 +19,7 @@
 #include "Poco/FileStream.h"
 #include "Poco/Format.h"
 #include "Poco/StreamCopier.h"
+#include <algorithm>
 #include <sstream>
 #include <openssl/evp.h>
 #include <openssl/bn.h>
@@ -229,11 +230,11 @@ int ECKeyImpl::getCurveNID(std::string& name)
 	}
 	else
 	{
-		for (int i = 0; i < len; ++i)
+		for (std::size_t i = 0; i < len; ++i)
 		{
 			std::memset(buf, 0, bufLen);
 			OBJ_obj2txt(buf, bufLen, OBJ_nid2obj(pCurves[i].nid), 0);
-			if (strncmp(name.c_str(), buf, name.size() > bufLen ? bufLen : name.size()) == 0)
+			if (strncmp(name.c_str(), buf, std::min(name.size(), static_cast<std::size_t>(bufLen))) == 0)
 			{
 				nid = pCurves[i].nid;
 				break;

--- a/Crypto/src/EVPCipherImpl.cpp
+++ b/Crypto/src/EVPCipherImpl.cpp
@@ -150,8 +150,8 @@ namespace
 
 		std::streamsize finalize(unsigned char*	output, std::streamsize length)
 		{
-			poco_assert (length >= blockSize());
-			poco_assert (_pos <= maxDataSize(output, length));
+			poco_assert (length >= static_cast<std::streamsize>(blockSize()));
+			poco_assert (static_cast<std::size_t>(_pos) <= maxDataSize(output, length));
 			std::string fmt = "EVPEncryptImpl::finalize():%s()";
 			std::size_t outLen = 0;
 			if (_pos > 0)
@@ -265,7 +265,7 @@ namespace
 			std::size_t outLen = 0;
 			if (EVP_PKEY_decrypt(_pCtx, nullptr, &outLen, _pBuf, static_cast<std::size_t>(_pos)) <= 0)
 					throwError(Poco::format(fmt, std::string("EVP_PKEY_decrypt(NULL)")));
-			poco_assert (length >= outLen);
+			poco_assert (static_cast<std::size_t>(length) >= outLen);
 			if (_pos > 0)
 			{
 				if (EVP_PKEY_decrypt(_pCtx, output, &outLen, _pBuf, static_cast<std::size_t>(_pos)) <= 0)

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -183,8 +183,8 @@ namespace
 
 	std::streamsize RSAEncryptImpl::finalize(unsigned char*	output, std::streamsize length)
 	{
-		poco_assert (length >= blockSize());
-		poco_assert (_pos <= maxDataSize());
+		poco_assert (length >= static_cast<std::streamsize>(blockSize()));
+		poco_assert (static_cast<std::size_t>(_pos) <= maxDataSize());
 		int rc = 0;
 		if (_pos > 0)
 		{
@@ -301,7 +301,7 @@ namespace
 
 	std::streamsize RSADecryptImpl::finalize(unsigned char*	output, std::streamsize length)
 	{
-		poco_assert (length >= blockSize());
+		poco_assert (length >= static_cast<std::streamsize>(blockSize()));
 		int rc = 0;
 		if (_pos > 0)
 		{

--- a/Data/MySQL/src/Binder.cpp
+++ b/Data/MySQL/src/Binder.cpp
@@ -159,7 +159,7 @@ void Binder::bind(std::size_t pos, const Poco::Data::CLOB& val, Direction dir)
 void Binder::bind(std::size_t pos, const DateTime& val, Direction dir)
 {
 	poco_assert(dir == PD_IN);
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	mt.year = val.year();
 	mt.month = val.month();
@@ -180,7 +180,7 @@ void Binder::bind(std::size_t pos, const DateTime& val, Direction dir)
 void Binder::bind(std::size_t pos, const Date& val, Direction dir)
 {
 	poco_assert(dir == PD_IN);
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	mt.year  = val.year();
 	mt.month = val.month();
@@ -197,7 +197,7 @@ void Binder::bind(std::size_t pos, const Date& val, Direction dir)
 void Binder::bind(std::size_t pos, const Time& val, Direction dir)
 {
 	poco_assert(dir == PD_IN);
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	mt.hour   = val.hour();
 	mt.minute = val.minute();
@@ -286,7 +286,7 @@ void Binder::realBind(std::size_t pos, enum_field_types type, const void* buffer
 		std::memset(&_bindArray[s], 0, sizeof(MYSQL_BIND) * (_bindArray.size() - s));
 	}
 
-	MYSQL_BIND b = {nullptr};
+	MYSQL_BIND b = {};
 
 	b.buffer_type   = type;
 	b.buffer  = const_cast<void*>(buffer);

--- a/Data/MySQL/src/Extractor.cpp
+++ b/Data/MySQL/src/Extractor.cpp
@@ -186,7 +186,7 @@ bool Extractor::extract(std::size_t pos, Poco::Data::CLOB& val)
 
 bool Extractor::extract(std::size_t pos, DateTime& val)
 {
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	if (!realExtractFixed(pos, MYSQL_TYPE_DATETIME, &mt))
 		return false;
@@ -198,7 +198,7 @@ bool Extractor::extract(std::size_t pos, DateTime& val)
 
 bool Extractor::extract(std::size_t pos, Date& val)
 {
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	if (!realExtractFixed(pos, MYSQL_TYPE_DATE, &mt))
 		return false;
@@ -210,7 +210,7 @@ bool Extractor::extract(std::size_t pos, Date& val)
 
 bool Extractor::extract(std::size_t pos, Time& val)
 {
-	MYSQL_TIME mt = {0};
+	MYSQL_TIME mt = {};
 
 	if (!realExtractFixed(pos, MYSQL_TYPE_TIME, &mt))
 		return false;
@@ -265,7 +265,7 @@ void Extractor::reset()
 
 bool Extractor::realExtractFixed(std::size_t pos, enum_field_types type, void* buffer, bool isUnsigned)
 {
-	MYSQL_BIND bind = {nullptr};
+	MYSQL_BIND bind = {};
 	my_bool isNull = 0;
 
 	bind.is_null     = &isNull;

--- a/Data/ODBC/src/Binder.cpp
+++ b/Data/ODBC/src/Binder.cpp
@@ -19,6 +19,7 @@
 #include "Poco/Data/ODBC/ODBCException.h"
 #include "Poco/DateTime.h"
 #include "Poco/Exception.h"
+#include <algorithm>
 #include <sql.h>
 
 
@@ -649,7 +650,7 @@ void Binder::getColumnOrParameterSize(std::size_t pos, SQLINTEGER& size)
 		paramSize = getParamSizeDirect(pos, size);
 
 	if (colSize > 0 && paramSize > 0)
-		size = colSize < paramSize ? static_cast<SQLINTEGER>(colSize) : static_cast<SQLINTEGER>(paramSize);
+		size = static_cast<SQLINTEGER>(std::min(colSize, paramSize));
 	else if (colSize > 0)
 		size = static_cast<SQLINTEGER>(colSize);
 	else if (paramSize > 0)

--- a/Data/ODBC/src/Unicode_UNIXODBC.cpp
+++ b/Data/ODBC/src/Unicode_UNIXODBC.cpp
@@ -20,6 +20,7 @@
 #include "Poco/UTF16Encoding.h"
 #include "Poco/Buffer.h"
 #include "Poco/Exception.h"
+#include <algorithm>
 #include <iostream>
 
 
@@ -62,7 +63,7 @@ void makeUTF8(Poco::Buffer<SQLWCHAR>& buffer, SQLINTEGER length, SQLPOINTER pTar
 		throw DataFormatException("Error converting UTF-16 to UTF-8");
 
 	std::memset(pTarget, 0, targetLength);
-	std::strncpy((char*) pTarget, result.c_str(), result.size() < targetLength ? result.size() : targetLength);
+	std::strncpy((char*) pTarget, result.c_str(), std::min(result.size(), static_cast<std::size_t>(targetLength)));
 }
 
 

--- a/Data/PostgreSQL/src/StatementExecutor.cpp
+++ b/Data/PostgreSQL/src/StatementExecutor.cpp
@@ -43,7 +43,7 @@ namespace
 		std::set<std::string> placeholderSet;
 
 		Poco::RegularExpression placeholderRE("[$][0-9]+");
-		Poco::RegularExpression::Match match = { 0 , 0 }; // Match is a struct, not a class :-(
+		Poco::RegularExpression::Match match = {}; // Match is a struct, not a class :-(
 
 		std::size_t startingPosition = 0;
 		while (match.offset != std::string::npos)

--- a/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
+++ b/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
@@ -98,7 +98,7 @@ public:
 
 		char_traits::move(_pReadBuffer + (4 - putback), this->gptr() - putback, putback);
 
-		int n = readFromDevice(_pReadBuffer + 4, _bufsize - 4);
+		std::streamsize n = readFromDevice(_pReadBuffer + 4, _bufsize - 4);
 		if (n <= 0) return char_traits::eof();
 
 		this->setg(_pReadBuffer + (4 - putback), _pReadBuffer + 4, _pReadBuffer + 4 + n);
@@ -150,22 +150,22 @@ protected:
 	}
 
 private:
-	virtual int readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
+	virtual std::streamsize readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	virtual int writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
+	virtual std::streamsize writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	int flushBuffer()
+	std::streamsize flushBuffer()
 	{
-		int n = int(this->pptr() - this->pbase());
+		std::streamsize n = this->pptr() - this->pbase();
 		if (writeToDevice(this->pbase(), n) == n)
 		{
-			this->pbump(-n);
+			this->pbump(static_cast<int>(-n));
 			return n;
 		}
 		return -1;

--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -104,7 +104,7 @@ public:
 
 		char_traits::move(_pBuffer + (4 - putback), this->gptr() - putback, putback);
 
-		int n = readFromDevice(_pBuffer + 4, _bufsize - 4);
+		std::streamsize n = readFromDevice(_pBuffer + 4, _bufsize - 4);
 		if (n <= 0) return char_traits::eof();
 
 		this->setg(_pBuffer + (4 - putback), _pBuffer + 4, _pBuffer + 4 + n);
@@ -134,22 +134,22 @@ protected:
 	}
 
 private:
-	virtual int readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
+	virtual std::streamsize readFromDevice(char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	virtual int writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
+	virtual std::streamsize writeToDevice(const char_type* /*buffer*/, std::streamsize /*length*/)
 	{
 		return 0;
 	}
 
-	int flushBuffer()
+	std::streamsize flushBuffer()
 	{
-		int n = int(this->pptr() - this->pbase());
+		std::streamsize n = this->pptr() - this->pbase();
 		if (writeToDevice(this->pbase(), n) == n)
 		{
-			this->pbump(-n);
+			this->pbump(static_cast<int>(-n));
 			return n;
 		}
 		return -1;

--- a/Foundation/include/Poco/DeflatingStream.h
+++ b/Foundation/include/Poco/DeflatingStream.h
@@ -86,8 +86,8 @@ public:
 		/// Must be called when deflating to an output stream.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 	int sync() override;
 
 private:

--- a/Foundation/include/Poco/DigestStream.h
+++ b/Foundation/include/Poco/DigestStream.h
@@ -37,8 +37,8 @@ public:
 	DigestBuf(DigestEngine& eng, std::istream& istr);
 	DigestBuf(DigestEngine& eng, std::ostream& ostr);
 	~DigestBuf() override;
-	int readFromDevice(char *buffer, std::streamsize length) override;
-	int writeToDevice(const char *buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char *buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char *buffer, std::streamsize length) override;
 	void close();
 
 private:

--- a/Foundation/include/Poco/FIFOBufferStream.h
+++ b/Foundation/include/Poco/FIFOBufferStream.h
@@ -56,8 +56,8 @@ public:
 		/// Returns the underlying FIFO buffer reference.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 
 private:
 	enum

--- a/Foundation/include/Poco/FileStream_POSIX.h
+++ b/Foundation/include/Poco/FileStream_POSIX.h
@@ -76,8 +76,8 @@ protected:
 		BUFFER_SIZE = 4096
 	};
 
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 
 private:
 	std::string _path;

--- a/Foundation/include/Poco/FileStream_WIN32.h
+++ b/Foundation/include/Poco/FileStream_WIN32.h
@@ -74,8 +74,8 @@ protected:
 		BUFFER_SIZE = 4096
 	};
 
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 
 private:
 	std::string _path;

--- a/Foundation/include/Poco/InflatingStream.h
+++ b/Foundation/include/Poco/InflatingStream.h
@@ -78,8 +78,8 @@ public:
 		/// Resets the stream buffer.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 	int sync() override;
 
 private:

--- a/Foundation/include/Poco/PipeStream.h
+++ b/Foundation/include/Poco/PipeStream.h
@@ -44,8 +44,8 @@ public:
 		/// Closes the pipe.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 
 private:
 	enum

--- a/Foundation/include/Poco/RandomStream.h
+++ b/Foundation/include/Poco/RandomStream.h
@@ -37,7 +37,7 @@ class Foundation_API RandomBuf: public BufferedStreamBuf
 public:
 	RandomBuf();
 	~RandomBuf() override;
-	int readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
 };
 
 

--- a/Foundation/include/Poco/UUID.h
+++ b/Foundation/include/Poco/UUID.h
@@ -138,7 +138,7 @@ public:
 		/// Returns the namespace identifier for the X500 namespace.
 
 protected:
-	UUID(UInt32 timeLow, UInt32 timeMid, UInt32 timeHiAndVersion, UInt16 clockSeq, UInt8 node[]);
+	UUID(UInt32 timeLow, UInt16 timeMid, UInt16 timeHiAndVersion, UInt16 clockSeq, UInt8 node[]);
 	UUID(const char* bytes, Version version);
 	int compare(const UUID& uuid) const;
 	static void appendHex(std::string& str, UInt8 n);

--- a/Foundation/src/DateTime.cpp
+++ b/Foundation/src/DateTime.cpp
@@ -35,12 +35,14 @@ DateTime::DateTime()
 
 
 DateTime::DateTime(const tm& tmStruct):
-	_year(tmStruct.tm_year + 1900),
-	_month(tmStruct.tm_mon + 1),
-	_day(tmStruct.tm_mday),
-	_hour(tmStruct.tm_hour),
-	_minute(tmStruct.tm_min),
-	_second(tmStruct.tm_sec),
+	// Note: Member variables are short to minimize memory footprint.
+	// All valid DateTime values fit within short range; inputs are validated by checkValid().
+	_year(static_cast<short>(tmStruct.tm_year + 1900)),
+	_month(static_cast<short>(tmStruct.tm_mon + 1)),
+	_day(static_cast<short>(tmStruct.tm_mday)),
+	_hour(static_cast<short>(tmStruct.tm_hour)),
+	_minute(static_cast<short>(tmStruct.tm_min)),
+	_second(static_cast<short>(tmStruct.tm_sec)),
 	_millisecond(0),
 	_microsecond(0)
 {
@@ -60,14 +62,14 @@ DateTime::DateTime(const Timestamp& timestamp):
 
 
 DateTime::DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond):
-	_year(year),
-	_month(month),
-	_day(day),
-	_hour(hour),
-	_minute(minute),
-	_second(second),
-	_millisecond(millisecond),
-	_microsecond(microsecond)
+	_year(static_cast<short>(year)),
+	_month(static_cast<short>(month)),
+	_day(static_cast<short>(day)),
+	_hour(static_cast<short>(hour)),
+	_minute(static_cast<short>(minute)),
+	_second(static_cast<short>(second)),
+	_millisecond(static_cast<short>(millisecond)),
+	_microsecond(static_cast<short>(microsecond))
 {
 	checkValid();
 	_utcTime = toUtcTime(toJulianDay(year, month, day)) +
@@ -152,14 +154,14 @@ DateTime& DateTime::operator = (double julianDay)
 DateTime& DateTime::assign(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond)
 {
 	_utcTime     = toUtcTime(toJulianDay(year, month, day)) + 10*(hour*Timespan::HOURS + minute*Timespan::MINUTES + second*Timespan::SECONDS + millisecond*Timespan::MILLISECONDS + microsecond);
-	_year        = year;
-	_month       = month;
-	_day         = day;
-	_hour        = hour;
-	_minute      = minute;
-	_second      = second;
-	_millisecond = millisecond;
-	_microsecond = microsecond;
+	_year        = static_cast<short>(year);
+	_month       = static_cast<short>(month);
+	_day         = static_cast<short>(day);
+	_hour        = static_cast<short>(hour);
+	_minute      = static_cast<short>(minute);
+	_second      = static_cast<short>(second);
+	_millisecond = static_cast<short>(millisecond);
+	_microsecond = static_cast<short>(microsecond);
 	checkValid();
 
 	return *this;
@@ -373,7 +375,7 @@ void DateTime::normalize()
 
 	if (_day > daysOfMonth(_year, _month))
 	{
-		_day -= daysOfMonth(_year, _month);
+		_day = static_cast<short>(_day - daysOfMonth(_year, _month));
 		if (++_month > 12)
 		{
 			++_year;
@@ -443,7 +445,7 @@ void DateTime::computeDaytime()
 				_month = 12;
 				_year--;
 			}
-			_day = daysOfMonth(_year, _month);
+			_day = static_cast<short>(daysOfMonth(_year, _month));
 		}
 	}
 	else if (hour == 0 && _hour == 23)
@@ -460,11 +462,11 @@ void DateTime::computeDaytime()
 			_day = 1;
 		}
 	}
-	_hour        = hour;
-	_minute      = span.minutes();
-	_second      = span.seconds();
-	_millisecond = span.milliseconds();
-	_microsecond = span.microseconds();
+	_hour        = static_cast<short>(hour);
+	_minute      = static_cast<short>(span.minutes());
+	_second      = static_cast<short>(span.seconds());
+	_millisecond = static_cast<short>(span.milliseconds());
+	_microsecond = static_cast<short>(span.microseconds());
 }
 
 

--- a/Foundation/src/DeflatingStream.cpp
+++ b/Foundation/src/DeflatingStream.cpp
@@ -180,7 +180,7 @@ int DeflatingStreamBuf::sync()
 }
 
 
-int DeflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize DeflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (!_pIstr) return 0;
 	if (_pZstr->avail_in == 0 && !_eof)
@@ -211,12 +211,12 @@ int DeflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 		if (_eof && rc == Z_STREAM_END)
 		{
 			_pIstr = nullptr;
-			return static_cast<int>(length) - _pZstr->avail_out;
+			return length - _pZstr->avail_out;
 		}
 		if (rc != Z_OK) throw IOException(zError(rc));
 		if (_pZstr->avail_out == 0)
 		{
-			return static_cast<int>(length);
+			return length;
 		}
 		if (_pZstr->avail_in == 0)
 		{
@@ -242,7 +242,7 @@ int DeflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 }
 
 
-int DeflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize DeflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	if (length == 0 || !_pOstr) return 0;
 
@@ -270,7 +270,7 @@ int DeflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length
 			break;
 		}
 	}
-	return static_cast<int>(length);
+	return length;
 }
 
 

--- a/Foundation/src/DigestStream.cpp
+++ b/Foundation/src/DigestStream.cpp
@@ -53,24 +53,24 @@ DigestBuf::~DigestBuf()
 }
 
 
-int DigestBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize DigestBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (_pIstr && _pIstr->good())
 	{
 		_pIstr->read(buffer, length);
 		std::streamsize n = _pIstr->gcount();
 		if (n > 0) _eng.update(buffer, static_cast<unsigned>(n));
-		return static_cast<int>(n);
+		return n;
 	}
 	return -1;
 }
 
 
-int DigestBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize DigestBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	_eng.update(buffer, (unsigned) length);
 	if (_pOstr) _pOstr->write(buffer, length);
-	return static_cast<int>(length);
+	return length;
 }
 
 

--- a/Foundation/src/FIFOBufferStream.cpp
+++ b/Foundation/src/FIFOBufferStream.cpp
@@ -70,17 +70,17 @@ FIFOBufferStreamBuf::~FIFOBufferStreamBuf()
 }
 
 
-int FIFOBufferStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize FIFOBufferStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	poco_assert (length > 0);
-	return static_cast<int>(_fifoBuffer.read(buffer, static_cast<std::size_t>(length)));
+	return static_cast<std::streamsize>(_fifoBuffer.read(buffer, static_cast<std::size_t>(length)));
 }
 
 
-int FIFOBufferStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize FIFOBufferStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	poco_assert (length > 0);
-	return static_cast<int>(_fifoBuffer.write(buffer, static_cast<std::size_t>(length)));
+	return static_cast<std::streamsize>(_fifoBuffer.write(buffer, static_cast<std::size_t>(length)));
 }
 
 

--- a/Foundation/src/FileStream_POSIX.cpp
+++ b/Foundation/src/FileStream_POSIX.cpp
@@ -88,34 +88,34 @@ void FileStreamBuf::openHandle(NativeHandle fd, std::ios::openmode mode)
 }
 
 
-int FileStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize FileStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (_fd == -1) return -1;
 
 	if (getMode() & std::ios::out)
 		sync();
 
-	int n = ::read(_fd, buffer, length);
+	auto n = ::read(_fd, buffer, length);
 	if (n == -1)
 		File::handleLastError(_path);
 	_pos += n;
-	return n;
+	return static_cast<std::streamsize>(n);
 }
 
 
-int FileStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize FileStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	if (_fd == -1) return -1;
 
 #if defined(POCO_VXWORKS)
-	int n = ::write(_fd, const_cast<char*>(buffer), length);
+	auto n = ::write(_fd, const_cast<char*>(buffer), length);
 #else
-	int n = ::write(_fd, buffer, length);
+	auto n = ::write(_fd, buffer, length);
 #endif
 	if (n == -1)
 		File::handleLastError(_path);
 	_pos += n;
-	return n;
+	return static_cast<std::streamsize>(n);
 }
 
 

--- a/Foundation/src/FileStream_WIN32.cpp
+++ b/Foundation/src/FileStream_WIN32.cpp
@@ -89,7 +89,7 @@ void FileStreamBuf::openHandle(NativeHandle handle, std::ios::openmode mode)
 }
 
 
-int FileStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize FileStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (INVALID_HANDLE_VALUE == _handle || !(getMode() & std::ios::in))
 		return -1;
@@ -111,11 +111,11 @@ int FileStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 
 	_pos += bytesRead;
 
-	return static_cast<int>(bytesRead);
+	return static_cast<std::streamsize>(bytesRead);
 }
 
 
-int FileStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize FileStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	if (INVALID_HANDLE_VALUE == _handle || !(getMode() & std::ios::out))
 		return -1;
@@ -137,7 +137,7 @@ int FileStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 
 	_pos += bytesWritten;
 
-	return static_cast<int>(bytesWritten);
+	return static_cast<std::streamsize>(bytesWritten);
 }
 
 

--- a/Foundation/src/InflatingStream.cpp
+++ b/Foundation/src/InflatingStream.cpp
@@ -140,7 +140,7 @@ void InflatingStreamBuf::reset()
 }
 
 
-int InflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize InflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (_eof || !_pIstr) return 0;
 
@@ -173,11 +173,11 @@ int InflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 		if (rc == Z_STREAM_END)
 		{
 			_eof = true;
-			return static_cast<int>(length) - _pZstr->avail_out;
+			return length - _pZstr->avail_out;
 		}
 		if (rc != Z_OK) throw IOException(zError(rc));
 		if (_pZstr->avail_out == 0)
-			return static_cast<int>(length);
+			return length;
 		if (_pZstr->avail_in == 0)
 		{
 			int n = 0;
@@ -191,13 +191,13 @@ int InflatingStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 				_pZstr->next_in  = (unsigned char*) _buffer;
 				_pZstr->avail_in = n;
 			}
-			else return static_cast<int>(length) - _pZstr->avail_out;
+			else return length - _pZstr->avail_out;
 		}
 	}
 }
 
 
-int InflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize InflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	if (length == 0 || !_pOstr) return 0;
 
@@ -231,7 +231,7 @@ int InflatingStreamBuf::writeToDevice(const char* buffer, std::streamsize length
 			break;
 		}
 	}
-	return static_cast<int>(length);
+	return length;
 }
 
 

--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -245,7 +245,7 @@ void Logger::formatDump(std::string& message, const void* buffer, std::size_t le
 	message.reserve(message.size() + length*6);
 	if (!message.empty()) message.append("\n");
 	unsigned char* base = (unsigned char*) buffer;
-	int addr = 0;
+	std::size_t addr = 0;
 	while (addr < length)
 	{
 		if (addr > 0) message.append("\n");

--- a/Foundation/src/Path.cpp
+++ b/Foundation/src/Path.cpp
@@ -454,9 +454,9 @@ Path& Path::setDevice(const std::string& device)
 
 const std::string& Path::directory(int n) const
 {
-	poco_assert (0 <= n && n <= _dirs.size());
+	poco_assert (0 <= n && static_cast<std::size_t>(n) <= _dirs.size());
 
-	if (n < _dirs.size())
+	if (static_cast<std::size_t>(n) < _dirs.size())
 		return _dirs[n];
 	else
 		return _name;
@@ -465,9 +465,9 @@ const std::string& Path::directory(int n) const
 
 const std::string& Path::operator [] (int n) const
 {
-	poco_assert (0 <= n && n <= _dirs.size());
+	poco_assert (0 <= n && static_cast<std::size_t>(n) <= _dirs.size());
 
-	if (n < _dirs.size())
+	if (static_cast<std::size_t>(n) < _dirs.size())
 		return _dirs[n];
 	else
 		return _name;
@@ -929,7 +929,7 @@ void Path::parseVMS(const std::string& path)
 							if (!_absolute) throw PathSyntaxException(path);
 							++it;
 							if (it != end && *it == '.') throw PathSyntaxException(path);
-							int d = int(_dirs.size());
+							auto d = _dirs.size();
 							while (it != end && *it != ']')
 							{
 								name.clear();

--- a/Foundation/src/PipeStream.cpp
+++ b/Foundation/src/PipeStream.cpp
@@ -35,15 +35,15 @@ PipeStreamBuf::~PipeStreamBuf()
 }
 
 
-int PipeStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize PipeStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	return _pipe.readBytes(buffer, (int) length);
+	return _pipe.readBytes(buffer, static_cast<int>(length));
 }
 
 
-int PipeStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize PipeStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
-	return _pipe.writeBytes(buffer, (int) length);
+	return _pipe.writeBytes(buffer, static_cast<int>(length));
 }
 
 

--- a/Foundation/src/RandomStream.cpp
+++ b/Foundation/src/RandomStream.cpp
@@ -38,16 +38,16 @@ RandomBuf::~RandomBuf()
 }
 
 
-int RandomBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize RandomBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	int n = 0;
+	std::streamsize n = 0;
 
 #if defined(POCO_OS_FAMILY_WINDOWS)
 	HCRYPTPROV hProvider = 0;
 	CryptAcquireContext(&hProvider, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
 	CryptGenRandom(hProvider, (DWORD) length, (BYTE*) buffer);
 	CryptReleaseContext(hProvider, 0);
-	n = static_cast<int>(length);
+	n = length;
 #else
 	#if defined(POCO_OS_FAMILY_UNIX)
 	int fd = open("/dev/urandom", O_RDONLY, 0);

--- a/Foundation/src/StreamConverter.cpp
+++ b/Foundation/src/StreamConverter.cpp
@@ -111,10 +111,10 @@ int StreamConverterBuf::writeToDevice(char c)
 				++_errors;
 				return -1;
 			}
-			int n = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
-			if (n == 0) n = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
-			poco_assert_dbg (n <= sizeof(_buffer));
-			_pOstr->write((char*) _buffer, n);
+			int written = _outEncoding.convert(uc, _buffer, sizeof(_buffer));
+			if (written == 0) written = _outEncoding.convert(_defaultChar, _buffer, sizeof(_buffer));
+			poco_assert_dbg (written <= sizeof(_buffer));
+			_pOstr->write((char*) _buffer, written);
 			_sequenceLength = 0;
 			_pos = 0;
 		}

--- a/Foundation/src/ThreadPool.cpp
+++ b/Foundation/src/ThreadPool.cpp
@@ -385,7 +385,7 @@ void ThreadPool::collect()
 void ThreadPool::housekeep()
 {
 	_age = 0;
-	if (_threads.size() <= _minCapacity)
+	if (_threads.size() <= static_cast<std::size_t>(_minCapacity))
 		return;
 
 	ThreadVec idleThreads;
@@ -438,7 +438,7 @@ PooledThread* ThreadPool::getThread()
 	}
 	if (!pThread)
 	{
-		if (_threads.size() < _maxCapacity)
+		if (_threads.size() < static_cast<std::size_t>(_maxCapacity))
 		{
 			pThread = createThread();
 			try

--- a/Foundation/src/Timezone_WIN32.cpp
+++ b/Foundation/src/Timezone_WIN32.cpp
@@ -25,7 +25,7 @@ namespace Poco {
 int Timezone::utcOffset()
 {
 	TIME_ZONE_INFORMATION tzInfo;
-	DWORD dstFlag = GetTimeZoneInformation(&tzInfo);
+	(void) GetTimeZoneInformation(&tzInfo);
 	return -tzInfo.Bias*60;
 }
 
@@ -75,7 +75,7 @@ std::string Timezone::standardName()
 {
 	std::string result;
 	TIME_ZONE_INFORMATION tzInfo;
-	DWORD dstFlag = GetTimeZoneInformation(&tzInfo);
+	(void) GetTimeZoneInformation(&tzInfo);
 	WCHAR* ptr = tzInfo.StandardName;
 	UnicodeConverter::toUTF8(ptr, result);
 	return result;
@@ -86,7 +86,7 @@ std::string Timezone::dstName()
 {
 	std::string result;
 	TIME_ZONE_INFORMATION tzInfo;
-	DWORD dstFlag = GetTimeZoneInformation(&tzInfo);
+	(void) GetTimeZoneInformation(&tzInfo);
 	WCHAR* ptr = tzInfo.DaylightName;
 	UnicodeConverter::toUTF8(ptr, result);
 	return result;

--- a/Foundation/src/UUID.cpp
+++ b/Foundation/src/UUID.cpp
@@ -55,7 +55,7 @@ UUID::UUID(const char* uuid)
 }
 
 
-UUID::UUID(UInt32 timeLow, UInt32 timeMid, UInt32 timeHiAndVersion, UInt16 clockSeq, UInt8 node[]):
+UUID::UUID(UInt32 timeLow, UInt16 timeMid, UInt16 timeHiAndVersion, UInt16 clockSeq, UInt8 node[]):
 	_timeLow(timeLow),
 	_timeMid(timeMid),
 	_timeHiAndVersion(timeHiAndVersion),

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -271,7 +271,7 @@ private:
 	}
 
 	template <typename C>
-	void doStringify(const C& container, std::ostream& out, unsigned int indent, unsigned int step) const
+	void doStringify(const C& container, std::ostream& out, unsigned int indent, int step) const
 	{
 		int options = Poco::JSON_WRAP_STRINGS;
 		options |= _escapeUnicode ? Poco::JSON_ESCAPE_UNICODE : 0;
@@ -290,14 +290,14 @@ private:
 			Stringifier::stringify(getKey(it), out, indent, step, options);
 			out << ((indent > 0) ? ": " : ":");
 
-			Stringifier::stringify(getValue(it), out, indent + step, step, options);
+			Stringifier::stringify(getValue(it), out, indent + static_cast<unsigned int>(step), step, options);
 
 			if (++it != container.end()) out << ',';
 
 			if (step > 0) out << std::endl;
 		}
 
-		if (indent >= step) indent -= step;
+		if (step > 0 && indent >= static_cast<unsigned int>(step)) indent -= static_cast<unsigned int>(step);
 
 		for (unsigned int i = 0; i < indent; i++) out << ' ';
 

--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -161,7 +161,7 @@ void Array::stringify(std::ostream& out, unsigned int indent, int step) const
 	options |= _escapeUnicode ? Poco::JSON_ESCAPE_UNICODE : 0;
 	options |= _lowercaseHex ? Poco::JSON_LOWERCASE_HEX : 0;
 
-	if (step == -1) step = indent;
+	if (step == -1) step = static_cast<int>(indent);
 
 	out << "[";
 
@@ -169,9 +169,9 @@ void Array::stringify(std::ostream& out, unsigned int indent, int step) const
 
 	for (auto it = _values.begin(); it != _values.end();)
 	{
-		for (int i = 0; i < indent; i++) out << ' ';
+		for (unsigned int i = 0; i < indent; i++) out << ' ';
 
-		Stringifier::stringify(*it, out, indent + step, step, options);
+		Stringifier::stringify(*it, out, indent + static_cast<unsigned int>(step), step, options);
 
 		if (++it != _values.end())
 		{
@@ -182,9 +182,9 @@ void Array::stringify(std::ostream& out, unsigned int indent, int step) const
 
 	if (step > 0) out << '\n';
 
-	if (indent >= step) indent -= step;
+	if (step > 0 && indent >= static_cast<unsigned int>(step)) indent -= static_cast<unsigned int>(step);
 
-	for (int i = 0; i < indent; i++) out << ' ';
+	for (unsigned int i = 0; i < indent; i++) out << ' ';
 
 	out << "]";
 }

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -186,7 +186,7 @@ Object::NameList Object::getNames() const
 
 void Object::stringify(std::ostream& out, unsigned int indent, int step) const
 {
-	if (step < 0) step = indent;
+	if (step < 0) step = static_cast<int>(indent);
 
 	if (!_preserveInsOrder)
 		doStringify(_values, out, indent, step);

--- a/JSON/src/Stringifier.cpp
+++ b/JSON/src/Stringifier.cpp
@@ -29,7 +29,7 @@ void Stringifier::stringify(const Var& any, std::ostream& out, unsigned int inde
 	bool escapeUnicode = ((options & Poco::JSON_ESCAPE_UNICODE) != 0);
 	bool lowercaseHex = ((options & Poco::JSON_LOWERCASE_HEX) != 0);
 
-	if (step == -1) step = indent;
+	if (step == -1) step = static_cast<int>(indent);
 
 	if (any.type() == typeid(Object))
 	{

--- a/JSON/src/Template.cpp
+++ b/JSON/src/Template.cpp
@@ -225,7 +225,7 @@ public:
 
 	void render(const Var& data, std::ostream& out) const override
 	{
-		int count = 0;
+		std::size_t count = 0;
 		for (auto it = _queries.begin(); it != _queries.end(); ++it, ++count)
 		{
 			if ((*it)->apply(data) && _parts.size() > count)
@@ -260,7 +260,7 @@ public:
 			Array::Ptr array = query.findArray(_query);
 			if (!array.isNull())
 			{
-				for (int i = 0; i < array->size(); i++)
+				for (std::size_t i = 0; i < array->size(); i++)
 				{
 					Var value = array->get(i);
 					dataObject->set(_name, value);

--- a/JSON/testsuite/src/JSONTest.cpp
+++ b/JSON/testsuite/src/JSONTest.cpp
@@ -1587,29 +1587,29 @@ void JSONTest::testStringify()
 	{
 		std::string jsonStr = R"json({"default":"\u0007\u0007"})json";
 		auto jsonStrUnescape = Poco::UTF8::unescape(jsonStr);
-		Poco::JSON::Parser parser;
-		Poco::Dynamic::Var result = parser.parse(jsonStr);
-		const auto & obj = result.extract<Poco::JSON::Object::Ptr>();
+		Poco::JSON::Parser parser1;
+		Poco::Dynamic::Var result1 = parser1.parse(jsonStr);
+		const auto & obj = result1.extract<Poco::JSON::Object::Ptr>();
 		auto default_val = obj->get("default");
-		Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
-		json->set("default", default_val);
-		std::stringstream ss;
-		json->stringify(ss);
-		assertEqual(ss.str(), jsonStr);
+		Poco::JSON::Object::Ptr json1 = new Poco::JSON::Object();
+		json1->set("default", default_val);
+		std::stringstream ss1;
+		json1->stringify(ss1);
+		assertEqual(ss1.str(), jsonStr);
 	}
 
 	{
 		std::string jsonStr = R"json({"default":"\u0050\u0050"})json";
 		auto jsonStrUnescape = Poco::UTF8::unescape(jsonStr);
-		Poco::JSON::Parser parser;
-		Poco::Dynamic::Var result = parser.parse(jsonStr);
-		const auto & obj = result.extract<Poco::JSON::Object::Ptr>();
+		Poco::JSON::Parser parser2;
+		Poco::Dynamic::Var result2 = parser2.parse(jsonStr);
+		const auto & obj = result2.extract<Poco::JSON::Object::Ptr>();
 		auto default_val = obj->get("default");
-		Poco::JSON::Object::Ptr json = new Poco::JSON::Object();
-		json->set("default", default_val);
-		std::stringstream ss;
-		json->stringify(ss);
-		assertEqual(ss.str(), jsonStrUnescape);
+		Poco::JSON::Object::Ptr json2 = new Poco::JSON::Object();
+		json2->set("default", default_val);
+		std::stringstream ss2;
+		json2->stringify(ss2);
+		assertEqual(ss2.str(), jsonStrUnescape);
 	}
 }
 

--- a/MongoDB/src/TopologyDescription.cpp
+++ b/MongoDB/src/TopologyDescription.cpp
@@ -336,7 +336,7 @@ void TopologyDescription::updateTopologyType()
 	int otherRsMembers = 0;  // Non-primary replica set members (secondaries, arbiters, etc.)
 	int mongosCount = 0;
 	int standaloneCount = 0;
-	int unknownCount = 0;
+	[[maybe_unused]] int unknownCount = 0;
 
 	for (const auto& [address, server] : _servers)
 	{

--- a/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
+++ b/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
@@ -148,7 +148,7 @@ void MongoDBTest::testOpCmdFind()
 			const auto& birthDateTimestamp = doc->get<Poco::Timestamp>("birthdate");
 			Poco::DateTime birthDate(birthDateTimestamp);
 			assertTrue (birthDate.year() == 1969 && birthDate.month() == 3 && birthDate.day() == 9);
-			const auto& lastupdatedTimestamp = doc->get<Poco::Timestamp>("lastupdated");
+			[[maybe_unused]] const auto& lastupdatedTimestamp = doc->get<Poco::Timestamp>("lastupdated");
 			assertTrue (doc->isType<NullValue>("unknown"));
 			bool active = doc->get<bool>("active");
 			assertEquals (false, active);

--- a/MongoDB/testsuite/src/ReplicaSetTest.cpp
+++ b/MongoDB/testsuite/src/ReplicaSetTest.cpp
@@ -1314,7 +1314,7 @@ void ReplicaSetTest::testReadPreferenceWithTags()
 	auto selected = pref.selectServers(topology);
 
 	// At least the tagged server should be selected
-	bool foundTaggedServer = false;
+	[[maybe_unused]] bool foundTaggedServer = false;
 	for (const auto& server : selected)
 	{
 		if (server.address().toString() == "localhost:27018"s)

--- a/Net/include/Poco/Net/HTTPChunkedStream.h
+++ b/Net/include/Poco/Net/HTTPChunkedStream.h
@@ -46,8 +46,8 @@ public:
 	void close();
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	HTTPSession&    _session;

--- a/Net/include/Poco/Net/HTTPFixedLengthStream.h
+++ b/Net/include/Poco/Net/HTTPFixedLengthStream.h
@@ -51,8 +51,8 @@ public:
 	~HTTPFixedLengthStreamBuf();
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	HTTPSession&    _session;

--- a/Net/include/Poco/Net/HTTPHeaderStream.h
+++ b/Net/include/Poco/Net/HTTPHeaderStream.h
@@ -44,8 +44,8 @@ public:
 	~HTTPHeaderStreamBuf();
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	HTTPSession& _session;

--- a/Net/include/Poco/Net/HTTPReactorServerSession.h
+++ b/Net/include/Poco/Net/HTTPReactorServerSession.h
@@ -51,10 +51,10 @@ private:
 
 private:
 	std::string&   _buf;
-	char*          _pcur;
-	char*          _pend;
-	int            _idx;
-	int            _complete;
+	char*          _pcur{nullptr};
+	char*          _pend{nullptr};
+	int            _idx{0};
+	int            _complete{0};
 	StreamSocket   _realsocket;
 };
 

--- a/Net/include/Poco/Net/HTTPStream.h
+++ b/Net/include/Poco/Net/HTTPStream.h
@@ -45,8 +45,8 @@ public:
 	void close();
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	HTTPSession& _session;

--- a/Net/include/Poco/Net/MultipartReader.h
+++ b/Net/include/Poco/Net/MultipartReader.h
@@ -40,7 +40,7 @@ public:
 	bool lastPart() const;
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
 
 private:
 	enum

--- a/Net/include/Poco/Net/SocketStream.h
+++ b/Net/include/Poco/Net/SocketStream.h
@@ -49,8 +49,8 @@ public:
 		/// Returns the internal SocketImpl.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length) override;
-	int writeToDevice(const char* buffer, std::streamsize length) override;
+	std::streamsize readFromDevice(char* buffer, std::streamsize length) override;
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length) override;
 
 private:
 	enum

--- a/Net/src/HTMLForm.cpp
+++ b/Net/src/HTMLForm.cpp
@@ -368,15 +368,15 @@ void HTMLForm::readMultipart(std::istream& istr, PartHandler& handler)
 		{
 			std::string name = params["name"];
 			std::string value;
-			std::istream& istr = reader.stream();
-			int ch = istr.get();
+			std::istream& partStream = reader.stream();
+			int ch = partStream.get();
 			while (ch != eof)
 			{
 				if (value.size() < _valueLengthLimit)
 					value += (char) ch;
 				else
 					throw HTMLFormException("Field value too long");
-				ch = istr.get();
+				ch = partStream.get();
 			}
 			add(name, value);
 		}

--- a/Net/src/HTTPChunkedStream.cpp
+++ b/Net/src/HTTPChunkedStream.cpp
@@ -68,7 +68,7 @@ void HTTPChunkedStreamBuf::close()
 }
 
 
-int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	static const int eof = std::char_traits<char>::eof();
 
@@ -94,7 +94,7 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 	if (_chunk > 0)
 	{
 		if (length > _chunk) length = _chunk;
-		int n = _session.read(buffer, length);
+		std::streamsize n = _session.read(buffer, length);
 		if (n > 0) _chunk -= n;
 		return n;
 	}
@@ -126,7 +126,7 @@ int HTTPChunkedStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 }
 
 
-int HTTPChunkedStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize HTTPChunkedStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	_chunkBuffer.clear();
 	NumberFormatter::appendHex(_chunkBuffer, length);
@@ -134,7 +134,7 @@ int HTTPChunkedStreamBuf::writeToDevice(const char* buffer, std::streamsize leng
 	_chunkBuffer.append(buffer, static_cast<std::string::size_type>(length));
 	_chunkBuffer.append("\r\n", 2);
 	_session.write(_chunkBuffer.data(), static_cast<std::streamsize>(_chunkBuffer.size()));
-	return static_cast<int>(length);
+	return length;
 }
 
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -304,7 +304,6 @@ std::ostream& HTTPClientSession::sendRequestImpl(const HTTPRequest& request)
 	clearException();
 	_responseReceived = false;
 	_expectResponseBody = request.getMethod() != HTTPRequest::HTTP_HEAD;
-	const std::string& method = request.getMethod();
 	if (request.getChunkedTransferEncoding())
 	{
 		HTTPHeaderOutputStream hos(*this);

--- a/Net/src/HTTPFixedLengthStream.cpp
+++ b/Net/src/HTTPFixedLengthStream.cpp
@@ -42,9 +42,9 @@ HTTPFixedLengthStreamBuf::~HTTPFixedLengthStreamBuf()
 }
 
 
-int HTTPFixedLengthStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize HTTPFixedLengthStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	int n = 0;
+	std::streamsize n = 0;
 	if (_count < _length)
 	{
 		if (_count + length > _length)
@@ -56,9 +56,9 @@ int HTTPFixedLengthStreamBuf::readFromDevice(char* buffer, std::streamsize lengt
 }
 
 
-int HTTPFixedLengthStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize HTTPFixedLengthStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
-	int n = 0;
+	std::streamsize n = 0;
 	if (_count < _length)
 	{
 		if (_count + length > _length)

--- a/Net/src/HTTPHeaderStream.cpp
+++ b/Net/src/HTTPHeaderStream.cpp
@@ -38,14 +38,14 @@ HTTPHeaderStreamBuf::~HTTPHeaderStreamBuf()
 }
 
 
-int HTTPHeaderStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize HTTPHeaderStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	// read line-by-line; an empty line denotes the end of the headers.
 	static const int eof = std::char_traits<char>::eof();
 
 	if (_end) return 0;
 
-	int n = 0;
+	std::streamsize n = 0;
 	int ch = _session.get();
 	while (ch != eof && ch != '\n' && n < length - 1)
 	{
@@ -61,7 +61,7 @@ int HTTPHeaderStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 }
 
 
-int HTTPHeaderStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize HTTPHeaderStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	return _session.write(buffer, length);
 }

--- a/Net/src/HTTPReactorServerSession.cpp
+++ b/Net/src/HTTPReactorServerSession.cpp
@@ -10,10 +10,9 @@ namespace Net {
 HTTPReactorServerSession::HTTPReactorServerSession(
 	const StreamSocket& socket, std::string& buf, HTTPServerParams::Ptr pParams)
 	: // do not deliver socket to HTTPSession
-	  HTTPSession(), _buf(buf), _realsocket(socket), _complete(0), _idx(0)
+	  HTTPSession(), _buf(buf), _realsocket(socket)
 {
 	_pcur = const_cast<char*>(_buf.c_str());
-	_idx = 0;
 }
 /// Creates the HTTPReactorServerSession.
 

--- a/Net/src/HTTPStream.cpp
+++ b/Net/src/HTTPStream.cpp
@@ -48,13 +48,13 @@ void HTTPStreamBuf::close()
 }
 
 
-int HTTPStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize HTTPStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	return _session.read(buffer, length);
 }
 
 
-int HTTPStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize HTTPStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 
 	return _session.write(buffer, length);

--- a/Net/src/MultipartReader.cpp
+++ b/Net/src/MultipartReader.cpp
@@ -44,14 +44,14 @@ MultipartStreamBuf::~MultipartStreamBuf()
 }
 
 
-int MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize MultipartStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	poco_assert (!_boundary.empty() && _boundary.length() < length - 6);
+	poco_assert (!_boundary.empty() && _boundary.length() < static_cast<std::size_t>(length - 6));
 
 	static const int eof = std::char_traits<char>::eof();
 	std::streambuf& buf = *_istr.rdbuf();
 
-	int n  = 0;
+	std::streamsize n  = 0;
 	int ch = buf.sbumpc();
 	if (ch == eof) return -1;
 	*buffer++ = (char) ch; ++n;

--- a/Net/src/PollSet.cpp
+++ b/Net/src/PollSet.cpp
@@ -221,7 +221,7 @@ public:
 				}
 #else
 				std::uint64_t val;
-				(void) read(_eventfd, &val, sizeof(val));
+				[[maybe_unused]] auto n = read(_eventfd, &val, sizeof(val));
 #endif
 			}
 		}
@@ -238,7 +238,7 @@ public:
 		// or 0 (meaning PollSet is being destroyed).
 		// Errors are ignored.
 		std::uint64_t val = 1;
-		(void) write(_eventfd, &val, sizeof(val));
+		[[maybe_unused]] auto n = write(_eventfd, &val, sizeof(val));
 #endif
 	}
 

--- a/Net/src/SocketStream.cpp
+++ b/Net/src/SocketStream.cpp
@@ -47,15 +47,15 @@ SocketStreamBuf::~SocketStreamBuf()
 }
 
 
-int SocketStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize SocketStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
-	return _pImpl->receiveBytes(buffer, (int) length);
+	return _pImpl->receiveBytes(buffer, static_cast<int>(length));
 }
 
 
-int SocketStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize SocketStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
-	return _pImpl->sendBytes(buffer, (int) length);
+	return _pImpl->sendBytes(buffer, static_cast<int>(length));
 }
 
 

--- a/Net/src/TCPReactorAcceptor.cpp
+++ b/Net/src/TCPReactorAcceptor.cpp
@@ -8,8 +8,10 @@ namespace Net {
 
 TCPReactorAcceptor::TCPReactorAcceptor(
 	Poco::Net::ServerSocket& socket, Poco::Net::SocketReactor& reactor, TCPServerParams::Ptr pParams)
-	: Poco::Net::SocketAcceptor<TCPReactorServerConnection>(socket, reactor), _pParams(pParams), _selfReactor(reactor),
-	  _useSelfReactor(pParams->getUseSelfReactor())
+	: Poco::Net::SocketAcceptor<TCPReactorServerConnection>(socket, reactor),
+	  _selfReactor(reactor),
+	  _useSelfReactor(pParams->getUseSelfReactor()),
+	  _pParams(pParams)
 {
 	int workerThreads = _useSelfReactor ? 0 : _pParams->getMaxThreads();
 	if (workerThreads > 0)

--- a/Net/src/TCPReactorServer.cpp
+++ b/Net/src/TCPReactorServer.cpp
@@ -9,8 +9,10 @@ namespace Net {
 
 
 TCPReactorServer::TCPReactorServer(int port, TCPServerParams::Ptr pParams)
-	: _threadPool("TCPR", pParams->getAcceptorNum()), _reactors(pParams->getAcceptorNum()), _port(port),
-	  _pParams(pParams)
+	: _threadPool("TCPR", pParams->getAcceptorNum()),
+	  _reactors(pParams->getAcceptorNum()),
+	  _pParams(pParams),
+	  _port(port)
 {
 	for (auto& reactor : _reactors)
 	{

--- a/Net/src/WebSocketImpl.cpp
+++ b/Net/src/WebSocketImpl.cpp
@@ -266,7 +266,7 @@ void WebSocketImpl::skipHeader(int headerLength)
 	if (headerLength > 0)
 	{
 		char header[MAX_HEADER_LENGTH];
-		int n = receiveNBytes(header, headerLength);
+		[[maybe_unused]] int n = receiveNBytes(header, headerLength);
 		poco_assert_dbg (n == headerLength);
 	}
 }

--- a/Net/testsuite/src/MailMessageTest.cpp
+++ b/Net/testsuite/src/MailMessageTest.cpp
@@ -22,10 +22,11 @@
 #include "Poco/FileStream.h"
 #include "Poco/String.h"
 #include "Poco/TemporaryFile.h"
-#include <sstream>
+#include <algorithm>
 #include <fstream>
-#include <vector>
 #include <iostream>
+#include <sstream>
+#include <vector>
 
 
 using Poco::Net::MailMessage;
@@ -727,7 +728,7 @@ void MailMessageTest::testReadWriteMultiPartStore()
 			std::string path = fps->path();
 			// for security reasons, the filesystem temporary
 			// filename is not the same as attachment name
-			std::size_t sz = (path.size() > filename.size()) ? filename.size() : path.size();
+			std::size_t sz = std::min(path.size(), filename.size());
 			assertTrue (0 != icompare(path, path.size() - sz, sz, path));
 
 			Poco::FileInputStream fis(path);

--- a/Redis/include/Poco/Redis/RedisStream.h
+++ b/Redis/include/Poco/Redis/RedisStream.h
@@ -43,8 +43,8 @@ public:
 		/// Reads a line from Redis (until \r\n is encountered).
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	enum

--- a/Redis/src/RedisStream.cpp
+++ b/Redis/src/RedisStream.cpp
@@ -39,13 +39,13 @@ RedisStreamBuf::~RedisStreamBuf()
 }
 
 
-int RedisStreamBuf::readFromDevice(char* buffer, std::streamsize len)
+std::streamsize RedisStreamBuf::readFromDevice(char* buffer, std::streamsize len)
 {
 	return _redis.receiveBytes(buffer, static_cast<int>(len));
 }
 
 
-int RedisStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize RedisStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	return _redis.sendBytes(buffer, static_cast<int>(length));
 }

--- a/XML/src/ParserEngine.cpp
+++ b/XML/src/ParserEngine.cpp
@@ -27,6 +27,7 @@
 #include "Poco/SAX/LocatorImpl.h"
 #include "Poco/SAX/SAXException.h"
 #include "Poco/URI.h"
+#include <algorithm>
 #include <cstring>
 
 
@@ -262,7 +263,7 @@ void ParserEngine::parse(const char* pBuffer, std::size_t size)
 	std::size_t processed = 0;
 	while (processed < size)
 	{
-		const int bufferSize = processed + PARSE_BUFFER_SIZE < size ? PARSE_BUFFER_SIZE : static_cast<int>(size - processed);
+		const int bufferSize = static_cast<int>(std::min(static_cast<std::size_t>(PARSE_BUFFER_SIZE), size - processed));
 		if (!XML_Parse(_parser, pBuffer + processed, bufferSize, 0))
 			handleError(XML_GetErrorCode(_parser));
 		processed += bufferSize;

--- a/Zip/include/Poco/Zip/AutoDetectStream.h
+++ b/Zip/include/Poco/Zip/AutoDetectStream.h
@@ -39,8 +39,8 @@ public:
 		/// Destroys the AutoDetectStream.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	enum

--- a/Zip/include/Poco/Zip/PartialStream.h
+++ b/Zip/include/Poco/Zip/PartialStream.h
@@ -33,12 +33,12 @@ class Zip_API PartialStreamBuf: public Poco::BufferedStreamBuf
 	/// A PartialStreamBuf is a class that limits one view on an inputstream to a selected view range
 {
 public:
-	PartialStreamBuf(std::istream& in, std::ios::pos_type start, std::ios::pos_type end, const std::string& prefix, const std::string& postfix, bool initStream);
+	PartialStreamBuf(std::istream& in, std::ios::pos_type start, std::ios::pos_type endPos, const std::string& prefix, const std::string& postfix, bool initStream);
 		/// Creates the PartialStream.
 		/// If initStream is true the status of the stream will be cleared on the first access, and the stream will be repositioned
 		/// to position start
 
-	PartialStreamBuf(std::ostream& out, std::size_t start, std::size_t end, bool initStream);
+	PartialStreamBuf(std::ostream& out, std::size_t start, std::size_t endPos, bool initStream);
 		/// Creates the PartialStream.
 		/// If initStream is true the status of the stream will be cleared on the first access.
 		/// start and end acts as offset values for the written content. A start value greater than zero,
@@ -57,9 +57,9 @@ public:
 	Poco::UInt64 bytesWritten() const;
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
 
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	enum
@@ -94,13 +94,13 @@ class Zip_API PartialIOS: public virtual std::ios
 	/// order of the stream buffer and base classes.
 {
 public:
-	PartialIOS(std::istream& istr, std::ios::pos_type start, std::ios::pos_type end, const std::string& prefix, const std::string& postfix, bool initStream);
+	PartialIOS(std::istream& istr, std::ios::pos_type start, std::ios::pos_type endPos, const std::string& prefix, const std::string& postfix, bool initStream);
 		/// Creates the basic stream and connects it
 		/// to the given input stream.
 		/// If initStream is true the status of the stream will be cleared on the first access, and the stream will be repositioned
 		/// to position start
 
-	PartialIOS(std::ostream& ostr, std::size_t start, std::size_t end, bool initStream);
+	PartialIOS(std::ostream& ostr, std::size_t start, std::size_t endPos, bool initStream);
 		/// Creates the basic stream and connects it
 		/// to the given output stream.
 		/// If initStream is true the status of the stream will be cleared on the first access.
@@ -127,7 +127,7 @@ class Zip_API PartialInputStream: public PartialIOS, public std::istream
 	/// to one or multiple output streams.
 {
 public:
-	PartialInputStream(std::istream& istr, std::ios::pos_type start, std::ios::pos_type end, bool initStream = true, const std::string& prefix = std::string(), const std::string& postfix = std::string());
+	PartialInputStream(std::istream& istr, std::ios::pos_type start, std::ios::pos_type endPos, bool initStream = true, const std::string& prefix = std::string(), const std::string& postfix = std::string());
 		/// Creates the PartialInputStream and connects it
 		/// to the given input stream. Bytes read are guaranteed to be in the range [start, end-1]
 		/// If initStream is true the status of the stream will be cleared on the first access, and the stream will be repositioned
@@ -143,7 +143,7 @@ class Zip_API PartialOutputStream: public PartialIOS, public std::ostream
 	/// to one or multiple output streams.
 {
 public:
-	PartialOutputStream(std::ostream& ostr, std::size_t start, std::size_t end, bool initStream = true);
+	PartialOutputStream(std::ostream& ostr, std::size_t start, std::size_t endPos, bool initStream = true);
 		/// Creates the PartialOutputStream and connects it
 		/// to the given output stream. Bytes written are guaranteed to be in the range [start, realEnd - end].
 		/// If initStream is true the status of the stream will be cleared on the first access.

--- a/Zip/include/Poco/Zip/ZipStream.h
+++ b/Zip/include/Poco/Zip/ZipStream.h
@@ -55,9 +55,9 @@ public:
 		/// Call this method once all bytes were read from the input stream to determine if the CRC is valid
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
 
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	enum

--- a/Zip/src/AutoDetectStream.cpp
+++ b/Zip/src/AutoDetectStream.cpp
@@ -45,7 +45,7 @@ AutoDetectStreamBuf::~AutoDetectStreamBuf()
 }
 
 
-int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	poco_assert_dbg(length >= 8);
 	if (_pIstr == nullptr || length == 0) return -1;
@@ -59,20 +59,20 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 
 	if (!_prefix.empty())
 	{
-		std::streamsize n = (_prefix.size() > length) ? length : static_cast<std::streamsize>(_prefix.size());
+		std::streamsize n = std::min(static_cast<std::streamsize>(_prefix.size()), length);
 		std::memcpy(buffer, _prefix.data(), n);
-		_prefix.erase(0, n);
-		return static_cast<int>(n);
+		_prefix.erase(0, static_cast<std::size_t>(n));
+		return n;
 	}
 
 	if (_eofDetected)
 	{
 		if (!_postfix.empty())
 		{
-			std::streamsize n = (_postfix.size() > length) ? length : static_cast<std::streamsize>(_postfix.size());
+			std::streamsize n = std::min(static_cast<std::streamsize>(_postfix.size()), length);
 			std::memcpy(buffer, _postfix.data(), n);
-			_postfix.erase(0, n);
-			return static_cast<int>(n);
+			_postfix.erase(0, static_cast<std::size_t>(n));
+			return n;
 		}
 		else return -1;
 	}
@@ -120,9 +120,9 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 						if (!_pIstr->good()) throw Poco::IOException("Failed to read data descriptor");
 
 						dataInfoSize = dataInfo.getFullHeaderSize();
-						if (dataInfo.getCompressedSize() == _length + offset)
+						if (dataInfo.getCompressedSize() == static_cast<Poco::UInt64>(_length + offset))
 						{
-							_pIstr->seekg(-static_cast<int>(dataInfoSize), std::ios::cur);
+							_pIstr->seekg(-static_cast<std::streamoff>(dataInfoSize), std::ios::cur);
 							if (!_pIstr->good()) throw Poco::IOException("Failed to seek on input stream");
 
 							_eofDetected = true;
@@ -130,12 +130,12 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 
 							if (offset == 0 && !_postfix.empty())
 							{
-								offset = (_postfix.size() > length) ? length : static_cast<std::streamsize>(_postfix.size());
-								std::memcpy(buffer, _postfix.data(), offset);
-								_postfix.erase(0, offset);
+								offset = std::min(static_cast<std::streamsize>(_postfix.size()), length);
+								std::memcpy(buffer, _postfix.data(), static_cast<std::size_t>(offset));
+								_postfix.erase(0, static_cast<std::size_t>(offset));
 							}
 
-							return static_cast<int>(offset);
+							return offset;
 						}
 					}
 					else
@@ -144,9 +144,9 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 						if (!_pIstr->good()) throw Poco::IOException("Failed to read data descriptor");
 
 						dataInfoSize = dataInfo.getFullHeaderSize();
-						if (dataInfo.getCompressedSize() == _length + offset)
+						if (dataInfo.getCompressedSize() == static_cast<Poco::UInt64>(_length + offset))
 						{
-							_pIstr->seekg(-static_cast<int>(dataInfoSize), std::ios::cur);
+							_pIstr->seekg(-static_cast<std::streamoff>(dataInfoSize), std::ios::cur);
 							if (!_pIstr->good()) throw Poco::IOException("Failed to seek on input stream");
 
 							_eofDetected = true;
@@ -154,16 +154,16 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 
 							if (offset == 0 && !_postfix.empty())
 							{
-								offset = (_postfix.size() > length) ? length : static_cast<std::streamsize>(_postfix.size());
-								std::memcpy(buffer, _postfix.data(), offset);
-								_postfix.erase(0, offset);
+								offset = std::min(static_cast<std::streamsize>(_postfix.size()), length);
+								std::memcpy(buffer, _postfix.data(), static_cast<std::size_t>(offset));
+								_postfix.erase(0, static_cast<std::size_t>(offset));
 							}
 
-							return static_cast<int>(offset);
+							return offset;
 						}
 					}
 
-					_pIstr->seekg(-static_cast<int>(dataInfoSize - 4), std::ios::cur);
+					_pIstr->seekg(-static_cast<std::streamoff>(dataInfoSize - 4), std::ios::cur);
 					if (!_pIstr->good()) throw Poco::IOException("Failed to seek on input stream");
 
 					buffer[offset++] = ZipDataInfo::HEADER[0];
@@ -177,7 +177,7 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 					buffer[offset++] = ZipDataInfo::HEADER[0];
 					buffer[offset++] = ZipDataInfo::HEADER[1];
 					buffer[offset++] = ZipDataInfo::HEADER[2];
-					buffer[offset++] = c;
+					buffer[offset++] = static_cast<char>(c);
 					_matchCnt = 0;
 				}
 			}
@@ -185,12 +185,12 @@ int AutoDetectStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 	}
 
 	_length += offset;
-	return static_cast<int>(offset);
+	return offset;
 
 }
 
 
-int AutoDetectStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize AutoDetectStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	return -1; // not supported
 }

--- a/Zip/src/ZipStream.cpp
+++ b/Zip/src/ZipStream.cpp
@@ -147,14 +147,14 @@ ZipStreamBuf::~ZipStreamBuf()
 }
 
 
-int ZipStreamBuf::readFromDevice(char* buffer, std::streamsize length)
+std::streamsize ZipStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 {
 	if (!_ptrBuf) return 0; // directory entry
 	_ptrBuf->read(buffer, length);
-	int cnt = static_cast<int>(_ptrBuf->gcount());
+	std::streamsize cnt = _ptrBuf->gcount();
 	if (cnt > 0)
 	{
-		_crc32.update(buffer, cnt);
+		_crc32.update(buffer, static_cast<unsigned int>(cnt));
 	}
 	else
 	{
@@ -181,7 +181,7 @@ int ZipStreamBuf::readFromDevice(char* buffer, std::streamsize length)
 }
 
 
-int ZipStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize ZipStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	if (!_ptrOBuf) return 0; // directory entry
 	if (length == 0)
@@ -189,7 +189,7 @@ int ZipStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 	_bytesWritten += length;
 	_ptrOBuf->write(buffer, length);
 	_crc32.update(buffer, static_cast<unsigned int>(length));
-	return static_cast<int>(length);
+	return length;
 }
 
 

--- a/Zip/src/ZipUtil.cpp
+++ b/Zip/src/ZipUtil.cpp
@@ -189,7 +189,7 @@ void ZipUtil::syncDataDescriptor(std::istream & in, bool force64)
 				ZipDataInfo64 nfo(in, true);
 				if (nfo.isValid())
 				{
-					if (end - start == nfo.getCompressedSize() + 4)
+					if (static_cast<Poco::UInt64>(end - start) == nfo.getCompressedSize() + 4)
 					{
 						in.seekg(-static_cast<int>(ZipDataInfo64::getFullHeaderSize()), std::ios::cur);
 						if (!in.good()) throw Poco::IOException("Failed to seek on input stream");

--- a/Zip/testsuite/src/ZipTest.cpp
+++ b/Zip/testsuite/src/ZipTest.cpp
@@ -54,16 +54,16 @@ void ZipTest::testSkipSingleFile()
 	ZipLocalFileHeader hdr(inp, false, skip);
 	assertTrue (ZipCommon::HS_FAT == hdr.getHostSystem());
 	int major = hdr.getMajorVersionNumber();
-	int POCO_UNUSED minor = hdr.getMinorVersionNumber();
+	[[maybe_unused]] int minor = hdr.getMinorVersionNumber();
 	assertTrue (major <= 2);
 	std::size_t hdrSize = hdr.getHeaderSize();
 	assertTrue (hdrSize > 30);
-	ZipCommon::CompressionMethod POCO_UNUSED cm = hdr.getCompressionMethod();
+	[[maybe_unused]] ZipCommon::CompressionMethod cm = hdr.getCompressionMethod();
 	assertTrue (!hdr.isEncrypted());
 	Poco::DateTime aDate = hdr.lastModifiedAt();
-	Poco::UInt64 POCO_UNUSED cS = hdr.getCompressedSize();
-	Poco::UInt64 POCO_UNUSED uS = hdr.getUncompressedSize();
-	const std::string& POCO_UNUSED fileName = hdr.getFileName();
+	[[maybe_unused]] Poco::UInt64 cS = hdr.getCompressedSize();
+	[[maybe_unused]] Poco::UInt64 uS = hdr.getUncompressedSize();
+	[[maybe_unused]] const std::string& fileName = hdr.getFileName();
 }
 
 


### PR DESCRIPTION
## Summary

This PR addresses compiler warnings reported in CI builds (GCC, Clang, MSVC) across multiple modules, improving code quality and C++ standards compliance.

**80 files changed** across Foundation, Net, Crypto, Data, JSON, MongoDB, Redis, XML, and Zip modules.

---

### 1. Stream Buffer Return Types
Changed `readFromDevice()` and `writeToDevice()` return types from `int` to `std::streamsize` to match the C++ standard library interface.

**Affected files:**
- `Foundation/include/Poco/BufferedStreamBuf.h`, `BufferedBidirectionalStreamBuf.h`
- `Foundation/include/Poco/DeflatingStream.h`, `InflatingStream.h`, `DigestStream.h`, `FIFOBufferStream.h`, `FileStream_*.h`, `PipeStream.h`, `RandomStream.h`
- `Foundation/src/DeflatingStream.cpp`, `InflatingStream.cpp`, `DigestStream.cpp`, `FIFOBufferStream.cpp`, `FileStream_*.cpp`, `PipeStream.cpp`, `RandomStream.cpp`, `StreamConverter.cpp`
- `Net/include/Poco/Net/HTTPChunkedStream.h`, `HTTPFixedLengthStream.h`, `HTTPHeaderStream.h`, `HTTPStream.h`, `MultipartReader.h`, `SocketStream.h`, `HTTPReactorServerSession.h`
- `Net/src/HTTPChunkedStream.cpp`, `HTTPFixedLengthStream.cpp`, `HTTPHeaderStream.cpp`, `HTTPStream.cpp`, `MultipartReader.cpp`, `SocketStream.cpp`, `HTTPReactorServerSession.cpp`
- `Crypto/include/Poco/Crypto/CryptoStream.h`, `Crypto/src/CryptoStream.cpp`
- `Redis/include/Poco/Redis/RedisStream.h`, `Redis/src/RedisStream.cpp`
- `Zip/include/Poco/Zip/AutoDetectStream.h`, `PartialStream.h`, `ZipStream.h`
- `Zip/src/AutoDetectStream.cpp`, `PartialStream.cpp`, `ZipStream.cpp`

---

### 2. Signed/Unsigned Comparison Warnings (C4244, C4245)
Added explicit `static_cast<>` to fix comparisons between signed and unsigned types.

| File | Change |
|------|--------|
| `Foundation/src/DateTime.cpp` | `static_cast<short>()` for int-to-short member initialization |
| `Foundation/src/Path.cpp` | `static_cast<std::size_t>()` for int-to-size_t comparisons |
| `Foundation/src/ThreadPool.cpp` | `static_cast<std::size_t>()` for capacity comparisons |
| `Foundation/src/Logger.cpp` | Changed `int addr` to `std::size_t addr` |
| `Crypto/src/CipherImpl.cpp` | `static_cast<int>()` and `static_cast<std::streamsize>()` |
| `Crypto/src/Envelope.cpp`, `EVPCipherImpl.cpp`, `RSACipherImpl.cpp` | Similar casts for size comparisons |
| `JSON/include/Poco/JSON/Object.h`, `Array.h`, `Stringifier.h` | Kept `unsigned int indent`, fixed internal loop variables and arithmetic with `static_cast<unsigned int>(step)` |
| `JSON/src/Object.cpp`, `Array.cpp`, `Stringifier.cpp` | Matching implementation changes |
| `Zip/src/ZipUtil.cpp` | Size comparison fix |

---

### 3. Constructor Member Initializer Order
Fixed member initializer list order to match declaration order (GCC `-Wreorder`).

- `Net/src/TCPReactorAcceptor.cpp`
- `Net/src/TCPReactorServer.cpp`

---

### 4. Unused Result Warnings
Added `[[maybe_unused]]` for system call return values.

- `Net/src/PollSet.cpp`: `read()` and `write()` on eventfd

---

### 5. Unused Variable Warnings (C4189)
Added `[[maybe_unused]]` attribute or `(void)` cast for intentionally unused variables.

| File | Variable |
|------|----------|
| `Net/src/WebSocketImpl.cpp` | `n` in debug assertion |
| `MongoDB/src/TopologyDescription.cpp` | `unknownCount` |
| `MongoDB/testsuite/src/MongoDBTestOpMsg.cpp` | `lastupdatedTimestamp` |
| `MongoDB/testsuite/src/ReplicaSetTest.cpp` | `foundTaggedServer` |
| `Foundation/src/Timezone_WIN32.cpp` | `dstFlag` from `GetTimeZoneInformation()` |
| `Zip/testsuite/src/ZipTest.cpp` | Multiple test variables (changed `POCO_UNUSED` to `[[maybe_unused]]`) |

---

### 6. Missing Field Initializers (C4351)
Changed `= {0}` and `= {nullptr}` to `= {}` for proper aggregate initialization.

- `Data/MySQL/src/Binder.cpp`: `MYSQL_TIME` and `MYSQL_BIND` structs
- `Data/MySQL/src/Extractor.cpp`: `MYSQL_TIME` and `MYSQL_BIND` structs
- `Data/PostgreSQL/src/StatementExecutor.cpp`: `RegularExpression::Match` struct

---

### 7. Parameter/Variable Shadowing (C4456, C4457, C4458)
Renamed variables to avoid shadowing.

| File | Change |
|------|--------|
| `Zip/include/Poco/Zip/PartialStream.h` | `end` → `endPos` (shadows `std::ios::end`) |
| `Zip/src/PartialStream.cpp` | `end` → `endPos` |
| `Net/src/HTMLForm.cpp` | `istr` → `partStream` (shadows function parameter) |
| `JSON/testsuite/src/JSONTest.cpp` | Inner scope vars renamed to `parser1/2`, `result1/2`, `json1/2`, `ss1/2` |

---

### 8. Other Fixes

| File | Change |
|------|--------|
| `Data/ODBC/src/Binder.cpp` | Cast fix |
| `Data/ODBC/src/Unicode_UNIXODBC.cpp` | Cast fix |
| `XML/src/ParserEngine.cpp` | Warning fix |
| `Net/src/HTTPClientSession.cpp` | Removed unused variable |
| `Net/testsuite/src/MailMessageTest.cpp` | Added `#include <algorithm>`, use `std::min()` |
| `Foundation/src/UUID.cpp`, `Foundation/include/Poco/UUID.h` | Type consistency |
| `Crypto/src/CipherKeyImpl.cpp`, `ECKeyImpl.cpp` | Size comparison fixes |

---

## Test plan

- [ ] CI builds pass on Linux (GCC/Clang)
- [ ] CI builds pass on Windows (MSVC)
- [ ] CI builds pass on macOS
- [ ] No new warnings introduced
- [ ] All existing tests pass