### PR TITLE
enh(NetSSL): add file-path overload for addCertificateAuthority() #5250

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -312,6 +312,16 @@ public:
 	void addCertificateAuthority(const Poco::Crypto::X509Certificate& certificate);
 		/// Add one trusted certification authority to be used by the Context.
 
+	void addCertificateAuthority(const std::string& caLocation);
+		/// Add one or more trusted certification authorities to be used by the Context.
+		///
+		/// The caLocation can refer to a single CA file (containing one or more
+		/// PEM-encoded certificates) or a directory containing certificate files
+		/// looked up by hash values (see OpenSSL c_rehash documentation).
+		///
+		/// Uses SSL_CTX_load_verify_locations() internally, which correctly
+		/// handles certificate trust settings on all OpenSSL versions.
+
 	//POCO_DEPRECATED("")
 	void usePrivateKey(const Poco::Crypto::RSAKey& key);
 		/// Sets the private key to be used by the Context.

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -293,6 +293,22 @@ void Context::addCertificateAuthority(const Crypto::X509Certificate &certificate
 }
 
 
+void Context::addCertificateAuthority(const std::string& caLocation)
+{
+	Poco::File aFile(caLocation);
+	int errCode = 0;
+	if (aFile.isDirectory())
+		errCode = SSL_CTX_load_verify_locations(_pSSLContext, nullptr, Poco::Path::transcode(caLocation).c_str());
+	else
+		errCode = SSL_CTX_load_verify_locations(_pSSLContext, Poco::Path::transcode(caLocation).c_str(), nullptr);
+	if (errCode != 1)
+	{
+		std::string msg = Utility::getLastError();
+		throw SSLContextException(std::string("Cannot add certificate authority from ") + caLocation, msg);
+	}
+}
+
+
 void Context::usePrivateKey(const Poco::Crypto::RSAKey& key)
 {
 	int errCode = SSL_CTX_use_RSAPrivateKey(_pSSLContext, key.impl()->getRSA());

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
@@ -457,6 +457,55 @@ void TCPServerTest::testContextInvalidCertificateHandler()
 }
 
 
+void TCPServerTest::testAddCertificateAuthority()
+{
+	Context::Ptr pServerContext = new Context(
+		Context::SERVER_USE,
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.caConfig"),
+		Context::VERIFY_NONE,
+		9,
+		false,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+
+	SecureServerSocket svs(0, 64, pServerContext);
+	TCPServer srv(new TCPServerConnectionFactoryImpl<EchoConnection>(), svs);
+	srv.start();
+
+	// Client context with no CA location and no default CAs
+	Context::Ptr pClientContext = new Context(
+		Context::CLIENT_USE,
+		"",
+		"",
+		"",
+		Context::VERIFY_RELAXED,
+		9,
+		false,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+
+	// Add root CA via file-path overload
+	std::string rootCertPath = Application::instance().config().getString("openSSL.server.caConfig");
+	pClientContext->addCertificateAuthority(rootCertPath);
+
+	pClientContext->setInvalidCertificateHandler(new Poco::Net::AcceptCertificateHandler(false));
+
+	SocketAddress sa("127.0.0.1", svs.address().port());
+
+	SecureStreamSocket ss1(sa, pClientContext);
+	std::string data("hello, world");
+	ss1.sendBytes(data.data(), (int) data.size());
+	char buffer[256];
+	int n = ss1.receiveBytes(buffer, sizeof(buffer));
+	assertTrue (n > 0);
+	assertTrue (std::string(buffer, n) == data);
+	ss1.close();
+	Thread::sleep(300);
+
+	srv.stop();
+}
+
+
 void TCPServerTest::setUp()
 {
 }
@@ -477,6 +526,7 @@ CppUnit::Test* TCPServerTest::suite()
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSocket);
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSession);
 	CppUnit_addTest(pSuite, TCPServerTest, testContextInvalidCertificateHandler);
+	CppUnit_addTest(pSuite, TCPServerTest, testAddCertificateAuthority);
 
 	return pSuite;
 }

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
@@ -30,6 +30,7 @@ public:
 	void testReuseSocket();
 	void testReuseSession();
 	void testContextInvalidCertificateHandler();
+	void testAddCertificateAuthority();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
## Summary

- Add `Context::addCertificateAuthority(const std::string& caLocation)` overload that accepts a file path or directory
- Uses `SSL_CTX_load_verify_locations()` internally, which correctly preserves certificate trust auxiliary data on OpenSSL 3.x
- The existing `addCertificateAuthority(const X509Certificate&)` overload uses `X509_STORE_add_cert()` which may not work for peer verification on OpenSSL 3.x due to trust settings being stripped during `PEM_read_bio_X509()` loading

Closes #5250

## Test plan

- [x] Added `TCPServerTest::testAddCertificateAuthority` — creates a client context with no CA, adds root CA via the new file-path overload, verifies TLS echo connection succeeds
- [x] Full `TCPServerTestSuite` passes (7/7 tests)
- [x] Full `NetSSL-testrunner -all` passes (2 pre-existing proxy test errors unrelated to this change)