### PR TITLE
net: Fix position of dll attribute in pocoNetworkInitializer to also support MinGW-GCC/Clang

### DIFF
--- a/Net/include/Poco/Net/Net.h
+++ b/Net/include/Poco/Net/Net.h
@@ -103,7 +103,7 @@ std::string Net_API htmlize(const std::string& str);
 
 #if defined(POCO_OS_FAMILY_WINDOWS) && !defined(POCO_NO_AUTOMATIC_LIB_INIT)
 
-extern "C" const struct Net_API NetworkInitializer pocoNetworkInitializer;
+extern "C" const struct NetworkInitializer Net_API pocoNetworkInitializer;
 
 #if defined(POCO_COMPILER_MINGW)
 	#define POCO_NET_FORCE_SYMBOL(x) static void *__ ## x ## _fp = (void*)&x;


### PR DESCRIPTION
Fixes https://github.com/pocoproject/poco/issues/5087