### PR TITLE
enh(ci): modernize CI, add missing components, DRY up matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux-clang-20-cmake-modules:
+  linux-clang-21-cmake-modules:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Install Clang 20
+      - name: Install Clang 21
         run: |
           sudo apt -y update
           sudo apt -y install wget lsb-release software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 20
-          sudo apt -y install clang-20 libc++-20-dev libc++abi-20-dev
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+          sudo ./llvm.sh 21
+          sudo apt -y install clang-21 libc++-21-dev libc++abi-21-dev
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
       - name: Install dependencies
         run: sudo apt -y install cmake ninja-build
-      - name: Configure with Clang 20 and modules
+      - name: Configure with Clang 21 and modules
         run: |
-          export CC=clang-20
-          export CXX=clang++-20
+          export CC=clang-21
+          export CXX=clang++-21
           cmake -S . -B build -G Ninja -DENABLE_MODULES=ON -DENABLE_TESTS=ON
       - name: Build
         run: cmake --build build --parallel 4
@@ -308,13 +308,13 @@ jobs:
   #            PWD=`pwd`
   #            ctest --output-on-failure -E "(DataMySQL)|(DataODBC)|(PostgreSQL)|(MongoDB)"
 
-  macos-clang-18-cmake-openssl3:
+  macos-clang-21-cmake-openssl3:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
-      - run: brew install openssl@3 mysql-client unixodbc libpq
+      - run: brew install llvm@21 openssl@3 mysql-client unixodbc libpq
       - run: >-
-          CXX=$(brew --prefix llvm@18)/bin/clang++ CC=$(brew --prefix llvm@18)/bin/clang
+          CXX=$(brew --prefix llvm@21)/bin/clang++ CC=$(brew --prefix llvm@21)/bin/clang
           cmake -S. -Bcmake-build -DENABLE_TESTS=ON
           -DENABLE_DATA_POSTGRESQL=ON -DENABLE_DATA_MYSQL=ON -DENABLE_PDF=OFF
           -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 -DMYSQL_ROOT_DIR=/opt/homebrew/opt/mysql-client/


### PR DESCRIPTION
## Summary

Modernize CI workflow: improve component coverage, upgrade runners and toolchains, switch Windows to Ninja, and DRY up duplicate job definitions using matrices.

## Component Coverage Changes

| Component | Before | After |
|---|---|---|
| **ApacheConnector** | Never compiled in CI | Compiled in Linux sanitizer builds |
| **DNSSD** (Avahi) | Never compiled in CI | Compiled in Linux sanitizer builds |
| **DNSSD** (Bonjour) | Never compiled in CI | Compiled in macOS visibility-hidden builds |
| **Benchmark** | Never compiled in CI | Compiled in trace builds (Linux + macOS) |
| **Clang 20 modules** | Build-only | Tests now run via ctest |

## Sanitizer Coverage Changes

| | Before | After |
|---|---|---|
| **macOS ARM (Apple Silicon)** | ubsan + tsan only | asan + ubsan + tsan |
| **macOS Intel** | asan only (no visibility-hidden) | asan + ubsan + tsan (+ visibility-hidden variants) |

## Platform Upgrades

| What | Before | After |
|---|---|---|
| Ubuntu runners (8 jobs) | ubuntu-22.04 | ubuntu-24.04 |
| Windows static-mt job | windows-2022 | windows-2025 |
| Windows MSVC generator (5 jobs) | Visual Studio / default | Ninja (via setup-msvc-dev) |
| Android NDK | r25c | r27d (LTS) |
| Oracle Instant Client | 23.26.0 | 23.26.1 |
| ODBC packages | libaio1, odbcinst1debian2, libodbc1 | libaio1t64, libodbcinst2, libodbc2 (Ubuntu 24.04 names) |

## DRY Refactoring

| Change | Before | After |
|---|---|---|
| Android NDK jobs | 3 separate jobs (2 duplicate arm64) | 1 matrix job (2 ABIs) |
| Linux sanitizer jobs | 3 separate jobs | 1 matrix job (3 sanitizers) |
| macOS Intel visibility-hidden sanitizers | 3 separate jobs | 1 matrix job (3 sanitizers) |
| macOS sanitizers (ARM + Intel) | 3 separate jobs | 1 matrix job (3 sanitizers × 2 runners) |

Net diff: **-237 lines, +119 lines** (-118 net).

## Ubuntu 24.04 Compatibility Fixes

- ODBC package renames: libaio1→libaio1t64, odbcinst1debian2→libodbcinst2, libodbc1→libodbc2
- Oracle Instant Client libaio symlink: Ubuntu 24.04 provides libaio.so.1t64 but Oracle IC links against libaio.so.1 (upstream Ubuntu bug LP#2067501)

## Known Issues

- macOS ARM ASan: dyld4 on Apple Silicon registers ASan globals twice for dlopen'd libraries, causing a false ODR violation on `vtable for TestPlugin` in Foundation tests. Confirmed via `nm` that the symbol exists only once in TestLibrary.dylib. Suppressed with `detect_odr_violation=0` for ARM ASan only.

## Test plan

- [x] All matrix entries appear as separate jobs in GitHub Actions UI
- [x] Windows Ninja builds succeed (all 5 MSVC jobs)
- [ ] ODBC Oracle/SQLServer/PostgreSQL jobs pass on Ubuntu 24.04
- [x] All existing tests continue to pass