### PR TITLE
fix(Foundation): Fix deadlock in NotificationCenter removeObserver

### DIFF
--- a/Foundation/include/Poco/Observer.h
+++ b/Foundation/include/Poco/Observer.h
@@ -22,6 +22,8 @@
 #include "Poco/AbstractObserver.h"
 #include "Poco/Mutex.h"
 
+#include <atomic>
+
 
 namespace Poco {
 
@@ -52,7 +54,7 @@ public:
 
 	Observer(const Observer& observer):
 		AbstractObserver(observer),
-		_pObject(observer._pObject),
+		_pObject(observer._pObject.load()),
 		_method(observer._method)
 	{
 	}
@@ -110,7 +112,7 @@ public:
 	}
 
 private:
-	C*       _pObject;
+	std::atomic<C*> _pObject;
 	Callback _method;
 	mutable Poco::Mutex _mutex;
 };


### PR DESCRIPTION
## Summary

Fix deadlock when calling `removeEventHandler()` from another thread while also calling it from within an event handler (reactor thread).

## Problem

A deadlock occurred due to lock ordering inversion:
- **Thread 1** (external): `NotificationCenter::_mutex` → `NObserver::_mutex`
- **Thread 2** (handler): `NObserver::_mutex` → `NotificationCenter::_mutex`

When Thread 1 called `removeObserver()` holding `_mutex` and trying to call `disable()`, while Thread 2 was in `notify()` holding `NObserver::_mutex` and the handler called `removeObserver()`, both threads would deadlock.

## Solution

1. **Make `_pObject` atomic** in `NObserver` and `Observer` to allow safe concurrent access without always requiring the mutex
2. **Call `disable()` outside the lock** in `NotificationCenter::removeObserver()` and destructor

The fix breaks the nested lock acquisition by releasing `NotificationCenter::_mutex` before calling `disable()`.

## Changes

- `NObserver.h`: Changed `C* _pObject` to `std::atomic<C*> _pObject`
- `Observer.h`: Same change (deprecated but still used)
- `NotificationCenter.cpp`: Modified `removeObserver()` and destructor to call `disable()` after releasing the lock

Fixes #4970