### PR TITLE
enh(Crypto,NetSSL): Drop support for OpenSSL < 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if (WIN32 AND CMAKE_VERSION VERSION_LESS  "4.1.0")
 endif()
 
 if (NOT POCO_MINIMAL_BUILD)
-	find_package(OpenSSL)
+	find_package(OpenSSL 1.1.1)
 	find_package(MySQL)
 	find_package(PostgreSQL)
 	find_package(ODBC)
@@ -410,7 +410,7 @@ if(ENABLE_APACHECONNECTOR)
 endif()
 
 if(ENABLE_CRYPTO OR ENABLE_NETSSL OR ENABLE_JWT)
-	find_package(OpenSSL REQUIRED)
+	find_package(OpenSSL 1.1.1 REQUIRED)
 endif()
 
 if(ENABLE_DATA_MYSQL)

--- a/Crypto/include/Poco/Crypto/Crypto.h
+++ b/Crypto/include/Poco/Crypto/Crypto.h
@@ -45,8 +45,8 @@
 #endif
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
-#error "OpenSSL version too old. At least OpenSSL 1.0.0 is required."
+#if OPENSSL_VERSION_NUMBER < 0x10101000L
+#error "OpenSSL version too old. At least OpenSSL 1.1.1 is required."
 #endif
 
 

--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -65,8 +65,6 @@ public:
 	EVPPKey(const PKCS12Container& cert);
 		/// Constructs EVPPKey from the given container.
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-
 	EVPPKey(int type, int param);
 		/// Creates the EVPPKey.
 		/// Creates a new public/private keypair using the given parameters.
@@ -79,10 +77,6 @@ public:
 		/// Parameters:
 		///   - for EVP_PKEY_RSA: key length in bits
 		///   - for EVP_PKEY_EC: curve NID
-		///
-		/// This constructor is not available for OpenSSL version < 1.0.0
-
-#endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	explicit EVPPKey(const std::vector<unsigned char>* publicKey, const std::vector<unsigned char>* privateKey, unsigned long exponent, int type);

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -19,25 +19,12 @@
 
 
 #include "Poco/Crypto/Crypto.h"
-#include "Poco/Mutex.h"
 #include "Poco/AtomicCounter.h"
 #include <openssl/crypto.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/provider.h>
 #include <atomic>
 #endif
-#if defined(OPENSSL_FIPS) && OPENSSL_VERSION_NUMBER < 0x010001000L
-#include <openssl/fips.h>
-#endif
-
-
-extern "C"
-{
-	struct CRYPTO_dynlock_value
-	{
-		Poco::FastMutex _mutex;
-	};
-}
 
 
 namespace Poco {
@@ -72,27 +59,8 @@ public:
 	static bool haveLegacyProvider();
 		/// Returns true if the OpenSSL legacy provider is available, otherwise false.
 
-protected:
-	enum
-	{
-		SEEDSIZE = 256
-	};
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	// OpenSSL multithreading support
-	static void lock(int mode, int n, const char* file, int line);
-	static unsigned long id();
-	static struct CRYPTO_dynlock_value* dynlockCreate(const char* file, int line);
-	static void dynlock(int mode, struct CRYPTO_dynlock_value* lock, const char* file, int line);
-	static void dynlockDestroy(struct CRYPTO_dynlock_value* lock, const char* file, int line);
-#endif
-
 private:
 	static Poco::AtomicCounter _rc;
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	static Poco::FastMutex* _mutexes;
-#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	static OSSL_PROVIDER* _defaultProvider;

--- a/Crypto/src/CipherKeyImpl.cpp
+++ b/Crypto/src/CipherKeyImpl.cpp
@@ -134,7 +134,6 @@ CipherKeyImpl::Mode CipherKeyImpl::mode() const
 	case EVP_CIPH_OFB_MODE:
 		return MODE_OFB;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
 	case EVP_CIPH_CTR_MODE:
 		return MODE_CTR;
 
@@ -143,7 +142,6 @@ CipherKeyImpl::Mode CipherKeyImpl::mode() const
 
 	case EVP_CIPH_CCM_MODE:
 		return MODE_CCM;
-#endif
 	}
 	throw Poco::IllegalStateException("Unexpected value of EVP_CIPHER_mode()");
 }

--- a/Crypto/src/EVPPKey.cpp
+++ b/Crypto/src/EVPPKey.cpp
@@ -172,7 +172,6 @@ EVPPKey::EVPPKey(const std::vector<unsigned char>* public_key, const std::vector
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 
 EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 {
@@ -231,8 +230,6 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 	EVP_PKEY_CTX_free(pCtx);
 	checkType();
 }
-
-#endif // OPENSSL_VERSION_NUMBER >= 0x10000000L
 
 
 EVPPKey::EVPPKey(EVP_PKEY* pEVPPKey) : _pEVPPKey(nullptr)

--- a/Crypto/src/OpenSSLInitializer.cpp
+++ b/Crypto/src/OpenSSLInitializer.cpp
@@ -14,10 +14,7 @@
 
 #include "Poco/Crypto/OpenSSLInitializer.h"
 #include "Poco/Crypto/CryptoException.h"
-#include "Poco/RandomStream.h"
-#include "Poco/Thread.h"
 #include <openssl/ssl.h>
-#include <openssl/rand.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/conf.h>
@@ -35,10 +32,6 @@
 	#endif
 	#pragma message (OPENSSL_VERSION_TEXT POCO_INTERNAL_OPENSSL_BUILD)
 #endif
-
-
-using Poco::RandomInputStream;
-using Poco::Thread;
 
 
 #if defined(_MSC_VER) && !defined(_DLL) && defined(POCO_INTERNAL_OPENSSL_MSVC_VER)
@@ -60,10 +53,6 @@ namespace Crypto {
 
 
 Poco::AtomicCounter OpenSSLInitializer::_rc;
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-Poco::FastMutex* OpenSSLInitializer::_mutexes(0);
-#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 OSSL_PROVIDER* OpenSSLInitializer::_defaultProvider(nullptr);
@@ -94,39 +83,7 @@ void OpenSSLInitializer::initialize()
 {
 	if (++_rc == 1)
 	{
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 		CONF_modules_load(nullptr, nullptr, 0);
-#else
-		OPENSSL_config(nullptr);
-#endif
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-		SSL_library_init();
-		SSL_load_error_strings();
-		OpenSSL_add_all_algorithms();
-
-		int nMutexes = CRYPTO_num_locks();
-		_mutexes = new Poco::FastMutex[nMutexes];
-		CRYPTO_set_locking_callback(&OpenSSLInitializer::lock);
-#ifndef POCO_OS_FAMILY_WINDOWS
-// Not needed on Windows (see SF #110: random unhandled exceptions when linking with ssl).
-// https://sourceforge.net/p/poco/bugs/110/
-//
-// From http://www.openssl.org/docs/crypto/threads.html :
-// "If the application does not register such a callback using CRYPTO_THREADID_set_callback(),
-//  then a default implementation is used - on Windows and BeOS this uses the system's
-//  default thread identifying APIs"
-		CRYPTO_set_id_callback(&OpenSSLInitializer::id);
-#endif
-		CRYPTO_set_dynlock_create_callback(&OpenSSLInitializer::dynlockCreate);
-		CRYPTO_set_dynlock_lock_callback(&OpenSSLInitializer::dynlock);
-		CRYPTO_set_dynlock_destroy_callback(&OpenSSLInitializer::dynlockDestroy);
-
-		char seed[SEEDSIZE];
-		RandomInputStream rnd;
-		rnd.read(seed, sizeof(seed));
-		RAND_seed(seed, SEEDSIZE);
-#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 		if (!_defaultProvider)
@@ -148,64 +105,9 @@ void OpenSSLInitializer::uninitialize()
 {
 	if (--_rc == 0)
 	{
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-		EVP_cleanup();
-		ERR_free_strings();
-		CRYPTO_set_locking_callback(0);
-#ifndef POCO_OS_FAMILY_WINDOWS
-		CRYPTO_set_id_callback(0);
-#endif
-		delete [] _mutexes;
-#endif
+		// OpenSSL 1.1.0+ handles cleanup automatically
 	}
 }
-
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-
-void OpenSSLInitializer::lock(int mode, int n, const char* file, int line)
-{
-	if (mode & CRYPTO_LOCK)
-		_mutexes[n].lock();
-	else
-		_mutexes[n].unlock();
-}
-
-
-unsigned long OpenSSLInitializer::id()
-{
-	// Note: we use an old-style C cast here because
-	// neither static_cast<> nor reinterpret_cast<>
-	// work uniformly across all platforms.
-	return (unsigned long) Poco::Thread::currentTid();
-}
-
-
-struct CRYPTO_dynlock_value* OpenSSLInitializer::dynlockCreate(const char* file, int line)
-{
-	return new CRYPTO_dynlock_value;
-}
-
-
-void OpenSSLInitializer::dynlock(int mode, struct CRYPTO_dynlock_value* lock, const char* file, int line)
-{
-	poco_check_ptr (lock);
-
-	if (mode & CRYPTO_LOCK)
-		lock->_mutex.lock();
-	else
-		lock->_mutex.unlock();
-}
-
-
-void OpenSSLInitializer::dynlockDestroy(struct CRYPTO_dynlock_value* lock, const char* file, int line)
-{
-	delete lock;
-}
-
-
-#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
 
 
 void initializeCrypto()

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -218,43 +218,31 @@ int RSAKeyImpl::size() const
 
 RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	const BIGNUM* n = nullptr;
 	const BIGNUM* e = nullptr;
 	const BIGNUM* d = nullptr;
 	RSA_get0_key(_pRSA, &n, &e, &d);
 	return convertToByteVec(n);
-#else
-	return convertToByteVec(_pRSA->n);
-#endif
 }
 
 
 RSAKeyImpl::ByteVec RSAKeyImpl::encryptionExponent() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	const BIGNUM* n = nullptr;
 	const BIGNUM* e = nullptr;
 	const BIGNUM* d = nullptr;
 	RSA_get0_key(_pRSA, &n, &e, &d);
 	return convertToByteVec(e);
-#else
-	return convertToByteVec(_pRSA->e);
-#endif
 }
 
 
 RSAKeyImpl::ByteVec RSAKeyImpl::decryptionExponent() const
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	const BIGNUM* n = nullptr;
 	const BIGNUM* e = nullptr;
 	const BIGNUM* d = nullptr;
 	RSA_get0_key(_pRSA, &n, &e, &d);
 	return convertToByteVec(d);
-#else
-	return convertToByteVec(_pRSA->d);
-#endif
 }
 
 

--- a/Crypto/src/X509Certificate.cpp
+++ b/Crypto/src/X509Certificate.cpp
@@ -29,13 +29,6 @@
 #include <openssl/bn.h>
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define ASN1_STRING_get0_data ASN1_STRING_data
-#define X509_get0_notBefore X509_get_notBefore
-#define X509_get0_notAfter X509_get_notAfter
-#endif
-
-
 namespace Poco {
 namespace Crypto {
 
@@ -68,11 +61,7 @@ X509Certificate::X509Certificate(X509* pCert, bool shared):
 
 	if (shared)
 	{
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 		X509_up_ref(_pCert);
-#else
-		_pCert->references++;
-#endif
 	}
 
 	init();
@@ -385,14 +374,7 @@ bool X509Certificate::equals(const X509Certificate& otherCertificate) const
 
 std::string X509Certificate::signatureAlgorithm() const
 {
-	int sigNID = NID_undef;
-
-#if (OPENSSL_VERSION_NUMBER >=  0x1010000fL)
-	sigNID = X509_get_signature_nid(_pCert);
-#else
-	poco_check_ptr(_pCert->sig_alg);
-	sigNID = OBJ_obj2nid(_pCert->sig_alg->algorithm);
-#endif
+	int sigNID = X509_get_signature_nid(_pCert);
 
 	if (sigNID != NID_undef)
 	{

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -23,6 +23,7 @@
 #include "Poco/Net/Context.h"
 #include "Poco/Net/X509Certificate.h"
 #include "Poco/Net/Session.h"
+#include "Poco/Mutex.h"
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -93,7 +93,6 @@ void SecureSocketImpl::acceptSSL()
 		throw SSLException("Cannot create SSL object");
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 	/* TLS 1.3 server sends session tickets after a handhake as part of
 	* the SSL_accept(). If a client finishes all its job before server
 	* sends the tickets, SSL_accept() fails with EPIPE errno. Since we
@@ -105,7 +104,6 @@ void SecureSocketImpl::acceptSSL()
 		throw SSLException("Cannot create SSL object");
 	}
 	//Otherwise we can perform two-way shutdown. Client must call SSL_read() before the final SSL_shutdown().
-#endif
 
 	::SSL_set_bio(_pSSL, pBIO, pBIO);
 	::SSL_set_accept_state(_pSSL);
@@ -178,12 +176,10 @@ void SecureSocketImpl::connectSSL(bool performHandshake)
 		SSL_set_tlsext_host_name(_pSSL, _peerHostName.c_str());
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
 	if(_pContext->ocspStaplingResponseVerificationEnabled())
 	{
 		SSL_set_tlsext_status_type(_pSSL, TLSEXT_STATUSTYPE_ocsp);
 	}
-#endif
 
 	if (_pSession && _pSession->isResumable())
 	{


### PR DESCRIPTION
## Summary

This PR removes all compatibility code for OpenSSL versions prior to 1.1.1, significantly simplifying the codebase.

Closes #3739

## Changes

### CMake Requirements
- Added minimum OpenSSL version 1.1.1 to `find_package()` calls

### Crypto Library
- Updated compile-time version check in `Crypto.h` to require OpenSSL 1.1.1
- **OpenSSLInitializer**: Removed manual thread locking callbacks (OpenSSL 1.1.0+ handles threading automatically via `CRYPTO_set_locking_callback`)
- **CipherImpl**: Simplified `EVP_CIPHER_CTX` handling to use pointer-based API only (removed stack allocation path)
- **CipherKeyImpl**: Removed version conditional around CTR/GCM/CCM cipher modes
- **EVPPKey**: Removed version conditional for EC key support constructor
- **RSAKeyImpl**: Simplified `RSA_get0_key()` usage (removed manual BIGNUM access)
- **X509Certificate**: Removed compatibility macros for `ASN1_STRING_get0_data`, `X509_get0_notBefore/notAfter`, `X509_up_ref`, and `X509_get_signature_nid`

### NetSSL_OpenSSL Library
- **Context**: Removed all TLS method version conditionals, now uses `TLS_method()/TLS_client_method()/TLS_server_method()` only. Simplified ECDH initialization and security level functions
- **SecureSocketImpl**: Removed conditionals for TLS 1.3 session tickets and OCSP stapling. Added explicit `Mutex.h` include (previously transitive through OpenSSLInitializer.h)

## Rationale

OpenSSL 1.1.1 reached end-of-life on 2023-09-11. All actively maintained systems should have at least this version available. The 1.1.x series introduced significant API changes that required extensive version conditionals in the codebase. Removing this legacy support:

- Reduces code complexity (~370 lines removed)
- Eliminates potential bugs in rarely-tested code paths
- Simplifies maintenance and future development
- OpenSSL 3.x is backward compatible with 1.1.1 APIs used here