### PR TITLE
fix(Foundation): Fix FileChannel purge race with compression

### DIFF
--- a/Foundation/src/FileChannel.cpp
+++ b/Foundation/src/FileChannel.cpp
@@ -49,6 +49,7 @@ FileChannel::FileChannel():
 	_pArchiveStrategy(new ArchiveByNumberStrategy),
 	_pPurgeStrategy(new NullPurgeStrategy())
 {
+	_pArchiveStrategy->setPurgeCallback([this]() { purge(); });
 }
 
 
@@ -63,6 +64,7 @@ FileChannel::FileChannel(const std::string& path):
 	_pArchiveStrategy(new ArchiveByNumberStrategy),
 	_pPurgeStrategy(new NullPurgeStrategy())
 {
+	_pArchiveStrategy->setPurgeCallback([this]() { purge(); });
 }
 
 
@@ -94,7 +96,6 @@ void FileChannel::open()
 			try
 			{
 				_pFile = _pArchiveStrategy->archive(_pFile);
-				purge();
 			}
 			catch (...)
 			{
@@ -130,7 +131,6 @@ void FileChannel::log(const Message& msg)
 		try
 		{
 			_pFile = _pArchiveStrategy->archive(_pFile);
-			purge();
 		}
 		catch (...)
 		{
@@ -326,6 +326,7 @@ void FileChannel::setArchiveStrategy(ArchiveStrategy* strategy)
 
 	delete _pArchiveStrategy;
 	_pArchiveStrategy = strategy;
+	_pArchiveStrategy->setPurgeCallback([this]() { purge(); });
 }
 
 
@@ -348,6 +349,7 @@ void FileChannel::setArchive(const std::string& archive)
 	else throw InvalidArgumentException("archive", archive);
 	delete _pArchiveStrategy;
 	pStrategy->compress(_compress);
+	pStrategy->setPurgeCallback([this]() { purge(); });
 	_pArchiveStrategy = pStrategy;
 	_archive = archive;
 }

--- a/Foundation/testsuite/src/FileChannelTest.cpp
+++ b/Foundation/testsuite/src/FileChannelTest.cpp
@@ -608,14 +608,13 @@ void FileChannelTest::testCompressedRotation()
 	for (const auto& f: files)
 		std::cout << "log file: " << f << std::endl;
 
-	assertEqual(5+1+1, files.size()); // 5+1 rotated files, current file
+	assertEqual(5+1, files.size()); // 5 archived files + current file
 	assertEqual("test.log", files[0]);
 	assertEqual("test.log.0.gz", files[1]);
 	assertEqual("test.log.1.gz", files[2]);
 	assertEqual("test.log.2.gz", files[3]);
 	assertEqual("test.log.3.gz", files[4]);
 	assertEqual("test.log.4.gz", files[5]);
-	assertEqual("test.log.5.gz", files[6]);
 
 	logsDir.remove(true);
 }


### PR DESCRIPTION
## Summary

Fixes #4848 (and completes the fix for #2439).

The previous fix (commit 9aec79719) synchronized log rotation with compression by waiting for previous compressions to complete. However, `purge()` was still called immediately after `archive()` returned, while the **new** compression was still running in the background. This race condition could cause incorrect file counts during purging.

## Changes

**ArchiveStrategy.h:**
- Added `PurgeCallback` type and `setPurgeCallback()` method
- Fixed `ArchiveByTimestampStrategy::archive()` - added missing `_rotateMutex` lock and compression wait (was completely unsynchronized)

**ArchiveStrategy.cpp:**
- Invoke purge callback when all compressions complete (in `compressFile()`)
- Invoke purge callback at end of `archive()` if no compression was started

**FileChannel.cpp:**
- Set purge callback on archive strategy in constructors and setters
- Removed direct `purge()` calls from `log()` and `open()` - now handled via callback

**FileChannelTest.cpp:**
- Fixed `testCompressedRotation` expectations: with `purgeCount=5`, expect 5 archives (was incorrectly expecting 6 due to the race condition)

## How it works

- When compression is **enabled**: purge callback fires after compression completes (in compression thread, under `_rotateMutex`)
- When compression is **disabled**: purge callback fires at end of `archive()` (under `_rotateMutex`)
- No additional blocking in the logging thread
- All purge operations are properly serialized with rotation and compression

## Test plan

- [x] `FileChannelTest` passes (12 tests including `testCompressedRotation`)
- [x] `testPurgeCount` passes