### PR TITLE
fix(Net): Handle negative available() return in receiveBytes (#4537)

### DIFF
--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -492,7 +492,8 @@ int SocketImpl::receiveBytes(Poco::Buffer<char>& buffer, int flags, const Poco::
 	if (poll(timeout, SELECT_READ))
 	{
 		int avail = available();
-		if (buffer.size() < avail) buffer.resize(avail);
+		if (avail < 0) error();
+		if (buffer.size() < static_cast<std::size_t>(avail)) buffer.resize(avail);
 
 		do
 		{

--- a/Net/src/SocketProactor.cpp
+++ b/Net/src/SocketProactor.cpp
@@ -559,7 +559,8 @@ int SocketProactor::receive(Socket& sock)
 	auto end = handlers.end();
 	for (; it != end;)
 	{
-		if ((avail = sock.available()))
+		avail = sock.available();
+		if (avail > 0)
 		{
 			if (sock.isDatagram())
 				receiveFrom(*sock.impl(), it, avail);
@@ -588,7 +589,7 @@ void SocketProactor::receiveFrom(SocketImpl& sock, IOHandlerIt& it, int availabl
 	SocketAddress *pAddr = (*it)->_pAddr;
 	SocketAddress addr = *pAddr;
 	poco_check_ptr(pBuf);
-	if (pBuf->size() < available) pBuf->resize(available);
+	if (pBuf->size() < static_cast<std::size_t>(available)) pBuf->resize(available);
 	int n = 0, err = 0;
 	try
 	{
@@ -606,7 +607,7 @@ void SocketProactor::receive(SocketImpl& sock, IOHandlerIt& it, int available)
 {
 	Buffer *pBuf = (*it)->_pBuf;
 	poco_check_ptr(pBuf);
-	if (pBuf->size() < available) pBuf->resize(available);
+	if (pBuf->size() < static_cast<std::size_t>(available)) pBuf->resize(available);
 	int n = 0, err = 0;
 	try
 	{

--- a/Net/testsuite/src/DatagramSocketTest.h
+++ b/Net/testsuite/src/DatagramSocketTest.h
@@ -36,6 +36,7 @@ public:
 	void testBroadcast();
 	void testGatherScatterFixed();
 	void testGatherScatterVariable();
+	void testClosedPortError();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
## Summary

Fixes #4537 - On Windows, sending UDP to a closed port causes `available()` to return -1 due to ICMP "connection reset" error. When this negative value was used for buffer allocation in `receiveBytes(Buffer&)`, it caused `std::bad_array_new_length` crash.

Changes:
- `SocketImpl::receiveBytes(Buffer&)`: Check for negative `available()` and throw `IOException`
- `SocketProactor`: Check `available() > 0` before processing, with explicit cast to avoid signed/unsigned comparison
- Added test case `testClosedPortError` to verify the fix

Supersedes #4539 (implements the maintainer's preferred approach of fixing callers rather than having `available()` throw).