### PR TITLE
Update readme with Windows and Arch Linux instructions

### DIFF
--- a/README
+++ b/README
@@ -99,7 +99,8 @@ does not have OpenSSL, please get it from https://www.openssl.org or
 another source. You do not have to build OpenSSL yourself - a binary
 distribution is fine (e.g., apt-get install openssl libssl-dev).
 On macOS, install OpenSSL via Homebrew (brew install openssl).
-On Windows, OpenSSL can be installed with vcpkg.
+On Windows, OpenSSL can be installed with vcpkg, or through WinGet 
+(winget install -e --id ShiningLight.OpenSSL.Dev).
 
 The easiest way to install OpenSSL on Windows is to get the pre-built
 libraries from the pocoproject/openssl Git repository at

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ The easiest way to install OpenSSL on Windows is to use a binary
 (prebuilt) release, for example the one from Shining Light
 Productions that comes with a
 [Windows installer](https://www.slproweb.com/products/Win32OpenSSL.html).
-OpenSSL can also be installed via the `vcpkg` package manager.
+OpenSSL can also be installed via the `vcpkg` package manager. One may
+also use the
+[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
+package.
 
 On Windows, POCO can also use the native Windows TLS APIs (SChannel).
 
@@ -70,10 +73,22 @@ $ sudo apt-get -y update && sudo apt-get -y install git g++ cmake libssl-dev lib
 $ sudo dnf install -y git gcc-c++ cmake openssl-devel mysql-devel postgresql-devel
 ```
 
+#### Arch Linux
+
+```
+$ sudo pacman -Syu --noconfirm git gcc make cmake openssl mariadb-libs postgresql-libs
+```
+
 #### macOS (with Homebrew)
 
 ```
 $ brew install cmake openssl mysql-client libpq
+```
+
+#### Windows (with WinGet)
+
+```
+$ winget install --id -e Git.Git LLVM.LLVM Kitware.CMake ShiningLight.OpenSSL.Dev PostgreSQL.PostgreSQL Oracle.MySQL Microsoft.msodbcsql
 ```
 
 ### Building with CMake (Linux, macOS, Windows)


### PR DESCRIPTION
This PR updates the `README.md` file to include installation guides for WinGet (Windows) and Pacman (Arch Linux).

While preferably the installation guides should not become an exhaustive list for every operating system, I do believe Windows (with WinGet) and Arch (with Pacman) are prominent enough to warrant inclusion.