### PR TITLE
fix(Data/PostgreSQL): Map UUIDOID to FDT_UUID instead of FDT_BLOB

### DIFF
--- a/Data/PostgreSQL/src/PostgreSQLTypes.cpp
+++ b/Data/PostgreSQL/src/PostgreSQLTypes.cpp
@@ -96,7 +96,7 @@ Poco::Data::MetaColumn::ColumnDataType oidToColumnDataType(const Oid anOID)
 
 	//uuid
 	case UUIDOID:
-		cdt = Poco::Data::MetaColumn::FDT_BLOB;
+		cdt = Poco::Data::MetaColumn::FDT_UUID;
 		break;
 
 	// everything else is a string


### PR DESCRIPTION
## Summary

Fix PostgreSQL UUID column type mapping so that UUID columns are properly recognized and can be converted to `Poco::UUID`.

## Problem

In `PostgreSQLTypes.cpp`, `UUIDOID` was incorrectly mapped to `FDT_BLOB`, causing UUID columns to be treated as `Poco::Data::LOB<unsigned char>` instead of `Poco::UUID`.

This prevented users from using `recordset.value("uuid").convert<Poco::UUID>()` on PostgreSQL UUID columns.

## Solution

Change the mapping from `FDT_BLOB` to `FDT_UUID`. The extractors (`Extractor.cpp`, `BinaryExtractor.cpp`) already have proper UUID extraction support for `UUIDOID`.

Fixes #4924