### PR TITLE
fix(Net): Dispatch ErrorNotification to socket-specific handler only

### DIFF
--- a/Net/include/Poco/Net/SocketReactor.h
+++ b/Net/include/Poco/Net/SocketReactor.h
@@ -334,7 +334,7 @@ inline bool SocketReactor::has(const Socket& socket) const
 
 inline void SocketReactor::onError(const Socket& socket, int code, const std::string& description)
 {
-	dispatch(new ErrorNotification(this, socket, code, description));
+	dispatch(socket, new ErrorNotification(this, socket, code, description));
 }
 
 


### PR DESCRIPTION
## Summary

When an exception occurs during socket event processing in `SocketReactor::run()`, `onError(socket, ...)` is called with the specific socket that caused the error. However, the error notification was being dispatched to ALL registered handlers instead of only the handler for that socket.

This fix changes `onError(const Socket& socket, ...)` to call `dispatch(socket, notification)` instead of `dispatch(notification)`, ensuring the error is routed only to the relevant socket's observer.

Closes #4976