### PR TITLE
fix(File): is*() and can*() return false for non-existent files

### DIFF
--- a/Foundation/src/File_UNIX.cpp
+++ b/Foundation/src/File_UNIX.cpp
@@ -147,7 +147,10 @@ bool FileImpl::canReadImpl() const
 		else
 			return (st.st_mode & S_IROTH) != 0 || ::geteuid() == 0;
 	}
-	else handleLastErrorImpl(_path);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
+	else
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 
@@ -166,7 +169,10 @@ bool FileImpl::canWriteImpl() const
 		else
 			return (st.st_mode & S_IWOTH) != 0 || ::geteuid() == 0;
 	}
-	else handleLastErrorImpl(_path);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
+	else
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 
@@ -197,8 +203,10 @@ bool FileImpl::isFileImpl() const
 	struct stat st;
 	if (::stat(_path.c_str(), &st) == 0)
 		return S_ISREG(st.st_mode);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
 	else
-		handleLastErrorImpl(_path);
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 
@@ -210,8 +218,10 @@ bool FileImpl::isDirectoryImpl() const
 	struct stat st;
 	if (::stat(_path.c_str(), &st) == 0)
 		return S_ISDIR(st.st_mode);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
 	else
-		handleLastErrorImpl(_path);
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 
@@ -223,8 +233,10 @@ bool FileImpl::isLinkImpl() const
 	struct stat st;
 	if (::lstat(_path.c_str(), &st) == 0)
 		return S_ISLNK(st.st_mode);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
 	else
-		handleLastErrorImpl(_path);
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 
@@ -236,8 +248,10 @@ bool FileImpl::isDeviceImpl() const
 	struct stat st;
 	if (::stat(_path.c_str(), &st) == 0)
 		return S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode);
+	else if (const auto err = errno; err == ENOENT)
+		return false;
 	else
-		handleLastErrorImpl(_path);
+		handleLastErrorImpl(err, _path);
 	return false;
 }
 

--- a/Foundation/src/File_VX.cpp
+++ b/Foundation/src/File_VX.cpp
@@ -128,8 +128,10 @@ bool FileImpl::isFileImpl() const
 	poco_assert (!_path.empty());
 
 	struct stat st;
-	if (stat(const_cast<char*>(_path.c_str()), &st) == 0)
+	if (::stat(const_cast<char*>(_path.c_str()), &st) == 0)
 		return S_ISREG(st.st_mode);
+	else if (errno == ENOENT)
+		return false;
 	else
 		handleLastErrorImpl(_path);
 	return false;
@@ -141,8 +143,10 @@ bool FileImpl::isDirectoryImpl() const
 	poco_assert (!_path.empty());
 
 	struct stat st;
-	if (stat(const_cast<char*>(_path.c_str()), &st) == 0)
+	if (::stat(const_cast<char*>(_path.c_str()), &st) == 0)
 		return S_ISDIR(st.st_mode);
+	else if (errno == ENOENT)
+		return false;
 	else
 		handleLastErrorImpl(_path);
 	return false;
@@ -160,8 +164,10 @@ bool FileImpl::isDeviceImpl() const
 	poco_assert (!_path.empty());
 
 	struct stat st;
-	if (stat(const_cast<char*>(_path.c_str()), &st) == 0)
+	if (::stat(const_cast<char*>(_path.c_str()), &st) == 0)
 		return S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode);
+	else if (errno == ENOENT)
+		return false;
 	else
 		handleLastErrorImpl(_path);
 	return false;

--- a/Foundation/src/File_WIN32U.cpp
+++ b/Foundation/src/File_WIN32U.cpp
@@ -204,6 +204,9 @@ bool FileImpl::canReadImpl() const
 	{
 		switch (::GetLastError())
 		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
 		case ERROR_ACCESS_DENIED:
 			return false;
 		default:
@@ -220,7 +223,17 @@ bool FileImpl::canWriteImpl() const
 
 	DWORD attr = ::GetFileAttributesW(_upath.c_str());
 	if (attr == INVALID_FILE_ATTRIBUTES)
-		handleLastErrorImpl(_path);
+	{
+		switch (::GetLastError())
+		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
+			return false;
+		default:
+			handleLastErrorImpl(_path);
+		}
+	}
 	return (attr & FILE_ATTRIBUTE_READONLY) == 0;
 }
 
@@ -246,7 +259,22 @@ bool FileImpl::canExecuteImpl(const std::string& absolutePath) const
 
 bool FileImpl::isFileImpl() const
 {
-	return !isDirectoryImpl() && !isDeviceImpl();
+	poco_assert (!_path.empty());
+
+	DWORD attr = ::GetFileAttributesW(_upath.c_str());
+	if (attr == INVALID_FILE_ATTRIBUTES)
+	{
+		switch (::GetLastError())
+		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
+			return false;
+		default:
+			handleLastErrorImpl(_path);
+		}
+	}
+	return (attr & FILE_ATTRIBUTE_DIRECTORY) == 0 && !isDeviceImpl();
 }
 
 
@@ -256,7 +284,17 @@ bool FileImpl::isDirectoryImpl() const
 
 	DWORD attr = ::GetFileAttributesW(_upath.c_str());
 	if (attr == INVALID_FILE_ATTRIBUTES)
-		handleLastErrorImpl(_path);
+	{
+		switch (::GetLastError())
+		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
+			return false;
+		default:
+			handleLastErrorImpl(_path);
+		}
+	}
 	return (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
 }
 
@@ -267,7 +305,17 @@ bool FileImpl::isLinkImpl() const
 
 	DWORD attr = ::GetFileAttributesW(_upath.c_str());
 	if (attr == INVALID_FILE_ATTRIBUTES)
-		handleLastErrorImpl(_path);
+	{
+		switch (::GetLastError())
+		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
+			return false;
+		default:
+			handleLastErrorImpl(_path);
+		}
+	}
 	return (attr & FILE_ATTRIBUTE_DIRECTORY) == 0 && (attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
 }
 
@@ -294,7 +342,17 @@ bool FileImpl::isHiddenImpl() const
 
 	DWORD attr = ::GetFileAttributesW(_upath.c_str());
 	if (attr == INVALID_FILE_ATTRIBUTES)
-		handleLastErrorImpl(_path);
+	{
+		switch (::GetLastError())
+		{
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_DRIVE:
+			return false;
+		default:
+			handleLastErrorImpl(_path);
+		}
+	}
 	return (attr & FILE_ATTRIBUTE_HIDDEN) != 0;
 }
 

--- a/Foundation/testsuite/src/FileTest.cpp
+++ b/Foundation/testsuite/src/FileTest.cpp
@@ -55,41 +55,13 @@ void FileTest::testFileAttributes1()
 	File f("testfile.dat");
 	assertTrue (!f.exists());
 
-	try
-	{
-		bool POCO_UNUSED flag = f.canRead();
-		failmsg("file does not exist - must throw exception");
-	}
-	catch (Exception&)
-	{
-	}
-
-	try
-	{
-		bool POCO_UNUSED flag = f.canWrite();
-		failmsg("file does not exist - must throw exception");
-	}
-	catch (Exception&)
-	{
-	}
-
-	try
-	{
-		bool POCO_UNUSED flag = f.isFile();
-		failmsg("file does not exist - must throw exception");
-	}
-	catch (Exception&)
-	{
-	}
-
-	try
-	{
-		bool POCO_UNUSED flag = f.isDirectory();
-		failmsg("file does not exist - must throw exception");
-	}
-	catch (Exception&)
-	{
-	}
+	assertFalse (f.canRead());
+	assertFalse (f.canWrite());
+	assertFalse (f.isFile());
+	assertFalse (f.isDirectory());
+	assertFalse (f.isLink());
+	assertFalse (f.isDevice());
+	assertFalse (f.isHidden());
 
 	try
 	{


### PR DESCRIPTION
## Summary
- Boolean query methods (`canRead`, `canWrite`, `isFile`, `isDirectory`, `isLink`, `isDevice`, `isHidden`) now return `false` when the file does not exist, instead of throwing `FileNotFoundException`
- The error code from the underlying system call (`stat`/`GetFileAttributesW`) is checked directly, avoiding the TOCTOU race that a separate `exists()` check would introduce
- Other errors (I/O, permissions) still throw as before
- Fixed Windows `isFileImpl()` which previously delegated to `!isDirectoryImpl() && !isDeviceImpl()` — would have incorrectly returned `true` for non-existent files after the change

Closes #5212

## Test plan
- [x] Updated `testFileAttributes1` to assert `false` returns instead of expecting exceptions
- [x] Added assertions for `isLink()`, `isDevice()`, `isHidden()` on non-existent files
- [x] All 31 FileTest tests pass