### PR TITLE
enh(NetSSL_Win): NetSSL_Win does not support TLS 1.3 #5278

### DIFF
--- a/NetSSL_Win/CMakeLists.txt
+++ b/NetSSL_Win/CMakeLists.txt
@@ -33,14 +33,9 @@ POCO_INSTALL(NetSSLWin)
 POCO_GENERATE_PACKAGE(NetSSLWin)
 
 if(ENABLE_SAMPLES)
-	if(ENABLE_CRYPTO)
-		add_subdirectory(samples)
-	else()
-		message(STATUS "NetSSL_Win samples require Crypto and are not being built")
-	endif()
+	add_subdirectory(samples)
 endif()
 
 if(ENABLE_TESTS)
-	#add_subdirectory(testsuite)
+	add_subdirectory(testsuite)
 endif()
-

--- a/NetSSL_Win/include/Poco/Net/Context.h
+++ b/NetSSL_Win/include/Poco/Net/Context.h
@@ -27,6 +27,7 @@
 #if defined(POCO_OS_FAMILY_WINDOWS)
 #include <windows.h>
 #include <wincrypt.h>
+#include <subauth.h>
 #include <schannel.h>
 #ifndef SECURITY_WIN32
 #define SECURITY_WIN32
@@ -228,9 +229,11 @@ protected:
 	void loadCertificate();
 	void importCertificate();
 	void importCertificate(const char* pBuffer, std::size_t size);
-	void acquireSchannelCredentials(CredHandle& credHandle) const;
+	SECURITY_STATUS acquireSchannelCredentials(CredHandle& credHandle) const;
+	SECURITY_STATUS acquireSchannelCredentialsLegacy(CredHandle& credHandle) const;
 	DWORD proto() const;
 	DWORD enabledProtocols() const;
+	DWORD disabledProtocols() const;
 
 private:
 	Context(const Context&);

--- a/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_Win/include/Poco/Net/SecureSocketImpl.h
@@ -245,6 +245,7 @@ protected:
 		ST_CLIENT_HSK_LOOP_DONE,
 		ST_CLIENT_HSK_SEND_FINAL,
 		ST_CLIENT_HSK_SEND_ERROR,
+		ST_CLIENT_HSK_END,
 		ST_CLIENT_VERIFY,
 		ST_ACCEPTING,
 		ST_SERVER_HSK_START,
@@ -253,6 +254,7 @@ protected:
 		ST_SERVER_HSK_LOOP_PROCESS,
 		ST_SERVER_HSK_LOOP_SEND,
 		ST_SERVER_HSK_LOOP_DONE,
+		ST_SERVER_HSK_END,
 		ST_SERVER_VERIFY,
 		ST_DONE,
 		ST_ERROR,
@@ -289,6 +291,7 @@ protected:
 	void stateClientHandshakeLoopDone();
 	void stateClientHandshakeSendFinal();
 	void stateClientHandshakeSendError();
+	void stateClientHandshakeEnd();
 	void stateClientVerify();
 
 	void stateServerAccepted();
@@ -298,11 +301,12 @@ protected:
 	void stateServerHandshakeLoopProcess();
 	void stateServerHandshakeLoopSend();
 	void stateServerHandshakeLoopDone();
-	void stateServerHandshakeVerify();
+	void stateServerHandshakeEnd();
+	void stateServerVerify();
 
 	void sendOutSecBufferAndAdvanceState(State state);
 	void drainExtraBuffer();
-	static int getRecordLength(const BYTE* pBuffer, int length);
+	static int recordLength(const BYTE* pBuffer, int length);
 	static bool bufferHasCompleteRecords(const BYTE* pBuffer, int length);
 
 	void initClientCredentials();
@@ -353,6 +357,8 @@ private:
 	DWORD _sendBufferPending;
 	Poco::Buffer<BYTE> _recvBuffer;
 	DWORD _recvBufferOffset;
+	Poco::Buffer<BYTE> _extraBuffer;
+	DWORD _extraBufferOffset;
 	DWORD _ioBufferSize;
 
 	SecPkgContext_StreamSizes _streamSizes;
@@ -361,8 +367,6 @@ private:
 	SecBuffer _extraSecBuffer;
 	SECURITY_STATUS _securityStatus;
 	State _state;
-	bool _needData;
-	bool _needHandshake;
 	bool _initServerContext = false;
 
 	friend class SecureStreamSocketImpl;

--- a/NetSSL_Win/samples/HTTPSTimeServer/CMakeLists.txt
+++ b/NetSSL_Win/samples/HTTPSTimeServer/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(HTTPSTimeServer-win src/HTTPSTimeServer.cpp)
-target_link_libraries(HTTPSTimeServer-win PUBLIC Poco::NetSSLWin Poco::Crypto Poco::XML)
+target_link_libraries(HTTPSTimeServer-win PUBLIC Poco::NetSSLWin Poco::Util)

--- a/NetSSL_Win/samples/Mail/CMakeLists.txt
+++ b/NetSSL_Win/samples/Mail/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(Mail-ssl-win src/Mail.cpp)
-target_link_libraries(Mail-ssl-win PUBLIC Poco::NetSSLWin Poco::Crypto Poco::XML)
+target_link_libraries(Mail-ssl-win PUBLIC Poco::NetSSLWin Poco::Util)

--- a/NetSSL_Win/samples/download/CMakeLists.txt
+++ b/NetSSL_Win/samples/download/CMakeLists.txt
@@ -4,4 +4,4 @@ set(LOCAL_SRCS "")
 aux_source_directory(src LOCAL_SRCS)
 
 add_executable(download-ssl-win src/download.cpp)
-target_link_libraries(download-ssl-win PUBLIC Poco::NetSSLWin Poco::Crypto Poco::XML)
+target_link_libraries(download-ssl-win PUBLIC Poco::NetSSLWin Poco::Util)

--- a/NetSSL_Win/src/Context.cpp
+++ b/NetSSL_Win/src/Context.cpp
@@ -12,6 +12,9 @@
 //
 
 
+#define SCHANNEL_USE_BLACKLISTS // Required for SCH_CREDENTIALS which is required for TLS 1.3 on Windows 11
+
+
 #include "Poco/Net/Context.h"
 #include "Poco/Net/SSLManager.h"
 #include "Poco/Net/SSLException.h"
@@ -26,7 +29,6 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
-#include <stdio.h>
 
 
 namespace Poco::Net {
@@ -292,13 +294,89 @@ CredHandle& Context::credentials()
 
 	if (_hCreds.dwLower == 0 && _hCreds.dwUpper == 0)
 	{
-		acquireSchannelCredentials(_hCreds);
+		SECURITY_STATUS status = acquireSchannelCredentials(_hCreds);
+		if (status == SEC_E_UNKNOWN_CREDENTIALS || status == SEC_E_UNSUPPORTED_FUNCTION)
+		{
+			status = acquireSchannelCredentialsLegacy(_hCreds);
+		}
+		if (status != SEC_E_OK)
+		{
+			throw SSLException("Failed to acquire Schannel credentials", Utility::formatError(status));
+		}
 	}
 	return _hCreds;
 }
 
 
-void Context::acquireSchannelCredentials(CredHandle& credHandle) const
+SECURITY_STATUS Context::acquireSchannelCredentials(CredHandle& credHandle) const
+{
+	SCH_CREDENTIALS schannelCred;
+	ZeroMemory(&schannelCred, sizeof(schannelCred));
+	schannelCred.dwVersion  = SCH_CREDENTIALS_VERSION;
+
+	if (_pCert)
+	{
+		schannelCred.cCreds = 1; // how many cred are stored in &pCertContext
+		schannelCred.paCred = const_cast<PCCERT_CONTEXT*>(&_pCert);
+	}
+
+	TLS_PARAMETERS tlsParams;
+	ZeroMemory(&tlsParams, sizeof(tlsParams));
+	tlsParams.grbitDisabledProtocols = disabledProtocols();
+	schannelCred.cTlsParameters = 1;
+	schannelCred.pTlsParameters = &tlsParams;
+
+	if (_options & Context::OPT_PERFORM_REVOCATION_CHECK)
+		schannelCred.dwFlags |= SCH_CRED_REVOCATION_CHECK_CHAIN;
+	else
+		schannelCred.dwFlags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+
+	if (isForServerUse())
+	{
+		if (_mode >= Context::VERIFY_STRICT)
+			schannelCred.dwFlags |= SCH_CRED_NO_SYSTEM_MAPPER;
+
+		if (_mode == Context::VERIFY_NONE)
+			schannelCred.dwFlags |= SCH_CRED_MANUAL_CRED_VALIDATION;
+	}
+	else
+	{
+		if (_mode >= Context::VERIFY_STRICT)
+			schannelCred.dwFlags |= SCH_CRED_NO_DEFAULT_CREDS;
+		else
+			schannelCred.dwFlags |= SCH_CRED_USE_DEFAULT_CREDS;
+
+		if (_mode == Context::VERIFY_NONE)
+			schannelCred.dwFlags |= SCH_CRED_MANUAL_CRED_VALIDATION | SCH_CRED_NO_SERVERNAME_CHECK;
+
+		if (!_extendedCertificateVerification)
+			schannelCred.dwFlags |= SCH_CRED_NO_SERVERNAME_CHECK;
+	}
+
+#if defined(SCH_USE_STRONG_CRYPTO)
+	if (_options & Context::OPT_USE_STRONG_CRYPTO)
+		schannelCred.dwFlags |= SCH_USE_STRONG_CRYPTO;
+#endif
+
+	schannelCred.hRootStore = schannelCred.hRootStore = isForServerUse() ? _hCollectionCertStore : NULL;
+
+	TimeStamp tsExpiry;
+	tsExpiry.LowPart = tsExpiry.HighPart = 0;
+	::SEC_WCHAR name[] = UNISP_NAME_W;
+	return _securityFunctions.AcquireCredentialsHandleW(
+		NULL,
+		name,
+		isForServerUse() ? SECPKG_CRED_INBOUND : SECPKG_CRED_OUTBOUND,
+		NULL,
+		&schannelCred,
+		NULL,
+		NULL,
+		&credHandle,
+		&tsExpiry);
+}
+
+
+SECURITY_STATUS Context::acquireSchannelCredentialsLegacy(CredHandle& credHandle) const
 {
 	SCHANNEL_CRED schannelCred;
 	ZeroMemory(&schannelCred, sizeof(schannelCred));
@@ -350,7 +428,7 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 	TimeStamp tsExpiry;
 	tsExpiry.LowPart = tsExpiry.HighPart = 0;
 	::SEC_WCHAR name[] = UNISP_NAME_W;
-	SECURITY_STATUS status = _securityFunctions.AcquireCredentialsHandleW(
+	return _securityFunctions.AcquireCredentialsHandleW(
 		nullptr,
 		name,
 		isForServerUse() ? SECPKG_CRED_INBOUND : SECPKG_CRED_OUTBOUND,
@@ -360,11 +438,6 @@ void Context::acquireSchannelCredentials(CredHandle& credHandle) const
 		nullptr,
 		&credHandle,
 		&tsExpiry);
-
-	if (status != SEC_E_OK)
-	{
-		throw SSLException("Failed to acquire Schannel credentials", Utility::formatError(status));
-	}
 }
 
 
@@ -517,6 +590,39 @@ DWORD Context::enabledProtocols() const
 #endif
 	}
 	if (!(_disabledProtocols & PROTO_TLSV1_3))
+	{
+#ifdef SP_PROT_TLS1_3_CLIENT
+		result |= SP_PROT_TLS1_3_CLIENT | SP_PROT_TLS1_3_SERVER;
+#endif
+	}
+	return result;
+}
+
+
+DWORD Context::disabledProtocols() const
+{
+	DWORD result = 0;
+	if (_disabledProtocols & PROTO_SSLV3)
+	{
+		result |= SP_PROT_SSL3_CLIENT | SP_PROT_SSL3_SERVER;
+	}
+	if (_disabledProtocols & PROTO_TLSV1)
+	{
+		result |= SP_PROT_TLS1_CLIENT | SP_PROT_TLS1_SERVER;
+	}
+	if (_disabledProtocols & PROTO_TLSV1_1)
+	{
+#ifdef SP_PROT_TLS1_1_CLIENT
+		result |= SP_PROT_TLS1_1_CLIENT | SP_PROT_TLS1_1_SERVER;
+#endif
+	}
+	if (_disabledProtocols & PROTO_TLSV1_2)
+	{
+#ifdef SP_PROT_TLS1_2_CLIENT
+		result |= SP_PROT_TLS1_2_CLIENT | SP_PROT_TLS1_2_SERVER;
+#endif
+	}
+	if (_disabledProtocols & PROTO_TLSV1_3)
 	{
 #ifdef SP_PROT_TLS1_3_CLIENT
 		result |= SP_PROT_TLS1_3_CLIENT | SP_PROT_TLS1_3_SERVER;

--- a/NetSSL_Win/src/SecureSocketImpl.cpp
+++ b/NetSSL_Win/src/SecureSocketImpl.cpp
@@ -71,15 +71,15 @@ SecureSocketImpl::SecureSocketImpl(Poco::AutoPtr<SocketImpl> pSocketImpl, Contex
 	_sendBufferPending(0),
 	_recvBuffer(IO_BUFFER_SIZE),
 	_recvBufferOffset(0),
+	_extraBuffer(IO_BUFFER_SIZE),
+	_extraBufferOffset(0),
 	_ioBufferSize(0),
 	_streamSizes(),
 	_outSecBuffer(&_securityFunctions, true),
 	_inSecBuffer(&_securityFunctions, false),
 	_extraSecBuffer(),
 	_securityStatus(SEC_E_INCOMPLETE_MESSAGE),
-	_state(ST_INITIAL),
-	_needData(true),
-	_needHandshake(false)
+	_state(ST_INITIAL)
 {
 	SecInvalidateHandle(&_hCreds);
 	SecInvalidateHandle(&_hContext);
@@ -88,6 +88,8 @@ SecureSocketImpl::SecureSocketImpl(Poco::AutoPtr<SocketImpl> pSocketImpl, Contex
 	_streamSizes.cbHeader         = 0;
 	_streamSizes.cbMaximumMessage = 0;
 	_streamSizes.cbTrailer        = 0;
+
+	_extraSecBuffer.BufferType = SECBUFFER_EXTRA;
 
 	_overflowBuffer.resize(0);
 
@@ -302,14 +304,13 @@ void SecureSocketImpl::abort()
 
 int SecureSocketImpl::available() const
 {
-	return static_cast<int>(_overflowBuffer.size() + _recvBufferOffset);
+	return static_cast<int>(_overflowBuffer.size() + _recvBufferOffset + _extraBufferOffset);
 }
 
 
 void SecureSocketImpl::acceptSSL()
 {
 	setState(ST_ACCEPTING);
-	_needHandshake = true;
 }
 
 
@@ -380,25 +381,30 @@ int SecureSocketImpl::sendRawBytes(const void* buffer, int length, int flags)
 
 int SecureSocketImpl::receiveRawBytes(void* buffer, int length, int flags)
 {
-	return _pSocket->receiveBytes(buffer, length, flags);
+	int extra = _extraBufferOffset >= length ? length : _extraBufferOffset;
+	if (extra > 0)
+	{
+		std::memcpy(buffer, _extraBuffer.begin(), extra);
+		std::memmove(_extraBuffer.begin(), _extraBuffer.begin() + extra, _extraBufferOffset - extra);
+		_extraBufferOffset -= extra;
+		return extra;
+	}
+	else
+	{
+		return _pSocket->receiveBytes(buffer, length, flags);
+	}
 }
 
 
 int SecureSocketImpl::sendBytes(const void* buffer, int length, int flags)
 {
-	if (_needHandshake)
-	{
-		doHandshake();
-		_needHandshake = false;
-	}
-
 	if (_state == ST_ERROR) return 0;
 
 	if (_state != ST_DONE)
 	{
 		if (_pSocket->getBlocking())
 		{
-			doHandshake();
+			if (doHandshake() != SEC_E_OK) throw SSLException("Handshake failure");
 		}
 		else
 		{
@@ -454,8 +460,8 @@ int SecureSocketImpl::sendBytes(const void* buffer, int length, int flags)
 		if (FAILED(securityStatus) && securityStatus != SEC_E_CONTEXT_EXPIRED)
 			throw SSLException("Failed to encrypt message", Utility::formatError(securityStatus));
 
-		poco_assert_dbg (_streamSizes.cbHeader == msg[0].cbBuffer);
-		poco_assert_dbg (_streamSizes.cbTrailer == msg[2].cbBuffer);
+		poco_assert_dbg (_streamSizes.cbHeader >= msg[0].cbBuffer);
+		poco_assert_dbg (_streamSizes.cbTrailer >= msg[2].cbBuffer);
 		poco_assert_dbg (dataSize == msg[1].cbBuffer);
 
 		_sendBufferPending += msg[0].cbBuffer + msg[1].cbBuffer + msg[2].cbBuffer;
@@ -484,18 +490,12 @@ int SecureSocketImpl::sendBytes(const void* buffer, int length, int flags)
 
 int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 {
-	if (_needHandshake)
-	{
-		doHandshake();
-		_needHandshake = false;
-	}
-
 	if (_state == ST_ERROR) return 0;
 	if (_state != ST_DONE)
 	{
 		if (_pSocket->getBlocking())
 		{
-			doHandshake();
+			if (doHandshake() != SEC_E_OK) throw SSLException("Handshake failure");
 		}
 		else
 		{
@@ -507,7 +507,7 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 		}
 	}
 
-	int rc(0);
+	int rc = 0;
 	std::size_t overflowSize = _overflowBuffer.size();
 	if (overflowSize > 0) // any remaining data from previous calls?
 	{
@@ -533,11 +533,6 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 	}
 	else
 	{
-		// adjust buffer size to optimize memory usage
-		if (_ioBufferSize != _recvBuffer.capacity() && _recvBufferOffset < _ioBufferSize)
-		{
-			_recvBuffer.setCapacity(_ioBufferSize);
-		}
 		bool needData = _recvBufferOffset == 0;
 		bool cont = true;
 		do
@@ -553,11 +548,11 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 				else
 					_recvBufferOffset += numBytes;
 			}
-			else needData = true;
-
+			else 
+			{
+				needData = true;
+			}
 			int bytesDecoded = 0;
-			_extraSecBuffer.pvBuffer = nullptr;
-			_extraSecBuffer.cbBuffer = 0;
 			SECURITY_STATUS securityStatus = decodeBufferFull(_recvBuffer.begin(), _recvBufferOffset, reinterpret_cast<char*>(buffer), length, bytesDecoded);
 			if (_extraSecBuffer.cbBuffer > 0)
 			{
@@ -569,9 +564,6 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 				_recvBufferOffset = 0;
 				cont = false;
 			}
-
-			_extraSecBuffer.pvBuffer = nullptr;
-			_extraSecBuffer.cbBuffer = 0;
 
 			if (bytesDecoded > 0)
 			{
@@ -596,38 +588,53 @@ int SecureSocketImpl::receiveBytes(void* buffer, int length, int flags)
 			{
 				continue;
 			}
-
-			if (securityStatus == SEC_I_CONTEXT_EXPIRED)
-			{
+			else if (securityStatus == SEC_I_CONTEXT_EXPIRED)
+			{				
 				_shutdownFlags |= TLS_SHUTDOWN_RECEIVED;
 				break;
 			}
-
-			if (securityStatus != SEC_E_OK && securityStatus != SEC_I_RENEGOTIATE)
+			else if (securityStatus != SEC_E_OK && securityStatus != SEC_I_RENEGOTIATE)
 			{
 				break;
 			}
-
-			if (securityStatus == SEC_I_RENEGOTIATE)
+			else if (securityStatus == SEC_I_RENEGOTIATE)
 			{
-				_needData = false;
+				// We need to pass data to InitializeSecurityContext() record by record, due to an apparent
+				// bug in SChannel TLS 1.3 handling. After a successful handshake, the server
+				// will send additional post-handshake messages (e.g., NewSessionTicket),
+				// which are recognized by DecryptMessage() and reported with a
+				// SEC_I_RENEGOTIATE return value. The message will be unwrapped and
+				// made available in the _extraSecBuffer. This message must then be passed
+				// to InitializeSecurityContext(). The problem now is that if receiveRawBytes()
+				// returns two such post-handshake messages in a single read, as can happen
+				// in some cases, DecryptMessage() will only upwrap the first one and keep the 
+				// second one as is. If both messages are then passed to InitializeSecurityContext(), 
+				// only the first one will be processed and the second one will be silently discarded
+				// (not even passed back in SECBUFFER_EXTRA). 
+				// The next call to DecryptMessage() with regular data then fails with SEC_E_DECRYPT_FAILURE.
+				// 
+				// Passing received data record by record fixes this issue.
+
+				int recLength = recordLength(_recvBuffer.begin(), _recvBufferOffset);
+				if (recLength <= 0)  throw SSLException("Renegotiation with incomplete record"); // should not happen
+				if (recLength < _recvBufferOffset)
+				{
+					poco_assert_dbg (_extraBufferOffset == 0);
+					DWORD extra = _recvBufferOffset - recLength;
+					std::memcpy(_extraBuffer.begin(), _recvBuffer.begin() + recLength, extra);
+					_recvBufferOffset = recLength;
+					_extraBufferOffset = extra;
+				}
+
 				setState(ST_CLIENT_HSK_LOOP_INIT);
+
 				if (!_pSocket->getBlocking())
 					return bytesDecoded > 0 ? bytesDecoded : SecureStreamSocket::ERR_SSL_WOULD_BLOCK;
 
-				securityStatus = doHandshake();
+				if (doHandshake() != SEC_E_OK) throw SSLException("Handshake failure");
 
-				if (securityStatus != SEC_E_OK)
-					break;
-
-				if (_extraSecBuffer.pvBuffer)
-				{
-					std::memmove(_recvBuffer.begin(), _extraSecBuffer.pvBuffer, _extraSecBuffer.cbBuffer);
-					_recvBufferOffset = _extraSecBuffer.cbBuffer;
-				}
-
-				_extraSecBuffer.pvBuffer = nullptr;
-				_extraSecBuffer.cbBuffer = 0;
+				needData = _recvBufferOffset == 0;
+				cont = needData;
 			}
 		}
 		while (cont);
@@ -656,8 +663,7 @@ SECURITY_STATUS SecureSocketImpl::decodeMessage(BYTE* pBuffer, DWORD bufSize, Au
 		{
 			if (!pDataBuffer && msg[i].BufferType == SECBUFFER_DATA)
 				pDataBuffer = &msg[i];
-
-			if (!pExtraBuffer && msg[i].BufferType == SECBUFFER_EXTRA)
+			else if (!pExtraBuffer && msg[i].BufferType == SECBUFFER_EXTRA)
 				pExtraBuffer = &msg[i];
 		}
 	}
@@ -747,7 +753,11 @@ SECURITY_STATUS SecureSocketImpl::decodeBufferFull(BYTE* pBuffer, DWORD bufSize,
 
 		if (securityStatus == SEC_I_RENEGOTIATE)
 		{
-			_needData = false;
+			if (bufSize > 0)
+			{
+				_extraSecBuffer.cbBuffer = bufSize;
+				_extraSecBuffer.pvBuffer = pBuffer;
+			}
 			return securityStatus;
 		}
 	}
@@ -806,12 +816,7 @@ void SecureSocketImpl::connectSSL(bool completeHandshake)
 	setState(ST_CONNECTING);
 	if (completeHandshake)
 	{
-		doHandshake();
-		_needHandshake = false;
-	}
-	else
-	{
-		_needHandshake = true;
+		if (doHandshake() != SEC_E_OK) throw SSLException("Handshake failure");
 	}
 }
 
@@ -835,8 +840,9 @@ void SecureSocketImpl::stateError()
 void SecureSocketImpl::stateClientConnected()
 {
 	if (_peerHostName.empty())
+	{
 		_peerHostName = _pSocket->peerAddress().host().toString();
-
+	}
 	setState(ST_CLIENT_HSK_START);
 }
 
@@ -848,8 +854,12 @@ void SecureSocketImpl::stateClientHandshakeStart()
 	// get initial security token
 	_outSecBuffer.reset(true);
 	_outSecBuffer.setSecBufferToken(0, nullptr, 0);
-	_recvBuffer.setCapacity(IO_BUFFER_SIZE);
+	_recvBuffer.resize(IO_BUFFER_SIZE);
 	_recvBufferOffset = 0;
+	_extraBuffer.resize(IO_BUFFER_SIZE);
+	_extraBufferOffset = 0;
+	_extraSecBuffer.pvBuffer = nullptr;
+	_extraSecBuffer.cbBuffer = 0;
 
 	TimeStamp ts;
 	DWORD contextAttributes(0);
@@ -881,10 +891,6 @@ void SecureSocketImpl::stateClientHandshakeStart()
 			throw SSLException("Handshake failed", Utility::formatError(_securityStatus));
 		}
 	}
-
-	_extraSecBuffer.pvBuffer = nullptr;
-	_extraSecBuffer.cbBuffer = 0;
-	_needData = true;
 
 	setState(ST_CLIENT_HSK_SEND_TOKEN);
 }
@@ -943,46 +949,6 @@ void SecureSocketImpl::stateClientHandshakeLoopInit()
 }
 
 
-int SecureSocketImpl::getRecordLength(const BYTE* pRec, int len)
-{
-	// TLS Record Header:
-	// struct {
-	//     ContentType type;        /* 1 byte */
-	//     ProtocolVersion version; /* 2 bytes */
-	//     uint16 length;           /* must be <= 2^14 */
-	//     opaque fragment[TLSPlaintext.length];
-	// } TLSPlaintext;
-
-	if (len >= 5)
-	{
-		Poco::UInt16 recLen = (pRec[3] << 8) + pRec[4];
-		if (recLen <= 16384)
-		{
-			return recLen + 5;
-		}
-		else
-		{
-			return -1;
-		}
-	}
-	return 0;
-}
-
-
-bool SecureSocketImpl::bufferHasCompleteRecords(const BYTE* pBuffer, int length)
-{
-	const BYTE* pEnd = pBuffer + length;
-	int recLen = getRecordLength(pBuffer, length);
-	while (recLen > 0 && length >= recLen)
-	{
-		pBuffer += recLen;
-		length -= recLen;
-		recLen = getRecordLength(pBuffer, length);
-	}
-	return pBuffer == pEnd;
-}
-
-
 void SecureSocketImpl::stateClientHandshakeLoopRecv()
 {
 	poco_assert (IO_BUFFER_SIZE > _recvBufferOffset);
@@ -1000,7 +966,6 @@ void SecureSocketImpl::stateClientHandshakeLoopRecv()
 		{
 			setState(ST_CLIENT_HSK_LOOP_PROCESS);
 		}
-		
 	}
 }
 
@@ -1043,7 +1008,6 @@ void SecureSocketImpl::stateClientHandshakeLoopProcess()
 	}
 	else if (_securityStatus == SEC_E_INCOMPLETE_MESSAGE)
 	{
-		_needData = true;
 		setState(ST_CLIENT_HSK_LOOP_INIT);
 	}
 	else if (FAILED(_securityStatus))
@@ -1080,14 +1044,14 @@ void SecureSocketImpl::stateClientHandshakeLoopDone()
 	}
 	else
 	{
-		setState(ST_CLIENT_VERIFY);
+		setState(ST_CLIENT_HSK_END);
 	}
 }
 
 
 void SecureSocketImpl::stateClientHandshakeSendFinal()
 {
-	sendOutSecBufferAndAdvanceState(ST_CLIENT_VERIFY);
+	sendOutSecBufferAndAdvanceState(ST_CLIENT_HSK_END);
 }
 
 
@@ -1122,28 +1086,49 @@ void SecureSocketImpl::drainExtraBuffer()
 		std::memmove(_recvBuffer.begin(), _recvBuffer.begin() + (_recvBufferOffset - _inSecBuffer[1].cbBuffer), _inSecBuffer[1].cbBuffer);
 		_recvBufferOffset = _inSecBuffer[1].cbBuffer;
 	}
-	else _recvBufferOffset = 0;
+	else 
+	{
+		_recvBufferOffset = 0;
+	}
+}
+
+
+void SecureSocketImpl::stateClientHandshakeEnd()
+{
+	SECURITY_STATUS securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_STREAM_SIZES, &_streamSizes);
+	if (securityStatus != SEC_E_OK)
+		throw SSLException("Failed to query stream sizes", Utility::formatError(securityStatus));
+
+	_ioBufferSize = _streamSizes.cbHeader + _streamSizes.cbMaximumMessage + _streamSizes.cbTrailer;
+	if (_ioBufferSize != _recvBuffer.size() && _recvBufferOffset <= _ioBufferSize) 
+	{
+		_recvBuffer.resize(_ioBufferSize);
+	}
+	if (_ioBufferSize != _extraBuffer.size() && _extraBufferOffset <= _ioBufferSize)
+	{
+		_extraBuffer.resize(_ioBufferSize);
+	}
+	setState(ST_CLIENT_VERIFY);
 }
 
 
 void SecureSocketImpl::stateClientVerify()
 {
-	poco_assert_dbg(!_pPeerCertificate);
+	// With TLS 1.3, this may be entered multiple times.
+	// Only verify certificate once, but we still need to query stream sizes.
+
 	poco_assert_dbg(!_peerHostName.empty());
 
 	try
 	{
-		SECURITY_STATUS securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_REMOTE_CERT_CONTEXT, (PVOID) &_pPeerCertificate);
-		if (securityStatus != SEC_E_OK)
-			throw SSLException("Failed to obtain peer certificate", Utility::formatError(securityStatus));
+		if (!_pPeerCertificate)
+		{
+			SECURITY_STATUS securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_REMOTE_CERT_CONTEXT, (PVOID) &_pPeerCertificate);
+			if (securityStatus != SEC_E_OK)
+				throw SSLException("Failed to obtain peer certificate", Utility::formatError(securityStatus));
 
-		clientVerifyCertificate(_peerHostName);
-
-		securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_STREAM_SIZES, &_streamSizes);
-		if (securityStatus != SEC_E_OK)
-			throw SSLException("Failed to query stream sizes", Utility::formatError(securityStatus));
-
-		_ioBufferSize = _streamSizes.cbHeader + _streamSizes.cbMaximumMessage + _streamSizes.cbTrailer;
+			clientVerifyCertificate(_peerHostName);
+		}
 		setState(ST_DONE);
 	}
 	catch (...)
@@ -1151,7 +1136,7 @@ void SecureSocketImpl::stateClientVerify()
 		if (_pPeerCertificate)
 		{
 			CertFreeCertificateContext(_pPeerCertificate);
-			_pPeerCertificate = nullptr;
+			_pPeerCertificate = 0;
 		}
 		throw;
 	}
@@ -1171,6 +1156,10 @@ void SecureSocketImpl::stateServerHandshakeStart()
 	_initServerContext = true;
 	_recvBuffer.setCapacity(IO_BUFFER_SIZE);
 	_recvBufferOffset = 0;
+	_extraBuffer.resize(IO_BUFFER_SIZE);
+	_extraBufferOffset = 0;
+	_extraSecBuffer.pvBuffer = nullptr;
+	_extraSecBuffer.cbBuffer = 0;
 	setState(ST_SERVER_HSK_LOOP_INIT);
 }
 
@@ -1273,11 +1262,30 @@ void  SecureSocketImpl::stateServerHandshakeLoopDone()
 	_securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_STREAM_SIZES, &_streamSizes);
 	if (_securityStatus != SEC_E_OK) throw SSLException("Cannot query stream sizes", Utility::formatError(_securityStatus));
 	_ioBufferSize = _streamSizes.cbHeader + _streamSizes.cbMaximumMessage + _streamSizes.cbTrailer;
+	setState(ST_SERVER_HSK_END);
+}
+
+
+void SecureSocketImpl::stateServerHandshakeEnd()
+{
+	SECURITY_STATUS securityStatus = _securityFunctions.QueryContextAttributesW(&_hContext, SECPKG_ATTR_STREAM_SIZES, &_streamSizes);
+	if (securityStatus != SEC_E_OK)
+		throw SSLException("Failed to query stream sizes", Utility::formatError(securityStatus));
+
+	_ioBufferSize = _streamSizes.cbHeader + _streamSizes.cbMaximumMessage + _streamSizes.cbTrailer;
+	if (_ioBufferSize != _recvBuffer.size() && _recvBufferOffset <= _ioBufferSize) 
+	{
+		_recvBuffer.resize(_ioBufferSize);
+	}
+	if (_ioBufferSize != _extraBuffer.size() && _extraBufferOffset <= _ioBufferSize)
+	{
+		_extraBuffer.resize(_ioBufferSize);
+	}
 	setState(ST_SERVER_VERIFY);
 }
 
 
-void SecureSocketImpl::stateServerHandshakeVerify()
+void SecureSocketImpl::stateServerVerify()
 {
 	SECURITY_STATUS securityStatus;
 	if (_clientAuthRequired)
@@ -1300,6 +1308,46 @@ void SecureSocketImpl::stateServerHandshakeVerify()
 		}
 	}
 	setState(ST_DONE);
+}
+
+
+int SecureSocketImpl::recordLength(const BYTE* pRec, int len)
+{
+	// TLS Record Header:
+	// struct {
+    //     ContentType type;        /* 1 byte */
+    //     ProtocolVersion version; /* 2 bytes */
+    //     uint16 length;           /* must be <= 2^14 */
+    //     opaque fragment[TLSPlaintext.length];
+    // } TLSPlaintext;
+
+	if (len >= 5)
+	{
+		Poco::UInt16 recLen = (pRec[3] << 8) + pRec[4];
+		if (recLen <= 16384)
+		{
+			return recLen + 5;
+		}
+		else
+		{
+			return -1;
+		}
+	}
+	return 0;
+}
+
+
+bool SecureSocketImpl::bufferHasCompleteRecords(const BYTE* pBuffer, int length)
+{
+	const BYTE* pEnd = pBuffer + length;
+	int recLen = recordLength(pBuffer, length);
+	while (recLen > 0 && length >= recLen)
+	{
+		pBuffer += recLen;
+		length -= recLen;
+		recLen = recordLength(pBuffer, length);
+	}
+	return pBuffer == pEnd;
 }
 
 
@@ -1331,7 +1379,7 @@ int SecureSocketImpl::completeHandshake()
 {
 	if (_pSocket->getBlocking())
 	{
-		doHandshake();
+		if (doHandshake() != SEC_E_OK) throw SSLException("Handshake failure");
 		return 0;
 	}
 	else
@@ -1653,7 +1701,6 @@ int SecureSocketImpl::serverShutdown(PCredHandle phCreds, CtxtHandle* phContext)
 	if (!SecIsValidHandle(phContext))
 	{
 		// handshake has never been done
-		poco_assert_dbg (_needHandshake);
 		return SEC_E_OK;
 	}
 
@@ -1673,7 +1720,7 @@ int SecureSocketImpl::serverShutdown(PCredHandle phCreds, CtxtHandle* phContext)
 					| ASC_REQ_STREAM;
 
 	AutoSecBufferDesc<1> outBuffer(&_securityFunctions, true);
-	outBuffer.setSecBufferToken(0,nullptr,0);
+	outBuffer.setSecBufferToken(0, nullptr, 0);
 
 	DWORD sspiOutFlags;
 	TimeStamp expiry;
@@ -1738,6 +1785,7 @@ void SecureSocketImpl::printState(const std::string& message)
 		CASE_PRINT_ENUM(ST_CLIENT_HSK_LOOP_DONE)
 		CASE_PRINT_ENUM(ST_CLIENT_HSK_SEND_FINAL)
 		CASE_PRINT_ENUM(ST_CLIENT_HSK_SEND_ERROR)
+		CASE_PRINT_ENUM(ST_CLIENT_HSK_END)
 		CASE_PRINT_ENUM(ST_CLIENT_VERIFY)
 		CASE_PRINT_ENUM(ST_ACCEPTING)
 		CASE_PRINT_ENUM(ST_SERVER_HSK_START)
@@ -1746,16 +1794,17 @@ void SecureSocketImpl::printState(const std::string& message)
 		CASE_PRINT_ENUM(ST_SERVER_HSK_LOOP_PROCESS)
 		CASE_PRINT_ENUM(ST_SERVER_HSK_LOOP_SEND)
 		CASE_PRINT_ENUM(ST_SERVER_HSK_LOOP_DONE)
+		CASE_PRINT_ENUM(ST_SERVER_HSK_END)
 		CASE_PRINT_ENUM(ST_SERVER_VERIFY)
 		CASE_PRINT_ENUM(ST_DONE)
 		CASE_PRINT_ENUM(ST_ERROR)
 	}
 
-	std::cout << "  securityStatus=" << Utility::formatError(_securityStatus) << "  hCreds="<< SecIsValidHandle(&_hCreds) << "  hContext=" << SecIsValidHandle(&_hContext) << "  recvBufOff=" << _recvBufferOffset << std::endl;
+	std::cerr << "  securityStatus=" << Utility::formatError(_securityStatus) << "  hCreds="<< SecIsValidHandle(&_hCreds) << "  hContext=" << SecIsValidHandle(&_hContext) << "  recvBufOff=" << _recvBufferOffset << std::endl;
 }
 
 
-#endif 
+#endif // ENABLE_PRINT_STATE
 
 
 StateMachine& StateMachine::instance()
@@ -1780,6 +1829,7 @@ StateMachine::StateMachine():
 	_states[SecureSocketImpl::ST_CLIENT_HSK_LOOP_DONE]       = &SecureSocketImpl::stateClientHandshakeLoopDone;
 	_states[SecureSocketImpl::ST_CLIENT_HSK_SEND_FINAL]      = &SecureSocketImpl::stateClientHandshakeSendFinal;
 	_states[SecureSocketImpl::ST_CLIENT_HSK_SEND_ERROR]      = &SecureSocketImpl::stateClientHandshakeSendError;
+	_states[SecureSocketImpl::ST_CLIENT_HSK_END]             = &SecureSocketImpl::stateClientHandshakeEnd;
 	_states[SecureSocketImpl::ST_CLIENT_VERIFY]              = &SecureSocketImpl::stateClientVerify;
 		
 	_states[SecureSocketImpl::ST_ACCEPTING]                  = &SecureSocketImpl::stateServerAccepted;
@@ -1789,7 +1839,8 @@ StateMachine::StateMachine():
 	_states[SecureSocketImpl::ST_SERVER_HSK_LOOP_PROCESS]    = &SecureSocketImpl::stateServerHandshakeLoopProcess;
 	_states[SecureSocketImpl::ST_SERVER_HSK_LOOP_SEND]       = &SecureSocketImpl::stateServerHandshakeLoopSend;
 	_states[SecureSocketImpl::ST_SERVER_HSK_LOOP_DONE]       = &SecureSocketImpl::stateServerHandshakeLoopDone;
-	_states[SecureSocketImpl::ST_SERVER_VERIFY]              = &SecureSocketImpl::stateServerHandshakeVerify;
+	_states[SecureSocketImpl::ST_SERVER_HSK_END]             = &SecureSocketImpl::stateServerHandshakeEnd;
+	_states[SecureSocketImpl::ST_SERVER_VERIFY]              = &SecureSocketImpl::stateServerVerify;
 
 	_states[SecureSocketImpl::ST_DONE]                       = &SecureSocketImpl::stateIllegal;
 	_states[SecureSocketImpl::ST_ERROR]                      = &SecureSocketImpl::stateError;

--- a/NetSSL_Win/testsuite/CMakeLists.txt
+++ b/NetSSL_Win/testsuite/CMakeLists.txt
@@ -18,9 +18,8 @@ add_test(
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 	COMMAND NetSSLWin-testrunner -ignore ${CMAKE_SOURCE_DIR}/cppignore.win -all
 )
-target_link_libraries(NetSSLWin-testrunner PUBLIC Poco::NetSSL Poco::Util Poco::XML CppUnit)
+target_link_libraries(NetSSLWin-testrunner PUBLIC Poco::NetSSLWin Poco::Util Poco::XML CppUnit)
 
 # Test data
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/any.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/any.pem COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rootcert.pem ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcert.pem COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSLWin.xml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/any.pfx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/any.pfx COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/testrunner.xml ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NetSSLWin-testrunner.xml COPYONLY)

--- a/NetSSL_Win/testsuite/testrunner.xml
+++ b/NetSSL_Win/testsuite/testrunner.xml
@@ -1,7 +1,7 @@
 <AppConfig>
 	<schannel>
 		<server>
-			<certificatePath>any.pfx</certificatePath>
+			<certificatePath>${application.configDir}any.pfx</certificatePath>
 			<verificationMode>none</verificationMode>
 			<useMachineStore>false</useMachineStore>
 			<privateKeyPassphraseHandler>


### PR DESCRIPTION
Add long overdue support for TLS 1.3. See #5278 

While at it, also fix test suite and samples build for NetSSL_Win.