### PR TITLE
fix(Data): Add using AbstractBinder::bind to prevent hidden virtual warning (#4900)

### DIFF
--- a/Data/MySQL/include/Poco/Data/MySQL/Binder.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/Binder.h
@@ -34,6 +34,8 @@ class MySQL_API Binder: public Poco::Data::AbstractBinder
 	/// Binds placeholders in the sql query to the provided values. Performs data types mapping.
 {
 public:
+	using AbstractBinder::bind;
+
 	typedef SharedPtr<Binder> Ptr;
 
 	Binder();

--- a/Data/ODBC/include/Poco/Data/ODBC/Binder.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/Binder.h
@@ -57,6 +57,8 @@ class ODBC_API Binder: public Poco::Data::AbstractBinder
 	/// Binds placeholders in the sql query to the provided values. Performs data types mapping.
 {
 public:
+	using AbstractBinder::bind;
+
 	typedef AbstractBinder::Direction Direction;
 	typedef std::map<SQLPOINTER, SQLLEN> ParamMap;
 

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Binder.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/Binder.h
@@ -38,6 +38,8 @@ class PostgreSQL_API Binder: public Poco::Data::AbstractBinder
 	/// Allows data type mapping at statement execution time.
 {
 public:
+	using AbstractBinder::bind;
+
 	using Ptr = SharedPtr<Binder>;
 
 	Binder();

--- a/Data/SQLite/include/Poco/Data/SQLite/Binder.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/Binder.h
@@ -35,6 +35,8 @@ class SQLite_API Binder: public Poco::Data::AbstractBinder
 	/// Binds placeholders in the sql query to the provided values. Performs data types mapping.
 {
 public:
+	using AbstractBinder::bind;
+
 	Binder(sqlite3_stmt* pStmt);
 		/// Creates the Binder.
 


### PR DESCRIPTION
## Summary

Fixes #4900 - Adds `using AbstractBinder::bind;` to all Binder classes to prevent `-Woverloaded-virtual` compiler warnings.

## Problem

When a derived class overrides some overloads of a virtual function without bringing all base class overloads into scope, the compiler warns about "hidden" virtual functions:

```
warning: 'virtual void Poco::Data::AbstractBinder::bind(...)' was hidden [-Woverloaded-virtual=]
```

## Solution

Add `using AbstractBinder::bind;` to bring all base class `bind()` overloads into scope in each derived Binder class:

- `Data/ODBC/include/Poco/Data/ODBC/Binder.h`
- `Data/MySQL/include/Poco/Data/MySQL/Binder.h`
- `Data/PostgreSQL/include/Poco/Data/PostgreSQL/Binder.h`
- `Data/SQLite/include/Poco/Data/SQLite/Binder.h`