### PR TITLE
Util: Add [[nodiscard]] to createView/createLocalView

### DIFF
--- a/Util/include/Poco/Util/AbstractConfiguration.h
+++ b/Util/include/Poco/Util/AbstractConfiguration.h
@@ -383,17 +383,25 @@ public:
 		/// Returns in range the names of all subkeys under the given key.
 		/// If an empty key is passed, all root level keys are returned.
 
-	const Ptr createView(const std::string& prefix) const;
+	[[nodiscard]] const Ptr createView(const std::string& prefix) const;
 		/// Creates a non-mutable view (see ConfigurationView) into the configuration.
+		/// The returned Ptr must be assigned to an AbstractConfiguration::Ptr,
+		/// not a raw pointer, to prevent use-after-free.
 
-	Ptr createView(const std::string& prefix);
+	[[nodiscard]] Ptr createView(const std::string& prefix);
 		/// Creates a view (see ConfigurationView) into the configuration.
+		/// The returned Ptr must be assigned to an AbstractConfiguration::Ptr,
+		/// not a raw pointer, to prevent use-after-free.
 
-	const Ptr createLocalView(const std::string& prefix) const;
+	[[nodiscard]] const Ptr createLocalView(const std::string& prefix) const;
 		/// Creates a non-mutable view (see LocalConfigurationView) into the configuration.
+		/// The returned Ptr must be assigned to an AbstractConfiguration::Ptr,
+		/// not a raw pointer, to prevent use-after-free.
 
-	Ptr createLocalView(const std::string& prefix);
+	[[nodiscard]] Ptr createLocalView(const std::string& prefix);
 		/// Creates a view (see LocalConfigurationView) into the configuration.
+		/// The returned Ptr must be assigned to an AbstractConfiguration::Ptr,
+		/// not a raw pointer, to prevent use-after-free.
 	
 	std::string expand(const std::string& value) const;
 		/// Replaces all occurrences of ${<property>} in value with the


### PR DESCRIPTION
## Summary

Adds `[[nodiscard]]` attribute and documentation to `createView()` and `createLocalView()` methods to help prevent use-after-free bugs.

## Problem

Since POCO 1.11, these methods return `AbstractConfiguration::Ptr` (AutoPtr) instead of raw pointers. Code that assigns the return value to a raw pointer compiles but causes use-after-free:

```cpp
// WRONG - compiles but crashes!
AbstractConfiguration* view = cfg->createView("prefix");
view->keys(keys);  // use-after-free

// CORRECT
AbstractConfiguration::Ptr view = cfg->createView("prefix");
// or: auto view = cfg->createView("prefix");
```

## Changes

- Added `[[nodiscard]]` attribute to warn when return value is discarded
- Added documentation noting that the return value must be assigned to `Ptr`, not raw pointer

Related: Migration note added to CHANGELOG.md on branch `4383-rename-changelog`.