### PR TITLE
fix(Data): clear bindings in Statement::addBinding() to allow reuse #5220

### DIFF
--- a/Data/SQLite/testsuite/src/SQLiteTest.h
+++ b/Data/SQLite/testsuite/src/SQLiteTest.h
@@ -148,6 +148,7 @@ public:
 	void testTransactionTypeProperty();
 
 	void testRecordsetCopyMove();
+	void testAddBindingReuse();
 
 	void setUp();
 	void tearDown();

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -180,10 +180,12 @@ public:
 	Statement& addBinding(C& bindingCont, bool reset)
 		/// Registers binding container with the Statement.
 	{
-		if (reset) _pImpl->resetBinding();
-		typename C::iterator itAB = bindingCont.begin();
-		typename C::iterator itABEnd = bindingCont.end();
-		for (; itAB != itABEnd; ++itAB) addBind(*itAB);
+		if (reset)
+		{
+			_pImpl->resetBinding();
+			_pImpl->bindings().clear();
+		}
+		for (auto& ab : bindingCont) addBind(ab);
 		return *this;
 	}
 


### PR DESCRIPTION
## Summary
- `Statement::addBinding(container, reset=true)` only reset `_bound` flags via `resetBinding()` but did not clear the bindings vector, causing new bindings to accumulate on each call
- Second and subsequent `execute()` calls failed due to mismatch between placeholder count and binding count
- Fix: also call `bindings().clear()` when `reset=true`, so the old bindings are removed before new ones are added

Closes #5220

## Test plan
- [x] Added `testAddBindingReuse` test that exercises the exact scenario from the issue (prepare once, addBinding + execute multiple times)
- [x] All 99 SQLite tests pass