### PR TITLE
fix(ApacheConnector,Foundation): fix compile warnings with GCC 15

### DIFF
--- a/ApacheConnector/include/ApacheStream.h
+++ b/ApacheConnector/include/ApacheStream.h
@@ -29,8 +29,8 @@ public:
 		/// Destroys the SocketStreamBuf.
 
 protected:
-	int readFromDevice(char* buffer, std::streamsize length);
-	int writeToDevice(const char* buffer, std::streamsize length);
+	std::streamsize readFromDevice(char* buffer, std::streamsize length);
+	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
 	enum

--- a/ApacheConnector/src/ApacheConnector.cpp
+++ b/ApacheConnector/src/ApacheConnector.cpp
@@ -166,7 +166,7 @@ void ApacheConnector::log(const char* file, int line, int level, int status, con
 #if AP_SERVER_MAJORVERSION_NUMBER == 2 && AP_SERVER_MINORVERSION_NUMBER < 4
 		ap_log_error(file, line, level, 0, nullptr, "%s", text);
 #else
-	ap_log_error(file, line, level, 0, 0, 0, text);
+	ap_log_error(file, line, level, 0, 0, 0, "%s", text);
 #endif
 }
 

--- a/ApacheConnector/src/ApacheStream.cpp
+++ b/ApacheConnector/src/ApacheStream.cpp
@@ -34,7 +34,7 @@ ApacheStreamBuf::~ApacheStreamBuf()
 }
 
 
-int ApacheStreamBuf::readFromDevice(char* buffer, std::streamsize len)
+std::streamsize ApacheStreamBuf::readFromDevice(char* buffer, std::streamsize len)
 {
 	if (_haveData)
 		return _pApacheRequest->readRequest(buffer, static_cast<int>(len));
@@ -43,7 +43,7 @@ int ApacheStreamBuf::readFromDevice(char* buffer, std::streamsize len)
 }
 
 
-int ApacheStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
+std::streamsize ApacheStreamBuf::writeToDevice(const char* buffer, std::streamsize length)
 {
 	_pApacheRequest->writeResponse(buffer, length);
 	return length;

--- a/Foundation/include/Poco/NotificationCenter.h
+++ b/Foundation/include/Poco/NotificationCenter.h
@@ -120,7 +120,21 @@ public:
 		///     nc.addNObserver(*this, &MyClass::onEvent);
 		///     void MyClass::onEvent(const AutoPtr<MyNotification>& pNf) { /* no release needed */ }
 	{
+		// Suppress deprecation warning for Observer<C, N> construction;
+		// this deprecated method necessarily references the deprecated class.
+#ifdef POCO_COMPILER_MSVC
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 		addObserver(Observer<C, N>(object, method));
+#ifdef POCO_COMPILER_MSVC
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 	}
 
 	template <class C, class N>
@@ -130,7 +144,21 @@ public:
 		/// Observer<C, N> class template. See addObserver() deprecation note
 		/// for migration details.
 	{
+		// Suppress deprecation warning for Observer<C, N> construction;
+		// this deprecated method necessarily references the deprecated class.
+#ifdef POCO_COMPILER_MSVC
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 		removeObserver(Observer<C, N>(object, method));
+#ifdef POCO_COMPILER_MSVC
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 	}
 
 	template <class C, class N>


### PR DESCRIPTION
## Summary

- **ApacheStreamBuf**: `readFromDevice()`/`writeToDevice()` return type changed from `int` to `std::streamsize` to match the `BufferedStreamBuf` base class virtual signatures (fixes `-Werror=conflicting-return-type` with GCC 15)
- **ApacheConnector::log**: pass `"%s"` format string to `ap_log_error()` on the Apache >= 2.4 code path to fix `-Wformat-security` warning
- **NotificationCenter**: suppress `-Wdeprecated-declarations` inside the deprecated `addObserver()`/`removeObserver()` convenience templates that necessarily construct the deprecated `Observer<C, N>` class

## Test plan

- [x] Full Linux build with GCC 15 completes with no errors or warnings from these files