### PR TITLE
fix(RegularExpression): use matchOptions() in MatchVec overload of ma…

### DIFF
--- a/Foundation/src/RegularExpression.cpp
+++ b/Foundation/src/RegularExpression.cpp
@@ -154,7 +154,7 @@ int RegularExpression::match(const std::string& subject, std::string::size_type 
 	matches.clear();
 
 	MatchData matchData(reinterpret_cast<pcre2_code*>(_pcre));
-	int rc = pcre2_match(reinterpret_cast<pcre2_code*>(_pcre), reinterpret_cast<PCRE2_SPTR>(subject.c_str()), subject.size(), offset, options & 0xFFFF, matchData, nullptr);
+	int rc = pcre2_match(reinterpret_cast<pcre2_code*>(_pcre), reinterpret_cast<PCRE2_SPTR>(subject.c_str()), subject.size(), offset, matchOptions(options), matchData, nullptr);
 	if (rc == PCRE2_ERROR_NOMATCH)
 	{
 		return 0;

--- a/Foundation/testsuite/src/RegularExpressionTest.h
+++ b/Foundation/testsuite/src/RegularExpressionTest.h
@@ -42,6 +42,7 @@ public:
 	void testSubst5();
 	void testError();
 	void testGroup();
+	void testMatchCaptureGroupCount();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
…tch()

The MatchVec overload of RegularExpression::match() was passing raw Poco options (options & 0xFFFF) directly to pcre2_match() instead of using matchOptions() to translate them to PCRE2 flags. Since Poco RE_* constants do not map 1:1 to PCRE2 constants (unlike the old PCRE1 API), raw bits could accidentally enable PCRE2 flags like PCRE2_NO_AUTO_CAPTURE, causing capture groups to be suppressed. This resulted in match() returning only 1 result (the full match) instead of including captured sub-groups.

This broke JSONConfiguration::getIndexes() which relies on matches[1] to extract array indices from patterns like 'prop3[1]'.

The other two call sites (single Match overload and substOne) already used matchOptions() correctly; this overload was missed during the PCRE2 migration in commit bbe09e48d.

Added test case testMatchCaptureGroupCount to verify the fix.

Fixes #5157 
