### PR TITLE
enh(Foundation): Improve Windows version detection using RtlGetVersion

### DIFF
--- a/Foundation/testsuite/src/CoreTest.cpp
+++ b/Foundation/testsuite/src/CoreTest.cpp
@@ -196,13 +196,41 @@ void CoreTest::testEnvironment()
 	{
 	}
 
-	std::cout << "OS Name:         " << Environment::osName() << std::endl;
-	std::cout << "OS Display Name: " << Environment::osDisplayName() << std::endl;
-	std::cout << "OS Version:      " << Environment::osVersion() << std::endl;
-	std::cout << "OS Architecture: " << Environment::osArchitecture() << std::endl;
-	std::cout << "Node Name:       " << Environment::nodeName() << std::endl;
-	std::cout << "Node ID:         " << Environment::nodeId() << std::endl;
-	std::cout << "Number of CPUs:  " << Environment::processorCount() << std::endl;
+	std::string osName = Environment::osName();
+	std::string osDisplayName = Environment::osDisplayName();
+	std::string osVersion = Environment::osVersion();
+	std::string osArch = Environment::osArchitecture();
+	std::string nodeName = Environment::nodeName();
+	std::string nodeId = Environment::nodeId();
+	unsigned int cpuCount = Environment::processorCount();
+
+	std::cout << "OS Name:         " << osName << std::endl;
+	std::cout << "OS Display Name: " << osDisplayName << std::endl;
+	std::cout << "OS Version:      " << osVersion << std::endl;
+	std::cout << "OS Architecture: " << osArch << std::endl;
+	std::cout << "Node Name:       " << nodeName << std::endl;
+	std::cout << "Node ID:         " << nodeId << std::endl;
+	std::cout << "Number of CPUs:  " << cpuCount << std::endl;
+
+	// Basic validation
+	assertTrue (!osName.empty());
+	assertTrue (!osDisplayName.empty());
+	assertTrue (!osVersion.empty());
+	assertTrue (!osArch.empty());
+	assertTrue (!nodeName.empty());
+	assertTrue (cpuCount > 0);
+
+#if defined(_WIN32)
+	// Windows-specific validation
+	// osName returns "Windows NT" for all modern Windows versions
+	assertTrue (osName == "Windows NT" || osName == "Unknown");
+	// osDisplayName returns specific version like "Windows 10", "Windows 11", etc.
+	assertTrue (osDisplayName.find("Windows") != std::string::npos || osDisplayName == "Unknown");
+#elif defined(__linux__)
+	assertTrue (osName == "Linux");
+#elif defined(__APPLE__)
+	assertTrue (osName == "Darwin");
+#endif
 }
 
 


### PR DESCRIPTION
## Summary

Improves Windows version detection by using `RtlGetVersion()` from ntdll.dll instead of the deprecated `GetVersionEx()` API.

Closes #4932

## Changes

### RtlGetVersion instead of GetVersionEx
- The deprecated `GetVersionEx()` API lies about Windows version on Windows 8.1+ unless the application manifest explicitly declares support for newer Windows versions
- `RtlGetVersion()` from ntdll.dll returns accurate version info regardless of manifest settings
- This is the recommended approach for reliable Windows version detection

### Caching
- Version info is now cached using `std::call_once` since OS version doesn't change during runtime
- Eliminates repeated ntdll.dll lookups on every call

### Windows Server 2025 Support
- Added detection for Windows Server 2025 (build >= 26100)

### Code Cleanup
- Removed `#pragma warning(disable:4996)` since we no longer use deprecated APIs
- Simplified code structure with `isWorkstation` variable

### Test Improvements
- Added basic validation assertions to `CoreTest::testEnvironment()`
- Platform-specific checks verify OS name returns expected values

## References
- [Microsoft Docs: RtlGetVersion](https://learn.microsoft.com/en-us/windows/win32/devnotes/rtlgetversion)
- [Microsoft Q&A: Get real OS Version](https://learn.microsoft.com/en-us/answers/questions/595325/need-to-get-real-os-version)