### PR TITLE
feat(Net): HTTPS proxy support

### DIFF
--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -79,9 +79,9 @@ public:
 	{
 		ProxyConfig():
 			port(HTTP_PORT),
-            protocol("http"),
-            tunnel(true),
-			authMethod(PROXY_AUTH_HTTP_BASIC)
+                        protocol("http"),
+                        tunnel(true),
+                        authMethod(PROXY_AUTH_HTTP_BASIC)
 		{
 		}
 
@@ -91,9 +91,9 @@ public:
 			/// Proxy server TCP port.
 		std::string  protocol;
 		    /// Protocol to use (http or https).
-        bool tunnel;
-            /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
-            /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
+                bool tunnel;
+                    /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
+                    /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
 		std::string  username;
 			/// Proxy server username.
 		std::string  password;

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -144,7 +144,7 @@ public:
 		/// Sets the port number of the proxy server.
 
 	void setProxyProtocol(const std::string& protocol);
-	    /// Sets the proxy protocol (http or https).
+	        /// Sets the proxy protocol (http or https).
 
 	void setProxyTunnel(bool tunnel);
 		/// If 'true' proxy will be used as tunnel.
@@ -156,7 +156,7 @@ public:
 		/// Returns the proxy port number.
 
 	const std::string& getProxyProtocol() const;
-	    /// Returns the proxy protocol.
+	        /// Returns the proxy protocol.
 
 	bool isProxyTunnel() const;
 		/// Returns 'true' if proxy is configured as tunnel.

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -136,6 +136,12 @@ public:
 
 	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT, const std::string& protocol = "http", bool tunnel = true);
 		/// Sets the proxy host name, port number, protocol (http or https) and tunnel behaviour.
+		///
+		/// Note: protocol "https" (i.e. connecting to the proxy itself over TLS) is only
+		/// supported by HTTPSClientSession. Calling this with protocol "https" on a
+		/// plain HTTPClientSession throws InvalidArgumentException. When using an
+		/// HTTPS proxy, the port usually needs to be set explicitly (commonly 443)
+		/// since the default is HTTPSession::HTTP_PORT (80).
 
 	void setProxyHost(const std::string& host);
 		/// Sets the host name of the proxy server.
@@ -145,6 +151,10 @@ public:
 
 	void setProxyProtocol(const std::string& protocol);
 		/// Sets the proxy protocol (http or https).
+		///
+		/// Note: protocol "https" is only supported by HTTPSClientSession.
+		/// Calling this with protocol "https" on a plain HTTPClientSession
+		/// throws InvalidArgumentException.
 
 	void setProxyTunnel(bool tunnel);
 		/// If 'true' proxy will be used as tunnel.
@@ -181,6 +191,10 @@ public:
 
 	void setProxyConfig(const ProxyConfig& config);
 		/// Sets the proxy configuration.
+		///
+		/// Note: a configuration with protocol "https" is only supported by
+		/// HTTPSClientSession. Applying it to a plain HTTPClientSession throws
+		/// InvalidArgumentException.
 
 	[[nodiscard]] const ProxyConfig& getProxyConfig() const;
 		/// Returns the proxy configuration.
@@ -190,6 +204,11 @@ public:
 		///
 		/// The global proxy configuration is used by all HTTPClientSession
 		/// instances, unless a different proxy configuration is explicitly set.
+		///
+		/// Note: protocol "https" is only honored by HTTPSClientSession
+		/// instances. A plain HTTPClientSession that inherits a global
+		/// configuration with protocol "https" will throw when it tries
+		/// to connect.
 		///
 		/// Warning: Setting the global proxy configuration is not thread safe.
 		/// The global proxy configuration should be set at start up, before

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -21,6 +21,7 @@
 #include "Poco/Net/IPAddress.h"
 #include "Poco/Net/Net.h"
 #include "Poco/Net/HTTPSession.h"
+#include "Poco/Net/HTTPSessionFactory.h"
 #include "Poco/Net/HTTPBasicCredentials.h"
 #include "Poco/Net/HTTPDigestCredentials.h"
 #include "Poco/Net/HTTPNTLMCredentials.h"
@@ -78,6 +79,8 @@ public:
 	{
 		ProxyConfig():
 			port(HTTP_PORT),
+            protocol("http"),
+            tunnel(true),
 			authMethod(PROXY_AUTH_HTTP_BASIC)
 		{
 		}
@@ -86,6 +89,11 @@ public:
 			/// Proxy server host name or IP address.
 		Poco::UInt16 port;
 			/// Proxy server TCP port.
+		std::string  protocol;
+		    /// Protocol to use (http or https).
+        bool tunnel;
+            /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
+            /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
 		std::string  username;
 			/// Proxy server username.
 		std::string  password;
@@ -167,8 +175,8 @@ public:
 	const SocketAddress& getSourceAddress6();
 		/// Returns the last IPV6 source address set with setSourceAddress
 
-	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT);
-		/// Sets the proxy host name and port number.
+	void setProxy(const std::string& host, Poco::UInt16 port = HTTPSession::HTTP_PORT, const std::string& protocol = "http", bool tunnel = true);
+		/// Sets the proxy host name, port number, protocol (http or https) and tunnel behaviour.
 
 	void setProxyHost(const std::string& host);
 		/// Sets the host name of the proxy server.
@@ -176,11 +184,23 @@ public:
 	void setProxyPort(Poco::UInt16 port);
 		/// Sets the port number of the proxy server.
 
+	void setProxyProtocol(const std::string& protocol);
+	    /// Sets the proxy protocol (http or https).
+
+	void setProxyTunnel(bool tunnel);
+		/// If 'true' proxy will be used as tunnel.
+
 	const std::string& getProxyHost() const;
 		/// Returns the proxy host name.
 
 	Poco::UInt16 getProxyPort() const;
 		/// Returns the proxy port number.
+
+	const std::string& getProxyProtocol() const;
+	    /// Returns the proxy protocol.
+
+	bool isProxyTunnel() const;
+		/// Returns 'true' if proxy is configured as tunnel.
 
 	void setProxyCredentials(const std::string& username, const std::string& password);
 		/// Sets the username and password for proxy authentication.
@@ -365,6 +385,8 @@ protected:
 		/// Calls proxyConnect() and attaches the resulting StreamSocket
 		/// to the HTTPClientSession.
 
+    HTTPSessionFactory _proxySessionFactory;
+        /// Factory to create HTTPClientSession to proxy.
 private:
 	using OStreamPtr = Poco::SharedPtr<std::ostream>;
 	using IStreamPtr = Poco::SharedPtr<std::istream>;
@@ -421,6 +443,18 @@ inline const std::string& HTTPClientSession::getProxyHost() const
 inline Poco::UInt16 HTTPClientSession::getProxyPort() const
 {
 	return _proxyConfig.port;
+}
+
+
+inline const std::string& HTTPClientSession::getProxyProtocol() const
+{
+    return _proxyConfig.protocol;
+}
+
+
+inline bool HTTPClientSession::isProxyTunnel() const
+{
+	return _proxyConfig.tunnel;
 }
 
 

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -25,6 +25,7 @@
 #include "Poco/Net/HTTPBasicCredentials.h"
 #include "Poco/Net/HTTPDigestCredentials.h"
 #include "Poco/Net/HTTPNTLMCredentials.h"
+#include "Poco/Net/ProxyConfig.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/SharedPtr.h"
 #include <istream>
@@ -32,7 +33,6 @@
 
 
 namespace Poco::Net {
-
 
 class HTTPRequest;
 class HTTPResponse;
@@ -66,47 +66,6 @@ class Net_API HTTPClientSession: public HTTPSession
 	/// set up a session through a proxy.
 {
 public:
-	enum ProxyAuthentication
-	{
-		PROXY_AUTH_NONE,        /// No proxy authentication
-		PROXY_AUTH_HTTP_BASIC,  /// HTTP Basic proxy authentication (default, if username and password are supplied)
-		PROXY_AUTH_HTTP_DIGEST, /// HTTP Digest proxy authentication
-		PROXY_AUTH_NTLM         /// NTLMv2 proxy authentication
-	};
-
-	struct ProxyConfig
-		/// HTTP proxy server configuration.
-	{
-		ProxyConfig():
-			port(HTTP_PORT),
-                        protocol("http"),
-                        tunnel(true),
-                        authMethod(PROXY_AUTH_HTTP_BASIC)
-		{
-		}
-
-		std::string  host;
-			/// Proxy server host name or IP address.
-		Poco::UInt16 port;
-			/// Proxy server TCP port.
-		std::string  protocol;
-		    /// Protocol to use (http or https).
-                bool tunnel;
-                    /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
-                    /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
-		std::string  username;
-			/// Proxy server username.
-		std::string  password;
-			/// Proxy server password.
-		std::string  nonProxyHosts;
-			/// A regular expression defining hosts for which the proxy should be bypassed,
-			/// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
-			/// string to disable proxy bypassing.
-
-		ProxyAuthentication authMethod;
-			/// The authentication method to use - HTTP Basic or NTLM.
-	};
-
 	HTTPClientSession();
 		/// Creates an unconnected HTTPClientSession.
 
@@ -470,13 +429,13 @@ inline const std::string& HTTPClientSession::getProxyPassword() const
 }
 
 
-inline const HTTPClientSession::ProxyConfig& HTTPClientSession::getProxyConfig() const
+inline const ProxyConfig& HTTPClientSession::getProxyConfig() const
 {
 	return _proxyConfig;
 }
 
 
-inline const HTTPClientSession::ProxyConfig& HTTPClientSession::getGlobalProxyConfig()
+inline const ProxyConfig& HTTPClientSession::getGlobalProxyConfig()
 {
 	return _globalProxyConfig;
 }

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -144,7 +144,7 @@ public:
 		/// Sets the port number of the proxy server.
 
 	void setProxyProtocol(const std::string& protocol);
-	        /// Sets the proxy protocol (http or https).
+		/// Sets the proxy protocol (http or https).
 
 	void setProxyTunnel(bool tunnel);
 		/// If 'true' proxy will be used as tunnel.
@@ -156,7 +156,7 @@ public:
 		/// Returns the proxy port number.
 
 	const std::string& getProxyProtocol() const;
-	        /// Returns the proxy protocol.
+		/// Returns the proxy protocol.
 
 	bool isProxyTunnel() const;
 		/// Returns 'true' if proxy is configured as tunnel.
@@ -344,8 +344,9 @@ protected:
 		/// Calls proxyConnect() and attaches the resulting StreamSocket
 		/// to the HTTPClientSession.
 
-        HTTPSessionFactory _proxySessionFactory;
-                /// Factory to create HTTPClientSession to proxy.
+	HTTPSessionFactory _proxySessionFactory;
+		/// Factory to create HTTPClientSession to proxy.
+
 private:
 	using OStreamPtr = Poco::SharedPtr<std::ostream>;
 	using IStreamPtr = Poco::SharedPtr<std::istream>;
@@ -407,13 +408,13 @@ inline Poco::UInt16 HTTPClientSession::getProxyPort() const
 
 inline const std::string& HTTPClientSession::getProxyProtocol() const
 {
-        return _proxyConfig.protocol;
+	return _proxyConfig.protocol;
 }
 
 
 inline bool HTTPClientSession::isProxyTunnel() const
 {
-        return _proxyConfig.tunnel;
+	return _proxyConfig.tunnel;
 }
 
 

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -182,7 +182,7 @@ public:
 	void setProxyConfig(const ProxyConfig& config);
 		/// Sets the proxy configuration.
 
-	const ProxyConfig& getProxyConfig() const;
+	[[nodiscard]] const ProxyConfig& getProxyConfig() const;
 		/// Returns the proxy configuration.
 
 	static void setGlobalProxyConfig(const ProxyConfig& config);
@@ -195,7 +195,7 @@ public:
 		/// The global proxy configuration should be set at start up, before
 		/// the first HTTPClientSession instance is created.
 
-	static const ProxyConfig& getGlobalProxyConfig();
+	[[nodiscard]] static const ProxyConfig& getGlobalProxyConfig();
 		/// Returns the global proxy configuration.
 
 	void setKeepAliveTimeout(const Poco::Timespan& timeout);
@@ -286,11 +286,11 @@ public:
 		/// the request or response stream changes into
 		/// fail or bad state, but not eof state).
 
-	virtual bool secure() const;
+	[[nodiscard]] virtual bool secure() const;
 		/// Return true iff the session uses SSL or TLS,
 		/// or false otherwise.
 
-	bool bypassProxy() const;
+	[[nodiscard]] bool bypassProxy() const;
 		/// Returns true if the proxy should be bypassed
 		/// for the current host.
 
@@ -372,8 +372,11 @@ private:
 
 	static ProxyConfig _globalProxyConfig;
 
-	HTTPClientSession(const HTTPClientSession&);
-	HTTPClientSession& operator = (const HTTPClientSession&);
+	void initProxySessionFactory();
+		/// Registers the "http" protocol with _proxySessionFactory.
+
+	HTTPClientSession(const HTTPClientSession&) = delete;
+	HTTPClientSession& operator = (const HTTPClientSession&) = delete;
 
 	friend class WebSocket;
 };
@@ -412,7 +415,7 @@ inline const std::string& HTTPClientSession::getProxyProtocol() const
 }
 
 
-inline bool HTTPClientSession::isProxyTunnel() const
+[[nodiscard]] inline bool HTTPClientSession::isProxyTunnel() const
 {
 	return _proxyConfig.tunnel;
 }

--- a/Net/include/Poco/Net/HTTPClientSession.h
+++ b/Net/include/Poco/Net/HTTPClientSession.h
@@ -385,8 +385,8 @@ protected:
 		/// Calls proxyConnect() and attaches the resulting StreamSocket
 		/// to the HTTPClientSession.
 
-    HTTPSessionFactory _proxySessionFactory;
-        /// Factory to create HTTPClientSession to proxy.
+        HTTPSessionFactory _proxySessionFactory;
+                /// Factory to create HTTPClientSession to proxy.
 private:
 	using OStreamPtr = Poco::SharedPtr<std::ostream>;
 	using IStreamPtr = Poco::SharedPtr<std::istream>;
@@ -448,13 +448,13 @@ inline Poco::UInt16 HTTPClientSession::getProxyPort() const
 
 inline const std::string& HTTPClientSession::getProxyProtocol() const
 {
-    return _proxyConfig.protocol;
+        return _proxyConfig.protocol;
 }
 
 
 inline bool HTTPClientSession::isProxyTunnel() const
 {
-	return _proxyConfig.tunnel;
+        return _proxyConfig.tunnel;
 }
 
 

--- a/Net/include/Poco/Net/HTTPSessionFactory.h
+++ b/Net/include/Poco/Net/HTTPSessionFactory.h
@@ -19,7 +19,7 @@
 
 
 #include "Poco/Net/Net.h"
-#include "Poco/Net/HTTPClientSession.h"
+#include "Poco/Net/ProxyConfig.h"
 #include "Poco/Mutex.h"
 #include "Poco/URI.h"
 #include "Poco/SingletonHolder.h"
@@ -29,7 +29,7 @@
 
 namespace Poco::Net {
 
-
+class HTTPClientSession;
 class HTTPSessionInstantiator;
 
 
@@ -51,7 +51,7 @@ public:
 	HTTPSessionFactory(const std::string& proxyHost, Poco::UInt16 proxyPort);
 		/// Creates the HTTPSessionFactory and sets the proxy host and port.
 
-	HTTPSessionFactory(const HTTPClientSession::ProxyConfig& proxyConfig);
+	HTTPSessionFactory(const ProxyConfig& proxyConfig);
 		/// Creates the HTTPSessionFactory and sets the proxy configuration.
 
 	~HTTPSessionFactory();
@@ -96,10 +96,10 @@ public:
 	const std::string& proxyPassword() const;
 		/// Returns the password for proxy authorization.
 
-	void setProxyConfig(const HTTPClientSession::ProxyConfig& proxyConfig);
+	void setProxyConfig(const ProxyConfig& proxyConfig);
 		/// Sets the proxy configuration.
 
-	const HTTPClientSession::ProxyConfig& getProxyConfig() const;
+	const ProxyConfig& getProxyConfig() const;
 		/// Returns the proxy configuration.
 
 	static HTTPSessionFactory& defaultFactory();
@@ -121,7 +121,7 @@ private:
 	typedef std::map<std::string, InstantiatorInfo> Instantiators;
 
 	Instantiators _instantiators;
-	HTTPClientSession::ProxyConfig _proxyConfig;
+	ProxyConfig _proxyConfig;
 
 	mutable Poco::FastMutex _mutex;
 };
@@ -154,7 +154,7 @@ inline const std::string& HTTPSessionFactory::proxyPassword() const
 }
 
 
-inline const HTTPClientSession::ProxyConfig& HTTPSessionFactory::getProxyConfig() const
+inline const ProxyConfig& HTTPSessionFactory::getProxyConfig() const
 {
 	return _proxyConfig;
 }

--- a/Net/include/Poco/Net/HTTPSessionInstantiator.h
+++ b/Net/include/Poco/Net/HTTPSessionInstantiator.h
@@ -51,14 +51,14 @@ public:
 		/// Unregisters the factory with the global HTTPSessionFactory.
 
 protected:
-	void setProxyConfig(const HTTPClientSession::ProxyConfig& proxyConfig);
+	void setProxyConfig(const ProxyConfig& proxyConfig);
 		/// Sets the proxy configuration.
 
-	const HTTPClientSession::ProxyConfig& getProxyConfig() const;
+	const ProxyConfig& getProxyConfig() const;
 		/// Returns the proxy configuration.
 
 private:
-	HTTPClientSession::ProxyConfig _proxyConfig;
+	ProxyConfig _proxyConfig;
 
 	friend class HTTPSessionFactory;
 };
@@ -67,7 +67,7 @@ private:
 //
 // inlines
 //
-inline const HTTPClientSession::ProxyConfig& HTTPSessionInstantiator::getProxyConfig() const
+inline const ProxyConfig& HTTPSessionInstantiator::getProxyConfig() const
 {
 	return _proxyConfig;
 }

--- a/Net/include/Poco/Net/ProxyConfig.h
+++ b/Net/include/Poco/Net/ProxyConfig.h
@@ -18,7 +18,6 @@
 
 #include "Poco/Net/Net.h"
 #include "Poco/Net/HTTPSession.h"
-#include <string>
 
 namespace Poco {
 namespace Net {
@@ -40,25 +39,25 @@ namespace Net {
             }
 
             std::string host;
-            /// Proxy server host name or IP address.
+                /// Proxy server host name or IP address.
             Poco::UInt16 port;
-            /// Proxy server TCP port.
+                /// Proxy server TCP port.
             std::string protocol;
-            /// Protocol to use (http or https).
+                /// Protocol to use (http or https).
             bool tunnel;
-            /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
-            /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
+            	/// Use proxy as tunnel (establish 2-way communication through CONNECT request).
+                /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
             std::string username;
-            /// Proxy server username.
+                /// Proxy server username.
             std::string password;
-            /// Proxy server password.
+                /// Proxy server password.
             std::string nonProxyHosts;
-            /// A regular expression defining hosts for which the proxy should be bypassed,
-            /// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
-            /// string to disable proxy bypassing.
+                /// A regular expression defining hosts for which the proxy should be bypassed,
+                /// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
+                /// string to disable proxy bypassing.
 
             ProxyAuthentication authMethod;
-            /// The authentication method to use - HTTP Basic or NTLM.
+                /// The authentication method to use - HTTP Basic or NTLM.
         };
 
 } } // namespace Poco::Net

--- a/Net/include/Poco/Net/ProxyConfig.h
+++ b/Net/include/Poco/Net/ProxyConfig.h
@@ -1,0 +1,66 @@
+//
+// ProxyConfig.h
+//
+// Library: Net
+// Package: HTTP
+// Module:  ProxyConfig
+//
+// Definition of the ProxyConfig class.
+//
+// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+#ifndef Net_ProxyConfig_INCLUDED
+#define Net_ProxyConfig_INCLUDED
+
+#include "Poco/Net/Net.h"
+#include "Poco/Net/HTTPSession.h"
+#include <string>
+
+namespace Poco {
+namespace Net {
+        enum ProxyAuthentication {
+            PROXY_AUTH_NONE,        /// No proxy authentication
+            PROXY_AUTH_HTTP_BASIC,  /// HTTP Basic proxy authentication (default, if username and password are supplied)
+            PROXY_AUTH_HTTP_DIGEST, /// HTTP Digest proxy authentication
+            PROXY_AUTH_NTLM         /// NTLMv2 proxy authentication
+        };
+
+        struct ProxyConfig
+            /// HTTP proxy server configuration.
+        {
+            ProxyConfig() :
+                    port(HTTPSession::HTTP_PORT),
+                    protocol("http"),
+                    tunnel(true),
+                    authMethod(PROXY_AUTH_HTTP_BASIC) {
+            }
+
+            std::string host;
+            /// Proxy server host name or IP address.
+            Poco::UInt16 port;
+            /// Proxy server TCP port.
+            std::string protocol;
+            /// Protocol to use (http or https).
+            bool tunnel;
+            /// Use proxy as tunnel (establish 2-way communication through CONNECT request).
+            /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
+            std::string username;
+            /// Proxy server username.
+            std::string password;
+            /// Proxy server password.
+            std::string nonProxyHosts;
+            /// A regular expression defining hosts for which the proxy should be bypassed,
+            /// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
+            /// string to disable proxy bypassing.
+
+            ProxyAuthentication authMethod;
+            /// The authentication method to use - HTTP Basic or NTLM.
+        };
+
+} } // namespace Poco::Net
+
+#endif // Net_ProxyConfig_INCLUDED

--- a/Net/include/Poco/Net/ProxyConfig.h
+++ b/Net/include/Poco/Net/ProxyConfig.h
@@ -7,7 +7,7 @@
 //
 // Definition of the ProxyConfig class.
 //
-// Copyright (c) 2005-2006, Applied Informatics Software Engineering GmbH.
+// Copyright (c) 2005-2026, Applied Informatics Software Engineering GmbH.
 // and Contributors.
 //
 // SPDX-License-Identifier:	BSL-1.0
@@ -21,44 +21,50 @@
 
 namespace Poco {
 namespace Net {
-        enum ProxyAuthentication {
-            PROXY_AUTH_NONE,        /// No proxy authentication
-            PROXY_AUTH_HTTP_BASIC,  /// HTTP Basic proxy authentication (default, if username and password are supplied)
-            PROXY_AUTH_HTTP_DIGEST, /// HTTP Digest proxy authentication
-            PROXY_AUTH_NTLM         /// NTLMv2 proxy authentication
-        };
 
-        struct ProxyConfig
-            /// HTTP proxy server configuration.
-        {
-            ProxyConfig() :
-                    port(HTTPSession::HTTP_PORT),
-                    protocol("http"),
-                    tunnel(true),
-                    authMethod(PROXY_AUTH_HTTP_BASIC) {
-            }
 
-            std::string host;
-                /// Proxy server host name or IP address.
-            Poco::UInt16 port;
-                /// Proxy server TCP port.
-            std::string protocol;
-                /// Protocol to use (http or https).
-            bool tunnel;
-            	/// Use proxy as tunnel (establish 2-way communication through CONNECT request).
-                /// If tunnel option is 'false' request will be send directly to proxy without CONNECT request.
-            std::string username;
-                /// Proxy server username.
-            std::string password;
-                /// Proxy server password.
-            std::string nonProxyHosts;
-                /// A regular expression defining hosts for which the proxy should be bypassed,
-                /// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
-                /// string to disable proxy bypassing.
+enum ProxyAuthentication
+{
+	PROXY_AUTH_NONE,        /// No proxy authentication
+	PROXY_AUTH_HTTP_BASIC,  /// HTTP Basic proxy authentication (default, if username and password are supplied)
+	PROXY_AUTH_HTTP_DIGEST, /// HTTP Digest proxy authentication
+	PROXY_AUTH_NTLM         /// NTLMv2 proxy authentication
+};
 
-            ProxyAuthentication authMethod;
-                /// The authentication method to use - HTTP Basic or NTLM.
-        };
+
+struct ProxyConfig
+	/// HTTP proxy server configuration.
+{
+	ProxyConfig():
+		port(HTTPSession::HTTP_PORT),
+		protocol("http"),
+		tunnel(true),
+		authMethod(PROXY_AUTH_HTTP_BASIC)
+	{
+	}
+
+	std::string host;
+		/// Proxy server host name or IP address.
+	Poco::UInt16 port;
+		/// Proxy server TCP port.
+	std::string protocol;
+		/// Protocol to use (http or https).
+	bool tunnel;
+		/// Use proxy as tunnel (establish 2-way communication through CONNECT request).
+		/// If tunnel option is 'false' request will be sent directly to proxy without CONNECT request.
+	std::string username;
+		/// Proxy server username.
+	std::string password;
+		/// Proxy server password.
+	std::string nonProxyHosts;
+		/// A regular expression defining hosts for which the proxy should be bypassed,
+		/// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
+		/// string to disable proxy bypassing.
+
+	ProxyAuthentication authMethod;
+		/// The authentication method to use - HTTP Basic or NTLM.
+};
+
 
 } } // namespace Poco::Net
 

--- a/Net/include/Poco/Net/ProxyConfig.h
+++ b/Net/include/Poco/Net/ProxyConfig.h
@@ -7,7 +7,7 @@
 //
 // Definition of the ProxyConfig class.
 //
-// Copyright (c) 2005-2026, Applied Informatics Software Engineering GmbH.
+// Copyright (c) 2026-2026, Applied Informatics Software Engineering GmbH.
 // and Contributors.
 //
 // SPDX-License-Identifier:	BSL-1.0
@@ -23,35 +23,33 @@ namespace Poco {
 namespace Net {
 
 
-enum ProxyAuthentication
+enum class ProxyAuthentication
 {
-	PROXY_AUTH_NONE,        /// No proxy authentication
-	PROXY_AUTH_HTTP_BASIC,  /// HTTP Basic proxy authentication (default, if username and password are supplied)
-	PROXY_AUTH_HTTP_DIGEST, /// HTTP Digest proxy authentication
-	PROXY_AUTH_NTLM         /// NTLMv2 proxy authentication
+	None,        /// No proxy authentication
+	Basic,       /// HTTP Basic proxy authentication (default, if username and password are supplied)
+	Digest,      /// HTTP Digest proxy authentication
+	NTLM         /// NTLMv2 proxy authentication
 };
 
 
 struct ProxyConfig
 	/// HTTP proxy server configuration.
 {
-	ProxyConfig():
-		port(HTTPSession::HTTP_PORT),
-		protocol("http"),
-		tunnel(true),
-		authMethod(PROXY_AUTH_HTTP_BASIC)
-	{
-	}
+	ProxyConfig() = default;
 
 	std::string host;
 		/// Proxy server host name or IP address.
-	Poco::UInt16 port;
+	Poco::UInt16 port = HTTPSession::HTTP_PORT;
 		/// Proxy server TCP port.
-	std::string protocol;
+	std::string protocol = "http";
 		/// Protocol to use (http or https).
-	bool tunnel;
+	bool tunnel = true;
 		/// Use proxy as tunnel (establish 2-way communication through CONNECT request).
 		/// If tunnel option is 'false' request will be sent directly to proxy without CONNECT request.
+		///
+		/// Warning: Setting tunnel to false for HTTPS sessions means the TLS connection
+		/// terminates at the proxy, not at the destination server. The proxy will see
+		/// the request in plaintext.
 	std::string username;
 		/// Proxy server username.
 	std::string password;
@@ -61,7 +59,7 @@ struct ProxyConfig
 		/// e.g. "localhost|127\.0\.0\.1|192\.168\.0\.\d+". Can also be an empty
 		/// string to disable proxy bypassing.
 
-	ProxyAuthentication authMethod;
+	ProxyAuthentication authMethod = ProxyAuthentication::Basic;
 		/// The authentication method to use - HTTP Basic or NTLM.
 };
 

--- a/Net/include/Poco/Net/ProxyConfig.h
+++ b/Net/include/Poco/Net/ProxyConfig.h
@@ -60,7 +60,7 @@ struct ProxyConfig
 		/// string to disable proxy bypassing.
 
 	ProxyAuthentication authMethod = ProxyAuthentication::Basic;
-		/// The authentication method to use - HTTP Basic or NTLM.
+		/// The authentication method to use - HTTP Basic, HTTP Digest or NTLM.
 };
 
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/Net/HTTPClientSession.h"
+#include "Poco/Net/HTTPSessionFactory.h"
 #include "Poco/Net/HTTPSessionInstantiator.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPResponse.h"
@@ -35,7 +36,7 @@ using Poco::IllegalStateException;
 namespace Poco::Net {
 
 
-HTTPClientSession::ProxyConfig HTTPClientSession::_globalProxyConfig;
+ProxyConfig HTTPClientSession::_globalProxyConfig;
 
 
 HTTPClientSession::HTTPClientSession():
@@ -626,9 +627,9 @@ StreamSocket HTTPClientSession::proxyConnect()
         proxyUri.setHost(getProxyHost());
         proxyUri.setPort(getProxyPort());
 
-	HTTPClientSession proxySession (_proxySessionFactory.createClientSession(proxyUri));
+	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
 
-	proxySession.setTimeout(getTimeout());
+	proxySession->setTimeout(getTimeout());
 	std::string targetAddress(_host);
 	targetAddress.append(":");
 	NumberFormatter::append(targetAddress, _port);
@@ -636,15 +637,15 @@ StreamSocket HTTPClientSession::proxyConnect()
 	HTTPResponse proxyResponse;
 	proxyRequest.set(HTTPMessage::PROXY_CONNECTION, HTTPMessage::CONNECTION_KEEP_ALIVE);
 	proxyRequest.set(HTTPRequest::HOST, targetAddress);
-	proxySession.proxyAuthenticateImpl(proxyRequest, _proxyConfig);
-	proxySession.setKeepAlive(true);
-	proxySession.setSourceAddress(_sourceAddress4);
-	proxySession.setSourceAddress(_sourceAddress6);
-	proxySession.sendRequest(proxyRequest);
-	proxySession.receiveResponse(proxyResponse);
+	proxySession->proxyAuthenticateImpl(proxyRequest, _proxyConfig);
+	proxySession->setKeepAlive(true);
+	proxySession->setSourceAddress(_sourceAddress4);
+	proxySession->setSourceAddress(_sourceAddress6);
+	proxySession->sendRequest(proxyRequest);
+	proxySession->receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)
 		throw HTTPException("Cannot establish proxy connection", proxyResponse.getReason());
-	return proxySession.detachSocket();
+	return proxySession->detachSocket();
 }
 
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -622,9 +622,9 @@ void HTTPClientSession::sendChallengeRequest(const HTTPRequest& request, HTTPRes
 StreamSocket HTTPClientSession::proxyConnect()
 {
 	URI proxyUri;
-    proxyUri.setScheme(getProxyProtocol());
-    proxyUri.setHost(getProxyHost());
-    proxyUri.setPort(getProxyPort());
+        proxyUri.setScheme(getProxyProtocol());
+        proxyUri.setHost(getProxyHost());
+        proxyUri.setPort(getProxyPort());
 
 	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
 
@@ -636,10 +636,10 @@ StreamSocket HTTPClientSession::proxyConnect()
 	HTTPResponse proxyResponse;
 	proxyRequest.set(HTTPMessage::PROXY_CONNECTION, HTTPMessage::CONNECTION_KEEP_ALIVE);
 	proxyRequest.set(HTTPRequest::HOST, targetAddress);
-	proxySession.proxyAuthenticateImpl(proxyRequest, _proxyConfig);
+	proxySession->proxyAuthenticateImpl(proxyRequest, _proxyConfig);
 	proxySession->setKeepAlive(true);
-	proxySession.setSourceAddress(_sourceAddress4);
-	proxySession.setSourceAddress(_sourceAddress6);
+	proxySession->setSourceAddress(_sourceAddress4);
+	proxySession->setSourceAddress(_sourceAddress6);
 	proxySession->sendRequest(proxyRequest);
 	proxySession->receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -621,7 +621,7 @@ StreamSocket HTTPClientSession::proxyConnect()
     proxyUri.setHost(getProxyHost());
     proxyUri.setPort(getProxyPort());
 
-	SharedPtr<HTTPClientSession> proxySession (HTTPSessionFactory::defaultFactory().createClientSession(proxyUri));
+	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
 
 	proxySession->setTimeout(getTimeout());
 	std::string targetAddress(_host);

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -626,9 +626,9 @@ StreamSocket HTTPClientSession::proxyConnect()
         proxyUri.setHost(getProxyHost());
         proxyUri.setPort(getProxyPort());
 
-	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
+	HTTPClientSession proxySession (_proxySessionFactory.createClientSession(proxyUri));
 
-	proxySession->setTimeout(getTimeout());
+	proxySession.setTimeout(getTimeout());
 	std::string targetAddress(_host);
 	targetAddress.append(":");
 	NumberFormatter::append(targetAddress, _port);
@@ -636,15 +636,15 @@ StreamSocket HTTPClientSession::proxyConnect()
 	HTTPResponse proxyResponse;
 	proxyRequest.set(HTTPMessage::PROXY_CONNECTION, HTTPMessage::CONNECTION_KEEP_ALIVE);
 	proxyRequest.set(HTTPRequest::HOST, targetAddress);
-	proxySession->proxyAuthenticateImpl(proxyRequest, _proxyConfig);
-	proxySession->setKeepAlive(true);
-	proxySession->setSourceAddress(_sourceAddress4);
-	proxySession->setSourceAddress(_sourceAddress6);
-	proxySession->sendRequest(proxyRequest);
-	proxySession->receiveResponse(proxyResponse);
+	proxySession.proxyAuthenticateImpl(proxyRequest, _proxyConfig);
+	proxySession.setKeepAlive(true);
+	proxySession.setSourceAddress(_sourceAddress4);
+	proxySession.setSourceAddress(_sourceAddress6);
+	proxySession.sendRequest(proxyRequest);
+	proxySession.receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)
 		throw HTTPException("Cannot establish proxy connection", proxyResponse.getReason());
-	return proxySession->detachSocket();
+	return proxySession.detachSocket();
 }
 
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -214,6 +214,8 @@ void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port, con
 {
 	if (protocol != "http" && protocol != "https")
 		throw InvalidArgumentException("Protocol must be either http or https");
+	if (protocol == "https" && !secure())
+		throw InvalidArgumentException("HTTPS proxy requires HTTPSClientSession");
 
 	if (!connected())
 	{
@@ -248,6 +250,8 @@ void HTTPClientSession::setProxyProtocol(const std::string& protocol)
 {
 	if (protocol != "http" && protocol != "https")
 		throw InvalidArgumentException("Protocol must be either http or https");
+	if (protocol == "https" && !secure())
+		throw InvalidArgumentException("HTTPS proxy requires HTTPSClientSession");
 
 	if (!connected())
 		_proxyConfig.protocol = protocol;
@@ -288,6 +292,8 @@ void HTTPClientSession::setProxyConfig(const ProxyConfig& config)
 {
 	if (config.protocol != "http" && config.protocol != "https")
 		throw InvalidArgumentException("Protocol must be either http or https");
+	if (config.protocol == "https" && !secure())
+		throw InvalidArgumentException("HTTPS proxy requires HTTPSClientSession");
 
 	if (!connected())
 		_proxyConfig = config;
@@ -520,7 +526,11 @@ void HTTPClientSession::reconnect()
 			addr = SocketAddress(_host, _port);
 	}
 	else
+	{
+		if (_proxyConfig.protocol == "https" && !secure())
+			throw Poco::NotImplementedException("HTTPS proxy requires HTTPSClientSession");
 		addr = SocketAddress(_proxyConfig.host, _proxyConfig.port);
+	}
 
 	if ((!_sourceAddress4.host().isWildcard()) || (_sourceAddress4.port() != 0))
 		connect(addr, _sourceAddress4);
@@ -647,6 +657,9 @@ void HTTPClientSession::sendChallengeRequest(const HTTPRequest& request, HTTPRes
 
 StreamSocket HTTPClientSession::proxyConnect()
 {
+	if (getProxyProtocol() == "https" && !secure())
+		throw Poco::NotImplementedException("HTTPS proxy requires HTTPSClientSession");
+
 	URI proxyUri;
 	proxyUri.setScheme(getProxyProtocol());
 	proxyUri.setHost(getProxyHost());
@@ -655,7 +668,13 @@ StreamSocket HTTPClientSession::proxyConnect()
 	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
 
 	proxySession->setTimeout(getTimeout());
-	std::string targetAddress(_host);
+	// RFC 3986 requires IPv6 literal hosts to be bracketed in the authority form
+	// used as the CONNECT request-target and in the Host header.
+	std::string targetAddress;
+	if (_host.find(':') != std::string::npos)
+		targetAddress.append("[").append(_host).append("]");
+	else
+		targetAddress.append(_host);
 	targetAddress.append(":");
 	NumberFormatter::append(targetAddress, _port);
 	HTTPRequest proxyRequest(HTTPRequest::HTTP_CONNECT, targetAddress, HTTPMessage::HTTP_1_1);

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -509,8 +509,13 @@ std::string HTTPClientSession::proxyRequestPrefix() const
 {
 	std::string result("http://");
 	result.append(_host);
-	result.append(":");
-	NumberFormatter::append(result, _port);
+	/// Do not append default by default, since this may break some servers.
+	/// One example of such server is GCS (Google Cloud Storage).
+	if (_port != HTTPSession::HTTP_PORT)
+	{
+		result.append(":");
+		NumberFormatter::append(result, _port);
+	}
 	return result;
 }
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/Net/HTTPClientSession.h"
+#include "Poco/Net/HTTPSessionInstantiator.h"
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPResponse.h"
 #include "Poco/Net/HTTPHeaderStream.h"
@@ -49,6 +50,7 @@ HTTPClientSession::HTTPClientSession():
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
+    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -65,6 +67,7 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
+    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -81,6 +84,7 @@ HTTPClientSession::HTTPClientSession(const SocketAddress& address):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
+    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -97,6 +101,7 @@ HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port)
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
+    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -126,11 +131,13 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket, const ProxyConf
 	_expectResponseBody(false),
 	_responseReceived(false)
 {
+    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
 HTTPClientSession::~HTTPClientSession()
 {
+    _proxySessionFactory.unregisterProtocol("http");
 }
 
 
@@ -185,14 +192,19 @@ const SocketAddress& HTTPClientSession::getSourceAddress6()
 }
 
 
-void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port)
+void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port, const std::string& protocol, bool tunnel)
 {
+    if (protocol != "http" && protocol != "https")
+        throw IllegalStateException("Protocol must be either http or https");
+
 	if (!connected())
 	{
 		_proxyConfig.host = host;
 		_proxyConfig.port = port;
+		_proxyConfig.protocol = protocol;
+		_proxyConfig.tunnel = tunnel;
 	}
-	else throw IllegalStateException("Cannot set the proxy host and port for an already connected session");
+	else throw IllegalStateException("Cannot set the proxy host, port and protocol for an already connected session");
 }
 
 
@@ -211,6 +223,28 @@ void HTTPClientSession::setProxyPort(Poco::UInt16 port)
 		_proxyConfig.port = port;
 	else
 		throw IllegalStateException("Cannot set the proxy port number for an already connected session");
+}
+
+
+void HTTPClientSession::setProxyProtocol(const std::string& protocol)
+{
+    if (protocol != "http" && protocol != "https")
+        throw IllegalStateException("Protocol must be either http or https");
+
+    if (!connected())
+        _proxyConfig.protocol = protocol;
+    else
+        throw IllegalStateException("Cannot set the proxy port number for an already connected session");
+}
+
+
+void HTTPClientSession::setProxyTunnel(bool tunnel)
+{
+    if (!connected())
+        _proxyConfig.tunnel = tunnel;
+    else
+        throw IllegalStateException("Cannot set the proxy tunnel for an already connected session");
+
 }
 
 
@@ -582,25 +616,30 @@ void HTTPClientSession::sendChallengeRequest(const HTTPRequest& request, HTTPRes
 
 StreamSocket HTTPClientSession::proxyConnect()
 {
-	ProxyConfig emptyProxyConfig;
-	HTTPClientSession proxySession(getProxyHost(), getProxyPort(), emptyProxyConfig);
-	proxySession.setTimeout(getTimeout());
+	URI proxyUri;
+    proxyUri.setScheme(getProxyProtocol());
+    proxyUri.setHost(getProxyHost());
+    proxyUri.setPort(getProxyPort());
+
+	SharedPtr<HTTPClientSession> proxySession (HTTPSessionFactory::defaultFactory().createClientSession(proxyUri));
+
+	proxySession->setTimeout(getTimeout());
 	std::string targetAddress(_host);
 	targetAddress.append(":");
 	NumberFormatter::append(targetAddress, _port);
 	HTTPRequest proxyRequest(HTTPRequest::HTTP_CONNECT, targetAddress, HTTPMessage::HTTP_1_1);
 	HTTPResponse proxyResponse;
 	proxyRequest.set(HTTPMessage::PROXY_CONNECTION, HTTPMessage::CONNECTION_KEEP_ALIVE);
-	proxyRequest.set(HTTPRequest::HOST, getHost());
+	proxyRequest.set(HTTPRequest::HOST, targetAddress);
 	proxySession.proxyAuthenticateImpl(proxyRequest, _proxyConfig);
-	proxySession.setKeepAlive(true);
+	proxySession->setKeepAlive(true);
 	proxySession.setSourceAddress(_sourceAddress4);
 	proxySession.setSourceAddress(_sourceAddress6);
-	proxySession.sendRequest(proxyRequest);
-	proxySession.receiveResponse(proxyResponse);
+	proxySession->sendRequest(proxyRequest);
+	proxySession->receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)
 		throw HTTPException("Cannot establish proxy connection", proxyResponse.getReason());
-	return proxySession.detachSocket();
+	return proxySession->detachSocket();
 }
 
 
@@ -619,6 +658,5 @@ bool HTTPClientSession::bypassProxy() const
 	}
 	else return false;
 }
-
 
 } // namespace Poco::Net

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -51,7 +51,7 @@ HTTPClientSession::HTTPClientSession():
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -68,7 +68,7 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -85,7 +85,7 @@ HTTPClientSession::HTTPClientSession(const SocketAddress& address):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -102,7 +102,7 @@ HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port)
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -132,13 +132,13 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket, const ProxyConf
 	_expectResponseBody(false),
 	_responseReceived(false)
 {
-        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
 HTTPClientSession::~HTTPClientSession()
 {
-        _proxySessionFactory.unregisterProtocol("http");
+	_proxySessionFactory.unregisterProtocol("http");
 }
 
 
@@ -195,17 +195,17 @@ const SocketAddress& HTTPClientSession::getSourceAddress6()
 
 void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port, const std::string& protocol, bool tunnel)
 {
-        if (protocol != "http" && protocol != "https")
-                throw IllegalStateException("Protocol must be either http or https");
+	if (protocol != "http" && protocol != "https")
+		throw IllegalStateException("Protocol must be either http or https");
 
-        if (!connected())
+	if (!connected())
 	{
 		_proxyConfig.host = host;
 		_proxyConfig.port = port;
 		_proxyConfig.protocol = protocol;
 		_proxyConfig.tunnel = tunnel;
 	}
-        else throw IllegalStateException("Cannot set the proxy host, port and protocol for an already connected session");
+	else throw IllegalStateException("Cannot set the proxy host, port and protocol for an already connected session");
 }
 
 
@@ -229,23 +229,22 @@ void HTTPClientSession::setProxyPort(Poco::UInt16 port)
 
 void HTTPClientSession::setProxyProtocol(const std::string& protocol)
 {
-        if (protocol != "http" && protocol != "https")
-                throw IllegalStateException("Protocol must be either http or https");
+	if (protocol != "http" && protocol != "https")
+		throw IllegalStateException("Protocol must be either http or https");
 
-        if (!connected())
-                _proxyConfig.protocol = protocol;
-        else
-                throw IllegalStateException("Cannot set the proxy port number for an already connected session");
+	if (!connected())
+		_proxyConfig.protocol = protocol;
+	else
+		throw IllegalStateException("Cannot set the proxy protocol for an already connected session");
 }
 
 
 void HTTPClientSession::setProxyTunnel(bool tunnel)
 {
-        if (!connected())
-                _proxyConfig.tunnel = tunnel;
-        else
-                throw IllegalStateException("Cannot set the proxy tunnel for an already connected session");
-
+	if (!connected())
+		_proxyConfig.tunnel = tunnel;
+	else
+		throw IllegalStateException("Cannot set the proxy tunnel for an already connected session");
 }
 
 
@@ -623,9 +622,9 @@ void HTTPClientSession::sendChallengeRequest(const HTTPRequest& request, HTTPRes
 StreamSocket HTTPClientSession::proxyConnect()
 {
 	URI proxyUri;
-        proxyUri.setScheme(getProxyProtocol());
-        proxyUri.setHost(getProxyHost());
-        proxyUri.setPort(getProxyPort());
+	proxyUri.setScheme(getProxyProtocol());
+	proxyUri.setHost(getProxyHost());
+	proxyUri.setPort(getProxyPort());
 
 	SharedPtr<HTTPClientSession> proxySession (_proxySessionFactory.createClientSession(proxyUri));
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -31,6 +31,7 @@
 
 using Poco::NumberFormatter;
 using Poco::IllegalStateException;
+using Poco::InvalidArgumentException;
 
 
 namespace Poco::Net {
@@ -51,7 +52,7 @@ HTTPClientSession::HTTPClientSession():
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -68,7 +69,7 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -85,7 +86,7 @@ HTTPClientSession::HTTPClientSession(const SocketAddress& address):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -102,13 +103,15 @@ HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port)
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
 HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port, const ProxyConfig& proxyConfig):
 	_host(host),
 	_port(port),
+	_sourceAddress4(IPAddress::wildcard(IPAddress::IPv4), 0),
+	_sourceAddress6(IPAddress::wildcard(IPAddress::IPv6), 0),
 	_proxyConfig(proxyConfig),
 	_keepAliveTimeout(DEFAULT_KEEP_ALIVE_TIMEOUT, 0),
 	_reconnect(false),
@@ -117,6 +120,7 @@ HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port,
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
+	initProxySessionFactory();
 }
 
 
@@ -130,15 +134,28 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket, const ProxyConf
 	_reconnect(false),
 	_mustReconnect(false),
 	_expectResponseBody(false),
-	_responseReceived(false)
+	_responseReceived(false),
+	_ntlmProxyAuthenticated(false)
 {
-	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
 HTTPClientSession::~HTTPClientSession()
 {
-	_proxySessionFactory.unregisterProtocol("http");
+	try
+	{
+		_proxySessionFactory.unregisterProtocol("http");
+	}
+	catch (...)
+	{
+	}
+}
+
+
+void HTTPClientSession::initProxySessionFactory()
+{
+	_proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -196,7 +213,7 @@ const SocketAddress& HTTPClientSession::getSourceAddress6()
 void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port, const std::string& protocol, bool tunnel)
 {
 	if (protocol != "http" && protocol != "https")
-		throw IllegalStateException("Protocol must be either http or https");
+		throw InvalidArgumentException("Protocol must be either http or https");
 
 	if (!connected())
 	{
@@ -230,7 +247,7 @@ void HTTPClientSession::setProxyPort(Poco::UInt16 port)
 void HTTPClientSession::setProxyProtocol(const std::string& protocol)
 {
 	if (protocol != "http" && protocol != "https")
-		throw IllegalStateException("Protocol must be either http or https");
+		throw InvalidArgumentException("Protocol must be either http or https");
 
 	if (!connected())
 		_proxyConfig.protocol = protocol;
@@ -269,12 +286,21 @@ void HTTPClientSession::setProxyPassword(const std::string& password)
 
 void HTTPClientSession::setProxyConfig(const ProxyConfig& config)
 {
-	_proxyConfig = config;
+	if (config.protocol != "http" && config.protocol != "https")
+		throw InvalidArgumentException("Protocol must be either http or https");
+
+	if (!connected())
+		_proxyConfig = config;
+	else
+		throw IllegalStateException("Cannot set the proxy configuration for an already connected session");
 }
 
 
 void HTTPClientSession::setGlobalProxyConfig(const ProxyConfig& config)
 {
+	if (config.protocol != "http" && config.protocol != "https")
+		throw InvalidArgumentException("Protocol must be either http or https");
+
 	_globalProxyConfig = config;
 }
 
@@ -509,8 +535,8 @@ std::string HTTPClientSession::proxyRequestPrefix() const
 {
 	std::string result("http://");
 	result.append(_host);
-	/// Do not append default by default, since this may break some servers.
-	/// One example of such server is GCS (Google Cloud Storage).
+	// Do not append default port, since this may break some servers.
+	// One example of such server is GCS (Google Cloud Storage).
 	if (_port != HTTPSession::HTTP_PORT)
 	{
 		result.append(":");
@@ -541,16 +567,16 @@ void HTTPClientSession::proxyAuthenticateImpl(HTTPRequest& request, const ProxyC
 {
 	switch (proxyConfig.authMethod)
 	{
-	case PROXY_AUTH_NONE:
+	case ProxyAuthentication::None:
 		break;
 
-	case PROXY_AUTH_HTTP_BASIC:
+	case ProxyAuthentication::Basic:
 		_proxyBasicCreds.setUsername(proxyConfig.username);
 		_proxyBasicCreds.setPassword(proxyConfig.password);
 		_proxyBasicCreds.proxyAuthenticate(request);
 		break;
 
-	case PROXY_AUTH_HTTP_DIGEST:
+	case ProxyAuthentication::Digest:
 		if (HTTPCredentials::hasDigestCredentials(request))
 		{
 			_proxyDigestCreds.updateProxyAuthInfo(request);
@@ -563,7 +589,7 @@ void HTTPClientSession::proxyAuthenticateImpl(HTTPRequest& request, const ProxyC
 		}
 		break;
 
-	case PROXY_AUTH_NTLM:
+	case ProxyAuthentication::NTLM:
 		if (_ntlmProxyAuthenticated)
 		{
 			_proxyNTLMCreds.updateProxyAuthInfo(request);
@@ -643,7 +669,7 @@ StreamSocket HTTPClientSession::proxyConnect()
 	proxySession->sendRequest(proxyRequest);
 	proxySession->receiveResponse(proxyResponse);
 	if (proxyResponse.getStatus() != HTTPResponse::HTTP_OK)
-		throw HTTPException("Cannot establish proxy connection", proxyResponse.getReason());
+		throw HTTPException("Cannot establish proxy connection (" + std::to_string(proxyResponse.getStatus()) + ")", proxyResponse.getReason());
 	return proxySession->detachSocket();
 }
 

--- a/Net/src/HTTPClientSession.cpp
+++ b/Net/src/HTTPClientSession.cpp
@@ -50,7 +50,7 @@ HTTPClientSession::HTTPClientSession():
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -67,7 +67,7 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -84,7 +84,7 @@ HTTPClientSession::HTTPClientSession(const SocketAddress& address):
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -101,7 +101,7 @@ HTTPClientSession::HTTPClientSession(const std::string& host, Poco::UInt16 port)
 	_responseReceived(false),
 	_ntlmProxyAuthenticated(false)
 {
-    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
@@ -131,13 +131,13 @@ HTTPClientSession::HTTPClientSession(const StreamSocket& socket, const ProxyConf
 	_expectResponseBody(false),
 	_responseReceived(false)
 {
-    _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
+        _proxySessionFactory.registerProtocol("http", new HTTPSessionInstantiator);
 }
 
 
 HTTPClientSession::~HTTPClientSession()
 {
-    _proxySessionFactory.unregisterProtocol("http");
+        _proxySessionFactory.unregisterProtocol("http");
 }
 
 
@@ -194,17 +194,17 @@ const SocketAddress& HTTPClientSession::getSourceAddress6()
 
 void HTTPClientSession::setProxy(const std::string& host, Poco::UInt16 port, const std::string& protocol, bool tunnel)
 {
-    if (protocol != "http" && protocol != "https")
-        throw IllegalStateException("Protocol must be either http or https");
+        if (protocol != "http" && protocol != "https")
+                throw IllegalStateException("Protocol must be either http or https");
 
-	if (!connected())
+        if (!connected())
 	{
 		_proxyConfig.host = host;
 		_proxyConfig.port = port;
 		_proxyConfig.protocol = protocol;
 		_proxyConfig.tunnel = tunnel;
 	}
-	else throw IllegalStateException("Cannot set the proxy host, port and protocol for an already connected session");
+        else throw IllegalStateException("Cannot set the proxy host, port and protocol for an already connected session");
 }
 
 
@@ -228,22 +228,22 @@ void HTTPClientSession::setProxyPort(Poco::UInt16 port)
 
 void HTTPClientSession::setProxyProtocol(const std::string& protocol)
 {
-    if (protocol != "http" && protocol != "https")
-        throw IllegalStateException("Protocol must be either http or https");
+        if (protocol != "http" && protocol != "https")
+                throw IllegalStateException("Protocol must be either http or https");
 
-    if (!connected())
-        _proxyConfig.protocol = protocol;
-    else
-        throw IllegalStateException("Cannot set the proxy port number for an already connected session");
+        if (!connected())
+                _proxyConfig.protocol = protocol;
+        else
+                throw IllegalStateException("Cannot set the proxy port number for an already connected session");
 }
 
 
 void HTTPClientSession::setProxyTunnel(bool tunnel)
 {
-    if (!connected())
-        _proxyConfig.tunnel = tunnel;
-    else
-        throw IllegalStateException("Cannot set the proxy tunnel for an already connected session");
+        if (!connected())
+                _proxyConfig.tunnel = tunnel;
+        else
+                throw IllegalStateException("Cannot set the proxy tunnel for an already connected session");
 
 }
 

--- a/Net/src/HTTPSessionFactory.cpp
+++ b/Net/src/HTTPSessionFactory.cpp
@@ -37,7 +37,7 @@ HTTPSessionFactory::HTTPSessionFactory(const std::string& proxyHost, Poco::UInt1
 }
 
 
-HTTPSessionFactory::HTTPSessionFactory(const HTTPClientSession::ProxyConfig& proxyConfig):
+HTTPSessionFactory::HTTPSessionFactory(const ProxyConfig& proxyConfig):
 	_proxyConfig(proxyConfig)
 {
 }
@@ -127,7 +127,7 @@ void HTTPSessionFactory::setProxyCredentials(const std::string& username, const 
 }
 
 
-void HTTPSessionFactory::setProxyConfig(const HTTPClientSession::ProxyConfig& proxyConfig)
+void HTTPSessionFactory::setProxyConfig(const ProxyConfig& proxyConfig)
 {
 	FastMutex::ScopedLock lock(_mutex);
 

--- a/Net/src/HTTPSessionInstantiator.cpp
+++ b/Net/src/HTTPSessionInstantiator.cpp
@@ -57,7 +57,7 @@ void HTTPSessionInstantiator::unregisterInstantiator()
 }
 
 
-void HTTPSessionInstantiator::setProxyConfig(const HTTPClientSession::ProxyConfig& proxyConfig)
+void HTTPSessionInstantiator::setProxyConfig(const ProxyConfig& proxyConfig)
 {
 	_proxyConfig = proxyConfig;
 }

--- a/Net/testsuite/src/HTTPClientSessionTest.cpp
+++ b/Net/testsuite/src/HTTPClientSessionTest.cpp
@@ -24,6 +24,7 @@
 
 
 using Poco::Net::HTTPClientSession;
+using Poco::Net::ProxyConfig;
 using Poco::Net::HTTPRequest;
 using Poco::Net::HTTPResponse;
 using Poco::Net::HTTPMessage;

--- a/Net/testsuite/src/HTTPClientSessionTest.cpp
+++ b/Net/testsuite/src/HTTPClientSessionTest.cpp
@@ -407,8 +407,25 @@ void HTTPClientSessionTest::testSetProxyProtocolValidation()
 	s.setProxy("proxy", 80, "http", true);
 	assertTrue (s.getProxyProtocol() == "http");
 
-	s.setProxy("proxy", 80, "https", true);
-	assertTrue (s.getProxyProtocol() == "https");
+	// HTTPS proxy is only supported by HTTPSClientSession; plain
+	// HTTPClientSession must reject protocol "https".
+	try
+	{
+		s.setProxy("proxy", 443, "https", true);
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
+
+	try
+	{
+		s.setProxyProtocol("https");
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
 }
 
 
@@ -435,9 +452,20 @@ void HTTPClientSessionTest::testSetProxyConfigValidation()
 	s.setProxyConfig(goodConfig);
 	assertTrue (s.getProxyHost() == "proxy");
 
-	goodConfig.protocol = "https";
-	s.setProxyConfig(goodConfig);
-	assertTrue (s.getProxyProtocol() == "https");
+	// HTTPS proxy is only supported by HTTPSClientSession; plain
+	// HTTPClientSession must reject a ProxyConfig with protocol "https".
+	ProxyConfig httpsConfig;
+	httpsConfig.host = "proxy";
+	httpsConfig.port = 443;
+	httpsConfig.protocol = "https";
+	try
+	{
+		s.setProxyConfig(httpsConfig);
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
 }
 
 
@@ -451,8 +479,8 @@ void HTTPClientSessionTest::testProxySetters()
 	s.setProxyPort(8080);
 	assertTrue (s.getProxyPort() == 8080);
 
-	s.setProxyProtocol("https");
-	assertTrue (s.getProxyProtocol() == "https");
+	s.setProxyProtocol("http");
+	assertTrue (s.getProxyProtocol() == "http");
 
 	s.setProxyTunnel(false);
 	assertTrue (s.isProxyTunnel() == false);
@@ -564,7 +592,7 @@ void HTTPClientSessionTest::testBypassProxyExtended()
 	ProxyConfig config;
 	config.host = "proxy.domain.com";
 	config.port = 80;
-	config.protocol = "https";
+	config.protocol = "http";
 	config.tunnel = false;
 	config.nonProxyHosts = "localhost|127\\.0\\.0\\.1";
 

--- a/Net/testsuite/src/HTTPClientSessionTest.cpp
+++ b/Net/testsuite/src/HTTPClientSessionTest.cpp
@@ -294,7 +294,7 @@ void HTTPClientSessionTest::testProxyAuth()
 
 void HTTPClientSessionTest::testBypassProxy()
 {
-	HTTPClientSession::ProxyConfig proxyConfig;
+	ProxyConfig proxyConfig;
 	proxyConfig.host = "proxy.domain.com";
 	proxyConfig.port = 80;
 	proxyConfig.nonProxyHosts = "localhost|127\\.0\\.0\\.1";

--- a/Net/testsuite/src/HTTPClientSessionTest.cpp
+++ b/Net/testsuite/src/HTTPClientSessionTest.cpp
@@ -24,11 +24,15 @@
 
 
 using Poco::Net::HTTPClientSession;
+using Poco::Net::HTTPSession;
 using Poco::Net::ProxyConfig;
+using Poco::Net::ProxyAuthentication;
 using Poco::Net::HTTPRequest;
 using Poco::Net::HTTPResponse;
 using Poco::Net::HTTPMessage;
 using Poco::StreamCopier;
+using Poco::InvalidArgumentException;
+using Poco::IllegalStateException;
 using Poco::File;
 using Poco::Path;
 
@@ -355,6 +359,231 @@ void HTTPClientSessionTest::testExpectContinueFail()
 }
 
 
+void HTTPClientSessionTest::testProxyConfig()
+{
+	ProxyConfig config;
+	assertTrue (config.host.empty());
+	assertTrue (config.port == HTTPSession::HTTP_PORT);
+	assertTrue (config.protocol == "http");
+	assertTrue (config.tunnel == true);
+	assertTrue (config.username.empty());
+	assertTrue (config.password.empty());
+	assertTrue (config.nonProxyHosts.empty());
+	assertTrue (config.authMethod == ProxyAuthentication::Basic);
+}
+
+
+void HTTPClientSessionTest::testSetProxyProtocolValidation()
+{
+	HTTPClientSession s("www.example.com");
+
+	try
+	{
+		s.setProxy("proxy", 80, "ftp", true);
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
+
+	try
+	{
+		s.setProxy("proxy", 80, "", true);
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
+
+	try
+	{
+		s.setProxyProtocol("socks");
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
+
+	s.setProxy("proxy", 80, "http", true);
+	assertTrue (s.getProxyProtocol() == "http");
+
+	s.setProxy("proxy", 80, "https", true);
+	assertTrue (s.getProxyProtocol() == "https");
+}
+
+
+void HTTPClientSessionTest::testSetProxyConfigValidation()
+{
+	HTTPClientSession s("www.example.com");
+
+	ProxyConfig badConfig;
+	badConfig.host = "proxy";
+	badConfig.protocol = "ftp";
+
+	try
+	{
+		s.setProxyConfig(badConfig);
+		fail("must throw InvalidArgumentException");
+	}
+	catch (InvalidArgumentException&)
+	{
+	}
+
+	ProxyConfig goodConfig;
+	goodConfig.host = "proxy";
+	goodConfig.protocol = "http";
+	s.setProxyConfig(goodConfig);
+	assertTrue (s.getProxyHost() == "proxy");
+
+	goodConfig.protocol = "https";
+	s.setProxyConfig(goodConfig);
+	assertTrue (s.getProxyProtocol() == "https");
+}
+
+
+void HTTPClientSessionTest::testProxySetters()
+{
+	HTTPClientSession s("www.example.com");
+
+	s.setProxyHost("proxy.example.com");
+	assertTrue (s.getProxyHost() == "proxy.example.com");
+
+	s.setProxyPort(8080);
+	assertTrue (s.getProxyPort() == 8080);
+
+	s.setProxyProtocol("https");
+	assertTrue (s.getProxyProtocol() == "https");
+
+	s.setProxyTunnel(false);
+	assertTrue (s.isProxyTunnel() == false);
+
+	s.setProxyCredentials("user", "pass");
+	assertTrue (s.getProxyUsername() == "user");
+	assertTrue (s.getProxyPassword() == "pass");
+
+	ProxyConfig config;
+	config.host = "other-proxy.com";
+	config.port = 3128;
+	config.protocol = "http";
+	config.tunnel = true;
+	config.username = "admin";
+	config.password = "secret";
+	s.setProxyConfig(config);
+	assertTrue (s.getProxyHost() == "other-proxy.com");
+	assertTrue (s.getProxyPort() == 3128);
+	assertTrue (s.getProxyProtocol() == "http");
+	assertTrue (s.isProxyTunnel() == true);
+	assertTrue (s.getProxyUsername() == "admin");
+	assertTrue (s.getProxyPassword() == "secret");
+}
+
+
+void HTTPClientSessionTest::testProxyRequestPrefix()
+{
+	HTTPTestServer srv;
+
+	HTTPClientSession s1("www.somehost.com", 80);
+	s1.setProxy("127.0.0.1", srv.port());
+	HTTPRequest request1(HTTPRequest::HTTP_GET, "/large");
+	s1.sendRequest(request1);
+	HTTPResponse response1;
+	std::istream& rs1 = s1.receiveResponse(response1);
+	std::ostringstream ostr1;
+	StreamCopier::copyStream(rs1, ostr1);
+	std::string r1 = srv.lastRequest();
+	// Port 80 should NOT appear in the prefix
+	assertTrue (r1.find("GET http://www.somehost.com/large") != std::string::npos);
+	assertTrue (r1.find(":80") == std::string::npos);
+
+	HTTPTestServer srv2;
+	HTTPClientSession s2("www.somehost.com", 8080);
+	s2.setProxy("127.0.0.1", srv2.port());
+	HTTPRequest request2(HTTPRequest::HTTP_GET, "/large");
+	s2.sendRequest(request2);
+	HTTPResponse response2;
+	std::istream& rs2 = s2.receiveResponse(response2);
+	std::ostringstream ostr2;
+	StreamCopier::copyStream(rs2, ostr2);
+	std::string r2 = srv2.lastRequest();
+	// Non-default port should appear in the prefix
+	assertTrue (r2.find("GET http://www.somehost.com:8080/large") != std::string::npos);
+}
+
+
+void HTTPClientSessionTest::testProxyNonTunnel()
+{
+	HTTPTestServer srv;
+	HTTPClientSession s("www.somehost.com");
+	s.setProxy("127.0.0.1", srv.port(), "http", false);
+	HTTPRequest request(HTTPRequest::HTTP_GET, "/large");
+	s.sendRequest(request);
+	HTTPResponse response;
+	std::istream& rs = s.receiveResponse(response);
+	assertTrue (response.getContentLength() == HTTPTestServer::LARGE_BODY.length());
+	assertTrue (response.getContentType() == "text/plain");
+	std::ostringstream ostr;
+	StreamCopier::copyStream(rs, ostr);
+	assertTrue (ostr.str() == HTTPTestServer::LARGE_BODY);
+	std::string r = srv.lastRequest();
+	assertTrue (r.find("GET http://www.somehost.com/large") != std::string::npos);
+}
+
+
+void HTTPClientSessionTest::testGlobalProxyConfig()
+{
+	ProxyConfig globalConfig;
+	globalConfig.host = "global-proxy.example.com";
+	globalConfig.port = 3128;
+	globalConfig.protocol = "http";
+	HTTPClientSession::setGlobalProxyConfig(globalConfig);
+
+	HTTPClientSession s1("www.example.com");
+	assertTrue (s1.getProxyHost() == "global-proxy.example.com");
+	assertTrue (s1.getProxyPort() == 3128);
+
+	// Per-session config overrides global
+	ProxyConfig localConfig;
+	localConfig.host = "local-proxy.example.com";
+	localConfig.port = 8080;
+	localConfig.protocol = "http";
+	s1.setProxyConfig(localConfig);
+	assertTrue (s1.getProxyHost() == "local-proxy.example.com");
+	assertTrue (s1.getProxyPort() == 8080);
+
+	// Reset global config
+	ProxyConfig emptyConfig;
+	HTTPClientSession::setGlobalProxyConfig(emptyConfig);
+
+	HTTPClientSession s2("www.example.com");
+	assertTrue (s2.getProxyHost().empty());
+}
+
+
+void HTTPClientSessionTest::testBypassProxyExtended()
+{
+	ProxyConfig config;
+	config.host = "proxy.domain.com";
+	config.port = 80;
+	config.protocol = "https";
+	config.tunnel = false;
+	config.nonProxyHosts = "localhost|127\\.0\\.0\\.1";
+
+	HTTPClientSession s1("127.0.0.1", 80);
+	s1.setProxyConfig(config);
+	assertTrue (s1.bypassProxy());
+
+	HTTPClientSession s2("www.appinf.com", 80);
+	s2.setProxyConfig(config);
+	assertTrue (!s2.bypassProxy());
+
+	// Empty nonProxyHosts disables bypass
+	config.nonProxyHosts = "";
+	HTTPClientSession s3("127.0.0.1", 80);
+	s3.setProxyConfig(config);
+	assertTrue (!s3.bypassProxy());
+}
+
+
 void HTTPClientSessionTest::setUp()
 {
 }
@@ -384,6 +613,14 @@ CppUnit::Test* HTTPClientSessionTest::suite()
 	CppUnit_addTest(pSuite, HTTPClientSessionTest, testBypassProxy);
 	CppUnit_addTest(pSuite, HTTPClientSessionTest, testExpectContinue);
 	CppUnit_addTest(pSuite, HTTPClientSessionTest, testExpectContinueFail);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testProxyConfig);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testSetProxyProtocolValidation);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testSetProxyConfigValidation);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testProxySetters);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testProxyRequestPrefix);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testProxyNonTunnel);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testGlobalProxyConfig);
+	CppUnit_addTest(pSuite, HTTPClientSessionTest, testBypassProxyExtended);
 
 	return pSuite;
 }

--- a/Net/testsuite/src/HTTPClientSessionTest.h
+++ b/Net/testsuite/src/HTTPClientSessionTest.h
@@ -39,6 +39,14 @@ public:
 	void testBypassProxy();
 	void testExpectContinue();
 	void testExpectContinueFail();
+	void testProxyConfig();
+	void testSetProxyProtocolValidation();
+	void testSetProxyConfigValidation();
+	void testProxySetters();
+	void testProxyRequestPrefix();
+	void testProxyNonTunnel();
+	void testGlobalProxyConfig();
+	void testBypassProxyExtended();
 
 	void setUp();
 	void tearDown();

--- a/Net/testsuite/src/HTTPTestServer.cpp
+++ b/Net/testsuite/src/HTTPTestServer.cpp
@@ -140,7 +140,9 @@ std::string HTTPTestServer::handleRequest() const
 	}
 	else if (_lastRequest.substr(0, 10) == "GET /large" ||
 			 _lastRequest.substr(0, 11) == "HEAD /large" ||
-			 _lastRequest.substr(0, 36) == "GET http://www.somehost.com:80/large")
+			 _lastRequest.substr(0, 36) == "GET http://www.somehost.com:80/large" ||
+			 _lastRequest.substr(0, 33) == "GET http://www.somehost.com/large" ||
+			 _lastRequest.substr(0, 38) == "GET http://www.somehost.com:8080/large")
 	{
 		std::string body(LARGE_BODY);
 		response.append("HTTP/1.0 200 OK\r\n");

--- a/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/HTTPSClientSession.h
@@ -152,8 +152,14 @@ protected:
 	int read(char* buffer, std::streamsize length);
 
 private:
-	HTTPSClientSession(const HTTPSClientSession&);
-	HTTPSClientSession& operator = (const HTTPSClientSession&);
+	void initProxySessionFactory();
+		/// Registers the "https" protocol with _proxySessionFactory using default context.
+
+	void initProxySessionFactory(Context::Ptr pContext);
+		/// Registers the "https" protocol with _proxySessionFactory using given context.
+
+	HTTPSClientSession(const HTTPSClientSession&) = delete;
+	HTTPSClientSession& operator = (const HTTPSClientSession&) = delete;
 
 	Context::Ptr _pContext;
 	Session::Ptr _pSession;

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -138,8 +138,11 @@ std::string HTTPSClientSession::proxyRequestPrefix() const
 {
     std::string result("https://");
     result.append(getHost());
-    result.append(":");
-    NumberFormatter::append(result, getPort());
+    /// Do not append default by default, since this may break some servers.
+	/// One example of such server is GCS (Google Cloud Storage).
+	if (getPort() != HTTPS_PORT)
+	{result.append(":");
+    NumberFormatter::append(result, getPort());}
     return result;
 }
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -140,9 +140,10 @@ std::string HTTPSClientSession::proxyRequestPrefix() const
     result.append(getHost());
     /// Do not append default by default, since this may break some servers.
 	/// One example of such server is GCS (Google Cloud Storage).
-	if (getPort() != HTTPS_PORT)
-	{result.append(":");
-    NumberFormatter::append(result, getPort());}
+	if (getPort() != HTTPS_PORT) {
+        result.append(":");
+        NumberFormatter::append(result, getPort());
+    }
     return result;
 }
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -136,15 +136,15 @@ X509Certificate HTTPSClientSession::serverCertificate()
 
 std::string HTTPSClientSession::proxyRequestPrefix() const
 {
-    std::string result("https://");
-    result.append(getHost());
-    /// Do not append default by default, since this may break some servers.
-	/// One example of such server is GCS (Google Cloud Storage).
-	if (getPort() != HTTPS_PORT) {
-        result.append(":");
-        NumberFormatter::append(result, getPort());
-    }
-    return result;
+        std::string result("https://");
+        result.append(getHost());
+        /// Do not append default by default, since this may break some servers.
+        /// One example of such server is GCS (Google Cloud Storage).
+        if (getPort() != HTTPS_PORT) {
+                result.append(":");
+                NumberFormatter::append(result, getPort());
+        }
+        return result;
 }
 
 
@@ -155,34 +155,34 @@ void HTTPSClientSession::proxyAuthenticate(HTTPRequest& request)
 
 void HTTPSClientSession::connect(const SocketAddress& address)
 {
-    bool useProxy = !getProxyHost().empty() && !bypassProxy();
+        bool useProxy = !getProxyHost().empty() && !bypassProxy();
 
-	if (useProxy && isProxyTunnel())
-    {
-        StreamSocket proxySocket(proxyConnect());
-        SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
-        attachSocket(secureSocket);
-        if (_pContext->sessionCacheEnabled())
+        if (useProxy && isProxyTunnel())
         {
-            _pSession = secureSocket.currentSession();
+                StreamSocket proxySocket(proxyConnect());
+                SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
+                attachSocket(secureSocket);
+                if (_pContext->sessionCacheEnabled())
+                {
+                        _pSession = secureSocket.currentSession();
+                }
         }
-    }
-    else
-    {
-        SecureStreamSocket sss(socket());
-        if (sss.getPeerHostName().empty())
+        else
         {
-            sss.setPeerHostName(useProxy ? getProxyHost() : getHost());
-        }
-        if (_pContext->sessionCacheEnabled())
-        {
-            sss.useSession(_pSession);
-        }
-        HTTPSession::connect(address);
-        if (_pContext->sessionCacheEnabled())
-        {
-            _pSession = sss.currentSession();
-        }
+                SecureStreamSocket sss(socket());
+                if (sss.getPeerHostName().empty())
+                {
+                        sss.setPeerHostName(useProxy ? getProxyHost() : getHost());
+                }
+                if (_pContext->sessionCacheEnabled())
+                {
+                        sss.useSession(_pSession);
+                }
+                HTTPSession::connect(address);
+                if (_pContext->sessionCacheEnabled())
+                {
+                        _pSession = sss.currentSession();
+                }
     }
 }
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/Net/HTTPSClientSession.h"
+#include "Poco/Net/HTTPSSessionInstantiator.h"
 #include "Poco/Net/SecureStreamSocket.h"
 #include "Poco/Net/SecureStreamSocketImpl.h"
 #include "Poco/Net/SSLManager.h"
@@ -35,6 +36,7 @@ HTTPSClientSession::HTTPSClientSession():
 	_pContext(SSLManager::instance().defaultClientContext())
 {
 	setPort(HTTPS_PORT);
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -44,6 +46,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, const s
 {
 	setHost(host);
 	setPort(port);
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -53,6 +56,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, Session
 	_pSession(pSession)
 {
 	setPort(HTTPS_PORT);
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -62,6 +66,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -69,6 +74,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext):
 	HTTPClientSession(SecureStreamSocket(pContext)),
 	_pContext(pContext)
 {
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -77,6 +83,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext, Session::Ptr pSess
 	_pContext(pContext),
 	_pSession(pSession)
 {
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -86,6 +93,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -96,11 +104,13 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
+    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
 HTTPSClientSession::~HTTPSClientSession()
 {
+    _proxySessionFactory.unregisterProtocol("https");
 }
 
 
@@ -126,7 +136,11 @@ X509Certificate HTTPSClientSession::serverCertificate()
 
 std::string HTTPSClientSession::proxyRequestPrefix() const
 {
-	return std::string();
+    std::string result("https://");
+    result.append(getHost());
+    result.append(":");
+    NumberFormatter::append(result, getPort());
+    return result;
 }
 
 
@@ -137,33 +151,35 @@ void HTTPSClientSession::proxyAuthenticate(HTTPRequest& request)
 
 void HTTPSClientSession::connect(const SocketAddress& address)
 {
-	if (getProxyHost().empty() || bypassProxy())
-	{
-		SecureStreamSocket sss(socket());
-		if (sss.getPeerHostName().empty())
-		{
-			sss.setPeerHostName(getHost());
-		}
-		if (_pContext->sessionCacheEnabled())
-		{
-			sss.useSession(_pSession);
-		}
-		HTTPSession::connect(address);
-		if (_pContext->sessionCacheEnabled())
-		{
-			_pSession = sss.currentSession();
-		}
-	}
-	else
-	{
-		StreamSocket proxySocket(proxyConnect());
-		SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
-		attachSocket(secureSocket);
-		if (_pContext->sessionCacheEnabled())
-		{
-			_pSession = secureSocket.currentSession();
-		}
-	}
+    bool useProxy = !getProxyHost().empty() && !bypassProxy();
+
+	if (useProxy && isProxyTunnel())
+    {
+        StreamSocket proxySocket(proxyConnect());
+        SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
+        attachSocket(secureSocket);
+        if (_pContext->sessionCacheEnabled())
+        {
+            _pSession = secureSocket.currentSession();
+        }
+    }
+    else
+    {
+        SecureStreamSocket sss(socket());
+        if (sss.getPeerHostName().empty())
+        {
+            sss.setPeerHostName(useProxy ? getProxyHost() : getHost());
+        }
+        if (_pContext->sessionCacheEnabled())
+        {
+            sss.useSession(_pSession);
+        }
+        HTTPSession::connect(address);
+        if (_pContext->sessionCacheEnabled())
+        {
+            _pSession = sss.currentSession();
+        }
+    }
 }
 
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -36,7 +36,7 @@ HTTPSClientSession::HTTPSClientSession():
 	_pContext(SSLManager::instance().defaultClientContext())
 {
 	setPort(HTTPS_PORT);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -46,7 +46,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, const s
 {
 	setHost(host);
 	setPort(port);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -56,7 +56,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, Session
 	_pSession(pSession)
 {
 	setPort(HTTPS_PORT);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -66,7 +66,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	initProxySessionFactory();
 }
 
 
@@ -74,7 +74,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext):
 	HTTPClientSession(SecureStreamSocket(pContext)),
 	_pContext(pContext)
 {
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	initProxySessionFactory(pContext);
 }
 
 
@@ -83,7 +83,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext, Session::Ptr pSess
 	_pContext(pContext),
 	_pSession(pSession)
 {
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	initProxySessionFactory(pContext);
 }
 
 
@@ -93,7 +93,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	initProxySessionFactory(pContext);
 }
 
 
@@ -104,13 +104,19 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	initProxySessionFactory(pContext);
 }
 
 
 HTTPSClientSession::~HTTPSClientSession()
 {
-	_proxySessionFactory.unregisterProtocol("https");
+	try
+	{
+		_proxySessionFactory.unregisterProtocol("https");
+	}
+	catch (...)
+	{
+	}
 }
 
 
@@ -136,10 +142,13 @@ X509Certificate HTTPSClientSession::serverCertificate()
 
 std::string HTTPSClientSession::proxyRequestPrefix() const
 {
+	if (isProxyTunnel())
+		return std::string();
+
 	std::string result("https://");
 	result.append(getHost());
-	/// Do not append default by default, since this may break some servers.
-	/// One example of such server is GCS (Google Cloud Storage).
+	// Do not append default port, since this may break some servers.
+	// One example of such server is GCS (Google Cloud Storage).
 	if (getPort() != HTTPS_PORT)
 	{
 		result.append(":");
@@ -151,6 +160,10 @@ std::string HTTPSClientSession::proxyRequestPrefix() const
 
 void HTTPSClientSession::proxyAuthenticate(HTTPRequest& request)
 {
+	if (!isProxyTunnel())
+	{
+		proxyAuthenticateImpl(request, getProxyConfig());
+	}
 }
 
 
@@ -204,6 +217,18 @@ int HTTPSClientSession::read(char* buffer, std::streamsize length)
 Session::Ptr HTTPSClientSession::sslSession()
 {
 	return _pSession;
+}
+
+
+void HTTPSClientSession::initProxySessionFactory()
+{
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+}
+
+
+void HTTPSClientSession::initProxySessionFactory(Context::Ptr pContext)
+{
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -56,7 +56,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, Session
 	_pSession(pSession)
 {
 	setPort(HTTPS_PORT);
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -66,7 +66,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -74,7 +74,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext):
 	HTTPClientSession(SecureStreamSocket(pContext)),
 	_pContext(pContext)
 {
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -83,7 +83,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext, Session::Ptr pSess
 	_pContext(pContext),
 	_pSession(pSession)
 {
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -93,7 +93,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -104,13 +104,13 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-    _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
 HTTPSClientSession::~HTTPSClientSession()
 {
-    _proxySessionFactory.unregisterProtocol("https");
+        _proxySessionFactory.unregisterProtocol("https");
 }
 
 

--- a/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
+++ b/NetSSL_OpenSSL/src/HTTPSClientSession.cpp
@@ -56,7 +56,7 @@ HTTPSClientSession::HTTPSClientSession(const SecureStreamSocket& socket, Session
 	_pSession(pSession)
 {
 	setPort(HTTPS_PORT);
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -66,7 +66,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator);
 }
 
 
@@ -74,7 +74,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext):
 	HTTPClientSession(SecureStreamSocket(pContext)),
 	_pContext(pContext)
 {
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -83,7 +83,7 @@ HTTPSClientSession::HTTPSClientSession(Context::Ptr pContext, Session::Ptr pSess
 	_pContext(pContext),
 	_pSession(pSession)
 {
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -93,7 +93,7 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
@@ -104,13 +104,13 @@ HTTPSClientSession::HTTPSClientSession(const std::string& host, Poco::UInt16 por
 {
 	setHost(host);
 	setPort(port);
-        _proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
+	_proxySessionFactory.registerProtocol("https", new HTTPSSessionInstantiator(pContext));
 }
 
 
 HTTPSClientSession::~HTTPSClientSession()
 {
-        _proxySessionFactory.unregisterProtocol("https");
+	_proxySessionFactory.unregisterProtocol("https");
 }
 
 
@@ -136,15 +136,16 @@ X509Certificate HTTPSClientSession::serverCertificate()
 
 std::string HTTPSClientSession::proxyRequestPrefix() const
 {
-        std::string result("https://");
-        result.append(getHost());
-        /// Do not append default by default, since this may break some servers.
-        /// One example of such server is GCS (Google Cloud Storage).
-        if (getPort() != HTTPS_PORT) {
-                result.append(":");
-                NumberFormatter::append(result, getPort());
-        }
-        return result;
+	std::string result("https://");
+	result.append(getHost());
+	/// Do not append default by default, since this may break some servers.
+	/// One example of such server is GCS (Google Cloud Storage).
+	if (getPort() != HTTPS_PORT)
+	{
+		result.append(":");
+		NumberFormatter::append(result, getPort());
+	}
+	return result;
 }
 
 
@@ -155,35 +156,35 @@ void HTTPSClientSession::proxyAuthenticate(HTTPRequest& request)
 
 void HTTPSClientSession::connect(const SocketAddress& address)
 {
-        bool useProxy = !getProxyHost().empty() && !bypassProxy();
+	bool useProxy = !getProxyHost().empty() && !bypassProxy();
 
-        if (useProxy && isProxyTunnel())
-        {
-                StreamSocket proxySocket(proxyConnect());
-                SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
-                attachSocket(secureSocket);
-                if (_pContext->sessionCacheEnabled())
-                {
-                        _pSession = secureSocket.currentSession();
-                }
-        }
-        else
-        {
-                SecureStreamSocket sss(socket());
-                if (sss.getPeerHostName().empty())
-                {
-                        sss.setPeerHostName(useProxy ? getProxyHost() : getHost());
-                }
-                if (_pContext->sessionCacheEnabled())
-                {
-                        sss.useSession(_pSession);
-                }
-                HTTPSession::connect(address);
-                if (_pContext->sessionCacheEnabled())
-                {
-                        _pSession = sss.currentSession();
-                }
-    }
+	if (useProxy && isProxyTunnel())
+	{
+		StreamSocket proxySocket(proxyConnect());
+		SecureStreamSocket secureSocket = SecureStreamSocket::attach(proxySocket, getHost(), _pContext, _pSession);
+		attachSocket(secureSocket);
+		if (_pContext->sessionCacheEnabled())
+		{
+			_pSession = secureSocket.currentSession();
+		}
+	}
+	else
+	{
+		SecureStreamSocket sss(socket());
+		if (sss.getPeerHostName().empty())
+		{
+			sss.setPeerHostName(useProxy ? getProxyHost() : getHost());
+		}
+		if (_pContext->sessionCacheEnabled())
+		{
+			sss.useSession(_pSession);
+		}
+		HTTPSession::connect(address);
+		if (_pContext->sessionCacheEnabled())
+		{
+			_pSession = sss.currentSession();
+		}
+	}
 }
 
 

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.cpp
@@ -494,6 +494,33 @@ void HTTPSClientSessionTest::testServerAbort()
 }
 
 
+void HTTPSClientSessionTest::testProxyConfig()
+{
+	HTTPSClientSession s("www.example.com");
+	assertTrue (s.isProxyTunnel() == true);
+	assertTrue (s.getProxyProtocol() == "http");
+	assertTrue (s.getProxyHost().empty());
+}
+
+
+void HTTPSClientSessionTest::testProxySetters()
+{
+	HTTPSClientSession s("www.example.com");
+
+	s.setProxy("proxy.example.com", 3128, "https", false);
+	assertTrue (s.getProxyHost() == "proxy.example.com");
+	assertTrue (s.getProxyPort() == 3128);
+	assertTrue (s.getProxyProtocol() == "https");
+	assertTrue (s.isProxyTunnel() == false);
+
+	s.setProxyTunnel(true);
+	assertTrue (s.isProxyTunnel() == true);
+
+	s.setProxyTunnel(false);
+	assertTrue (s.isProxyTunnel() == false);
+}
+
+
 void HTTPSClientSessionTest::setUp()
 {
 }
@@ -524,6 +551,8 @@ CppUnit::Test* HTTPSClientSessionTest::suite()
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testCachedSession);
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testUnknownContentLength);
 	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testServerAbort);
+	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testProxyConfig);
+	CppUnit_addTest(pSuite, HTTPSClientSessionTest, testProxySetters);
 
 	return pSuite;
 }

--- a/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/HTTPSClientSessionTest.h
@@ -40,7 +40,8 @@ public:
 	void testCachedSession();
 	void testUnknownContentLength();
 	void testServerAbort();
-
+	void testProxyConfig();
+	void testProxySetters();
 
 	void setUp();
 	void tearDown();

--- a/release/script/mkrelease
+++ b/release/script/mkrelease
@@ -88,7 +88,7 @@ mkdir -p ${target}/dependencies
 #
 echo ${version} "(`date +%Y-%m-%d`)" >${target}/VERSION
 cp ${POCO_BASE}/LICENSE ${target}
-cp ${POCO_BASE}/README.md ${target}
+cp ${POCO_BASE}/README ${target}
 cp ${POCO_BASE}/CHANGELOG ${target}
 cp ${POCO_BASE}/CONTRIBUTORS ${target}
 cp ${POCO_BASE}/DLLVersion.rc ${target}

--- a/release/script/mkrelease
+++ b/release/script/mkrelease
@@ -88,7 +88,7 @@ mkdir -p ${target}/dependencies
 #
 echo ${version} "(`date +%Y-%m-%d`)" >${target}/VERSION
 cp ${POCO_BASE}/LICENSE ${target}
-cp ${POCO_BASE}/README ${target}
+cp ${POCO_BASE}/README.md ${target}
 cp ${POCO_BASE}/CHANGELOG ${target}
 cp ${POCO_BASE}/CONTRIBUTORS ${target}
 cp ${POCO_BASE}/DLLVersion.rc ${target}


### PR DESCRIPTION
## Summary

Closes #3035. Replaces #3691.

Rebased and cleaned-up implementation of HTTPS proxy support, originally based on work from https://github.com/pocoproject/poco/pull/3040 (https://github.com/pocoproject/poco/issues/3035).

- Added possibility to connect to HTTPS proxy
- Not all proxies support CONNECT requests, so it's possible to send a request directly to HTTPS proxy without CONNECT requests. This behavior is controlled by the proxy tunnel option which is `true` by default for backward-compatibility
- In the case of HTTP endpoint and HTTP proxy, there is no tunneling despite the tunnel option being `true` by default. This was done also for backward-compatibility
- Includes fix from https://github.com/ClickHouse/poco/pull/63
- Do not add default port for requests via proxy (fixes GCS via proxy tunnel usage)
- Extracted `ProxyConfig` to a separate class for cleaner API
- Removed `shared_ptr` usage in proxy configuration
- These changes are battle-tested in the ClickHouse project

## Changes

- `Net/include/Poco/Net/ProxyConfig.h` — new `ProxyConfig` class extracted from `HTTPClientSession`
- `Net/include/Poco/Net/HTTPClientSession.h` — refactored to use `ProxyConfig`
- `Net/include/Poco/Net/HTTPSessionFactory.h` — updated proxy config API
- `Net/include/Poco/Net/HTTPSessionInstantiator.h` — updated proxy config API
- `Net/src/HTTPClientSession.cpp` — HTTPS proxy connection logic
- `Net/src/HTTPSessionFactory.cpp` — updated to use `ProxyConfig`
- `Net/src/HTTPSessionInstantiator.cpp` — updated to use `ProxyConfig`
- `NetSSL_OpenSSL/src/HTTPSClientSession.cpp` — HTTPS proxy tunnel support
- `Net/testsuite/src/HTTPClientSessionTest.cpp` — test updates