### PR TITLE
Fix MongoDB Document::toString() to produce valid JSON

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Binary.h
+++ b/MongoDB/include/Poco/MongoDB/Binary.h
@@ -143,7 +143,7 @@ struct ElementTraits<Binary::Ptr>
 
 	static std::string toString(const Binary::Ptr& value, int indent = 0)
 	{
-		return value.isNull() ? "" : value->toString();
+		return value.isNull() ? R"("<null>")" : value->toString();
 	}
 };
 

--- a/MongoDB/include/Poco/MongoDB/JavaScriptCode.h
+++ b/MongoDB/include/Poco/MongoDB/JavaScriptCode.h
@@ -76,7 +76,8 @@ struct ElementTraits<JavaScriptCode::Ptr>
 
 	static std::string toString(const JavaScriptCode::Ptr& value, int indent = 0)
 	{
-		return value.isNull() ? "" : value->getCode();
+		if (value.isNull()) return R"("<null>")";
+		return ElementTraits<std::string>::toString(value->getCode(), indent);
 	}
 };
 

--- a/MongoDB/include/Poco/MongoDB/ObjectId.h
+++ b/MongoDB/include/Poco/MongoDB/ObjectId.h
@@ -131,7 +131,7 @@ struct ElementTraits<ObjectId::Ptr>
 		int indent = 0,
 		const std::string& fmt = "%02x")
 	{
-		return id->toString(fmt);
+		return R"(")" + id->toString(fmt) + '"';
 	}
 };
 

--- a/MongoDB/include/Poco/MongoDB/RegularExpression.h
+++ b/MongoDB/include/Poco/MongoDB/RegularExpression.h
@@ -137,14 +137,14 @@ struct ElementTraits<RegularExpression::Ptr>
 			return "null";
 		}
 
-		// Format as /pattern/options similar to MongoDB shell
-		std::string result;
-		result.reserve(value->getPattern().size() + value->getOptions().size() + 3);
-		result += '/';
-		result += value->getPattern();
-		result += '/';
-		result += value->getOptions();
-		return result;
+		// Format as /pattern/options similar to MongoDB shell, quoted for valid JSON
+		std::string formatted;
+		formatted.reserve(value->getPattern().size() + value->getOptions().size() + 2);
+		formatted += '/';
+		formatted += value->getPattern();
+		formatted += '/';
+		formatted += value->getOptions();
+		return ElementTraits<std::string>::toString(formatted, indent);
 	}
 };
 

--- a/MongoDB/src/Binary.cpp
+++ b/MongoDB/src/Binary.cpp
@@ -84,7 +84,7 @@ std::string Binary::toString(int indent) const
 	{
 		try
 		{
-			return "UUID(\""s + uuid().toString() + "\")"s;
+			return R"("UUID()"s + uuid().toString() + ")\""s;
 		}
 		catch (...)
 		{
@@ -94,10 +94,12 @@ std::string Binary::toString(int indent) const
 
 	// Default: Base64 encode the binary data
 	std::ostringstream oss;
+	oss << '"';
 	Base64Encoder encoder(oss);
 	MemoryInputStream mis(reinterpret_cast<const char*>(_buffer.begin()), _buffer.size());
 	StreamCopier::copyStream(mis, encoder);
 	encoder.close();
+	oss << '"';
 	return oss.str();
 }
 


### PR DESCRIPTION
## Summary
- Quote string-like BSON values (Binary, ObjectId, RegularExpression, JavaScriptCode) in `Document::toString()` output so it produces valid JSON
- Previously, values like `UUID(...)`, Base64 binary data, ObjectId hex strings, regex patterns, and JavaScript code were emitted unquoted, resulting in invalid JSON
- Add toString assertions to existing BSON tests to verify proper quoting

## Test plan
- [x] All 84 MongoDB tests pass (`MongoDB-testrunner -all`)
- [x] Verified Binary (Base64 and UUID), ObjectId, RegularExpression, and JavaScriptCode produce quoted values
- [x] Verified full Document::toString() output with these types is valid JSON