### PR TITLE
fix(Pipe): add coordinated close() to avoid deadlock on blocked IO #5269

### DIFF
--- a/Foundation/include/Poco/PipeImpl_POSIX.h
+++ b/Foundation/include/Poco/PipeImpl_POSIX.h
@@ -40,6 +40,7 @@ public:
 	int readBytes(void* buffer, int length);
 	Handle readHandle() const;
 	Handle writeHandle() const;
+	void close();
 	void closeRead();
 	void closeWrite();
 

--- a/Foundation/include/Poco/PipeImpl_WIN32.h
+++ b/Foundation/include/Poco/PipeImpl_WIN32.h
@@ -41,6 +41,7 @@ public:
 	int readBytes(void* buffer, int length);
 	Handle readHandle() const;
 	Handle writeHandle() const;
+	void close();
 	void closeRead();
 	void closeWrite();
 

--- a/Foundation/src/Pipe.cpp
+++ b/Foundation/src/Pipe.cpp
@@ -60,8 +60,7 @@ void Pipe::close(CloseMode mode)
 		_pImpl->closeWrite();
 		break;
 	default:
-		_pImpl->closeWrite();  // close write first to send EOF to blocked readers
-		_pImpl->closeRead();
+		_pImpl->close();
 		break;
 	}
 }

--- a/Foundation/src/PipeImpl_POSIX.cpp
+++ b/Foundation/src/PipeImpl_POSIX.cpp
@@ -37,8 +37,47 @@ PipeImpl::PipeImpl()
 
 PipeImpl::~PipeImpl()
 {
-	closeWrite();  // close write first to send EOF to blocked readers
-	closeRead();
+	close();
+}
+
+
+void PipeImpl::close()
+{
+	// Coordinated close of both pipe ends to unblock any blocked IO.
+	//
+	// On POSIX, a blocked write unblocks with EPIPE when the read end
+	// is closed, and a blocked read returns 0 (EOF) when the write end
+	// is closed. We must close both ends before waiting, because we
+	// don't know which end (if any) has blocked IO.
+	//
+	// This creates a benign race between close(fd) and a concurrent
+	// read(fd)/write(fd) on the same fd: the blocked syscall holds a
+	// kernel reference to the underlying file description, so it
+	// completes safely even after close() removes the fd from the
+	// table (see close(2) on Linux). The fd is cached in a local
+	// variable by readBytes/writeBytes, so fd recycling after close
+	// does not affect the in-progress syscall.
+	//
+	// TSan reports this as a data race (suppressed in tsan.suppress).
+
+	_writeLock.markClosed();
+	_readLock.markClosed();
+
+	// Close write fd — sends EOF to blocked readers.
+	int wfd = _writefd.exchange(-1, std::memory_order_acq_rel);
+	if (wfd != -1)
+		::close(wfd);
+
+	// Wait for reader to finish (it received EOF from closing write end).
+	_readLock.wait();
+
+	// Close read fd — sends EPIPE to blocked writers.
+	int rfd = _readfd.exchange(-1, std::memory_order_acq_rel);
+	if (rfd != -1)
+		::close(rfd);
+
+	// Wait for writer to finish (it received EPIPE from closing read end).
+	_writeLock.wait();
 }
 
 
@@ -48,12 +87,14 @@ int PipeImpl::writeBytes(const void* buffer, int length)
 	if (!lock)
 		return 0;
 
-	poco_assert (_writefd != -1);
+	int fd = _writefd.load(std::memory_order_relaxed);
+	if (fd == -1)
+		return 0;  // fd closed concurrently
 
 	int n;
 	do
 	{
-		n = write(_writefd.load(std::memory_order_relaxed), buffer, length);
+		n = write(fd, buffer, length);
 	}
 	while (n < 0 && errno == EINTR && !lock.isClosed());
 
@@ -73,12 +114,14 @@ int PipeImpl::readBytes(void* buffer, int length)
 	if (!lock)
 		return 0;
 
-	poco_assert (_readfd != -1);
+	int fd = _readfd.load(std::memory_order_relaxed);
+	if (fd == -1)
+		return 0;  // fd closed concurrently
 
 	int n;
 	do
 	{
-		n = read(_readfd.load(std::memory_order_relaxed), buffer, length);
+		n = read(fd, buffer, length);
 	}
 	while (n < 0 && errno == EINTR && !lock.isClosed());
 
@@ -107,20 +150,20 @@ PipeImpl::Handle PipeImpl::writeHandle() const
 void PipeImpl::closeRead()
 {
 	_readLock.markClosed();
-	_readLock.wait();  // wait for any in-progress read to finish
+	_readLock.wait();
 	int fd = _readfd.exchange(-1, std::memory_order_acq_rel);
 	if (fd != -1)
-		close(fd);
+		::close(fd);
 }
 
 
 void PipeImpl::closeWrite()
 {
 	_writeLock.markClosed();
-	_writeLock.wait();  // wait for any in-progress write to finish
+	_writeLock.wait();
 	int fd = _writefd.exchange(-1, std::memory_order_acq_rel);
 	if (fd != -1)
-		close(fd);
+		::close(fd);
 }
 
 

--- a/Foundation/src/PipeImpl_WIN32.cpp
+++ b/Foundation/src/PipeImpl_WIN32.cpp
@@ -14,6 +14,7 @@
 
 #include "Poco/PipeImpl_WIN32.h"
 #include "Poco/Exception.h"
+#include <ioapiset.h>  // CancelIoEx
 
 
 namespace Poco {
@@ -36,8 +37,47 @@ PipeImpl::PipeImpl()
 
 PipeImpl::~PipeImpl()
 {
-	closeWrite();  // close write first to send EOF to blocked readers
-	closeRead();
+	close();
+}
+
+
+void PipeImpl::close()
+{
+	// On Windows, CloseHandle while another thread is in ReadFile/WriteFile
+	// is undefined behavior — unlike POSIX where close(2) is safe due to
+	// kernel file-description refcounting. Use CancelIoEx to cancel pending
+	// IO, wait for completion, then safely close handles.
+	//
+	// CancelIoEx causes the blocked call to return FALSE with
+	// ERROR_OPERATION_ABORTED; the IO thread checks isClosed() and returns 0.
+	// Returns FALSE/ERROR_NOT_FOUND if no pending IO — safe to ignore.
+	//
+	// See: https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-cancelioex
+
+	_writeLock.markClosed();
+	_readLock.markClosed();
+
+	// Cancel any pending IO to unblock blocked ReadFile/WriteFile.
+	HANDLE rh = _readHandle.load(std::memory_order_acquire);
+	if (rh != INVALID_HANDLE_VALUE)
+		CancelIoEx(rh, nullptr);
+
+	HANDLE wh = _writeHandle.load(std::memory_order_acquire);
+	if (wh != INVALID_HANDLE_VALUE)
+		CancelIoEx(wh, nullptr);
+
+	// Wait for IO threads to finish (they received ERROR_OPERATION_ABORTED).
+	_readLock.wait();
+	_writeLock.wait();
+
+	// Safe to close handles — no IO is in progress.
+	rh = _readHandle.exchange(INVALID_HANDLE_VALUE, std::memory_order_acq_rel);
+	if (rh != INVALID_HANDLE_VALUE)
+		CloseHandle(rh);
+
+	wh = _writeHandle.exchange(INVALID_HANDLE_VALUE, std::memory_order_acq_rel);
+	if (wh != INVALID_HANDLE_VALUE)
+		CloseHandle(wh);
 }
 
 
@@ -47,10 +87,12 @@ int PipeImpl::writeBytes(const void* buffer, int length)
 	if (!lock)
 		return 0;
 
-	poco_assert (_writeHandle != INVALID_HANDLE_VALUE);
+	HANDLE handle = _writeHandle.load(std::memory_order_relaxed);
+	if (handle == INVALID_HANDLE_VALUE)
+		return 0;  // handle closed concurrently
 
 	DWORD bytesWritten = 0;
-	BOOL ok = WriteFile(_writeHandle.load(std::memory_order_relaxed), buffer, length, &bytesWritten, nullptr);
+	BOOL ok = WriteFile(handle, buffer, length, &bytesWritten, nullptr);
 
 	if (lock.isClosed())
 		return 0;
@@ -67,10 +109,12 @@ int PipeImpl::readBytes(void* buffer, int length)
 	if (!lock)
 		return 0;
 
-	poco_assert (_readHandle != INVALID_HANDLE_VALUE);
+	HANDLE handle = _readHandle.load(std::memory_order_relaxed);
+	if (handle == INVALID_HANDLE_VALUE)
+		return 0;  // handle closed concurrently
 
 	DWORD bytesRead = 0;
-	BOOL ok = ReadFile(_readHandle.load(std::memory_order_relaxed), buffer, length, &bytesRead, nullptr);
+	BOOL ok = ReadFile(handle, buffer, length, &bytesRead, nullptr);
 	DWORD lastError = GetLastError();
 
 	if (lock.isClosed())
@@ -98,7 +142,7 @@ PipeImpl::Handle PipeImpl::writeHandle() const
 void PipeImpl::closeRead()
 {
 	_readLock.markClosed();
-	_readLock.wait();  // wait for any in-progress read to finish
+	_readLock.wait();
 	HANDLE handle = _readHandle.exchange(INVALID_HANDLE_VALUE, std::memory_order_acq_rel);
 	if (handle != INVALID_HANDLE_VALUE)
 		CloseHandle(handle);
@@ -108,7 +152,7 @@ void PipeImpl::closeRead()
 void PipeImpl::closeWrite()
 {
 	_writeLock.markClosed();
-	_writeLock.wait();  // wait for any in-progress write to finish
+	_writeLock.wait();
 	HANDLE handle = _writeHandle.exchange(INVALID_HANDLE_VALUE, std::memory_order_acq_rel);
 	if (handle != INVALID_HANDLE_VALUE)
 		CloseHandle(handle);

--- a/Foundation/testsuite/src/PipeTest.cpp
+++ b/Foundation/testsuite/src/PipeTest.cpp
@@ -190,6 +190,53 @@ void PipeTest::testCloseRace()
 }
 
 
+void PipeTest::testCloseBlockedWrite()
+{
+	// Test that close() unblocks a writer that is blocked because the pipe buffer is full.
+	Pipe pipe;
+	std::atomic<bool> writeFinished{false};
+
+	Thread writerThread;
+	writerThread.startFunc([&pipe, &writeFinished]()
+	{
+		// Write enough data to fill the pipe buffer and block.
+		const std::string buffer(100'000, 'A');
+		pipe.writeBytes(buffer.data(), static_cast<int>(buffer.size()));
+		writeFinished.store(true, std::memory_order_release);
+	});
+
+	Thread::sleep(250);  // let the writer block
+
+	pipe.close();  // must not deadlock
+
+	writerThread.join();
+	assertTrue(writeFinished.load(std::memory_order_acquire));
+}
+
+
+void PipeTest::testCloseBlockedRead()
+{
+	// Test that close() unblocks a reader that is blocked waiting for data.
+	Pipe pipe;
+	std::atomic<bool> readFinished{false};
+
+	Thread readerThread;
+	readerThread.startFunc([&pipe, &readFinished]()
+	{
+		char buffer[64];
+		pipe.readBytes(buffer, sizeof(buffer));
+		readFinished.store(true, std::memory_order_release);
+	});
+
+	Thread::sleep(250);  // let the reader block
+
+	pipe.close();  // must not deadlock
+
+	readerThread.join();
+	assertTrue(readFinished.load(std::memory_order_acquire));
+}
+
+
 void PipeTest::setUp()
 {
 }
@@ -210,6 +257,8 @@ CppUnit::Test* PipeTest::suite()
 	CppUnit_addTest(pSuite, PipeTest, testCloseWrite);
 	CppUnit_addTest(pSuite, PipeTest, testCopy);
 	CppUnit_addTest(pSuite, PipeTest, testCloseRace);
+	CppUnit_addTest(pSuite, PipeTest, testCloseBlockedWrite);
+	CppUnit_addTest(pSuite, PipeTest, testCloseBlockedRead);
 
 	return pSuite;
 }

--- a/Foundation/testsuite/src/PipeTest.h
+++ b/Foundation/testsuite/src/PipeTest.h
@@ -30,6 +30,8 @@ public:
 	void testCloseWrite();
 	void testCopy();
 	void testCloseRace();
+	void testCloseBlockedWrite();
+	void testCloseBlockedRead();
 
 	void setUp();
 	void tearDown();

--- a/tsan.suppress
+++ b/tsan.suppress
@@ -23,3 +23,11 @@ race:ActiveDispatcherTest
 race:ArchiveStrategy::moveFile
 
 race:ThreadTest::testNotJoin
+
+# Pipe close races with blocked read()/write() on the same fd.
+# This is the standard POSIX mechanism for unblocking pipe IO:
+# close the other end to trigger EPIPE/EOF. The blocked syscall
+# holds a kernel reference to the file description, so it
+# completes safely after close() removes the fd from the table.
+# See close(2) and PipeImpl::close() for details.
+race:PipeImpl::close


### PR DESCRIPTION
## Summary

- Add `PipeImpl::close()` that performs a coordinated shutdown of both pipe ends, interleaving fd closes and IOLock waits to avoid deadlock while ensuring no fd is closed while still in use
- On POSIX: close write fd (EOF for readers) → wait for reader → close read fd (EPIPE for writers) → wait for writer
- On Windows: use `CancelIoEx()` to cancel blocked overlapped IO before closing handles, avoiding the need to close a handle while IO is in progress
- `Pipe::close(CLOSE_BOTH)` and `~PipeImpl()` use the new coordinated close; individual `closeRead()`/`closeWrite()` retain the original markClosed-wait-close order for standalone use (e.g. after fork in Process)
- Replace `poco_assert` with graceful `fd == -1` / `handle == INVALID_HANDLE_VALUE` checks in `readBytes()`/`writeBytes()` to handle concurrent close without aborting
- Cache fd/handle in a local variable to avoid reloading a concurrently-exchanged atomic
- Add `testCloseBlockedWrite` and `testCloseBlockedRead` regression tests
- Add TSan suppression for the benign close/read race (documented in source)

The previous order (`markClosed()` → `wait()` → `close(fd)`) deadlocked when a `write()`/`read()` was blocked in a kernel syscall, because `wait()` spun on `_inProgress` which could never clear while the fd remained open.

### TSan race note

The coordinated close creates a benign race between `close(fd)` and a concurrent `read(fd)`/`write(fd)` on the same fd. This is the standard POSIX mechanism for unblocking pipe IO — the kernel holds a file description reference for the blocked syscall, so it completes safely after `close()` removes the fd from the table (see `close(2)`). Suppressed in `tsan.suppress` with rationale in source comments.

Closes #5269

## Test plan

- [x] PipeTest (8 tests) passes on macOS normal build
- [x] PipeTest passes under ThreadSanitizer on Linux (via OrbStack) with suppression
- [x] PipeTest passes under AddressSanitizer — no memory errors
- [x] ProcessesTestSuite (29 tests) passes under ThreadSanitizer
- [x] Full Foundation suite (939 tests) passes under ThreadSanitizer (5 pre-existing thread-leak warnings, unchanged from baseline)
- [ ] CI: Linux, macOS, Windows