### PR TITLE
fix(ServerApplication): force service cmd line params on windows

### DIFF
--- a/Util/CMakeLists.txt
+++ b/Util/CMakeLists.txt
@@ -33,6 +33,9 @@ set_target_properties(Util
 )
 
 target_link_libraries(Util PUBLIC Poco::Foundation)
+if(WIN32)
+	target_link_libraries(Util PUBLIC shell32.lib)
+endif()
 if(ENABLE_XML)
 	target_link_libraries(Util PUBLIC Poco::XML)
 else()

--- a/Util/src/ServerApplication.cpp
+++ b/Util/src/ServerApplication.cpp
@@ -185,6 +185,9 @@ void ServerApplication::ServiceMain(DWORD argc, LPWSTR* argv)
 		// SCM-provided argv, which only contains the service name.
 		// This allows command-line options like --config-file to
 		// reach the application when running as a service.
+		// Since 1.15.1, args[0] is the executable path (from
+		// GetCommandLineW), matching the argv[0] convention on
+		// Unix/daemon startup.
 		std::vector<std::string> args;
 		int nArgs = 0;
 		LPWSTR* pArgv = CommandLineToArgvW(GetCommandLineW(), &nArgs);


### PR DESCRIPTION
On Windows, SCM passes only the service name in ServiceMain argv, dropping any extra options from binPath. Fixed by using CommandLineToArgvW(GetCommandLineW()) to read the actual process command line instead.