### PR TITLE
chore(cmake): copy test data at configure time, remove POCO_BASE from ctest

### DIFF
--- a/ActiveRecord/testsuite/CMakeLists.txt
+++ b/ActiveRecord/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND ActiveRecord-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(ActiveRecord PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 
 target_link_libraries(ActiveRecord-testrunner PUBLIC Poco::DataSQLite Poco::Data Poco::ActiveRecord CppUnit)

--- a/CppParser/testsuite/CMakeLists.txt
+++ b/CppParser/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND CppParser-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(CppParser PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(CppParser-testrunner PUBLIC Poco::CppParser CppUnit)

--- a/Crypto/testsuite/CMakeLists.txt
+++ b/Crypto/testsuite/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Test data
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 # Sources
 file(GLOB SRCS_G "src/*.cpp")
 POCO_SOURCES_AUTO(TEST_SRCS ${SRCS_G})
@@ -29,7 +32,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Crypto-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Crypto PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Crypto-testrunner PUBLIC Poco::Crypto CppUnit)
 if(MSVC)

--- a/Data/MySQL/testsuite/CMakeLists.txt
+++ b/Data/MySQL/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND DataMySQL-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(DataMySQL PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(DataMySQL-testrunner PUBLIC Poco::DataMySQL Poco::DataTest CppUnit)
 target_include_directories(DataMySQL-testrunner PUBLIC ${PROJECT_SOURCE_DIR}/Data/DataTest/include/)

--- a/Data/ODBC/testsuite/CMakeLists.txt
+++ b/Data/ODBC/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND DataODBC-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(DataODBC PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 
 target_link_libraries(DataODBC-testrunner PUBLIC Poco::DataTest Poco::DataODBC Poco::Data CppUnit)

--- a/Data/PostgreSQL/testsuite/CMakeLists.txt
+++ b/Data/PostgreSQL/testsuite/CMakeLists.txt
@@ -22,6 +22,5 @@ add_test(
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	COMMAND DataPostgreSQL-testrunner -ignore ${CPPIGNORE_FILE} -all
 )
-set_tests_properties(DataPostgreSQL PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 target_link_libraries(DataPostgreSQL-testrunner PUBLIC Poco::DataPostgreSQL Poco::DataTest CppUnit)
 target_include_directories(DataPostgreSQL-testrunner PUBLIC ${PROJECT_SOURCE_DIR}/Data/DataTest/include/)

--- a/Data/SQLite/testsuite/CMakeLists.txt
+++ b/Data/SQLite/testsuite/CMakeLists.txt
@@ -30,7 +30,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND DataSQLite-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(DataSQLite PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 
 target_link_libraries(DataSQLite-testrunner PUBLIC Poco::DataSQLite Poco::DataTest CppUnit)

--- a/Data/testsuite/CMakeLists.txt
+++ b/Data/testsuite/CMakeLists.txt
@@ -30,7 +30,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Data-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Data PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Data-testrunner PUBLIC Poco::DataTest Poco::Data CppUnit)
 

--- a/Encodings/testsuite/CMakeLists.txt
+++ b/Encodings/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Encodings-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Encodings PROPERTIES ENVIRONMENT POCO_BASE=${CMAKE_SOURCE_DIR})
 endif()
 
 target_link_libraries(Encodings-testrunner PUBLIC Poco::Encodings CppUnit)

--- a/Foundation/testsuite/CMakeLists.txt
+++ b/Foundation/testsuite/CMakeLists.txt
@@ -1,5 +1,8 @@
 set(TESTUNIT "Foundation-testrunner")
 
+# Test data
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
 # Sources
 file(GLOB SRCS_G "src/*.cpp")
 file(GLOB SRCS_G_REMOVE
@@ -48,12 +51,6 @@ else()
 	)
 	set_tests_properties(Foundation PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")	# The SharedLibaryTest has to look for shared libraries in the working directory
 	set_property(TEST Foundation APPEND PROPERTY ENVIRONMENT "PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:$ENV{PATH}") # The ProcessTest has to look for the TestApp in the working directory
-	set_property(TEST Foundation APPEND PROPERTY ENVIRONMENT "POCO_BASE=${PROJECT_SOURCE_DIR}")
-	# The test is run in the runtime directory. So the test data is copied there too
-	add_custom_command(
-		TARGET Foundation-testrunner POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/data
-	)
 endif()
 
 target_link_libraries(Foundation-testrunner PUBLIC Poco::Foundation CppUnit)

--- a/JSON/testsuite/CMakeLists.txt
+++ b/JSON/testsuite/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Test data
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 # Sources
 file(GLOB SRCS_G "src/*.cpp")
 POCO_SOURCES_AUTO(TEST_SRCS ${SRCS_G})
@@ -28,12 +31,6 @@ else()
 		NAME JSON
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND JSON-testrunner -ignore ${CPPIGNORE_FILE} -all
-	)
-	set_tests_properties(JSON PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
-	# The test is run in the build directory. So the test data is copied there too
-	add_custom_command(
-		TARGET JSON-testrunner POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data
 	)
 endif()
 target_link_libraries(JSON-testrunner PUBLIC Poco::JSON CppUnit)

--- a/JWT/testsuite/CMakeLists.txt
+++ b/JWT/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND JWT-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(JWT PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(JWT-testrunner PUBLIC Poco::JWT Poco::Crypto CppUnit)
 if(MSVC)

--- a/MongoDB/testsuite/CMakeLists.txt
+++ b/MongoDB/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND MongoDB-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(MongoDB PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(MongoDB-testrunner PUBLIC Poco::MongoDB CppUnit)

--- a/Net/testsuite/CMakeLists.txt
+++ b/Net/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Net-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Net PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Net-testrunner PUBLIC Poco::Net CppUnit)

--- a/NetSSL_OpenSSL/testsuite/CMakeLists.txt
+++ b/NetSSL_OpenSSL/testsuite/CMakeLists.txt
@@ -30,15 +30,10 @@ else()
 		WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 		COMMAND NetSSL-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(NetSSL PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
-	# The test is run in the build directory. So the test data is copied there too
-	add_custom_command(
-		TARGET NetSSL-testrunner POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dhparams.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-testrunner.xml
-	)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/any.pem COPYONLY)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcert.pem COPYONLY)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dhparams.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dhparams.pem COPYONLY)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-testrunner.xml COPYONLY)
 endif()
 target_link_libraries(NetSSL-testrunner PUBLIC Poco::NetSSL Poco::Util Poco::XML CppUnit)
 if(MSVC)
@@ -49,10 +44,7 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/ping/websocket-server.cpp)
 	add_executable(NetSSL-server ping/websocket-server.cpp)
 	target_link_libraries(NetSSL-server PUBLIC Poco::NetSSL Poco::Util)
 	if (NOT ANDROID)
-		add_custom_command(
-			TARGET NetSSL-server POST_BUILD
-			COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-server.xml
-		)
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-server.xml COPYONLY)
 	endif()
 endif()
 
@@ -60,9 +52,6 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/ping/websocket-client.cpp)
 	add_executable(NetSSL-client ping/websocket-client.cpp)
 	target_link_libraries(NetSSL-client PUBLIC Poco::NetSSL Poco::Util)
 	if (NOT ANDROID)
-	add_custom_command(
-		TARGET NetSSL-client POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-client.xml
-	)
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSL-client.xml COPYONLY)
 	endif()
 endif()

--- a/NetSSL_Win/testsuite/CMakeLists.txt
+++ b/NetSSL_Win/testsuite/CMakeLists.txt
@@ -18,13 +18,9 @@ add_test(
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 	COMMAND NetSSLWin-testrunner -ignore ${CMAKE_SOURCE_DIR}/cppignore.win -all
 )
-set_tests_properties(NetSSLWin PROPERTIES ENVIRONMENT POCO_BASE=${CMAKE_SOURCE_DIR})
 target_link_libraries(NetSSLWin-testrunner PUBLIC Poco::NetSSL Poco::Util Poco::XML CppUnit)
 
-# The test is run in the build directory. So the test data is copied there too
-add_custom_command(
-	TARGET NetSSLWin-testrunner POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSLWin.xml
-)
+# Test data
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/any.pem COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcert.pem COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSLWin.xml COPYONLY)

--- a/PDF/testsuite/CMakeLists.txt
+++ b/PDF/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND PDF-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(PDF PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(PDF-testrunner PUBLIC Poco::PDF CppUnit)

--- a/Prometheus/testsuite/CMakeLists.txt
+++ b/Prometheus/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Prometheus-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Prometheus PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Prometheus-testrunner PUBLIC Poco::Prometheus CppUnit)

--- a/Redis/testsuite/CMakeLists.txt
+++ b/Redis/testsuite/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Redis-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Redis PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 
 target_link_libraries(Redis-testrunner PUBLIC ${CMAKE_THREAD_LIBS_INIT}	 Poco::Redis CppUnit)

--- a/Util/testsuite/CMakeLists.txt
+++ b/Util/testsuite/CMakeLists.txt
@@ -36,6 +36,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Util-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Util PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Util-testrunner PUBLIC Poco::Util Poco::JSON Poco::XML CppUnit)

--- a/XML/testsuite/CMakeLists.txt
+++ b/XML/testsuite/CMakeLists.txt
@@ -29,6 +29,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND XML-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(XML PROPERTIES ENVIRONMENT POCO_BASE=${CMAKE_SOURCE_DIR})
 endif()
 target_link_libraries(XML-testrunner PUBLIC Poco::XML CppUnit)

--- a/Zip/testsuite/CMakeLists.txt
+++ b/Zip/testsuite/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Test data
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 # Sources
 file(GLOB SRCS_G "src/*.cpp")
 POCO_SOURCES_AUTO(TEST_SRCS ${SRCS_G})
@@ -28,12 +31,6 @@ else()
 		NAME Zip
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Zip-testrunner -ignore ${CPPIGNORE_FILE} -all
-	)
-	set_tests_properties(Zip PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
-	# The test is run in the build directory. So the test data is copied there too
-	add_custom_command(
-		TARGET Zip-testrunner POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/data ${CMAKE_CURRENT_BINARY_DIR}/data
 	)
 endif()
 target_link_libraries(Zip-testrunner PUBLIC Poco::Zip CppUnit)

--- a/modules/testsuite/CMakeLists.txt
+++ b/modules/testsuite/CMakeLists.txt
@@ -32,6 +32,5 @@ else()
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND Modules-testrunner -ignore ${CPPIGNORE_FILE} -all
 	)
-	set_tests_properties(Modules PROPERTIES ENVIRONMENT POCO_BASE=${PROJECT_SOURCE_DIR})
 endif()
 target_link_libraries(Modules-testrunner PUBLIC Poco::Modules CppUnit)


### PR DESCRIPTION
## Summary

- Replace `add_custom_command(POST_BUILD)` with `file(COPY)` / `configure_file(COPYONLY)` for copying test data to the build directory — runs once at configure time instead of every build
- Add missing data copy for Crypto testsuite (was relying entirely on `POCO_BASE` fallback)
- Remove `POCO_BASE` environment variable from all 23 testsuite ctest configurations — redundant for CMake builds once data is copied
- C++ fallback code reading `POCO_BASE` remains intact for Makefile builds

## Test plan

- [x] `cmake -B build-dir -DENABLE_TESTS=ON` — verify data directories appear in build tree
- [x] `cmake --build build-dir` — builds successfully
- [x] `ctest -R "(Crypto|JSON|Zip|Foundation)"` — all 4 pass without `POCO_BASE`