### PR TITLE
fix(Redis): use shared_ptr for NotificationCenter, harden AsyncNotificationCenter::stop()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,7 +657,7 @@ jobs:
           retry_on: any
           command: >-
             cd cmake-build;
-            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(Redis)|(MongoDB)" -C Release
+            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(MongoDB)" -C Release
 
   windows-2025-clang-cmake:
     runs-on: windows-2025

--- a/Foundation/src/AsyncNotificationCenter.cpp
+++ b/Foundation/src/AsyncNotificationCenter.cpp
@@ -203,9 +203,16 @@ void AsyncNotificationCenter::stop()
 		{
 			_nq.enqueueUrgentNotification(new ShutdownNotification);
 			_nq.wakeUpAll();
-			while (!_enqueueThreadDone) Thread::sleep(100);
-			_enqueueThread.join();
 		}
+		// Wait and join unconditionally: dequeue() sets _enqueueThreadStarted
+		// to false on exit, so a second call to stop() (or a call after the
+		// thread has already finished) would skip the shutdown signal above.
+		// Joining outside the guard ensures the thread is fully stopped
+		// before the object is destroyed in all cases.
+		// Poco::Thread::join() is safe to call on a never-started or
+		// already-joined thread.
+		while (!_enqueueThreadDone) Thread::sleep(100);
+		_enqueueThread.join();
 	}
 
 #if (POCO_HAVE_JTHREAD)

--- a/Redis/include/Poco/Redis/Client.h
+++ b/Redis/include/Poco/Redis/Client.h
@@ -216,6 +216,12 @@ private:
 		/// call readReply as many times as you called writeCommand, even when
 		/// an error occurred on a command.
 
+	NotificationCenterPtr loadNC() const;
+		/// Thread-safe load of the notification center pointer.
+
+	void storeNC(NotificationCenterPtr pNC);
+		/// Thread-safe store of the notification center pointer.
+
 	Net::SocketAddress _address;
 	Net::StreamSocket _socket;
 	std::unique_ptr<RedisInputStream> _pInput{};
@@ -224,7 +230,8 @@ private:
 #if POCO_HAVE_ATOMIC_SHARED_PTR
 	std::atomic<NotificationCenterPtr> _pNC{};
 #else
-	std::atomic<AsyncNotificationCenter*> _pNC{nullptr};
+	NotificationCenterPtr _pNC;
+	mutable std::mutex _ncMutex;
 #endif
 	mutable std::once_flag _ncInitFlag{};
 };

--- a/Redis/src/Client.cpp
+++ b/Redis/src/Client.cpp
@@ -54,12 +54,7 @@ Client::Client(const Net::StreamSocket& socket)
 }
 
 
-Client::~Client()
-{
-#if !POCO_HAVE_ATOMIC_SHARED_PTR
-	delete _pNC.load();
-#endif
-}
+Client::~Client() = default;
 
 
 void Client::connect()
@@ -73,7 +68,7 @@ void Client::connect()
 		_pInput = std::make_unique<RedisInputStream>(_socket);
 		_pOutput = std::make_unique<RedisOutputStream>(_socket);
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisConnectNotification);
 	}
 	catch (const Exception& ex)
@@ -81,7 +76,7 @@ void Client::connect()
 		_pInput.reset();
 		_pOutput.reset();
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisErrorNotification(ex));
 		throw;
 	}
@@ -121,7 +116,7 @@ void Client::connect(const Timespan& timeout)
 		_pInput = std::make_unique<RedisInputStream>(_socket);
 		_pOutput = std::make_unique<RedisOutputStream>(_socket);
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisConnectNotification);
 	}
 	catch (const Exception& ex)
@@ -129,7 +124,7 @@ void Client::connect(const Timespan& timeout)
 		_pInput.reset();
 		_pOutput.reset();
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisErrorNotification(ex));
 		throw;
 	}
@@ -169,7 +164,7 @@ void Client::connect(const Poco::Net::StreamSocket& socket)
 		_pInput = std::make_unique<RedisInputStream>(_socket);
 		_pOutput = std::make_unique<RedisOutputStream>(_socket);
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisConnectNotification);
 	}
 	catch (const Exception& ex)
@@ -177,7 +172,7 @@ void Client::connect(const Poco::Net::StreamSocket& socket)
 		_pInput.reset();
 		_pOutput.reset();
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisErrorNotification(ex));
 		throw;
 	}
@@ -193,7 +188,7 @@ void Client::disconnect()
 
 		_socket.close();
 
-		auto pNC = _pNC.load();
+		auto pNC = loadNC();
 		if (pNC) pNC->postNotification(new RedisDisconnectNotification);
 	}
 }
@@ -266,19 +261,32 @@ Array Client::sendCommands(const std::vector<Array>& commands)
 
 Client::NotificationCenterPtr Client::notificationCenter()
 {
-#if POCO_HAVE_ATOMIC_SHARED_PTR
 	std::call_once(_ncInitFlag, [this]()
 	{
-		_pNC.store(std::make_shared<AsyncNotificationCenter>());
+		storeNC(std::make_shared<AsyncNotificationCenter>());
 	});
+	return loadNC();
+}
+
+
+Client::NotificationCenterPtr Client::loadNC() const
+{
+#if POCO_HAVE_ATOMIC_SHARED_PTR
 	return _pNC.load();
 #else
-	std::call_once(_ncInitFlag, [this]()
-	{
-		_pNC.store(new AsyncNotificationCenter);
-	});
-	return NotificationCenterPtr(_pNC.load(), [](AsyncNotificationCenter*) {});
-		// Return shared_ptr with no-op deleter since Client owns the pointer
+	std::lock_guard<std::mutex> lock(_ncMutex);
+	return _pNC;
+#endif
+}
+
+
+void Client::storeNC(NotificationCenterPtr pNC)
+{
+#if POCO_HAVE_ATOMIC_SHARED_PTR
+	_pNC.store(std::move(pNC));
+#else
+	std::lock_guard<std::mutex> lock(_ncMutex);
+	_pNC = std::move(pNC);
 #endif
 }
 

--- a/Redis/testsuite/src/RedisTest.cpp
+++ b/Redis/testsuite/src/RedisTest.cpp
@@ -2908,6 +2908,12 @@ void RedisTest::testRPUSH()
 
 void RedisTest::testPool()
 {
+	if (!_connected)
+	{
+		std::cout << "Not connected, test skipped." << std::endl;
+		return;
+	}
+
 	Poco::Net::SocketAddress sa(_host, _port);
 	Poco::PoolableObjectFactory<Client, Client::Ptr> factory(sa);
 	Poco::ObjectPool<Client, Client::Ptr> pool(factory, 10, 15);


### PR DESCRIPTION
## Summary

- Use `shared_ptr` internally in `Redis::Client` for the `AsyncNotificationCenter`. When `std::atomic<shared_ptr>` is available (C++20 `__cpp_lib_atomic_shared_ptr`), use it directly; otherwise protect the `shared_ptr` with a `std::mutex`. This replaces the raw-pointer-with-no-op-deleter approach that could leave callers with dangling pointers if the `Client` was destroyed first.
- Harden `AsyncNotificationCenter::stop()` to unconditionally wait for and join the dequeue thread, preventing potential issues if `stop()` is called after the thread has already exited.
- Add missing connection guard to `RedisTest::testPool`.
- Enable Redis tests in `windows-2025-msvc-cmake` CI job.

## Test plan

- [x] Foundation `AsyncNotificationCenterTest` passes (14 tests)
- [x] Redis library and test runner build cleanly
- [x] Verify on Windows CI (Redis tests should skip gracefully without a server)