### PR TITLE
fix(cmake+msvc): Restore dllimport on extern template declarations (#5200)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,7 +645,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: >-
-          cmake -S. -Bcmake-build -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF
+          cmake -S. -Bcmake-build -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+          -DENABLE_NETSSL_WIN=ON -DENABLE_NETSSL=OFF
           -DENABLE_CRYPTO=OFF -DENABLE_JWT=OFF -DENABLE_DATA=ON -DENABLE_DATA_ODBC=ON
           -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_POSTGRESQL=OFF -DENABLE_TESTS=ON
       - run: cmake --build cmake-build --config Release --parallel 4

--- a/Data/ODBC/include/Poco/Data/ODBC/Diagnostics.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/Diagnostics.h
@@ -245,7 +245,7 @@ private:
 // explicit instantiation definition
 #ifndef POCO_DOC
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 extern template class Diagnostics<SQLHENV, SQL_HANDLE_ENV>;
 extern template class Diagnostics<SQLHDBC, SQL_HANDLE_DBC>;
 extern template class Diagnostics<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Data/ODBC/include/Poco/Data/ODBC/Error.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/Error.h
@@ -126,7 +126,7 @@ private:
 // explicit instantiation definition
 #ifndef POCO_DOC
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 extern template class Error<SQLHENV, SQL_HANDLE_ENV>;
 extern template class Error<SQLHDBC, SQL_HANDLE_DBC>;
 extern template class Error<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Data/ODBC/include/Poco/Data/ODBC/ODBCException.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBCException.h
@@ -140,7 +140,7 @@ private:
 // explicit instantiation definition
 #ifndef POCO_DOC
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 extern template class HandleException<SQLHENV, SQL_HANDLE_ENV>;
 extern template class HandleException<SQLHDBC, SQL_HANDLE_DBC>;
 extern template class HandleException<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Data/ODBC/src/Diagnostics.cpp
+++ b/Data/ODBC/src/Diagnostics.cpp
@@ -22,7 +22,7 @@ namespace ODBC {
 // explicit instantiation definition
 #ifndef POCO_DOC
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 template class ODBC_API Diagnostics<SQLHENV, SQL_HANDLE_ENV>;
 template class ODBC_API Diagnostics<SQLHDBC, SQL_HANDLE_DBC>;
 template class ODBC_API Diagnostics<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Data/ODBC/src/Error.cpp
+++ b/Data/ODBC/src/Error.cpp
@@ -22,7 +22,7 @@ namespace ODBC {
 // explicit instantiation definition
 #ifndef POCO_DOC
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 template class ODBC_API Error<SQLHENV, SQL_HANDLE_ENV>;
 template class ODBC_API Error<SQLHDBC, SQL_HANDLE_DBC>;
 template class ODBC_API Error<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Data/ODBC/src/ODBCException.cpp
+++ b/Data/ODBC/src/ODBCException.cpp
@@ -20,7 +20,7 @@ namespace Poco {
 namespace Data {
 namespace ODBC {
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(ODBC_EXPORTS)
 template class ODBC_API HandleException<SQLHENV, SQL_HANDLE_ENV>;
 template class ODBC_API HandleException<SQLHDBC, SQL_HANDLE_DBC>;
 template class ODBC_API HandleException<SQLHSTMT, SQL_HANDLE_STMT>;

--- a/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
+++ b/Foundation/include/Poco/BufferedBidirectionalStreamBuf.h
@@ -182,7 +182,7 @@ private:
 // We provide an instantiation for char.
 //
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 extern template class BasicBufferedBidirectionalStreamBuf<char, std::char_traits<char>>;
 #else
 extern template class Foundation_API BasicBufferedBidirectionalStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/include/Poco/BufferedStreamBuf.h
+++ b/Foundation/include/Poco/BufferedStreamBuf.h
@@ -164,7 +164,7 @@ private:
 // We provide an instantiation for char.
 //
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 extern template class BasicBufferedStreamBuf<char, std::char_traits<char>>;
 #else
 extern template class Foundation_API BasicBufferedStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/include/Poco/Dynamic/Struct.h
+++ b/Foundation/include/Poco/Dynamic/Struct.h
@@ -286,7 +286,7 @@ private:
 };
 
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 
 extern template class Struct<std::string>;
 extern template class Struct<int>;

--- a/Foundation/include/Poco/UnbufferedStreamBuf.h
+++ b/Foundation/include/Poco/UnbufferedStreamBuf.h
@@ -162,7 +162,7 @@ private:
 // We provide an instantiation for char.
 //
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 extern template class BasicUnbufferedStreamBuf<char, std::char_traits<char>>;
 #else
 extern template class Foundation_API BasicUnbufferedStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/src/BufferedBidirectionalStreamBuf.cpp
+++ b/Foundation/src/BufferedBidirectionalStreamBuf.cpp
@@ -16,7 +16,7 @@
 
 namespace Poco {
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 template class Foundation_API BasicBufferedBidirectionalStreamBuf<char, std::char_traits<char>>;
 #else
 template class BasicBufferedBidirectionalStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/src/BufferedStreamBuf.cpp
+++ b/Foundation/src/BufferedStreamBuf.cpp
@@ -16,7 +16,7 @@
 
 namespace Poco {
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 template class Foundation_API BasicBufferedStreamBuf<char, std::char_traits<char>>;
 #else
 template class BasicBufferedStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/src/UnbufferedStreamBuf.cpp
+++ b/Foundation/src/UnbufferedStreamBuf.cpp
@@ -16,7 +16,7 @@
 
 namespace Poco {
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 template class Foundation_API BasicUnbufferedStreamBuf<char, std::char_traits<char>>;
 #else
 template class BasicUnbufferedStreamBuf<char, std::char_traits<char>>;

--- a/Foundation/src/VarHolder.cpp
+++ b/Foundation/src/VarHolder.cpp
@@ -22,7 +22,7 @@ namespace Poco {
 namespace Dynamic {
 
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(Foundation_EXPORTS)
 
 template class Foundation_API Struct<std::string>;
 template class Foundation_API Struct<int>;

--- a/JSON/include/Poco/JSON/Array.h
+++ b/JSON/include/Poco/JSON/Array.h
@@ -34,7 +34,7 @@ class JSON_API Array;
 }
 
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(JSON_EXPORTS)
 // Explicitly instantiated shared pointer in JSON library
 extern template class Poco::SharedPtr<Poco::JSON::Array>;
 #else

--- a/JSON/include/Poco/JSON/Object.h
+++ b/JSON/include/Poco/JSON/Object.h
@@ -41,7 +41,7 @@ class JSON_API Object;
 
 }
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(JSON_EXPORTS)
 // Explicitly instatiated shared pointer in JSON library
 extern template class Poco::SharedPtr<Poco::JSON::Object>;
 #else

--- a/JSON/src/Array.cpp
+++ b/JSON/src/Array.cpp
@@ -23,7 +23,7 @@ using Poco::Dynamic::Var;
 // Explicitly instatiated shared pointer in JSON library is required to
 // have known instance of the pointer to be used with VarHolder when
 // compiling with -fvisibility=hidden
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(JSON_EXPORTS)
 template class JSON_API Poco::SharedPtr<Poco::JSON::Array>;
 #else
 template class Poco::SharedPtr<Poco::JSON::Array>;

--- a/JSON/src/Object.cpp
+++ b/JSON/src/Object.cpp
@@ -22,7 +22,7 @@ using Poco::Dynamic::Var;
 // have known instance of the pointer to be used with VarHolder when
 // compiling with -fvisibility=hidden
 
-#if defined(POCO_OS_FAMILY_WINDOWS)
+#if defined(POCO_OS_FAMILY_WINDOWS) && defined(JSON_EXPORTS)
 template class JSON_API Poco::SharedPtr<Poco::JSON::Object>;
 #else
 template class Poco::SharedPtr<Poco::JSON::Object>;


### PR DESCRIPTION
## Summary

- Fix MSVC LNK2005 linker errors when consumers build with LTCG (Link-Time Code Generation) enabled, reported in #5200
- Change `#if defined(POCO_OS_FAMILY_WINDOWS)` to `#if defined(POCO_OS_FAMILY_WINDOWS) && defined(<Component>_EXPORTS)` in all `extern template` declarations (headers) and explicit template instantiations (`.cpp` files) across Foundation, JSON, and Data/ODBC
- Enable LTCG (`CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`) on the `windows-2025-msvc-cmake` CI job to catch this class of bug going forward

## Root cause

Commit daf19e5 stripped the API macro (e.g. `Foundation_API`) from `extern template class` declarations in headers on all Windows builds. This is correct when **building** the DLL (`dllexport` is invalid on `extern template` in MSVC), but wrong when **consuming** the DLL — the `dllimport` annotation is needed so the compiler knows the instantiation lives in the DLL. Without it, consumer TUs silently generate local instantiations, which cause LNK2005 duplicate symbol errors under LTCG.

The fix narrows the condition to only strip the macro when `<Component>_EXPORTS` is defined (i.e. when building the DLL itself).

## Test plan

- [x] macOS build passes (verified locally)
- [x] Windows shared-library build with LTCG passes (CI `windows-2025-msvc-cmake` job, now with `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`)
- [x] All existing test suites pass

Closes #5200