### PR TITLE
fix(fuzzing): catch exception in DateTime fuzzer #5287

### DIFF
--- a/Foundation/fuzzing/DateTimeParse.cpp
+++ b/Foundation/fuzzing/DateTimeParse.cpp
@@ -31,8 +31,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 		DateTimeFormatter::format(dt.timestamp(), format, tzd);
 	}
 
-	dt.makeLocal(tzd);
-	dt.makeUTC(tzd);
+	try { dt.makeLocal(tzd); } catch (const std::exception&) {}
+	try { dt.makeUTC(tzd); } catch (const std::exception&) {}
 
 	try
 	{


### PR DESCRIPTION
## Summary
- Wrap `makeLocal(tzd)` and `makeUTC(tzd)` calls in the DateTime fuzzer harness with try-catch blocks
- Fixes OSS-Fuzz crash when timezone adjustment pushes a near-max DateTime (9999-12-31) past the valid year range
- Matches the existing exception handling pattern already used for `DateTimeParser::parse` in the same file

Closes #5287