### PR TITLE
fix(Crypto): Parse ASN1 timezone suffix in X509Certificate date methods

### DIFF
--- a/Crypto/src/X509Certificate.cpp
+++ b/Crypto/src/X509Certificate.cpp
@@ -32,6 +32,16 @@
 namespace Poco::Crypto {
 
 
+namespace {
+
+// ASN1 UTCTime format: YYMMDDHHMMSSZ (RFC 5280 Section 4.1.2.5.1)
+const std::string ASN1_UTCTIME_FORMAT("%y%m%d%H%M%S%Z");
+// ASN1 GeneralizedTime format: YYYYMMDDHHMMSSZ (RFC 5280 Section 4.1.2.5.2)
+const std::string ASN1_GENERALIZEDTIME_FORMAT("%Y%m%d%H%M%S%Z");
+
+} // namespace
+
+
 X509Certificate::X509Certificate(std::istream& istr) : _pCert(nullptr)
 {
 	load(istr);
@@ -301,11 +311,11 @@ Poco::DateTime X509Certificate::validFrom() const
 	int tzd;
 	if (certTimeType == V_ASN1_UTCTIME)
 	{
-		return DateTimeParser::parse("%y%m%d%H%M%S", dateTime, tzd);
+		return DateTimeParser::parse(ASN1_UTCTIME_FORMAT, dateTime, tzd);
 	}
 	else if (certTimeType == V_ASN1_GENERALIZEDTIME)
 	{
-		return DateTimeParser::parse("%Y%m%d%H%M%S", dateTime, tzd);
+		return DateTimeParser::parse(ASN1_GENERALIZEDTIME_FORMAT, dateTime, tzd);
 	}
 	else
 	{
@@ -322,11 +332,11 @@ Poco::DateTime X509Certificate::expiresOn() const
 	int tzd;
 	if (certTimeType == V_ASN1_UTCTIME)
 	{
-		return DateTimeParser::parse("%y%m%d%H%M%S", dateTime, tzd);
+		return DateTimeParser::parse(ASN1_UTCTIME_FORMAT, dateTime, tzd);
 	}
 	else if (certTimeType == V_ASN1_GENERALIZEDTIME)
 	{
-		return DateTimeParser::parse("%Y%m%d%H%M%S", dateTime, tzd);
+		return DateTimeParser::parse(ASN1_GENERALIZEDTIME_FORMAT, dateTime, tzd);
 	}
 	else
 	{

--- a/Crypto/testsuite/src/CryptoTest.cpp
+++ b/Crypto/testsuite/src/CryptoTest.cpp
@@ -363,6 +363,17 @@ void CryptoTest::testCertificate()
 	const auto fingerprint = cert.fingerprint();
 	assertTrue (Poco::DigestEngine::digestToHex(fingerprint) == "ac84e4eb72c861ccb20f2900f3f17a9ac11f6579");
 
+	// verify validFrom/expiresOn parse ASN1 timestamps with Z suffix (GH #5263)
+	Poco::DateTime validFrom = cert.validFrom();
+	assertTrue (validFrom.year() == 2009);
+	assertTrue (validFrom.month() == 5);
+	assertTrue (validFrom.day() == 7);
+
+	Poco::DateTime expiresOn = cert.expiresOn();
+	assertTrue (expiresOn.year() == 2029);
+	assertTrue (expiresOn.month() == 5);
+	assertTrue (expiresOn.day() == 2);
+
 	// fails with recent OpenSSL versions:
 	// assert (cert.issuedBy(cert));
 


### PR DESCRIPTION
## Summary

- Include `%Z` timezone specifier in the ASN1 date/time format strings used by `validFrom()` and `expiresOn()`, so the trailing 'Z' (UTC) in ASN1 timestamps is properly parsed instead of triggering the trailing-character validation added in 8410eb1a6
- Add `validFrom()`/`expiresOn()` assertions to the existing `testCertificate()` test

Closes #5263