### PR TITLE
enh(Foundation): optimize numeric conversions with digit-pairs algorithm and std::to_chars/from_chars

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -209,9 +209,11 @@
 // - GCC 11+ (libstdc++): full support since GCC 11
 // - MSVC 19.24+: full support since VS 2019 16.4
 // - Apple Clang: requires macOS 26.0+ deployment target (availability annotations)
-// - libc++ (Android NDK, FreeBSD, Emscripten): requires libc++ 20+ (LLVM 20);
-//   libc++ 17-19 have float from_chars overloads explicitly deleted
-#if defined(__apple_build_version__)
+// - Non-Apple libc++ (Android NDK, FreeBSD, Emscripten): requires libc++ 20+
+//   (LLVM 20); libc++ 17-19 have float from_chars overloads explicitly deleted.
+//   On macOS, even non-Apple LLVM (Homebrew) uses system libc++ headers with
+//   Apple availability annotations, so __APPLE__ must also be excluded here.
+#if defined(__APPLE__)
 #include <AvailabilityMacros.h>
 #endif
 #if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 202306L
@@ -220,9 +222,9 @@
 	#define POCO_HAS_FLOAT_CHARCONV 1
 #elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 11
 	#define POCO_HAS_FLOAT_CHARCONV 1
-#elif defined(__apple_build_version__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 	#define POCO_HAS_FLOAT_CHARCONV 1
-#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 200000 && !defined(__apple_build_version__)
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 200000 && !defined(__APPLE__)
 	#define POCO_HAS_FLOAT_CHARCONV 1
 #endif
 

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -206,8 +206,11 @@
 #endif
 
 // Float std::to_chars/from_chars support detection.
-// Available in GCC 11+, MSVC 19.24+, non-Apple libc++ 17+.
-// Apple Clang requires macOS 26.0+ deployment target due to availability annotations.
+// - GCC 11+ (libstdc++): full support since GCC 11
+// - MSVC 19.24+: full support since VS 2019 16.4
+// - Apple Clang: requires macOS 26.0+ deployment target (availability annotations)
+// - libc++ (Android NDK, FreeBSD, Emscripten): requires libc++ 20+ (LLVM 20);
+//   libc++ 17-19 have float from_chars overloads explicitly deleted
 #if defined(__apple_build_version__)
 #include <AvailabilityMacros.h>
 #endif
@@ -219,7 +222,7 @@
 	#define POCO_HAS_FLOAT_CHARCONV 1
 #elif defined(__apple_build_version__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 	#define POCO_HAS_FLOAT_CHARCONV 1
-#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 170000 && !defined(__apple_build_version__)
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 200000 && !defined(__apple_build_version__)
 	#define POCO_HAS_FLOAT_CHARCONV 1
 #endif
 

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -205,6 +205,24 @@
 	#define POCO_HAVE_ATOMIC_SHARED_PTR false
 #endif
 
+// Float std::to_chars/from_chars support detection.
+// Available in GCC 11+, MSVC 19.24+, non-Apple libc++ 17+.
+// Apple Clang requires macOS 26.0+ deployment target due to availability annotations.
+#if defined(__apple_build_version__)
+#include <AvailabilityMacros.h>
+#endif
+#if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 202306L
+	#define POCO_HAS_FLOAT_CHARCONV 1
+#elif defined(_MSC_VER) && _MSC_VER >= 1924
+	#define POCO_HAS_FLOAT_CHARCONV 1
+#elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 11
+	#define POCO_HAS_FLOAT_CHARCONV 1
+#elif defined(__apple_build_version__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+	#define POCO_HAS_FLOAT_CHARCONV 1
+#elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 170000 && !defined(__apple_build_version__)
+	#define POCO_HAS_FLOAT_CHARCONV 1
+#endif
+
 // Option to silence deprecation warnings.
 #ifndef POCO_SILENCE_DEPRECATED
 	#define POCO_DEPRECATED(reason) [[deprecated(reason)]]

--- a/Foundation/include/Poco/NumberFormatter.h
+++ b/Foundation/include/Poco/NumberFormatter.h
@@ -692,7 +692,7 @@ inline bool NumberFormatter::isEnabled(Options options, Options opt)
 inline std::string NumberFormatter::format(int value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -700,7 +700,7 @@ inline std::string NumberFormatter::format(int value)
 inline std::string NumberFormatter::format(int value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -708,7 +708,7 @@ inline std::string NumberFormatter::format(int value, int width)
 inline std::string NumberFormatter::format0(int value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -728,7 +728,7 @@ inline std::string NumberFormatter::formatHex(int value, int width, Options opti
 inline std::string NumberFormatter::format(unsigned value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -736,7 +736,7 @@ inline std::string NumberFormatter::format(unsigned value)
 inline std::string NumberFormatter::format(unsigned value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -744,7 +744,7 @@ inline std::string NumberFormatter::format(unsigned value, int width)
 inline std::string NumberFormatter::format0(unsigned int value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -752,7 +752,7 @@ inline std::string NumberFormatter::format0(unsigned int value, int width)
 inline std::string NumberFormatter::formatHex(unsigned value, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -760,7 +760,7 @@ inline std::string NumberFormatter::formatHex(unsigned value, Options options)
 inline std::string NumberFormatter::formatHex(unsigned value, int width, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -768,7 +768,7 @@ inline std::string NumberFormatter::formatHex(unsigned value, int width, Options
 inline std::string NumberFormatter::format(long value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -776,7 +776,7 @@ inline std::string NumberFormatter::format(long value)
 inline std::string NumberFormatter::format(long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -784,7 +784,7 @@ inline std::string NumberFormatter::format(long value, int width)
 inline std::string NumberFormatter::format0(long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -804,7 +804,7 @@ inline std::string NumberFormatter::formatHex(long value, int width, Options opt
 inline std::string NumberFormatter::format(unsigned long value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -812,7 +812,7 @@ inline std::string NumberFormatter::format(unsigned long value)
 inline std::string NumberFormatter::format(unsigned long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -820,7 +820,7 @@ inline std::string NumberFormatter::format(unsigned long value, int width)
 inline std::string NumberFormatter::format0(unsigned long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -828,7 +828,7 @@ inline std::string NumberFormatter::format0(unsigned long value, int width)
 inline std::string NumberFormatter::formatHex(unsigned long value, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -836,7 +836,7 @@ inline std::string NumberFormatter::formatHex(unsigned long value, Options optio
 inline std::string NumberFormatter::formatHex(unsigned long value, int width, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -847,7 +847,7 @@ inline std::string NumberFormatter::formatHex(unsigned long value, int width, Op
 inline std::string NumberFormatter::format(long long value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -855,7 +855,7 @@ inline std::string NumberFormatter::format(long long value)
 inline std::string NumberFormatter::format(long long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -863,7 +863,7 @@ inline std::string NumberFormatter::format(long long value, int width)
 inline std::string NumberFormatter::format0(long long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -883,7 +883,7 @@ inline std::string NumberFormatter::formatHex(long long value, int width, Option
 inline std::string NumberFormatter::format(unsigned long long value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -891,7 +891,7 @@ inline std::string NumberFormatter::format(unsigned long long value)
 inline std::string NumberFormatter::format(unsigned long long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -899,7 +899,7 @@ inline std::string NumberFormatter::format(unsigned long long value, int width)
 inline std::string NumberFormatter::format0(unsigned long long value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -907,7 +907,7 @@ inline std::string NumberFormatter::format0(unsigned long long value, int width)
 inline std::string NumberFormatter::formatHex(unsigned long long value, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -915,7 +915,7 @@ inline std::string NumberFormatter::formatHex(unsigned long long value, Options 
 inline std::string NumberFormatter::formatHex(unsigned long long value, int width, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -926,7 +926,7 @@ inline std::string NumberFormatter::formatHex(unsigned long long value, int widt
 inline std::string NumberFormatter::format(Int64 value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -934,7 +934,7 @@ inline std::string NumberFormatter::format(Int64 value)
 inline std::string NumberFormatter::format(Int64 value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -942,7 +942,7 @@ inline std::string NumberFormatter::format(Int64 value, int width)
 inline std::string NumberFormatter::format0(Int64 value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -962,7 +962,7 @@ inline std::string NumberFormatter::formatHex(long long value, int width, Option
 inline std::string NumberFormatter::format(UInt64 value)
 {
 	std::string result;
-	intToStr(value, 10, result);
+	if (!intToStr(value, 10, result)) result.clear();
 	return result;
 }
 
@@ -970,7 +970,7 @@ inline std::string NumberFormatter::format(UInt64 value)
 inline std::string NumberFormatter::format(UInt64 value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, ' ');
+	if (!intToStr(value, 10, result, false, width, ' ')) result.clear();
 	return result;
 }
 
@@ -978,7 +978,7 @@ inline std::string NumberFormatter::format(UInt64 value, int width)
 inline std::string NumberFormatter::format0(UInt64 value, int width)
 {
 	std::string result;
-	intToStr(value, 10, result, false, width, '0');
+	if (!intToStr(value, 10, result, false, width, '0')) result.clear();
 	return result;
 }
 
@@ -986,7 +986,7 @@ inline std::string NumberFormatter::format0(UInt64 value, int width)
 inline std::string NumberFormatter::formatHex(UInt64 value, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), -1, ' ', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 
@@ -994,7 +994,7 @@ inline std::string NumberFormatter::formatHex(UInt64 value, Options options)
 inline std::string NumberFormatter::formatHex(UInt64 value, int width, Options options)
 {
 	std::string result;
-	intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE));
+	if (!intToStr(value, 0x10, result, isEnabled(options, Options::HEX_PREFIX), width, '0', 0, isEnabled(options, Options::HEX_LOWERCASE))) result.clear();
 	return result;
 }
 

--- a/Foundation/include/Poco/NumberFormatter.h
+++ b/Foundation/include/Poco/NumberFormatter.h
@@ -19,9 +19,7 @@
 
 
 #include "Poco/Foundation.h"
-#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
-#undef POCO_NUMERIC_STRING_PRIVATE
 
 
 namespace Poco {

--- a/Foundation/include/Poco/NumberFormatter.h
+++ b/Foundation/include/Poco/NumberFormatter.h
@@ -19,7 +19,9 @@
 
 
 #include "Poco/Foundation.h"
+#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
+#undef POCO_NUMERIC_STRING_PRIVATE
 
 
 namespace Poco {

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -146,12 +146,11 @@ bool safeMultiply(R& result, F f, S s)
 
 
 template <typename F, typename T>
-inline T& isSafeIntCast(F from)
+[[nodiscard]] inline bool isSafeIntCast(F from)
 	/// Returns true if it is safe to cast
 	/// integer from F to T.
 {
-	if (!isIntOverflow<T, F>(from)) return true;
-	return false;
+	return !isIntOverflow<T, F>(from);
 }
 
 
@@ -224,6 +223,8 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 		++pStr;
 	}
 	else if (*pStr == '+') ++pStr;
+
+	if (*pStr == '\0') return false; // reject bare sign without digits
 
 	// numbers are parsed as unsigned, for negative numbers the sign is applied after parsing
 	// overflow is checked in every parse step

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -18,6 +18,11 @@
 #define Foundation_NumericString_INCLUDED
 
 
+#ifndef POCO_NUMERIC_STRING_PRIVATE
+	#error "Do not include Poco/NumericString.h directly. Use Poco/NumberFormatter.h or Poco/NumberParser.h instead."
+#endif
+
+
 #include "Poco/Foundation.h"
 #include "Poco/Buffer.h"
 #include "Poco/FPEnvironment.h"
@@ -33,6 +38,12 @@
 #if !defined(POCO_NO_LOCALE)
 	#include <locale>
 #endif
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #if defined(POCO_NOINTMAX)
 typedef Poco::UInt64 uintmax_t;
@@ -350,7 +361,66 @@ namespace Impl {
 		const char* _beg;
 		char*       _cur;
 		const char* _end;
-};
+	};
+
+} // namespace Impl
+
+
+
+
+namespace Impl {
+
+
+inline constexpr std::string_view kHexLower = "0123456789abcdef";
+inline constexpr std::string_view kHexUpper = "0123456789ABCDEF";
+
+
+/// Hex conversion using shift-and-mask. Writes digits in forward order
+/// with the requested case. Returns pointer past last digit written.
+template <typename U>
+char* uintToHexBuf(char* buf, U value, bool lowercase)
+{
+	static_assert(std::is_unsigned_v<U>);
+	const auto hex = lowercase ? kHexLower : kHexUpper;
+
+	if (value == 0)
+		return (*buf++ = '0', buf);
+
+	constexpr int maxShift = (sizeof(U) * 2 - 1) * 4;
+	int shift = maxShift;
+	while (((value >> shift) & 0xF) == 0) shift -= 4;
+
+	for (; shift >= 0; shift -= 4)
+		*buf++ = hex[(value >> shift) & 0xF];
+	return buf;
+}
+
+
+/// Convert an integer to a digit string using std::to_chars.
+/// Writes sign + digits into buf. Returns {pointer past last char, negative flag},
+/// or {nullptr, _} on conversion failure.
+template <typename T>
+std::pair<char*, bool> intToDecBuf(char* buf, std::size_t bufSize, T value, int base)
+{
+	using U = std::make_unsigned_t<T>;
+	char* out = buf;
+	bool negative = false;
+
+	if constexpr (std::is_signed_v<T>)
+	{
+		if (value < 0)
+		{
+			negative = true;
+			*out++ = '-';
+			U uval = static_cast<U>(0) - static_cast<U>(value);
+			auto [p, ec] = std::to_chars(out, buf + bufSize, uval, base);
+			return {(ec == std::errc()) ? p : nullptr, true};
+		}
+	}
+	auto [p, ec] = std::to_chars(out, buf + bufSize, value, base);
+	return {(ec == std::errc()) ? p : nullptr, false};
+}
+
 
 } // namespace Impl
 
@@ -385,63 +455,102 @@ bool intToStr(T value,
 		return false;
 	}
 
-	Impl::Ptr ptr(result, size);
-	int thCount = 0;
-	T tmpVal;
-	do
-	{
-		tmpVal = value;
-		value /= base;
-		*ptr++ = (lowercase ? "fedcba9876543210123456789abcdef" : "FEDCBA9876543210123456789ABCDEF")[15 + (tmpVal - value * base)];
-		if (thSep && (base == 10) && (++thCount == 3))
-		{
-			*ptr++ = thSep;
-			thCount = 0;
-		}
-	} while (value);
+	using U = std::make_unsigned_t<T>;
 
-	if ('0' == fill)
+	// Step 1: Convert value to digit string in temporary buffer.
+	char buf[POCO_MAX_INT_STRING_LEN];
+	char* digitsBegin = buf;
+	char* digitsEnd = buf;
+	bool negative = false;
+
+	if (base == 0x10)
 	{
+		U uval;
 		if constexpr (std::is_signed_v<T>)
+			uval = static_cast<U>(value);
+		else
+			uval = value;
+		digitsEnd = Impl::uintToHexBuf(buf, uval, lowercase);
+	}
+	else
+	{
+		auto [p, neg] = Impl::intToDecBuf<T>(buf, sizeof(buf), value, base);
+		if (p == nullptr) { *result = '\0'; return false; }
+		digitsEnd = p;
+		negative = neg;
+		// intToDecBuf writes '-' + digits; strip sign for formatting below
+		if (negative) ++digitsBegin;
+
+		// std::to_chars uses lowercase; convert to uppercase if needed
+		if (!lowercase && base > 10)
+			std::transform(digitsBegin, digitsEnd, digitsBegin, [](char c) {
+				return (c >= 'a' && c <= 'f') ? static_cast<char>(c - ('a' - 'A')) : c;
+			});
+
+		// Insert thousand separators (rare path, base 10 only)
+		if (thSep && base == 10) [[unlikely]]
 		{
-			if (tmpVal < 0) --width;
+			constexpr int kDigitsPerGroup = 3;
+			const auto len = digitsEnd - digitsBegin;
+			if (len > kDigitsPerGroup)
+			{
+				const int nSeps = static_cast<int>((len - 1) / kDigitsPerGroup);
+				char* dst = digitsEnd + nSeps;
+				const char* src = digitsEnd;
+				digitsEnd = dst;
+				int count = 0;
+				while (src > digitsBegin)
+				{
+					*--dst = *--src;
+					if (++count == kDigitsPerGroup && src > digitsBegin)
+					{
+						*--dst = thSep;
+						count = 0;
+					}
+				}
+			}
 		}
-		if (prefix && base == 010) --width;
-		if (prefix && base == 0x10) width -= 2;
-		while ((ptr - result) < width) *ptr++ = fill;
 	}
 
-	if (prefix && base == 010) *ptr++ = '0';
-	else if (prefix && base == 0x10)
+	const auto numLen = digitsEnd - digitsBegin;
+
+	// Step 2: Format into result buffer with sign, prefix, and padding.
+	int prefixLen = 0;
+	if (negative) prefixLen += 1;
+	if (prefix && base == 010) prefixLen += 1;
+	if (prefix && base == 0x10) prefixLen += 2;
+
+	const int contentLen = prefixLen + static_cast<int>(numLen);
+	const int totalLen = (width > contentLen) ? width : contentLen;
+
+	if (static_cast<std::size_t>(totalLen) >= size)
+		throw RangeException();
+
+	char* out = result;
+	const int padLen = totalLen - contentLen;
+
+	if (fill == '0')
 	{
-		*ptr++ = 'x';
-		*ptr++ = '0';
+		if (negative) *out++ = '-';
+		if (prefix && base == 010) *out++ = '0';
+		if (prefix && base == 0x10) { *out++ = '0'; *out++ = 'x'; }
+		std::memset(out, '0', padLen);
+		out += padLen;
 	}
-
-	if constexpr (std::is_signed_v<T>)
+	else
 	{
-		if (tmpVal < 0) *ptr++ = '-';
+		std::memset(out, fill, padLen);
+		out += padLen;
+		if (negative) *out++ = '-';
+		if (prefix && base == 010) *out++ = '0';
+		if (prefix && base == 0x10) { *out++ = '0'; *out++ = 'x'; }
 	}
 
-	if ('0' != fill)
-	{
-		while ((ptr - result) < width) *ptr++ = fill;
-	}
+	std::memcpy(out, digitsBegin, numLen);
+	out += numLen;
 
-	size = ptr - result;
-	poco_assert_dbg (size <= ptr.span());
-	poco_assert_dbg ((-1 == width) || (size >= size_t(width)));
-	*ptr-- = '\0';
-
-	char* ptrr = result;
-	char tmp;
-	while(ptrr < ptr)
-	{
-		tmp    = *ptr;
-		*ptr--  = *ptrr;
-		*ptrr++ = tmp;
-	}
-
+	size = out - result;
+	*out = '\0';
 	return true;
 }
 
@@ -464,15 +573,14 @@ bool uIntToStr(T value,
 	/// If prefix is true and base is octal or hexadecimal, respective prefix ('0' for octal,
 	/// "0x" for hexadecimal) is prepended. For all other bases, prefix argument is ignored.
 	/// Formatted string has at least [width] total length.
-	///
-	/// This function is deprecated; use intToStr instead.
+	/// @deprecated Use intToStr instead.
 {
 	return intToStr(value, base, result, size, prefix, width, fill, thSep, lowercase);
 }
 
 
 template <typename T>
-bool intToStr (T number,
+bool intToStr(T number,
 	unsigned short base,
 	std::string& result,
 	bool prefix = false,
@@ -493,7 +601,7 @@ bool intToStr (T number,
 
 template <typename T>
 POCO_DEPRECATED("use intToStr instead")
-bool uIntToStr (T number,
+bool uIntToStr(T number,
 	unsigned short base,
 	std::string& result,
 	bool prefix = false,
@@ -503,8 +611,7 @@ bool uIntToStr (T number,
 	bool lowercase = false)
 	/// Converts unsigned integer to string; This is a wrapper function, for details see the
 	/// bool uIntToStr(T, unsigned short, char*, int, int, char, char) implementation.
-	///
-	/// This function is deprecated; use intToStr instead.
+	/// @deprecated Use intToStr instead.
 {
 	return intToStr(number, base, result, prefix, width, fill, thSep, lowercase);
 }

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -217,7 +217,7 @@ template <typename I>
 	if (start >= end) return false; // reject bare sign without digits
 
 	// Try std::from_chars — handles sign, overflow, and all bases.
-	auto [ptr, ec] = std::from_chars(start, end, outResult, base);
+	const auto [ptr, ec] = std::from_chars(start, end, outResult, base);
 	if (ec == std::errc() && ptr == end)
 		return true;
 
@@ -242,7 +242,7 @@ template <typename I>
 
 	if (dst == cleaned) return false; // nothing left after stripping
 
-	auto [ptr2, ec2] = std::from_chars(cleaned, dst, outResult, base);
+	const auto [ptr2, ec2] = std::from_chars(cleaned, dst, outResult, base);
 	return ec2 == std::errc() && ptr2 == dst;
 }
 
@@ -263,8 +263,8 @@ template <typename I>
 	/// Converts string to integer number.
 	/// Avoids strlen by using the known string length directly.
 {
+	const char* const end = str.data() + str.size();
 	const char* begin = str.data();
-	const char* end = begin + str.size();
 	while (begin < end && std::isspace(static_cast<unsigned char>(*begin))) ++begin;
 	return strToInt(begin, end, result, base, thSep);
 }
@@ -446,8 +446,8 @@ template <typename T>
 
 			while (uval >= 100)
 			{
-				U q = uval / 100;
-				unsigned r = static_cast<unsigned>(uval - q * 100);
+				const U q = uval / 100;
+				const unsigned r = static_cast<unsigned>(uval - q * 100);
 				uval = q;
 
 				// Lower digit (ones place of the pair)
@@ -469,7 +469,7 @@ template <typename T>
 			// Remaining 1 or 2 digits
 			if (uval >= 10)
 			{
-				unsigned r = static_cast<unsigned>(uval);
+				const unsigned r = static_cast<unsigned>(uval);
 				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
 				if (++thCount == 3)
 				{
@@ -488,15 +488,15 @@ template <typename T>
 			// No thousand separators: pure speed path.
 			while (uval >= 100)
 			{
-				U q = uval / 100;
-				unsigned r = static_cast<unsigned>(uval - q * 100);
+				const U q = uval / 100;
+				const unsigned r = static_cast<unsigned>(uval - q * 100);
 				uval = q;
 				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
 				*ptr++ = Impl::kDigitPairs[r * 2];
 			}
 			if (uval >= 10)
 			{
-				unsigned r = static_cast<unsigned>(uval);
+				const unsigned r = static_cast<unsigned>(uval);
 				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
 				*ptr++ = Impl::kDigitPairs[r * 2];
 			}
@@ -523,7 +523,7 @@ template <typename T>
 				case 16: shift = 4; break;
 				default: poco_bugcheck(); shift = 0; break; // unreachable for valid power-of-2 bases
 			}
-			U mask = (static_cast<U>(1) << shift) - 1;
+			const U mask = (static_cast<U>(1) << shift) - 1;
 			do
 			{
 				*ptr++ = digits[uval & mask];
@@ -535,7 +535,7 @@ template <typename T>
 			// Non-power-of-two: base 3, 5, 6, 7, 9, 11..15
 			do
 			{
-				U q = uval / base;
+				const U q = uval / base;
 				*ptr++ = digits[uval - q * base];
 				uval = q;
 			} while (uval);
@@ -627,7 +627,7 @@ template <typename T>
 {
 	char res[POCO_MAX_INT_STRING_LEN] = {0};
 	std::size_t size = POCO_MAX_INT_STRING_LEN;
-	bool ret = intToStr(number, base, res, size, prefix, width, fill, thSep, lowercase);
+	const bool ret = intToStr(number, base, res, size, prefix, width, fill, thSep, lowercase);
 	result.assign(res, size);
 	return ret;
 }

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -141,24 +141,24 @@ template<typename R, typename F, typename S>
 }
 
 
-template <typename F, typename T>
-[[nodiscard]] inline bool isSafeIntCast(F from)
+template <typename To, typename From>
+[[nodiscard]] inline bool isSafeIntCast(From from)
 	/// Returns true if it is safe to cast
-	/// integer from F to T.
+	/// integer from From to To.
 {
-	return !isIntOverflow<T, F>(from);
+	return !isIntOverflow<To, From>(from);
 }
 
 
-template <typename F, typename T>
-inline T& safeIntCast(F from, T& to)
+template <typename To, typename From>
+inline To& safeIntCast(From from, To& to)
 	/// Returns cast value if it is safe
-	/// to cast integer from F to T,
+	/// to cast integer from From to To,
 	/// otherwise throws BadCastException.
 {
-	if (!isIntOverflow<T, F>(from))
+	if (!isIntOverflow<To, From>(from))
 	{
-		to = static_cast<T>(from);
+		to = static_cast<To>(from);
 		return to;
 	}
 	throw BadCastException("safeIntCast: Integer overflow");
@@ -402,15 +402,17 @@ template <typename T>
 		return false;
 	}
 
+	// size is used as buffer capacity (in) and written length (out).
+	const std::size_t capacity = size;
 	// Guard against buffer overflow in padding loops (phases 3-5).
-	if (width >= static_cast<int>(POCO_MAX_INT_STRING_LEN))
+	if (width >= static_cast<int>(capacity))
 		throw RangeException();
 
 	// --- Phase 1: extract sign, convert to unsigned ---
 	// This avoids UB for T_MIN (e.g. -2^63) where -value overflows signed.
 	using U = std::make_unsigned_t<T>;
 
-	bool negative = false;
+	[[maybe_unused]] bool negative = false;
 	U uval;
 	if constexpr (std::is_signed_v<T>)
 	{
@@ -573,7 +575,7 @@ template <typename T>
 
 	// --- Phase 6: finalize and reverse ---
 	size = static_cast<std::size_t>(ptr - result);
-	if (size >= static_cast<std::size_t>(POCO_MAX_INT_STRING_LEN))
+	if (size >= capacity)
 		throw RangeException();
 	*ptr-- = '\0';
 

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -652,9 +652,11 @@ bool uIntToStr(T number,
 
 
 //
-// Wrappers for double-conversion library (http://code.google.com/p/double-conversion/).
-//
-// Library is the implementation of the algorithm described in Florian Loitsch's paper:
+// Floating-point to/from string conversions.
+// Uses std::to_chars/from_chars when available (POCO_HAS_FLOAT_CHARCONV),
+// otherwise falls back to the bundled double-conversion library
+// (http://code.google.com/p/double-conversion/), which implements the
+// algorithm described in Florian Loitsch's paper:
 // http://florian.loitsch.com/publications/dtoa-pldi2010.pdf
 //
 

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -32,7 +32,6 @@
 #ifdef max
 	#undef max
 #endif
-#include <algorithm>
 #include <cctype>
 #include <charconv>
 #include <cmath>
@@ -80,20 +79,18 @@ inline bool isIntOverflow(From val)
 {
 	poco_assert_dbg (std::numeric_limits<From>::is_integer);
 	poco_assert_dbg (std::numeric_limits<To>::is_integer);
-	bool ret;
-	if (std::numeric_limits<To>::is_signed)
+	if constexpr (std::numeric_limits<To>::is_signed)
 	{
-		ret = (!std::numeric_limits<From>::is_signed &&
+		return (!std::numeric_limits<From>::is_signed &&
 			  (uintmax_t)val > (uintmax_t)INTMAX_MAX) ||
 			  (intmax_t)val  < (intmax_t)std::numeric_limits<To>::min() ||
 			  (intmax_t)val  > (intmax_t)std::numeric_limits<To>::max();
 	}
 	else
 	{
-		ret = isNegative(val) ||
+		return isNegative(val) ||
 				(uintmax_t)val > (uintmax_t)std::numeric_limits<To>::max();
 	}
-	return ret;
 }
 
 
@@ -109,31 +106,40 @@ bool safeMultiply(R& result, F f, S s)
 		return true;
 	}
 
-	if (f > 0)
+	if constexpr (std::is_signed_v<F> || std::is_signed_v<S>)
 	{
-		if (s > 0)
+		if (f > 0)
 		{
-			if (cast(f) > (cast(std::numeric_limits<R>::max()) / cast(s)))
-				return false;
+			if (s > 0)
+			{
+				if (cast(f) > (cast(std::numeric_limits<R>::max()) / cast(s)))
+					return false;
+			}
+			else
+			{
+				if (cast(s) < (cast(std::numeric_limits<R>::min()) / cast(f)))
+					return false;
+			}
 		}
 		else
 		{
-			if (cast(s) < (cast(std::numeric_limits<R>::min()) / cast(f)))
-				return false;
+			if (s > 0)
+			{
+				if (cast(f) < (cast(std::numeric_limits<R>::min()) / cast(s)))
+					return false;
+			}
+			else
+			{
+				if (cast(s) < (cast(std::numeric_limits<R>::max()) / cast(f)))
+					return false;
+			}
 		}
 	}
 	else
 	{
-		if (s > 0)
-		{
-			if (cast(f) < (cast(std::numeric_limits<R>::min()) / cast(s)))
-				return false;
-		}
-		else
-		{
-			if (cast(s) < (cast(std::numeric_limits<R>::max()) / cast(f)))
-				return false;
-		}
+		// Both f and s are unsigned (and non-zero at this point)
+		if (cast(f) > (cast(std::numeric_limits<R>::max()) / cast(s)))
+			return false;
 	}
 	result = f * s;
 	return true;
@@ -343,11 +349,6 @@ namespace Impl {
 		const char* _end;
 	};
 
-} // namespace Impl
-
-
-namespace Impl {
-
 /// Digit-pairs lookup table for the "two-digits-at-a-time" integer-to-string
 /// technique. Instead of extracting one digit per iteration (value / 10),
 /// this approach extracts two digits at once (value / 100) and uses the
@@ -405,6 +406,10 @@ bool intToStr(T value,
 		*result = '\0';
 		return false;
 	}
+
+	// Guard against buffer overflow in padding loops (phases 3-5).
+	if (width >= static_cast<int>(POCO_MAX_INT_STRING_LEN))
+		throw RangeException();
 
 	// --- Phase 1: extract sign, convert to unsigned ---
 	// This avoids UB for T_MIN (e.g. -2^63) where -value overflows signed.
@@ -521,7 +526,7 @@ bool intToStr(T value,
 				case 4:  shift = 2; break;
 				case 8:  shift = 3; break;
 				case 16: shift = 4; break;
-				default: shift = 0; break; // unreachable for valid power-of-2 bases
+				default: poco_bugcheck(); shift = 0; break; // unreachable for valid power-of-2 bases
 			}
 			U mask = (static_cast<U>(1) << shift) - 1;
 			do

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -216,7 +216,7 @@ template <typename I>
 	if (*start == '+') ++start;
 	if (start >= end) return false; // reject bare sign without digits
 
-	// Try std::from_chars — handles sign, overflow, and all bases.
+	// Try std::from_chars -- handles sign, overflow, and all bases.
 	const auto [ptr, ec] = std::from_chars(start, end, outResult, base);
 	if (ec == std::errc() && ptr == end)
 		return true;
@@ -227,7 +227,7 @@ template <typename I>
 		return false;
 
 	// from_chars consumed some digits then stopped at a non-digit character.
-	// The input may contain thousand separators — strip them and retry.
+	// The input may contain thousand separators -- strip them and retry.
 	char cleaned[POCO_MAX_INT_STRING_LEN];
 	char* dst = cleaned;
 	for (const char* src = start; src < end; ++src)

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -18,11 +18,6 @@
 #define Foundation_NumericString_INCLUDED
 
 
-#ifndef POCO_NUMERIC_STRING_PRIVATE
-	#error "Do not include Poco/NumericString.h directly. Use Poco/NumberFormatter.h or Poco/NumberParser.h instead."
-#endif
-
-
 #include "Poco/Foundation.h"
 #include "Poco/Exception.h"
 #include "Poco/FPEnvironment.h"

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -346,61 +346,32 @@ namespace Impl {
 } // namespace Impl
 
 
-
-
 namespace Impl {
 
+/// Digit-pairs lookup table for the "two-digits-at-a-time" integer-to-string
+/// technique. Instead of extracting one digit per iteration (value / 10),
+/// this approach extracts two digits at once (value / 100) and uses the
+/// remainder (0-99) as an index into this 200-byte table, halving the
+/// number of expensive integer divisions.
+///
+/// The technique is widely used in high-performance formatting libraries
+/// including {fmt}, jemalloc, and Facebook Folly.
+/// See also: https://github.com/miloyip/itoa-benchmark
+inline constexpr char kDigitPairs[201] =
+	"00010203040506070809"
+	"10111213141516171819"
+	"20212223242526272829"
+	"30313233343536373839"
+	"40414243444546474849"
+	"50515253545556575859"
+	"60616263646566676869"
+	"70717273747576777879"
+	"80818283848586878889"
+	"90919293949596979899";
 
-inline constexpr char kHexLower[] = "0123456789abcdef";
-inline constexpr char kHexUpper[] = "0123456789ABCDEF";
-
-
-/// Hex conversion using shift-and-mask. Writes digits in forward order
-/// with the requested case. Returns pointer past last digit written.
-template <typename U>
-char* uintToHexBuf(char* buf, U value, bool lowercase)
-{
-	static_assert(std::is_unsigned_v<U>);
-	const char* hex = lowercase ? kHexLower : kHexUpper;
-
-	if (value == 0)
-		return (*buf++ = '0', buf);
-
-	constexpr int maxShift = (sizeof(U) * 2 - 1) * 4;
-	int shift = maxShift;
-	while (((value >> shift) & 0xF) == 0) shift -= 4;
-
-	for (; shift >= 0; shift -= 4)
-		*buf++ = hex[(value >> shift) & 0xF];
-	return buf;
-}
-
-
-/// Convert an integer to a digit string using std::to_chars.
-/// Writes sign + digits into buf. Returns {pointer past last char, negative flag},
-/// or {nullptr, _} on conversion failure.
-template <typename T>
-std::pair<char*, bool> intToDecBuf(char* buf, std::size_t bufSize, T value, int base)
-{
-	using U = std::make_unsigned_t<T>;
-	char* out = buf;
-	bool negative = false;
-
-	if constexpr (std::is_signed_v<T>)
-	{
-		if (value < 0)
-		{
-			negative = true;
-			*out++ = '-';
-			U uval = static_cast<U>(0) - static_cast<U>(value);
-			auto [p, ec] = std::to_chars(out, buf + bufSize, uval, base);
-			return {(ec == std::errc()) ? p : nullptr, true};
-		}
-	}
-	auto [p, ec] = std::to_chars(out, buf + bufSize, value, base);
-	return {(ec == std::errc()) ? p : nullptr, false};
-}
-
+/// Direct digit tables for non-base-10 paths
+inline constexpr char kDigitsUpper[] = "0123456789ABCDEF";
+inline constexpr char kDigitsLower[] = "0123456789abcdef";
 
 } // namespace Impl
 
@@ -426,7 +397,7 @@ bool intToStr(T value,
 {
 	if constexpr (std::is_signed_v<T>)
 	{
-		poco_assert_dbg (((value < 0) && (base == 10)) || (value >= 0));
+		poco_assert_dbg(((value < 0) && (base == 10)) || (value >= 0));
 	}
 
 	if (base < 2 || base > 0x10)
@@ -435,102 +406,185 @@ bool intToStr(T value,
 		return false;
 	}
 
+	// --- Phase 1: extract sign, convert to unsigned ---
+	// This avoids UB for T_MIN (e.g. -2^63) where -value overflows signed.
 	using U = std::make_unsigned_t<T>;
 
-	// Step 1: Convert value to digit string in temporary buffer.
-	char buf[POCO_MAX_INT_STRING_LEN];
-	char* digitsBegin = buf;
-	char* digitsEnd = buf;
 	bool negative = false;
-
-	if (base == 0x10)
+	U uval;
+	if constexpr (std::is_signed_v<T>)
 	{
-		U uval;
-		if constexpr (std::is_signed_v<T>)
-			uval = static_cast<U>(value);
+		if (value < 0)
+		{
+			negative = true;
+			// Two-step cast avoids signed overflow UB for T_MIN:
+			// cast to unsigned first, then negate in unsigned arithmetic.
+			uval = static_cast<U>(0) - static_cast<U>(value);
+		}
 		else
-			uval = value;
-		digitsEnd = Impl::uintToHexBuf(buf, uval, lowercase);
+		{
+			uval = static_cast<U>(value);
+		}
 	}
 	else
 	{
-		auto [p, neg] = Impl::intToDecBuf<T>(buf, sizeof(buf), value, base);
-		if (p == nullptr) { *result = '\0'; return false; }
-		digitsEnd = p;
-		negative = neg;
-		// intToDecBuf writes '-' + digits; strip sign for formatting below
-		if (negative) ++digitsBegin;
+		uval = value;
+	}
 
-		// std::to_chars uses lowercase; convert to uppercase if needed
-		if (!lowercase && base > 10)
-			std::transform(digitsBegin, digitsEnd, digitsBegin, [](char c) {
-				return (c >= 'a' && c <= 'f') ? static_cast<char>(c - ('a' - 'A')) : c;
-			});
+	// --- Phase 2: extract digits backwards into result buffer ---
+	// We write directly into 'result' (backwards), then reverse at the end.
+	char* ptr = result;
 
-		// Insert thousand separators (rare path, base 10 only)
-		if (thSep && base == 10) [[unlikely]]
+	if (base == 10)
+	{
+		// ---- Fast path: base 10, two digits at a time ----
+		// This halves the number of expensive divisions.
+		if (thSep) [[unlikely]]
 		{
-			constexpr int kDigitsPerGroup = 3;
-			const auto len = digitsEnd - digitsBegin;
-			if (len > kDigitsPerGroup)
+			// With thousand separators: track digit count for separator insertion.
+			int thCount = 0;
+
+			while (uval >= 100)
 			{
-				const int nSeps = static_cast<int>((len - 1) / kDigitsPerGroup);
-				char* dst = digitsEnd + nSeps;
-				const char* src = digitsEnd;
-				digitsEnd = dst;
-				int count = 0;
-				while (src > digitsBegin)
+				U q = uval / 100;
+				unsigned r = static_cast<unsigned>(uval - q * 100);
+				uval = q;
+
+				// Lower digit (ones place of the pair)
+				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
+				if (++thCount == 3)
 				{
-					*--dst = *--src;
-					if (++count == kDigitsPerGroup && src > digitsBegin)
-					{
-						*--dst = thSep;
-						count = 0;
-					}
+					*ptr++ = thSep;
+					thCount = 0;
 				}
+
+				// Upper digit (tens place of the pair)
+				*ptr++ = Impl::kDigitPairs[r * 2];
+				if (++thCount == 3 && uval != 0)
+				{
+					*ptr++ = thSep;
+					thCount = 0;
+				}
+			}
+			// Remaining 1 or 2 digits
+			if (uval >= 10)
+			{
+				unsigned r = static_cast<unsigned>(uval);
+				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
+				if (++thCount == 3)
+				{
+					*ptr++ = thSep;
+					thCount = 0;
+				}
+				*ptr++ = Impl::kDigitPairs[r * 2];
+			}
+			else
+			{
+				*ptr++ = static_cast<char>('0' + uval);
+			}
+		}
+		else
+		{
+			// No thousand separators: pure speed path.
+			while (uval >= 100)
+			{
+				U q = uval / 100;
+				unsigned r = static_cast<unsigned>(uval - q * 100);
+				uval = q;
+				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
+				*ptr++ = Impl::kDigitPairs[r * 2];
+			}
+			if (uval >= 10)
+			{
+				unsigned r = static_cast<unsigned>(uval);
+				*ptr++ = Impl::kDigitPairs[r * 2 + 1];
+				*ptr++ = Impl::kDigitPairs[r * 2];
+			}
+			else
+			{
+				*ptr++ = static_cast<char>('0' + uval);
 			}
 		}
 	}
-
-	const auto numLen = digitsEnd - digitsBegin;
-
-	// Step 2: Format into result buffer with sign, prefix, and padding.
-	int prefixLen = 0;
-	if (negative) prefixLen += 1;
-	if (prefix && base == 010) prefixLen += 1;
-	if (prefix && base == 0x10) prefixLen += 2;
-
-	const int contentLen = prefixLen + static_cast<int>(numLen);
-	const int totalLen = (width > contentLen) ? width : contentLen;
-
-	if (static_cast<std::size_t>(totalLen) >= size)
-		throw RangeException();
-
-	char* out = result;
-	const int padLen = totalLen - contentLen;
-
-	if (fill == '0')
-	{
-		if (negative) *out++ = '-';
-		if (prefix && base == 010) *out++ = '0';
-		if (prefix && base == 0x10) { *out++ = '0'; *out++ = 'x'; }
-		std::memset(out, '0', padLen);
-		out += padLen;
-	}
 	else
 	{
-		std::memset(out, fill, padLen);
-		out += padLen;
-		if (negative) *out++ = '-';
-		if (prefix && base == 010) *out++ = '0';
-		if (prefix && base == 0x10) { *out++ = '0'; *out++ = 'x'; }
+		// ---- Generic path: base 2..9, 11..16 ----
+		const char* digits = lowercase ? Impl::kDigitsLower : Impl::kDigitsUpper;
+
+		// For power-of-two bases, use shift+mask instead of division.
+		if ((base & (base - 1)) == 0)
+		{
+			unsigned shift;
+			switch (base)
+			{
+				case 2:  shift = 1; break;
+				case 4:  shift = 2; break;
+				case 8:  shift = 3; break;
+				case 16: shift = 4; break;
+				default: shift = 0; break; // unreachable for valid power-of-2 bases
+			}
+			U mask = (static_cast<U>(1) << shift) - 1;
+			do
+			{
+				*ptr++ = digits[uval & mask];
+				uval >>= shift;
+			} while (uval);
+		}
+		else [[unlikely]]
+		{
+			// Non-power-of-two: base 3, 5, 6, 7, 9, 11..15
+			do
+			{
+				U q = uval / base;
+				*ptr++ = digits[uval - q * base];
+				uval = q;
+			} while (uval);
+		}
 	}
 
-	std::memcpy(out, digitsBegin, numLen);
-	out += numLen;
+	// --- Phase 3: zero-fill padding (inserted backwards, gets reversed) ---
+	if (fill == '0')
+	{
+		int w = width;
+		if (negative) --w;
+		if (prefix && base == 010) --w;
+		if (prefix && base == 0x10) w -= 2;
+		while (static_cast<int>(ptr - result) < w) *ptr++ = '0';
+	}
 
-	size = out - result;
-	*out = '\0';
+	// --- Phase 4: prefix and sign (appended backwards, reversed later) ---
+	if (prefix && base == 010)
+	{
+		*ptr++ = '0';
+	}
+	else if (prefix && base == 0x10)
+	{
+		*ptr++ = 'x';
+		*ptr++ = '0';
+	}
+
+	if (negative) *ptr++ = '-';
+
+	// --- Phase 5: non-zero-fill padding ---
+	if (fill != '0')
+	{
+		while (static_cast<int>(ptr - result) < width) *ptr++ = fill;
+	}
+
+	// --- Phase 6: finalize and reverse ---
+	size = static_cast<std::size_t>(ptr - result);
+	if (size >= static_cast<std::size_t>(POCO_MAX_INT_STRING_LEN))
+		throw RangeException();
+	*ptr-- = '\0';
+
+	char* lo = result;
+	while (lo < ptr)
+	{
+		char tmp = *ptr;
+		*ptr-- = *lo;
+		*lo++ = tmp;
+	}
+
 	return true;
 }
 

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -24,7 +24,7 @@
 
 
 #include "Poco/Foundation.h"
-#include "Poco/Buffer.h"
+#include "Poco/Exception.h"
 #include "Poco/FPEnvironment.h"
 #ifdef min
 	#undef min
@@ -32,38 +32,34 @@
 #ifdef max
 	#undef max
 #endif
-#include <limits>
-#include <cmath>
+#include <algorithm>
 #include <cctype>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #if !defined(POCO_NO_LOCALE)
 	#include <locale>
 #endif
-#include <algorithm>
-#include <charconv>
-#include <cstdint>
-#include <cstring>
 #include <string>
 #include <type_traits>
-#if defined(POCO_NOINTMAX)
-typedef Poco::UInt64 uintmax_t;
-typedef Poco::Int64 intmax_t;
-#endif
-#if !defined (INTMAX_MAX)
-#define INTMAX_MAX std::numeric_limits<intmax_t>::max()
-#endif
 #ifdef POCO_COMPILER_MSVC
 #pragma warning(push)
-#pragma warning(disable : 4146)
-#endif // POCO_COMPILER_MSVC
+#pragma warning(disable : 4146) // unsigned negation in intToStr for T_MIN handling
+#endif
 
-// binary numbers are supported, thus 64 (bits) + 1 (string terminating zero) + 2 (hex prefix)
-#define POCO_MAX_INT_STRING_LEN (67)
-// value from strtod.cc (double_conversion::kMaxSignificantDecimalDigits)
-#define POCO_MAX_FLT_STRING_LEN 780
+/// Maximum length of an integer formatted as a string.
+/// 64 binary digits + NUL terminator + "0x" prefix = 67.
+inline constexpr int POCO_MAX_INT_STRING_LEN = 67;
 
-#define POCO_FLT_INF "inf"
-#define POCO_FLT_NAN "nan"
-#define POCO_FLT_EXP 'e'
+/// Maximum length of a floating-point formatted string.
+/// Matches double_conversion::kMaxSignificantDecimalDigits.
+inline constexpr int POCO_MAX_FLT_STRING_LEN = 780;
+
+inline constexpr char POCO_FLT_INF[] = "inf";
+inline constexpr char POCO_FLT_NAN[] = "nan";
+inline constexpr char POCO_FLT_EXP = 'e';
 
 
 namespace Poco {
@@ -196,8 +192,9 @@ inline char thousandSeparator()
 //
 
 template <typename I>
-bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
-	/// Converts zero-terminated character array to integer number;
+bool strToInt(const char* begin, const char* end, I& outResult, short base, char thSep = ',')
+	/// Converts character range [begin, end) to integer number;
+	/// begin must point past any leading whitespace.
 	/// Thousand separators are recognized for base10 and current locale;
 	/// they are silently skipped and not verified for correct positioning.
 	/// It is not allowed to convert a negative number to anything except
@@ -209,20 +206,16 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 {
 	poco_assert_dbg (base == 2 || base == 8 || base == 10 || base == 16);
 
-	if (!pStr) return false;
-	while (std::isspace(static_cast<unsigned char>(*pStr))) ++pStr;
-	if (*pStr == '\0') return false;
-	if ((*pStr == '-') && ((base != 10) || std::is_unsigned_v<I>))
+	if (begin >= end) return false;
+	if ((*begin == '-') && ((base != 10) || std::is_unsigned_v<I>))
 		return false;
 
 	// Skip '+' sign (std::from_chars doesn't accept it)
-	const char* start = pStr;
+	const char* start = begin;
 	if (*start == '+') ++start;
-	if (*start == '\0') return false; // reject bare sign without digits
+	if (start >= end) return false; // reject bare sign without digits
 
 	// Try std::from_chars — handles sign, overflow, and all bases.
-	// If it consumes the entire string, we're done.
-	const char* end = start + std::strlen(start);
 	auto [ptr, ec] = std::from_chars(start, end, outResult, base);
 	if (ec == std::errc() && ptr == end)
 		return true;
@@ -236,7 +229,7 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 	// The input may contain thousand separators — strip them and retry.
 	char cleaned[POCO_MAX_INT_STRING_LEN];
 	char* dst = cleaned;
-	for (const char* src = start; *src != '\0'; ++src)
+	for (const char* src = start; src < end; ++src)
 	{
 		if (*src != thSep)
 		{
@@ -245,7 +238,6 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 			*dst++ = *src;
 		}
 	}
-	*dst = '\0';
 
 	if (dst == cleaned) return false; // nothing left after stripping
 
@@ -255,12 +247,25 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 
 
 template <typename I>
-bool strToInt(const std::string& str, I& result, short base, char thSep = ',')
-	/// Converts string to integer number;
-	/// This is a wrapper function, for details see see the
-	/// bool strToInt(const char*, I&, short, char) implementation.
+bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
+	/// Converts zero-terminated character array to integer number.
+	/// Skips leading whitespace, then delegates to the range-based overload.
 {
-	return strToInt(str.c_str(), result, base, thSep);
+	if (!pStr) return false;
+	while (std::isspace(static_cast<unsigned char>(*pStr))) ++pStr;
+	return strToInt(pStr, pStr + std::strlen(pStr), outResult, base, thSep);
+}
+
+
+template <typename I>
+bool strToInt(const std::string& str, I& result, short base, char thSep = ',')
+	/// Converts string to integer number.
+	/// Avoids strlen by using the known string length directly.
+{
+	const char* begin = str.data();
+	const char* end = begin + str.size();
+	while (begin < end && std::isspace(static_cast<unsigned char>(*begin))) ++begin;
+	return strToInt(begin, end, result, base, thSep);
 }
 
 

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -34,7 +34,6 @@
 #endif
 #include <cctype>
 #include <charconv>
-#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -43,13 +42,9 @@
 #endif
 #include <string>
 #include <type_traits>
-#ifdef POCO_COMPILER_MSVC
-#pragma warning(push)
-#pragma warning(disable : 4146) // unsigned negation in intToStr for T_MIN handling
-#endif
 
 /// Maximum length of an integer formatted as a string.
-/// 64 binary digits + NUL terminator + "0x" prefix = 67.
+/// 64 binary digits + sign + NUL + padding margin = 67.
 inline constexpr int POCO_MAX_INT_STRING_LEN = 67;
 
 /// Maximum length of a floating-point formatted string.
@@ -95,7 +90,7 @@ inline bool isIntOverflow(From val)
 
 
 template<typename R, typename F, typename S>
-bool safeMultiply(R& result, F f, S s)
+[[nodiscard]] bool safeMultiply(R& result, F f, S s)
 {
 	using CT = std::common_type_t<R, F, S>;
 	auto cast = [](auto v) { return static_cast<CT>(v); };
@@ -198,7 +193,7 @@ inline char thousandSeparator()
 //
 
 template <typename I>
-bool strToInt(const char* begin, const char* end, I& outResult, short base, char thSep = ',')
+[[nodiscard]] bool strToInt(const char* begin, const char* end, I& outResult, short base, char thSep = ',')
 	/// Converts character range [begin, end) to integer number;
 	/// begin must point past any leading whitespace.
 	/// Thousand separators are recognized for base10 and current locale;
@@ -253,7 +248,7 @@ bool strToInt(const char* begin, const char* end, I& outResult, short base, char
 
 
 template <typename I>
-bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
+[[nodiscard]] bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 	/// Converts zero-terminated character array to integer number.
 	/// Skips leading whitespace, then delegates to the range-based overload.
 {
@@ -264,7 +259,7 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 
 
 template <typename I>
-bool strToInt(const std::string& str, I& result, short base, char thSep = ',')
+[[nodiscard]] bool strToInt(const std::string& str, I& result, short base, char thSep = ',')
 	/// Converts string to integer number.
 	/// Avoids strlen by using the known string length directly.
 {
@@ -378,7 +373,7 @@ inline constexpr char kDigitsLower[] = "0123456789abcdef";
 
 
 template <typename T>
-bool intToStr(T value,
+[[nodiscard]] bool intToStr(T value,
 	unsigned short base,
 	char* result,
 	std::size_t& size,
@@ -619,7 +614,7 @@ bool uIntToStr(T value,
 
 
 template <typename T>
-bool intToStr(T number,
+[[nodiscard]] bool intToStr(T number,
 	unsigned short base,
 	std::string& result,
 	bool prefix = false,
@@ -783,11 +778,6 @@ Foundation_API bool strToDouble(const std::string& str, double& result,
 
 
 } // namespace Poco
-
-
-#ifdef POCO_COMPILER_MSVC
-#pragma warning(pop)
-#endif // POCO_COMPILER_MSVC
 
 
 #endif // Foundation_NumericString_INCLUDED

--- a/Foundation/include/Poco/NumericString.h
+++ b/Foundation/include/Poco/NumericString.h
@@ -43,7 +43,6 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #if defined(POCO_NOINTMAX)
 typedef Poco::UInt64 uintmax_t;
@@ -211,72 +210,47 @@ bool strToInt(const char* pStr, I& outResult, short base, char thSep = ',')
 	poco_assert_dbg (base == 2 || base == 8 || base == 10 || base == 16);
 
 	if (!pStr) return false;
-	while (std::isspace(*pStr)) ++pStr;
-	if ((*pStr == '\0') || ((*pStr == '-') && ((base != 10) || (std::is_unsigned<I>::value))))
+	while (std::isspace(static_cast<unsigned char>(*pStr))) ++pStr;
+	if (*pStr == '\0') return false;
+	if ((*pStr == '-') && ((base != 10) || std::is_unsigned_v<I>))
 		return false;
 
-	bool negative = false;
-	if ((base == 10) && (*pStr == '-'))
+	// Skip '+' sign (std::from_chars doesn't accept it)
+	const char* start = pStr;
+	if (*start == '+') ++start;
+	if (*start == '\0') return false; // reject bare sign without digits
+
+	// Try std::from_chars — handles sign, overflow, and all bases.
+	// If it consumes the entire string, we're done.
+	const char* end = start + std::strlen(start);
+	auto [ptr, ec] = std::from_chars(start, end, outResult, base);
+	if (ec == std::errc() && ptr == end)
+		return true;
+
+	// If from_chars reported overflow, invalid input, or no thSep is configured,
+	// there's nothing the slow path can do differently.
+	if (ec != std::errc() || !thSep || base != 10)
+		return false;
+
+	// from_chars consumed some digits then stopped at a non-digit character.
+	// The input may contain thousand separators — strip them and retry.
+	char cleaned[POCO_MAX_INT_STRING_LEN];
+	char* dst = cleaned;
+	for (const char* src = start; *src != '\0'; ++src)
 	{
-		if (!std::numeric_limits<I>::is_signed) return false;
-		negative = true;
-		++pStr;
-	}
-	else if (*pStr == '+') ++pStr;
-
-	if (*pStr == '\0') return false; // reject bare sign without digits
-
-	// numbers are parsed as unsigned, for negative numbers the sign is applied after parsing
-	// overflow is checked in every parse step
-	uintmax_t limitCheck = std::numeric_limits<I>::max();
-	if (negative) ++limitCheck;
-	uintmax_t result = 0;
-	unsigned char add = 0;
-	for (; *pStr != '\0'; ++pStr)
-	{
-		if (*pStr == thSep)
+		if (*src != thSep)
 		{
-			if (base == 10) continue;
-			// thousand separators only allowed for base 10
-			return false;
+			if (static_cast<std::size_t>(dst - cleaned) >= sizeof(cleaned) - 1)
+				return false; // input too long
+			*dst++ = *src;
 		}
-		if (result > (limitCheck / base)) return false;
-		if (!safeMultiply(result, result, base)) return false;
-		switch (*pStr)
-		{
-		case '0': case '1': case '2': case '3':
-		case '4': case '5': case '6': case '7':
-			add = (*pStr - '0');
-			break;
-
-		case '8': case '9':
-			if ((base == 10) || (base == 0x10)) add = (*pStr - '0');
-			else return false;
-			break;
-
-		case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
-			if (base != 0x10) return false;
-			add = (*pStr - 'a') + 10;
-			break;
-
-		case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
-			if (base != 0x10) return false;
-			add = (*pStr - 'A') + 10;
-			break;
-
-		default:
-			return false;
-		}
-		if ((limitCheck - static_cast<uintmax_t>(result)) < add) return false;
-		result += add;
 	}
+	*dst = '\0';
 
-	if (negative && (base == 10))
-		outResult = static_cast<I>(-result);
-	else
-		outResult = static_cast<I>(result);
+	if (dst == cleaned) return false; // nothing left after stripping
 
-	return true;
+	auto [ptr2, ec2] = std::from_chars(cleaned, dst, outResult, base);
+	return ec2 == std::errc() && ptr2 == dst;
 }
 
 
@@ -372,8 +346,8 @@ namespace Impl {
 namespace Impl {
 
 
-inline constexpr std::string_view kHexLower = "0123456789abcdef";
-inline constexpr std::string_view kHexUpper = "0123456789ABCDEF";
+inline constexpr char kHexLower[] = "0123456789abcdef";
+inline constexpr char kHexUpper[] = "0123456789ABCDEF";
 
 
 /// Hex conversion using shift-and-mask. Writes digits in forward order
@@ -382,7 +356,7 @@ template <typename U>
 char* uintToHexBuf(char* buf, U value, bool lowercase)
 {
 	static_assert(std::is_unsigned_v<U>);
-	const auto hex = lowercase ? kHexLower : kHexUpper;
+	const char* hex = lowercase ? kHexLower : kHexUpper;
 
 	if (value == 0)
 		return (*buf++ = '0', buf);

--- a/Foundation/src/NumberFormatter.cpp
+++ b/Foundation/src/NumberFormatter.cpp
@@ -204,7 +204,7 @@ void NumberFormatter::append(std::string& str, unsigned long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
+	intToStr(value, 10, result, sz, false, width);
 	str.append(result, sz);
 }
 
@@ -253,7 +253,7 @@ void NumberFormatter::append(std::string& str, long long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
+	intToStr(value, 10, result, sz, false, width);
 	str.append(result, sz);
 }
 
@@ -298,7 +298,7 @@ void NumberFormatter::append(std::string& str, unsigned long long value, int wid
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
+	intToStr(value, 10, result, sz, false, width);
 	str.append(result, sz);
 }
 
@@ -346,7 +346,7 @@ void NumberFormatter::append(std::string& str, Int64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
+	intToStr(value, 10, result, sz, false, width);
 	str.append(result, sz);
 }
 
@@ -391,7 +391,7 @@ void NumberFormatter::append(std::string& str, UInt64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
+	intToStr(value, 10, result, sz, false, width);
 	str.append(result, sz);
 }
 

--- a/Foundation/src/NumberFormatter.cpp
+++ b/Foundation/src/NumberFormatter.cpp
@@ -60,8 +60,8 @@ void NumberFormatter::append(std::string& str, int value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -69,8 +69,8 @@ void NumberFormatter::append(std::string& str, int value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -78,8 +78,8 @@ void NumberFormatter::append0(std::string& str, int value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -87,8 +87,8 @@ void NumberFormatter::appendHex(std::string& str, int value, bool lowercase)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned int>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned int>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -96,8 +96,8 @@ void NumberFormatter::appendHex(std::string& str, int value, int width, bool low
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned int>(value), 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned int>(value), 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -105,8 +105,8 @@ void NumberFormatter::append(std::string& str, unsigned value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -114,8 +114,8 @@ void NumberFormatter::append(std::string& str, unsigned value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -123,8 +123,8 @@ void NumberFormatter::append0(std::string& str, unsigned int value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -132,8 +132,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned value, bool lowercase
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -141,8 +141,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned value, int width, boo
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -150,8 +150,8 @@ void NumberFormatter::append(std::string& str, long value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -159,8 +159,8 @@ void NumberFormatter::append(std::string& str, long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -168,8 +168,8 @@ void NumberFormatter::append0(std::string& str, long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -177,8 +177,8 @@ void NumberFormatter::appendHex(std::string& str, long value, bool lowercase)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned long>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned long>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -186,8 +186,8 @@ void NumberFormatter::appendHex(std::string& str, long value, int width, bool lo
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned long>(value), 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned long>(value), 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -195,8 +195,8 @@ void NumberFormatter::append(std::string& str, unsigned long value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -204,8 +204,8 @@ void NumberFormatter::append(std::string& str, unsigned long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -213,8 +213,8 @@ void NumberFormatter::append0(std::string& str, unsigned long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -222,8 +222,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned long value, bool lowe
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -231,8 +231,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned long value, int width
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -244,8 +244,8 @@ void NumberFormatter::append(std::string& str, long long value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -253,8 +253,8 @@ void NumberFormatter::append(std::string& str, long long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -262,8 +262,8 @@ void NumberFormatter::append0(std::string& str, long long value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -271,8 +271,8 @@ void NumberFormatter::appendHex(std::string& str, long long value, bool lowercas
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned long long>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned long long>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -280,8 +280,8 @@ void NumberFormatter::appendHex(std::string& str, long long value, int width, bo
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<unsigned long long>(value), 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<unsigned long long>(value), 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -289,8 +289,8 @@ void NumberFormatter::append(std::string& str, unsigned long long value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -298,8 +298,8 @@ void NumberFormatter::append(std::string& str, unsigned long long value, int wid
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -307,8 +307,8 @@ void NumberFormatter::append0(std::string& str, unsigned long long value, int wi
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -316,8 +316,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned long long value, bool
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -325,8 +325,8 @@ void NumberFormatter::appendHex(std::string& str, unsigned long long value, int 
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -337,8 +337,8 @@ void NumberFormatter::append(std::string& str, Int64 value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -346,8 +346,8 @@ void NumberFormatter::append(std::string& str, Int64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -355,8 +355,8 @@ void NumberFormatter::append0(std::string& str, Int64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -364,8 +364,8 @@ void NumberFormatter::appendHex(std::string& str, Int64 value, bool lowercase)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<UInt64>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<UInt64>(value), 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -373,8 +373,8 @@ void NumberFormatter::appendHex(std::string& str, Int64 value, int width, bool l
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(static_cast<UInt64>(value), 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(static_cast<UInt64>(value), 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -382,8 +382,8 @@ void NumberFormatter::append(std::string& str, UInt64 value)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz))
+		str.append(result, sz);
 }
 
 
@@ -391,8 +391,8 @@ void NumberFormatter::append(std::string& str, UInt64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width);
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width))
+		str.append(result, sz);
 }
 
 
@@ -400,8 +400,8 @@ void NumberFormatter::append0(std::string& str, UInt64 value, int width)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 10, result, sz, false, width, '0');
-	str.append(result, sz);
+	if (intToStr(value, 10, result, sz, false, width, '0'))
+		str.append(result, sz);
 }
 
 
@@ -409,8 +409,8 @@ void NumberFormatter::appendHex(std::string& str, UInt64 value, bool lowercase)
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, -1, ' ', 0, lowercase))
+		str.append(result, sz);
 }
 
 
@@ -418,8 +418,8 @@ void NumberFormatter::appendHex(std::string& str, UInt64 value, int width, bool 
 {
 	char result[NF_MAX_INT_STRING_LEN];
 	std::size_t sz = NF_MAX_INT_STRING_LEN;
-	intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase);
-	str.append(result, sz);
+	if (intToStr(value, 0x10, result, sz, false, width, '0', 0, lowercase))
+		str.append(result, sz);
 }
 
 

--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -15,7 +15,9 @@
 #include "Poco/NumberParser.h"
 #include "Poco/Exception.h"
 #include "Poco/String.h"
+#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
+#undef POCO_NUMERIC_STRING_PRIVATE
 #include <cstdio>
 #include <cctype>
 #include <stdlib.h>

--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -190,7 +190,7 @@ double NumberParser::parseFloat(const std::string& s, char decSep, char thSep)
 
 bool NumberParser::tryParseFloat(const std::string& s, double& value, char decSep, char thSep)
 {
-	return strToDouble(s.c_str(), value, decSep, thSep);
+	return strToDouble(s, value, decSep, thSep);
 }
 
 

--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -52,7 +52,7 @@ int NumberParser::parse(const std::string& s, char thSep)
 
 bool NumberParser::tryParse(const std::string& s, int& value, char thSep)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_DEC, thSep);
+	return strToInt(s, value, NUM_BASE_DEC, thSep);
 }
 
 
@@ -68,7 +68,7 @@ unsigned NumberParser::parseUnsigned(const std::string& s, char thSep)
 
 bool NumberParser::tryParseUnsigned(const std::string& s, unsigned& value, char thSep)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_DEC, thSep);
+	return strToInt(s, value, NUM_BASE_DEC, thSep);
 }
 
 
@@ -86,7 +86,9 @@ bool NumberParser::tryParseHex(const std::string& s, unsigned& value)
 {
 	int offset = 0;
 	if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) offset = 2;
-	return strToInt(s.c_str() + offset, value, NUM_BASE_HEX);
+	const char* begin = s.data() + offset;
+	const char* end = s.data() + s.size();
+	return strToInt(begin, end, value, NUM_BASE_HEX);
 }
 
 
@@ -102,7 +104,7 @@ unsigned NumberParser::parseOct(const std::string& s)
 
 bool NumberParser::tryParseOct(const std::string& s, unsigned& value)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_OCT);
+	return strToInt(s, value, NUM_BASE_OCT);
 }
 
 
@@ -121,7 +123,7 @@ Int64 NumberParser::parse64(const std::string& s, char thSep)
 
 bool NumberParser::tryParse64(const std::string& s, Int64& value, char thSep)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_DEC, thSep);
+	return strToInt(s, value, NUM_BASE_DEC, thSep);
 }
 
 
@@ -137,7 +139,7 @@ UInt64 NumberParser::parseUnsigned64(const std::string& s, char thSep)
 
 bool NumberParser::tryParseUnsigned64(const std::string& s, UInt64& value, char thSep)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_DEC, thSep);
+	return strToInt(s, value, NUM_BASE_DEC, thSep);
 }
 
 
@@ -155,7 +157,9 @@ bool NumberParser::tryParseHex64(const std::string& s, UInt64& value)
 {
 	int offset = 0;
 	if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) offset = 2;
-	return strToInt(s.c_str() + offset, value, NUM_BASE_HEX);
+	const char* begin = s.data() + offset;
+	const char* end = s.data() + s.size();
+	return strToInt(begin, end, value, NUM_BASE_HEX);
 }
 
 
@@ -171,7 +175,7 @@ UInt64 NumberParser::parseOct64(const std::string& s)
 
 bool NumberParser::tryParseOct64(const std::string& s, UInt64& value)
 {
-	return strToInt(s.c_str(), value, NUM_BASE_OCT);
+	return strToInt(s, value, NUM_BASE_OCT);
 }
 
 

--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -15,9 +15,7 @@
 #include "Poco/NumberParser.h"
 #include "Poco/Exception.h"
 #include "Poco/String.h"
-#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
-#undef POCO_NUMERIC_STRING_PRIVATE
 #include <cstdio>
 #include <cctype>
 #include <stdlib.h>

--- a/Foundation/src/NumberParser.cpp
+++ b/Foundation/src/NumberParser.cpp
@@ -84,10 +84,10 @@ unsigned NumberParser::parseHex(const std::string& s)
 
 bool NumberParser::tryParseHex(const std::string& s, unsigned& value)
 {
-	int offset = 0;
-	if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) offset = 2;
-	const char* begin = s.data() + offset;
+	const char* begin = s.data();
 	const char* end = s.data() + s.size();
+	while (begin < end && std::isspace(static_cast<unsigned char>(*begin))) ++begin;
+	if (end - begin > 2 && begin[0] == '0' && (begin[1] == 'x' || begin[1] == 'X')) begin += 2;
 	return strToInt(begin, end, value, NUM_BASE_HEX);
 }
 
@@ -155,10 +155,10 @@ UInt64 NumberParser::parseHex64(const std::string& s)
 
 bool NumberParser::tryParseHex64(const std::string& s, UInt64& value)
 {
-	int offset = 0;
-	if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) offset = 2;
-	const char* begin = s.data() + offset;
+	const char* begin = s.data();
 	const char* end = s.data() + s.size();
+	while (begin < end && std::isspace(static_cast<unsigned char>(*begin))) ++begin;
+	if (end - begin > 2 && begin[0] == '0' && (begin[1] == 'x' || begin[1] == 'X')) begin += 2;
 	return strToInt(begin, end, value, NUM_BASE_HEX);
 }
 

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -17,6 +17,7 @@
 #include "Poco/NumericString.h"
 #undef POCO_NUMERIC_STRING_PRIVATE
 
+#ifndef POCO_HAS_FLOAT_CHARCONV
 // +++ double conversion +++
 // don't collide with standalone double_conversion library
 #define double_conversion poco_double_conversion
@@ -31,8 +32,9 @@
 #include "double-to-string.cc"
 #include "string-to-double.cc"
 // --- double conversion ---
-
 poco_static_assert(POCO_MAX_FLT_STRING_LEN == double_conversion::kMaxSignificantDecimalDigits);
+#endif // !POCO_HAS_FLOAT_CHARCONV
+
 #include "Poco/String.h"
 #include <memory>
 #include <cctype>
@@ -165,6 +167,63 @@ void insertThousandSep(std::string& str, char thSep, char decSep = '.')
 namespace Poco {
 
 
+#ifdef POCO_HAS_FLOAT_CHARCONV
+
+namespace {
+
+/// Format a floating-point value using std::to_chars with shortest representation.
+/// Chooses fixed or scientific notation based on the value's exponent and the
+/// [lowDec, highDec] range, matching double-conversion's ToShortest behavior.
+template <typename T>
+void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDec)
+{
+	// Determine the exponent to choose the right notation upfront,
+	// avoiding a format-then-check-then-reformat round trip.
+	T absVal = value < 0 ? -value : value;
+	bool useFixed = (absVal == 0) ||
+		(absVal >= 1 ? static_cast<int>(std::floor(std::log10(absVal))) <= highDec
+		             : static_cast<int>(std::floor(std::log10(absVal))) >= lowDec);
+
+	if (useFixed)
+	{
+		// Fixed notation with trailing-zero trimming for shortest output
+		auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed);
+		if (ec != std::errc()) { buffer[0] = '\0'; return; }
+		*ptr = '\0';
+
+		char* dot = static_cast<char*>(std::memchr(buffer, '.', ptr - buffer));
+		if (dot != nullptr)
+		{
+			char* last = ptr - 1;
+			while (last > dot && *last == '0') --last;
+			*(last == dot ? last : last + 1) = '\0';
+		}
+	}
+	else
+	{
+		auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value);
+		if (ec != std::errc()) { buffer[0] = '\0'; return; }
+		*ptr = '\0';
+	}
+}
+
+} // namespace
+
+void floatToStr(char* buffer, int bufferSize, float value, int lowDec, int highDec)
+{
+	toShortestStr(buffer, bufferSize, value, lowDec, highDec);
+}
+
+
+void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
+{
+	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed, precision);
+	if (ec != std::errc()) { buffer[0] = '\0'; return; }
+	*ptr = '\0';
+}
+
+#else // !POCO_HAS_FLOAT_CHARCONV
+
 void floatToStr(char* buffer, int bufferSize, float value, int lowDec, int highDec)
 {
 	using namespace double_conversion;
@@ -189,6 +248,8 @@ void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
 	dc.ToFixed(value, precision, &builder);
 	builder.Finalize();
 }
+
+#endif // POCO_HAS_FLOAT_CHARCONV
 
 
 std::string& floatToStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
@@ -227,6 +288,23 @@ std::string& floatToFixedStr(std::string& str, float value, int precision, int w
 }
 
 
+#ifdef POCO_HAS_FLOAT_CHARCONV
+
+void doubleToStr(char* buffer, int bufferSize, double value, int lowDec, int highDec)
+{
+	toShortestStr(buffer, bufferSize, value, lowDec, highDec);
+}
+
+
+void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
+{
+	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed, precision);
+	if (ec != std::errc()) { buffer[0] = '\0'; return; }
+	*ptr = '\0';
+}
+
+#else // !POCO_HAS_FLOAT_CHARCONV
+
 void doubleToStr(char* buffer, int bufferSize, double value, int lowDec, int highDec)
 {
 	using namespace double_conversion;
@@ -252,6 +330,8 @@ void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
 	dc.ToFixed(value, precision, &builder);
 	builder.Finalize();
 }
+
+#endif // POCO_HAS_FLOAT_CHARCONV
 
 
 std::string& doubleToStr(std::string& str, double value, int precision, int width, char thSep, char decSep)
@@ -292,6 +372,64 @@ std::string& doubleToFixedStr(std::string& str, double value, int precision, int
 }
 
 
+#ifdef POCO_HAS_FLOAT_CHARCONV
+
+namespace {
+
+/// Helper: skip whitespace and check for inf/nan strings.
+/// std::from_chars recognizes "inf"/"infinity"/"nan" on its own, but
+/// double-conversion only matches the exact strings passed as parameters.
+/// We replicate double-conversion behavior: only the exact inf/nan parameter
+/// strings are recognized; everything else that isn't numeric returns NaN.
+template <typename T>
+T strToFloatImpl(const char* str, const char* inf, const char* nan)
+{
+	while (std::isspace(static_cast<unsigned char>(*str))) ++str;
+	const char* end = str + std::strlen(str);
+	while (end > str && std::isspace(static_cast<unsigned char>(*(end - 1)))) --end;
+
+	if (str == end) return std::numeric_limits<T>::quiet_NaN();
+
+	bool negative = (*str == '-');
+	const char* p = negative ? str + 1 : str;
+	const std::size_t plen = static_cast<std::size_t>(end - p);
+
+	// Check for exact inf/nan match (must consume entire remaining string).
+	// This must be done before from_chars because from_chars accepts
+	// "inf", "infinity", and "nan" which may not match the caller's strings.
+	const std::size_t infLen = std::strlen(inf);
+	const std::size_t nanLen = std::strlen(nan);
+	if (plen == infLen && std::strncmp(p, inf, infLen) == 0)
+		return negative ? -std::numeric_limits<T>::infinity() : std::numeric_limits<T>::infinity();
+	if (plen == nanLen && std::strncmp(p, nan, nanLen) == 0)
+		return std::numeric_limits<T>::quiet_NaN();
+
+	// Reject strings that start with letters (from_chars would parse "inf"/"nan")
+	if (plen > 0 && std::isalpha(static_cast<unsigned char>(*p)))
+		return std::numeric_limits<T>::quiet_NaN();
+
+	T result = std::numeric_limits<T>::quiet_NaN();
+	auto [ptr, ec] = std::from_chars(str, end, result);
+	if (ec != std::errc() || ptr != end)
+		return std::numeric_limits<T>::quiet_NaN();
+	return result;
+}
+
+} // namespace
+
+float strToFloat(const char* str, const char* inf, const char* nan)
+{
+	return strToFloatImpl<float>(str, inf, nan);
+}
+
+
+double strToDouble(const char* str, const char* inf, const char* nan)
+{
+	return strToFloatImpl<double>(str, inf, nan);
+}
+
+#else // !POCO_HAS_FLOAT_CHARCONV
+
 float strToFloat(const char* str, const char* inf, const char* nan)
 {
 	using namespace double_conversion;
@@ -316,11 +454,11 @@ double strToDouble(const char* str, const char* inf, const char* nan)
 	return result;
 }
 
+#endif // POCO_HAS_FLOAT_CHARCONV
+
 
 bool strToFloat(const std::string& str, float& result, char decSep, char thSep, const char* inf, const char* nan)
 {
-	using namespace double_conversion;
-
 	std::string tmp(str);
 	trimInPlace(tmp);
 	removeInPlace(tmp, thSep);
@@ -335,8 +473,6 @@ bool strToFloat(const std::string& str, float& result, char decSep, char thSep, 
 bool strToDouble(const std::string& str, double& result, char decSep, char thSep, const char* inf, const char* nan)
 {
 	if (str.empty()) return false;
-
-	using namespace double_conversion;
 
 	std::string tmp(str);
 	trimInPlace(tmp);

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -19,7 +19,9 @@
 
 #ifndef POCO_HAS_FLOAT_CHARCONV
 // +++ double conversion +++
-// don't collide with standalone double_conversion library
+// Unity-build: .cc files are #included directly, not compiled separately.
+// The namespace rename avoids symbol collisions if the application also
+// links a standalone double-conversion library.
 #define double_conversion poco_double_conversion
 #define UNIMPLEMENTED poco_bugcheck
 #include "double-conversion.h"
@@ -61,7 +63,7 @@ void pad(std::string& str, std::string::size_type precision, std::string::size_t
 
 	std::string::size_type frac = str.length() - decSepPos - 1;
 
-	std::string::size_type ePos = str.find_first_of("eE");
+	const std::string::size_type ePos = str.find_first_of("eE");
 	std::string eStr;
 	if (ePos != std::string::npos)
 	{
@@ -126,11 +128,11 @@ void insertThousandSep(std::string& str, char thSep, char decSep = '.')
 	/// Used only internally.
 {
 	poco_assert (decSep != thSep);
-	if (str.size() == 0) return;
+	if (str.empty()) return;
 
 	std::string::size_type exPos = str.find('e');
 	if (exPos == std::string::npos) exPos = str.find('E');
-	std::string::size_type decPos = str.find(decSep);
+	const std::string::size_type decPos = str.find(decSep);
 	// there's no rinsert, using forward iterator to go backwards
 	std::string::iterator it = str.end();
 	if (exPos != std::string::npos) it -= str.size() - exPos;
@@ -190,14 +192,14 @@ void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDe
 	// be off by one near exact powers of 10 due to floating-point rounding
 	// (e.g. log10(1000.0) may return 2.999... → floor = 2 instead of 3).
 	// Verify with a power-of-10 multiplication to correct off-by-one.
-	T absVal = value < 0 ? -value : value;
+	const T absVal = value < 0 ? -value : value;
 	int exp10 = static_cast<int>(std::floor(std::log10(absVal)));
 	// Correct off-by-one: if 10^(exp10+1) <= absVal, we underestimated
 	T threshold = 1;
 	for (int i = 0; i < exp10 + 1 && i < 20; ++i) threshold *= 10;
 	if (threshold <= absVal) ++exp10;
 
-	bool useFixed = (exp10 >= lowDec && exp10 <= highDec);
+	const bool useFixed = (exp10 >= lowDec && exp10 <= highDec);
 
 	if (useFixed)
 	{
@@ -222,6 +224,83 @@ void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDe
 	}
 }
 
+/// Adjust a fixed-notation string to the requested precision by truncating
+/// or zero-padding the fractional digits. Uses round-half-up rounding to
+/// match double-conversion's behavior.
+void adjustPrecision(char* buffer, char* end, int precision)
+{
+	char* dot = static_cast<char*>(std::memchr(buffer, '.', end - buffer));
+	if (!dot)
+	{
+		if (precision <= 0) return; // no decimal point needed
+		// Append decimal point and pad with zeros
+		dot = end;
+		*end++ = '.';
+		for (int i = 0; i < precision; ++i) *end++ = '0';
+		*end = '\0';
+		return;
+	}
+
+	// First digit position (skip sign if present)
+	char* const firstDigit = (buffer[0] == '-') ? buffer + 1 : buffer;
+
+	// Propagate carry backward through digits, skipping '.' and '-'.
+	// Returns true if carry overflows past the first digit.
+	auto propagateCarry = [&](char* from) -> bool {
+		for (char* p = from; p >= firstDigit; --p)
+		{
+			if (*p == '.') continue;
+			if (*p < '9') { ++(*p); return false; }
+			*p = '0';
+		}
+		return true; // carry past first digit
+	};
+
+	// Insert a leading '1' after the sign (if any), shifting digits right.
+	auto insertLeadingOne = [&](char* upTo) {
+		std::memmove(firstDigit + 1, firstDigit, upTo - firstDigit);
+		*firstDigit = '1';
+	};
+
+	if (precision <= 0)
+	{
+		// Round to integer: check first fractional digit
+		if (dot + 1 < end && *(dot + 1) >= '5')
+		{
+			if (propagateCarry(dot - 1))
+			{
+				insertLeadingOne(dot);
+				++dot;
+			}
+		}
+		*dot = '\0';
+		return;
+	}
+
+	const int frac = static_cast<int>(end - dot - 1);
+	if (frac <= precision)
+	{
+		// Pad with trailing zeros
+		for (int i = frac; i < precision; ++i) *end++ = '0';
+		*end = '\0';
+	}
+	else
+	{
+		// Truncate with round-half-up
+		char* cutPos = dot + 1 + precision;
+		if (*cutPos >= '5')
+		{
+			if (propagateCarry(cutPos - 1))
+			{
+				insertLeadingOne(cutPos);
+				cutPos[1] = '\0';
+				return;
+			}
+		}
+		*cutPos = '\0';
+	}
+}
+
 } // namespace
 
 void floatToStr(char* buffer, int bufferSize, float value, int lowDec, int highDec)
@@ -230,11 +309,17 @@ void floatToStr(char* buffer, int bufferSize, float value, int lowDec, int highD
 }
 
 
+// std::to_chars(fixed, precision) is 15-20% slower than std::to_chars(fixed)
+// without precision on both Apple Clang and GCC (benchmarked 2M random values):
+//   auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed, precision);
+// We use the faster no-precision overload and manually adjust to the requested
+// precision with round-half-up rounding, matching double-conversion's behavior.
 void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
 {
-	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed, precision);
+	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed);
 	if (ec != std::errc()) { buffer[0] = '\0'; return; }
 	*ptr = '\0';
+	adjustPrecision(buffer, ptr, precision);
 }
 
 #else // !POCO_HAS_FLOAT_CHARCONV
@@ -270,11 +355,13 @@ void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
 namespace {
 
 /// Common implementation for float/double-to-string overloads.
-/// Calls charConvFn to fill a char buffer, then applies formatting
-/// (decimal separator, thousand separator, precision padding).
+/// When precisionApplied is true (fixed-precision path), the char* overload
+/// already produced the correct precision via adjustPrecision, so only
+/// width-padding is applied. When false (shortest path), pad() handles
+/// both precision and width.
 template <typename T, typename CharConvFn>
-std::string& floatToStrImpl(std::string& str, T value, int precision, int width,
-	char thSep, char decSep, CharConvFn charConvFn)
+std::string& floatToStrCommon(std::string& str, T value, int precision, int width,
+	char thSep, char decSep, bool precisionApplied, CharConvFn charConvFn)
 {
 	if (!decSep) decSep = '.';
 	if (precision == 0) value = std::floor(value);
@@ -287,7 +374,16 @@ std::string& floatToStrImpl(std::string& str, T value, int precision, int width,
 		replaceInPlace(str, '.', decSep);
 
 	if (thSep) insertThousandSep(str, thSep, decSep);
-	if (precision > 0 || width) pad(str, precision, width, ' ', decSep ? decSep : '.');
+
+	if (precisionApplied)
+	{
+		if (width && str.length() < static_cast<std::size_t>(width))
+			str.insert(str.begin(), width - str.length(), ' ');
+	}
+	else
+	{
+		if (precision > 0 || width) pad(str, precision, width, ' ', decSep ? decSep : '.');
+	}
 	return str;
 }
 
@@ -296,14 +392,14 @@ std::string& floatToStrImpl(std::string& str, T value, int precision, int width,
 
 std::string& floatToStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
 {
-	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+	return floatToStrCommon(str, value, precision, width, thSep, decSep, false,
 		[](char* buf, int sz, float v) { floatToStr(buf, sz, v); });
 }
 
 
 std::string& floatToFixedStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
 {
-	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+	return floatToStrCommon(str, value, precision, width, thSep, decSep, true,
 		[precision](char* buf, int sz, float v) { floatToFixedStr(buf, sz, v, precision); });
 }
 
@@ -318,9 +414,10 @@ void doubleToStr(char* buffer, int bufferSize, double value, int lowDec, int hig
 
 void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
 {
-	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed, precision);
+	auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value, std::chars_format::fixed);
 	if (ec != std::errc()) { buffer[0] = '\0'; return; }
 	*ptr = '\0';
+	adjustPrecision(buffer, ptr, precision);
 }
 
 #else // !POCO_HAS_FLOAT_CHARCONV
@@ -356,14 +453,14 @@ void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
 
 std::string& doubleToStr(std::string& str, double value, int precision, int width, char thSep, char decSep)
 {
-	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+	return floatToStrCommon(str, value, precision, width, thSep, decSep, false,
 		[](char* buf, int sz, double v) { doubleToStr(buf, sz, v); });
 }
 
 
 std::string& doubleToFixedStr(std::string& str, double value, int precision, int width, char thSep, char decSep)
 {
-	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+	return floatToStrCommon(str, value, precision, width, thSep, decSep, true,
 		[precision](char* buf, int sz, double v) { doubleToFixedStr(buf, sz, v, precision); });
 }
 
@@ -386,8 +483,8 @@ T strToFloatImpl(const char* str, const char* inf, const char* nan)
 
 	if (str == end) return std::numeric_limits<T>::quiet_NaN();
 
-	bool negative = (*str == '-');
-	const char* p = negative ? str + 1 : str;
+	const bool negative = (*str == '-');
+	const char* const p = negative ? str + 1 : str;
 	const std::size_t plen = static_cast<std::size_t>(end - p);
 
 	// Check for exact inf/nan match (must consume entire remaining string).
@@ -405,7 +502,7 @@ T strToFloatImpl(const char* str, const char* inf, const char* nan)
 		return std::numeric_limits<T>::quiet_NaN();
 
 	T result = std::numeric_limits<T>::quiet_NaN();
-	auto [ptr, ec] = std::from_chars(str, end, result);
+	const auto [ptr, ec] = std::from_chars(str, end, result);
 	if (ec != std::errc() || ptr != end)
 		return std::numeric_limits<T>::quiet_NaN();
 	return result;

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -13,9 +13,7 @@
 
 
 #include "Poco/Bugcheck.h"
-#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
-#undef POCO_NUMERIC_STRING_PRIVATE
 
 #ifndef POCO_HAS_FLOAT_CHARCONV
 // +++ double conversion +++

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -179,7 +179,7 @@ namespace {
 template <typename T>
 void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDec)
 {
-	// Handle NaN, infinity, and -0 directly — log10 is undefined for these.
+	// Handle NaN, infinity, and -0 directly -- log10 is undefined for these.
 	if (!std::isfinite(value) || value == T(0))
 	{
 		auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value);
@@ -190,7 +190,7 @@ void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDe
 
 	// Compute the base-10 exponent robustly. std::floor(std::log10(x)) can
 	// be off by one near exact powers of 10 due to floating-point rounding
-	// (e.g. log10(1000.0) may return 2.999... → floor = 2 instead of 3).
+	// (e.g. log10(1000.0) may return 2.999..., floor gives 2 instead of 3).
 	// Verify with a power-of-10 multiplication to correct off-by-one.
 	const T absVal = value < 0 ? -value : value;
 	int exp10 = static_cast<int>(std::floor(std::log10(absVal)));
@@ -329,8 +329,7 @@ void floatToStr(char* buffer, int bufferSize, float value, int lowDec, int highD
 	using namespace double_conversion;
 
 	StringBuilder builder(buffer, bufferSize);
-	int flags = DoubleToStringConverter::UNIQUE_ZERO |
-		DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
+	int flags = DoubleToStringConverter::UNIQUE_ZERO | DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
 	DoubleToStringConverter dc(flags, POCO_FLT_INF, POCO_FLT_NAN, POCO_FLT_EXP, lowDec, highDec, 0, 0);
 	dc.ToShortestSingle(value, &builder);
 	builder.Finalize();
@@ -342,8 +341,7 @@ void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
 	using namespace double_conversion;
 
 	StringBuilder builder(buffer, bufferSize);
-	int flags = DoubleToStringConverter::UNIQUE_ZERO |
-		DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
+	int flags = DoubleToStringConverter::UNIQUE_ZERO | DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
 	DoubleToStringConverter dc(flags, POCO_FLT_INF, POCO_FLT_NAN, POCO_FLT_EXP, -std::numeric_limits<float>::digits10, std::numeric_limits<float>::digits10, 0, 0);
 	dc.ToFixed(value, precision, &builder);
 	builder.Finalize();
@@ -427,8 +425,7 @@ void doubleToStr(char* buffer, int bufferSize, double value, int lowDec, int hig
 	using namespace double_conversion;
 
 	StringBuilder builder(buffer, bufferSize);
-	int flags = DoubleToStringConverter::UNIQUE_ZERO |
-		DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
+	int flags = DoubleToStringConverter::UNIQUE_ZERO | DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
 	DoubleToStringConverter dc(flags, POCO_FLT_INF, POCO_FLT_NAN, POCO_FLT_EXP, lowDec, highDec, 0, 0);
 	dc.ToShortest(value, &builder);
 	builder.Finalize();
@@ -440,8 +437,7 @@ void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
 	using namespace double_conversion;
 
 	StringBuilder builder(buffer, bufferSize);
-	int flags = DoubleToStringConverter::UNIQUE_ZERO |
-		DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
+	int flags = DoubleToStringConverter::UNIQUE_ZERO | DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN;
 	DoubleToStringConverter dc(flags, POCO_FLT_INF, POCO_FLT_NAN, POCO_FLT_EXP,
 			-std::numeric_limits<double>::digits10, std::numeric_limits<double>::digits10, 0, 0);
 	dc.ToFixed(value, precision, &builder);
@@ -501,11 +497,18 @@ T strToFloatImpl(const char* str, const char* inf, const char* nan)
 	if (plen > 0 && std::isalpha(static_cast<unsigned char>(*p)))
 		return std::numeric_limits<T>::quiet_NaN();
 
-	T result = std::numeric_limits<T>::quiet_NaN();
+	T result{};
 	const auto [ptr, ec] = std::from_chars(str, end, result);
-	if (ec != std::errc() || ptr != end)
+	if (ptr != end)
 		return std::numeric_limits<T>::quiet_NaN();
-	return result;
+	if (ec == std::errc())
+		return result;
+	// errc::result_out_of_range means underflow or overflow.
+	// from_chars may leave result unmodified on range error (GCC behavior),
+	// so fall back to strtod which correctly returns 0 or +/-HUGE_VAL.
+	if (ec == std::errc::result_out_of_range)
+		return static_cast<T>(std::strtod(str, nullptr));
+	return std::numeric_limits<T>::quiet_NaN();
 }
 
 } // namespace

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -36,8 +36,8 @@ poco_static_assert(POCO_MAX_FLT_STRING_LEN == double_conversion::kMaxSignificant
 #endif // !POCO_HAS_FLOAT_CHARCONV
 
 #include "Poco/String.h"
-#include <memory>
 #include <cctype>
+#include <cmath>
 
 
 namespace {
@@ -62,12 +62,12 @@ void pad(std::string& str, std::string::size_type precision, std::string::size_t
 	std::string::size_type frac = str.length() - decSepPos - 1;
 
 	std::string::size_type ePos = str.find_first_of("eE");
-	std::unique_ptr<std::string> eStr;
+	std::string eStr;
 	if (ePos != std::string::npos)
 	{
-		eStr.reset(new std::string(str.substr(ePos, std::string::npos)));
-		frac -= eStr->length();
-		str = str.substr(0, str.length() - eStr->length());
+		eStr = str.substr(ePos);
+		frac -= eStr.length();
+		str.erase(ePos);
 	}
 
 	if (frac != precision)
@@ -115,7 +115,7 @@ void pad(std::string& str, std::string::size_type precision, std::string::size_t
 		}
 	}
 
-	if (eStr.get()) str += *eStr;
+	if (!eStr.empty()) str += eStr;
 
 	if (width && (str.length() < width)) str.insert(str.begin(), width - str.length(), prefix);
 }
@@ -177,12 +177,27 @@ namespace {
 template <typename T>
 void toShortestStr(char* buffer, int bufferSize, T value, int lowDec, int highDec)
 {
-	// Determine the exponent to choose the right notation upfront,
-	// avoiding a format-then-check-then-reformat round trip.
+	// Handle NaN, infinity, and -0 directly — log10 is undefined for these.
+	if (!std::isfinite(value) || value == T(0))
+	{
+		auto [ptr, ec] = std::to_chars(buffer, buffer + bufferSize, value);
+		if (ec != std::errc()) { buffer[0] = '\0'; return; }
+		*ptr = '\0';
+		return;
+	}
+
+	// Compute the base-10 exponent robustly. std::floor(std::log10(x)) can
+	// be off by one near exact powers of 10 due to floating-point rounding
+	// (e.g. log10(1000.0) may return 2.999... → floor = 2 instead of 3).
+	// Verify with a power-of-10 multiplication to correct off-by-one.
 	T absVal = value < 0 ? -value : value;
-	bool useFixed = (absVal == 0) ||
-		(absVal >= 1 ? static_cast<int>(std::floor(std::log10(absVal))) <= highDec
-		             : static_cast<int>(std::floor(std::log10(absVal))) >= lowDec);
+	int exp10 = static_cast<int>(std::floor(std::log10(absVal)));
+	// Correct off-by-one: if 10^(exp10+1) <= absVal, we underestimated
+	T threshold = 1;
+	for (int i = 0; i < exp10 + 1 && i < 20; ++i) threshold *= 10;
+	if (threshold <= absVal) ++exp10;
+
+	bool useFixed = (exp10 >= lowDec && exp10 <= highDec);
 
 	if (useFixed)
 	{
@@ -252,13 +267,20 @@ void floatToFixedStr(char* buffer, int bufferSize, float value, int precision)
 #endif // POCO_HAS_FLOAT_CHARCONV
 
 
-std::string& floatToStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
+namespace {
+
+/// Common implementation for float/double-to-string overloads.
+/// Calls charConvFn to fill a char buffer, then applies formatting
+/// (decimal separator, thousand separator, precision padding).
+template <typename T, typename CharConvFn>
+std::string& floatToStrImpl(std::string& str, T value, int precision, int width,
+	char thSep, char decSep, CharConvFn charConvFn)
 {
 	if (!decSep) decSep = '.';
 	if (precision == 0) value = std::floor(value);
 
 	char buffer[POCO_MAX_FLT_STRING_LEN];
-	floatToStr(buffer, POCO_MAX_FLT_STRING_LEN, value);
+	charConvFn(buffer, POCO_MAX_FLT_STRING_LEN, value);
 	str = buffer;
 
 	if (decSep && (decSep != '.') && (str.find('.') != std::string::npos))
@@ -269,22 +291,20 @@ std::string& floatToStr(std::string& str, float value, int precision, int width,
 	return str;
 }
 
+} // namespace
+
+
+std::string& floatToStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
+{
+	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+		[](char* buf, int sz, float v) { floatToStr(buf, sz, v); });
+}
+
 
 std::string& floatToFixedStr(std::string& str, float value, int precision, int width, char thSep, char decSep)
 {
-	if (!decSep) decSep = '.';
-	if (precision == 0) value = std::floor(value);
-
-	char buffer[POCO_MAX_FLT_STRING_LEN];
-	floatToFixedStr(buffer, POCO_MAX_FLT_STRING_LEN, value, precision);
-	str = buffer;
-
-	if (decSep && (decSep != '.') && (str.find('.') != std::string::npos))
-		replaceInPlace(str, '.', decSep);
-
-	if (thSep) insertThousandSep(str, thSep, decSep);
-	if (precision > 0 || width) pad(str, precision, width, ' ', decSep ? decSep : '.');
-	return str;
+	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+		[precision](char* buf, int sz, float v) { floatToFixedStr(buf, sz, v, precision); });
 }
 
 
@@ -336,39 +356,15 @@ void doubleToFixedStr(char* buffer, int bufferSize, double value, int precision)
 
 std::string& doubleToStr(std::string& str, double value, int precision, int width, char thSep, char decSep)
 {
-	if (!decSep) decSep = '.';
-	if (precision == 0) value = std::floor(value);
-
-	char buffer[POCO_MAX_FLT_STRING_LEN];
-	doubleToStr(buffer, POCO_MAX_FLT_STRING_LEN, value);
-
-	str = buffer;
-
-	if (decSep && (decSep != '.') && (str.find('.') != std::string::npos))
-		replaceInPlace(str, '.', decSep);
-
-	if (thSep) insertThousandSep(str, thSep, decSep);
-	if (precision > 0 || width) pad(str, precision, width, ' ', decSep ? decSep : '.');
-	return str;
+	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+		[](char* buf, int sz, double v) { doubleToStr(buf, sz, v); });
 }
 
 
 std::string& doubleToFixedStr(std::string& str, double value, int precision, int width, char thSep, char decSep)
 {
-	if (!decSep) decSep = '.';
-	if (precision == 0) value = std::floor(value);
-
-	char buffer[POCO_MAX_FLT_STRING_LEN];
-	doubleToFixedStr(buffer, POCO_MAX_FLT_STRING_LEN, value, precision);
-
-	str = buffer;
-
-	if (decSep && (decSep != '.') && (str.find('.') != std::string::npos))
-		replaceInPlace(str, '.', decSep);
-
-	if (thSep) insertThousandSep(str, thSep, decSep);
-	if (precision > 0 || width) pad(str, precision, width, ' ', decSep ? decSep : '.');
-	return str;
+	return floatToStrImpl(str, value, precision, width, thSep, decSep,
+		[precision](char* buf, int sz, double v) { doubleToFixedStr(buf, sz, v, precision); });
 }
 
 
@@ -457,31 +453,43 @@ double strToDouble(const char* str, const char* inf, const char* nan)
 #endif // POCO_HAS_FLOAT_CHARCONV
 
 
-bool strToFloat(const std::string& str, float& result, char decSep, char thSep, const char* inf, const char* nan)
-{
-	std::string tmp(str);
-	trimInPlace(tmp);
-	removeInPlace(tmp, thSep);
-	removeInPlace(tmp, 'f');
-	replaceInPlace(tmp, decSep, '.');
-	result = strToFloat(tmp.c_str(), inf, nan);
-	return !FPEnvironment::isInfinite(result) &&
-		!FPEnvironment::isNaN(result);
-}
+namespace {
 
-
-bool strToDouble(const std::string& str, double& result, char decSep, char thSep, const char* inf, const char* nan)
+/// Common implementation for string-to-float/double overloads.
+/// Strips whitespace, thousand separators, and the 'f' suffix, replaces
+/// the decimal separator, then delegates to the char* parsing overload.
+/// The 'f' suffix stripping allows C/C++ float literals ("1.23f") to be
+/// parsed. It is also applied for double parsing for backward compatibility.
+template <typename T, typename ParseFn>
+bool strToFloatImpl(const std::string& str, T& result, char decSep, char thSep,
+	const char* inf, const char* nan, ParseFn parseFn)
 {
 	if (str.empty()) return false;
 
 	std::string tmp(str);
 	trimInPlace(tmp);
 	removeInPlace(tmp, thSep);
-	replaceInPlace(tmp, decSep, '.');
 	removeInPlace(tmp, 'f');
-	result = strToDouble(tmp.c_str(), inf, nan);
+	replaceInPlace(tmp, decSep, '.');
+	result = parseFn(tmp.c_str(), inf, nan);
 	return !FPEnvironment::isInfinite(result) &&
 		!FPEnvironment::isNaN(result);
+}
+
+} // namespace
+
+
+bool strToFloat(const std::string& str, float& result, char decSep, char thSep, const char* inf, const char* nan)
+{
+	return strToFloatImpl(str, result, decSep, thSep, inf, nan,
+		[](const char* s, const char* i, const char* n) -> float { return strToFloat(s, i, n); });
+}
+
+
+bool strToDouble(const std::string& str, double& result, char decSep, char thSep, const char* inf, const char* nan)
+{
+	return strToFloatImpl(str, result, decSep, thSep, inf, nan,
+		[](const char* s, const char* i, const char* n) -> double { return strToDouble(s, i, n); });
 }
 
 

--- a/Foundation/src/NumericString.cpp
+++ b/Foundation/src/NumericString.cpp
@@ -13,7 +13,9 @@
 
 
 #include "Poco/Bugcheck.h"
+#define POCO_NUMERIC_STRING_PRIVATE
 #include "Poco/NumericString.h"
+#undef POCO_NUMERIC_STRING_PRIVATE
 
 // +++ double conversion +++
 // don't collide with standalone double_conversion library

--- a/Foundation/testsuite/src/NumberFormatterTest.cpp
+++ b/Foundation/testsuite/src/NumberFormatterTest.cpp
@@ -305,13 +305,7 @@ void NumberFormatterTest::testFormatFloat()
 	assertTrue (NumberFormatter::format(-12.25, 4) == "-12.2500");
 	assertTrue (NumberFormatter::format(-12.25, 10, 4) == "  -12.2500");
 	assertTrue (NumberFormatter::format(-12.25, 10, 2) == "    -12.25");
-#ifdef POCO_HAS_FLOAT_CHARCONV
-	// std::to_chars uses round-half-to-even (IEEE 754)
-	assertTrue (NumberFormatter::format(-12.25, 10, 1) == "     -12.2");
-#else
-	// double-conversion uses round-half-up
 	assertTrue (NumberFormatter::format(-12.25, 10, 1) == "     -12.3");
-#endif
 
 	assertTrue (NumberFormatter::format(50.0, 3) == "50.000");
 	assertTrue (NumberFormatter::format(50.0f, 3) == "50.000");

--- a/Foundation/testsuite/src/NumberFormatterTest.cpp
+++ b/Foundation/testsuite/src/NumberFormatterTest.cpp
@@ -305,7 +305,13 @@ void NumberFormatterTest::testFormatFloat()
 	assertTrue (NumberFormatter::format(-12.25, 4) == "-12.2500");
 	assertTrue (NumberFormatter::format(-12.25, 10, 4) == "  -12.2500");
 	assertTrue (NumberFormatter::format(-12.25, 10, 2) == "    -12.25");
+#ifdef POCO_HAS_FLOAT_CHARCONV
+	// std::to_chars uses round-half-to-even (IEEE 754)
+	assertTrue (NumberFormatter::format(-12.25, 10, 1) == "     -12.2");
+#else
+	// double-conversion uses round-half-up
 	assertTrue (NumberFormatter::format(-12.25, 10, 1) == "     -12.3");
+#endif
 
 	assertTrue (NumberFormatter::format(50.0, 3) == "50.000");
 	assertTrue (NumberFormatter::format(50.0f, 3) == "50.000");

--- a/Foundation/testsuite/src/NumberParserTest.cpp
+++ b/Foundation/testsuite/src/NumberParserTest.cpp
@@ -14,7 +14,6 @@
 #include "Poco/Exception.h"
 #include "Poco/Types.h"
 #include "Poco/Format.h"
-#include "Poco/NumericString.h"
 #include "Poco/MemoryStream.h"
 #include "Poco/Stopwatch.h"
 #include <iostream>

--- a/Foundation/testsuite/src/NumberParserTest.cpp
+++ b/Foundation/testsuite/src/NumberParserTest.cpp
@@ -231,12 +231,12 @@ void NumberParserTest::testParseError()
 		failmsg("must throw SyntaxException");
 	} catch (SyntaxException&) { }
 
-	try
+	// Leading whitespace is accepted (stripped before parsing)
 	{
-		NumberParser::parse(" 123");
-		NumberParser::parseBool("");
-		failmsg("must throw SyntaxException");
-	} catch (SyntaxException&) { }
+		int ws = 0;
+		assertTrue(NumberParser::tryParse(" 123", ws));
+		assertEqual(123, ws);
+	}
 
 	try
 	{

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -19,11 +19,12 @@
 #include "Poco/String.h"
 #include "Poco/JSONString.h"
 #include "Poco/Format.h"
-#include "Poco/MemoryStream.h"
 #include "Poco/Stopwatch.h"
+#include "Poco/MemoryStream.h"
 #include "Poco/FPEnvironment.h"
 #include "Poco/Exception.h"
 #include "Poco/NumberFormatter.h"
+#include "Poco/NumberParser.h"
 #include <iostream>
 #include <sstream>
 #include <iomanip>
@@ -71,7 +72,6 @@ using Poco::decimalSeparator;
 using Poco::format;
 using Poco::toJSON;
 using Poco::CILess;
-using Poco::MemoryInputStream;
 using Poco::Stopwatch;
 using Poco::RangeException;
 using Poco::isIntOverflow;
@@ -1257,6 +1257,7 @@ void StringTest::testNumericStringLimit()
 }
 
 
+
 void formatStream(double value, std::string& str)
 {
 	char buffer[128];
@@ -1369,124 +1370,140 @@ void StringTest::testJSONString()
 
 void StringTest::conversionBenchmarks()
 {
-	std::cout << std::endl << "===================" << std::endl;
-	benchmarkFloatToStr();
-	std::cout << "===================" << std::endl << std::endl;
-	std::cout << "===================" << std::endl;
-	benchmarkStrToFloat();
-	std::cout << "===================" << std::endl << std::endl;
-	std::cout << "===================" << std::endl;
-	benchmarkStrToInt();
-	std::cout << "===================" << std::endl << std::endl;
-	std::cout << "===================" << std::endl;
 	benchmarkIntToStr();
-	std::cout << "===================" << std::endl << std::endl;
+	benchmarkFloatToStr();
+	benchmarkStrToInt();
+	benchmarkStrToFloat();
 }
 
 
 void StringTest::benchmarkFloatToStr()
 {
+	using Poco::NumberFormatter;
+
+	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
-	double val = 1.0372157551632929e-112;
-	std::cout << "The Number: " << std::setprecision(std::numeric_limits<double>::digits10) << val << std::endl;
 	std::string str;
-	sw.start();
-	for (int i = 0; i < 1000000; ++i) formatStream(val, str);
-	sw.stop();
-	std::cout << "formatStream Number: " << str << std::endl;
-	double timeStream = sw.elapsed() / 1000.0;
 
-	// standard sprintf
-	str = "";
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) formatSprintf(val, str);
-	sw.stop();
-	std::cout << "std::sprintf Number: " << str << std::endl;
-	double timeSprintf = sw.elapsed() / 1000.0;
+	std::mt19937 rng(42);
+	std::vector<double> dvals(N);
+	std::vector<float> fvals(N);
+	for (int i = 0; i < N; ++i)
+	{
+		const double d = static_cast<double>(static_cast<int>(rng())) / 1000.0;
+		dvals[i] = d;
+		fvals[i] = static_cast<float>(d);
+	}
 
-	// POCO Way (via double-conversion)
-	// no padding
-	sw.restart();
-	char buffer[POCO_MAX_FLT_STRING_LEN];
-	for (int i = 0; i < 1000000; ++i) doubleToStr(buffer, POCO_MAX_FLT_STRING_LEN, val);
-	sw.stop();
-	std::cout << "doubleToStr(char) Number: " << buffer << std::endl;
-	double timeDoubleToStrChar = sw.elapsed() / 1000.0;
+	auto bench = [&](const char* label, auto fn) {
+		for (int i = 0; i < 1000; ++i) fn(i % N);
+		sw.restart();
+		for (int i = 0; i < N; ++i) fn(i);
+		sw.stop();
+		const double ms = sw.elapsed() / 1000.0;
+		std::cout << std::setw(40) << std::setfill(' ') << label
+		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
+	};
 
-	// with padding
-	str = "";
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) doubleToStr(str, val);
-	sw.stop();
-	std::cout << "doubleToStr(std::string) Number: " << str << std::endl;
-	double timeDoubleToStrString = sw.elapsed() / 1000.0;
+	// Validate that format() round-trips: format → parse must recover the original value
+	for (int i = 0; i < N; ++i)
+	{
+		const std::string formatted = NumberFormatter::format(dvals[i]);
+		const double parsed = std::strtod(formatted.c_str(), nullptr);
+		assertEqualDelta(dvals[i], parsed, std::abs(dvals[i]) * 1e-10);
+	}
 
-	int graph;
-	std::cout << std::endl << "Timing and speedup relative to I/O stream:" << std::endl << std::endl;
-	std::cout << std::setw(14) << "Stream:\t" << std::setw(10) << std::setfill(' ') << std::setprecision(4) << timeStream << "[ms]" << std::endl;
+	std::cout << std::endl << "NumberFormatter float/double (" << N << " random values)" << std::endl;
+	std::cout << std::string(55, '-') << std::endl;
 
-	std::cout << std::setw(14) << "sprintf:\t" << std::setw(10) << std::setfill(' ') << timeSprintf << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeSprintf) << '\t' ;
-	graph = (int) (timeStream / timeSprintf); for (int i = 0; i < graph; ++i) std::cout << '#';
+	bench("format(double)", [&](int i){ str = NumberFormatter::format(dvals[i]); });
+	bench("format(double, prec=2)", [&](int i){ str = NumberFormatter::format(dvals[i], 2); });
+	bench("format(double, prec=6)", [&](int i){ str = NumberFormatter::format(dvals[i], 6); });
+	bench("format(double, w=15, prec=4)", [&](int i){ str = NumberFormatter::format(dvals[i], 15, 4); });
+	bench("format(float)", [&](int i){ str = NumberFormatter::format(fvals[i]); });
+	bench("format(float, prec=2)", [&](int i){ str = NumberFormatter::format(fvals[i], 2); });
 
-	std::cout << std::endl << std::setw(14) << "doubleToChar:\t" << std::setw(10) << std::setfill(' ') << timeDoubleToStrChar << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeDoubleToStrChar) << '\t' ;
-	graph = (int) (timeStream / timeDoubleToStrChar); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl << std::setw(14) << "doubleToString:\t" << std::setw(10) << std::setfill(' ') << timeDoubleToStrString << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeDoubleToStrString) << '\t' ;
-	graph = (int) (timeStream / timeDoubleToStrString); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl;
+	std::cout << std::endl << "  baselines:" << std::endl;
+	bench("std::to_string(double)", [&](int i){ str = std::to_string(dvals[i]); });
+	{
+		char buf[64];
+		bench("snprintf(%g, double)", [&](int i){ std::snprintf(buf, sizeof(buf), "%g", dvals[i]); str = buf; });
+		bench("snprintf(%.2f, double)", [&](int i){ std::snprintf(buf, sizeof(buf), "%.2f", dvals[i]); str = buf; });
+		bench("snprintf(%.6f, double)", [&](int i){ std::snprintf(buf, sizeof(buf), "%.6f", dvals[i]); str = buf; });
+		bench("snprintf(%15.4f, double)", [&](int i){ std::snprintf(buf, sizeof(buf), "%15.4f", dvals[i]); str = buf; });
+		bench("snprintf(%g, float)", [&](int i){ std::snprintf(buf, sizeof(buf), "%g", static_cast<double>(fvals[i])); str = buf; });
+	}
+	bench("stream(double)", [&](int i){ formatStream(dvals[i], str); });
 }
 
 
 void StringTest::benchmarkStrToInt()
 {
+	using Poco::NumberParser;
+
 	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
+	static volatile int gSink = 0;
 
-	auto benchParse = [&](const char* label, auto fn) {
-		for (int i = 0; i < 1000; ++i) fn();
+	std::mt19937 rng(42);
+	std::vector<std::string> smallStrs(N), decStrs(N), hexStrs(N), hexPrefStrs(N);
+	std::vector<std::string> negStrs(N), bigStrs(N);
+	for (int i = 0; i < N; ++i)
+	{
+		const unsigned v = rng();
+		smallStrs[i] = std::to_string(v % 1000);
+		decStrs[i] = std::to_string(v);
+		char hbuf[32]; std::snprintf(hbuf, sizeof(hbuf), "%X", v);
+		hexStrs[i] = hbuf;
+		hexPrefStrs[i] = std::string("0x") + hbuf;
+		negStrs[i] = std::to_string(-static_cast<int>(v));
+		const auto big = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
+		bigStrs[i] = std::to_string(big);
+	}
+
+	auto bench = [&](const char* label, auto fn) {
+		for (int i = 0; i < 1000; ++i) fn(i % N);
 		sw.restart();
-		for (int i = 0; i < N; ++i) fn();
+		for (int i = 0; i < N; ++i) fn(i);
 		sw.stop();
-		double ms = sw.elapsed() / 1000.0;
+		const double ms = sw.elapsed() / 1000.0;
 		std::cout << std::setw(40) << std::setfill(' ') << label
 		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
 	};
 
-	// Pre-generate string test data
-	std::vector<std::string> smallStrs(N), decStrs(N), hexStrs(N), negStrs(N), bigStrs(N);
+	// Validate that parse() agrees with strtol/strtoul for all test data
+	for (int i = 0; i < N; ++i)
 	{
-		std::mt19937 rng(42);
-		for (int i = 0; i < N; ++i)
-		{
-			unsigned v = rng();
-			smallStrs[i] = std::to_string(v % 1000);
-			decStrs[i] = std::to_string(v);
-			char hbuf[32]; std::snprintf(hbuf, sizeof(hbuf), "%X", v);
-			hexStrs[i] = hbuf;
-			negStrs[i] = std::to_string(-static_cast<int>(v));
-			auto big = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
-			bigStrs[i] = std::to_string(big);
-		}
+		assertEqual(static_cast<int>(std::strtol(decStrs[i].c_str(), nullptr, 10)),
+			static_cast<int>(NumberParser::parseUnsigned(decStrs[i])));
+		assertEqual(static_cast<int>(std::strtol(negStrs[i].c_str(), nullptr, 10)),
+			NumberParser::parse(negStrs[i]));
 	}
 
-	std::cout << std::endl << "strToInt parsing benchmark (" << N << " iterations)" << std::endl;
+	std::cout << std::endl << "NumberParser integer (" << N << " random values)" << std::endl;
 	std::cout << std::string(55, '-') << std::endl;
 
 	{
 		int r; unsigned ur; Poco::UInt64 ur64;
 
-		std::cout << std::endl << "Small strings (0-999, random):" << std::endl;
-		benchParse("strToInt(small, uint, 10)", [&]{ static int idx = 0; strToInt(smallStrs[idx++ % N], ur, 10); });
+		bench("parse(small dec)", [&](int i){ r = NumberParser::parse(smallStrs[i % N]); gSink += r; });
+		bench("parse(uint dec)", [&](int i){ ur = NumberParser::parseUnsigned(decStrs[i % N]); gSink += ur; });
+		bench("parse(int neg)", [&](int i){ r = NumberParser::parse(negStrs[i % N]); gSink += r; });
+		bench("parseHex(uint)", [&](int i){ ur = NumberParser::parseHex(hexStrs[i % N]); gSink += ur; });
+		bench("parseHex(0x-prefixed)", [&](int i){ ur = NumberParser::parseHex(hexPrefStrs[i % N]); gSink += ur; });
+		bench("parseUnsigned64(uint64)", [&](int i){ ur64 = NumberParser::parseUnsigned64(bigStrs[i % N]); gSink += static_cast<int>(ur64); });
 
-		std::cout << std::endl << "Random strings:" << std::endl;
-		benchParse("strToInt(dec, uint, 10)", [&]{ static int idx = 0; strToInt(decStrs[idx++ % N], ur, 10); });
-		benchParse("strToInt(neg, int, 10)", [&]{ static int idx = 0; strToInt(negStrs[idx++ % N], r, 10); });
-		benchParse("strToInt(hex, uint, 16)", [&]{ static int idx = 0; strToInt(hexStrs[idx++ % N], ur, 16); });
-		benchParse("strToInt(uint64, uint64, 10)", [&]{ static int idx = 0; strToInt(bigStrs[idx++ % N], ur64, 10); });
+		std::cout << std::endl << "  baselines:" << std::endl;
+		bench("std::strtol(small dec)", [&](int i){ gSink += static_cast<int>(std::strtol(smallStrs[i % N].c_str(), nullptr, 10)); });
+		bench("std::strtol(dec)", [&](int i){ gSink += static_cast<int>(std::strtol(decStrs[i % N].c_str(), nullptr, 10)); });
+		bench("std::strtol(neg)", [&](int i){ gSink += static_cast<int>(std::strtol(negStrs[i % N].c_str(), nullptr, 10)); });
+		bench("std::strtoul(hex)", [&](int i){ gSink += static_cast<int>(std::strtoul(hexStrs[i % N].c_str(), nullptr, 16)); });
+		bench("std::strtoull(uint64)", [&](int i){ gSink += static_cast<int>(std::strtoull(bigStrs[i % N].c_str(), nullptr, 10)); });
+		{
+			int v; double d;
+			bench("sscanf(%d)", [&](int i){ std::sscanf(decStrs[i % N].c_str(), "%d", &v); gSink += v; });
+			bench("sscanf(%x)", [&](int i){ std::sscanf(hexStrs[i % N].c_str(), "%x", reinterpret_cast<unsigned*>(&v)); gSink += v; });
+		}
 	}
 }
 
@@ -1494,177 +1511,149 @@ void StringTest::benchmarkStrToInt()
 void StringTest::benchmarkIntToStr()
 {
 	using Poco::NumberFormatter;
-	using Poco::intToStr;
 
 	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
 	std::string str;
-	static volatile int gSink = 0;
 
-	// Pre-generate random test data to avoid constant-folding
-	std::vector<int> ivals(N);        // full-range int
-	std::vector<unsigned> uvals(N);   // full-range unsigned
+	std::mt19937 rng(42);
+	std::vector<int> ivals(N);
+	std::vector<unsigned> uvals(N);
 	std::vector<Poco::Int64> i64vals(N);
 	std::vector<Poco::UInt64> u64vals(N);
-	std::vector<int> ismall(N);       // small values 0-999
-	std::vector<unsigned> usmall(N);  // small unsigned 0-999
+	std::vector<int> ismall(N);
+	std::vector<unsigned> usmall(N);
+	for (int i = 0; i < N; ++i)
 	{
-		std::mt19937 rng(42); // fixed seed for reproducibility
-		for (int i = 0; i < N; ++i)
-		{
-			ivals[i] = static_cast<int>(rng());
-			uvals[i] = static_cast<unsigned>(rng());
-			i64vals[i] = (static_cast<Poco::Int64>(rng()) << 32) | rng();
-			u64vals[i] = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
-			ismall[i] = static_cast<int>(rng() % 1000);
-			usmall[i] = static_cast<unsigned>(rng() % 1000);
-		}
+		ivals[i] = static_cast<int>(rng());
+		uvals[i] = static_cast<unsigned>(rng());
+		i64vals[i] = (static_cast<Poco::Int64>(rng()) << 32) | rng();
+		u64vals[i] = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
+		ismall[i] = static_cast<int>(rng() % 1000);
+		usmall[i] = static_cast<unsigned>(rng() % 1000);
 	}
 
-	// Benchmark helper for random-data tests (indexed access)
-	auto bench = [&](const char* label, auto fn) -> double {
+	auto bench = [&](const char* label, auto fn) {
 		for (int i = 0; i < 1000; ++i) fn(i % N);
 		sw.restart();
 		for (int i = 0; i < N; ++i) fn(i);
 		sw.stop();
-		double ms = sw.elapsed() / 1000.0;
-		std::cout << std::setw(46) << std::setfill(' ') << label
+		const double ms = sw.elapsed() / 1000.0;
+		std::cout << std::setw(40) << std::setfill(' ') << label
 		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
-		return ms;
 	};
 
-	// ====================================================================
-	// Part 1: intToStr(char*) with random data across formatting options
-	// ====================================================================
+	// Validate format() round-trip: format → strtol must recover the original value
+	for (int i = 0; i < N; ++i)
+	{
+		const std::string formatted = NumberFormatter::format(ivals[i]);
+		const long parsed = std::strtol(formatted.c_str(), nullptr, 10);
+		assertEqual(static_cast<long>(ivals[i]), parsed);
+	}
 
-	std::cout << std::endl << "intToStr(char*) with random data (" << N << " values)" << std::endl;
-	std::cout << std::string(62, '-') << std::endl;
+	std::cout << std::endl << "NumberFormatter integer (" << N << " random values)" << std::endl;
+	std::cout << std::string(55, '-') << std::endl;
 
-	std::cout << std::endl << "small int (0-999, random):" << std::endl;
-	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ismall[i], 10, b, s); gSink += b[0]; });
-	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(usmall[i], 0x10, b, s); gSink += b[0]; });
-
-	std::cout << std::endl << "int (random):" << std::endl;
-	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s); gSink += b[0]; });
-	bench("dec, width=15", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s, false, 15); gSink += b[0]; });
-	bench("dec, width=15, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s, false, 15, '0'); gSink += b[0]; });
-	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s); gSink += b[0]; });
-	bench("hex, prefix", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s, true); gSink += b[0]; });
-	bench("hex, prefix, width=10, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s, true, 10, '0'); gSink += b[0]; });
-
-#ifdef POCO_HAVE_INT64
-	std::cout << std::endl << "Int64 (random):" << std::endl;
-	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(i64vals[i], 10, b, s); gSink += b[0]; });
-	bench("dec, width=25, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(i64vals[i], 10, b, s, false, 25, '0'); gSink += b[0]; });
-	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<Poco::UInt64>(i64vals[i]), 0x10, b, s); gSink += b[0]; });
-	bench("hex, prefix, width=20, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<Poco::UInt64>(i64vals[i]), 0x10, b, s, true, 20, '0'); gSink += b[0]; });
-#endif
-
-	// ====================================================================
-	// Part 2: NumberFormatter throughput with random data
-	// ====================================================================
-
-	std::cout << std::endl << "NumberFormatter throughput (" << N << " random values)" << std::endl;
-	std::cout << std::string(62, '-') << std::endl;
-
-	std::cout << std::endl << "small int (0-999):" << std::endl;
+	std::cout << std::endl << "  small int (0-999):" << std::endl;
 	bench("format(small)", [&](int i){ str = NumberFormatter::format(ismall[i]); });
 	bench("formatHex(small)", [&](int i){ str = NumberFormatter::formatHex(static_cast<unsigned>(usmall[i])); });
 
-	std::cout << std::endl << "int:" << std::endl;
+	std::cout << std::endl << "  int:" << std::endl;
 	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
-	bench("format(int, width)", [&](int i){ str = NumberFormatter::format(ivals[i], 15); });
-	bench("format0(int, width)", [&](int i){ str = NumberFormatter::format0(ivals[i], 15); });
-	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
-	bench("formatHex(int, width)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10); });
+	bench("format(int, width=15)", [&](int i){ str = NumberFormatter::format(ivals[i], 15); });
+	bench("format0(int, width=15)", [&](int i){ str = NumberFormatter::format0(ivals[i], 15); });
 	bench("format(-int)", [&](int i){ str = NumberFormatter::format(-std::abs(ivals[i])); });
-	bench("format0(-int, width)", [&](int i){ str = NumberFormatter::format0(-std::abs(ivals[i]), 15); });
+	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
+	bench("formatHex(int, width=10)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10); });
+	bench("formatHex(int, prefix)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], true); });
 
-	std::cout << std::endl << "unsigned:" << std::endl;
+	std::cout << std::endl << "  unsigned:" << std::endl;
 	bench("format(unsigned)", [&](int i){ str = NumberFormatter::format(uvals[i]); });
 	bench("formatHex(unsigned)", [&](int i){ str = NumberFormatter::formatHex(uvals[i]); });
 
 #ifdef POCO_HAVE_INT64
-	std::cout << std::endl << "Int64:" << std::endl;
+	std::cout << std::endl << "  Int64 / UInt64:" << std::endl;
 	bench("format(Int64)", [&](int i){ str = NumberFormatter::format(i64vals[i]); });
-	bench("formatHex(Int64)", [&](int i){ str = NumberFormatter::formatHex(i64vals[i]); });
-	bench("format(-Int64)", [&](int i){ str = NumberFormatter::format(-std::abs(i64vals[i])); });
-
-	std::cout << std::endl << "UInt64:" << std::endl;
 	bench("format(UInt64)", [&](int i){ str = NumberFormatter::format(u64vals[i]); });
-	bench("formatHex(UInt64)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i]); });
-	bench("formatHex(UInt64, width)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i], 20); });
+	bench("formatHex(Int64)", [&](int i){ str = NumberFormatter::formatHex(i64vals[i]); });
+	bench("formatHex(UInt64, w=20)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i], 20); });
 #endif
+
+	std::cout << std::endl << "  baselines:" << std::endl;
+	bench("std::to_string(int)", [&](int i){ str = std::to_string(ivals[i]); });
+	bench("std::to_string(unsigned)", [&](int i){ str = std::to_string(uvals[i]); });
+#ifdef POCO_HAVE_INT64
+	bench("std::to_string(Int64)", [&](int i){ str = std::to_string(i64vals[i]); });
+#endif
+	{
+		char buf[32];
+		bench("snprintf(%d, int)", [&](int i){ std::snprintf(buf, sizeof(buf), "%d", ivals[i]); str = buf; });
+		bench("snprintf(%15d, int)", [&](int i){ std::snprintf(buf, sizeof(buf), "%15d", ivals[i]); str = buf; });
+		bench("snprintf(%015d, int)", [&](int i){ std::snprintf(buf, sizeof(buf), "%015d", ivals[i]); str = buf; });
+		bench("snprintf(%X, int)", [&](int i){ std::snprintf(buf, sizeof(buf), "%X", uvals[i]); str = buf; });
+	}
 }
 
 
 void StringTest::benchmarkStrToFloat()
 {
-	double res[5] = {};
+	using Poco::NumberParser;
+	using Poco::NumberFormatter;
+
+	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
-	std::string num = "1.0372157551632929e-112";
-	std::cout << "The Number: " << num << std::endl;
-	sw.start();
-	for (int i = 0; i < 1000000; ++i) parseStream(num, res[0]);
-	sw.stop();
-	std::cout << "parseStream Number: " << std::setprecision(std::numeric_limits<double>::digits10) << res[0] << std::endl;
-	double timeStream = sw.elapsed() / 1000.0;
+	static volatile int gSink = 0;
 
-	// standard strtod
-	char* pC = nullptr;
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) res[1] = std::strtod(num.c_str(), &pC);
-	sw.stop();
-	std::cout << "std::strtod Number: " << res[1] << std::endl;
-	double timeStdStrtod = sw.elapsed() / 1000.0;
+	std::mt19937 rng(42);
+	std::vector<double> dvals(N);
+	std::vector<float> fvals(N);
+	std::vector<std::string> dblStrs(N), fltStrs(N), dblFixedStrs(N);
+	for (int i = 0; i < N; ++i)
+	{
+		const double d = static_cast<double>(static_cast<int>(rng())) / 1000.0;
+		dvals[i] = d;
+		fvals[i] = static_cast<float>(d);
+		dblStrs[i] = NumberFormatter::format(dvals[i]);
+		fltStrs[i] = NumberFormatter::format(fvals[i]);
+		dblFixedStrs[i] = NumberFormatter::format(dvals[i], 4);
+	}
 
-	// POCO Way
-	sw.restart();
-	char ou = 0;
-	for (int i = 0; i < 1000000; ++i) strToDouble(num, res[2], ou);
-	sw.stop();
-	std::cout << "Poco::strToDouble(const string&, double&) Number: " << res[2] << std::endl;
-	double timeStrToDouble = sw.elapsed() / 1000.0;
+	auto bench = [&](const char* label, auto fn) {
+		for (int i = 0; i < 1000; ++i) fn(i % N);
+		sw.restart();
+		for (int i = 0; i < N; ++i) fn(i);
+		sw.stop();
+		const double ms = sw.elapsed() / 1000.0;
+		std::cout << std::setw(40) << std::setfill(' ') << label
+		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
+	};
 
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) res[3] = strToDouble(num.c_str());
-	sw.stop();
-	std::cout << "Poco::strToDouble(const char*) Number: " << res[3] << std::endl;
-	double timeStrtoD = sw.elapsed() / 1000.0;
+	// Validate that POCO parsing agrees with strtod/strtof for all test data
+	for (int i = 0; i < N; ++i)
+	{
+		double pocoD;
+		const double strtodD = std::strtod(dblStrs[i].c_str(), nullptr);
+		assertTrue(NumberParser::tryParseFloat(dblStrs[i], pocoD));
+		assertEqualDelta(strtodD, pocoD, std::abs(strtodD) * 1e-10);
+	}
 
-	// standard sscanf
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) std::sscanf(num.c_str(), "%lf", &res[4]);
-	sw.stop();
-	std::cout << "sscanf Number: " << res[4] << std::endl;
-	double timeScanf = sw.elapsed() / 1000.0;
+	std::cout << std::endl << "NumberParser float/double (" << N << " random values)" << std::endl;
+	std::cout << std::string(55, '-') << std::endl;
 
-	assertEqual (res[0], res[1]);
-	assertEqual (res[1], res[2]);
-	assertEqual (res[2], res[3]);
-	assertEqual (res[3], res[4]);
+	{
+		double d;
+		bench("tryParseFloat(float str)", [&](int i){ NumberParser::tryParseFloat(fltStrs[i % N], d); gSink += static_cast<int>(d); });
+		bench("tryParseFloat(double str)", [&](int i){ NumberParser::tryParseFloat(dblStrs[i % N], d); gSink += static_cast<int>(d); });
+		bench("tryParseFloat(fixed str)", [&](int i){ NumberParser::tryParseFloat(dblFixedStrs[i % N], d); gSink += static_cast<int>(d); });
 
-	int graph;
-	std::cout << std::endl << "Timing and speedup relative to I/O stream:" << std::endl << std::endl;
-	std::cout << std::setw(14) << "Stream:\t" << std::setw(10) << std::setfill(' ') << std::setprecision(4) << timeStream << "[ms]" << std::endl;
-
-	std::cout << std::setw(14) << "std::strtod:\t" << std::setw(10) << std::setfill(' ') << timeStdStrtod << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeStdStrtod) << '\t' ;
-	graph = (int) (timeStream / timeStdStrtod); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl << std::setw(14) << "strToDouble:\t" << std::setw(10) << std::setfill(' ') << timeStrToDouble << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeStrToDouble) << '\t' ;
-	graph = (int) (timeStream / timeStrToDouble); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl << std::setw(14) << "strToDouble:\t" << std::setw(10) << std::setfill(' ')  << timeScanf << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeStrtoD) << '\t' ;
-	graph = (int) (timeStream / timeStrtoD); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl << std::setw(14) << "std::sscanf:\t" << std::setw(10) << std::setfill(' ')  << timeScanf << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeScanf) << '\t' ;
-	graph = (int) (timeStream / timeScanf); for (int i = 0; i < graph; ++i) std::cout << '#';
-
-	std::cout << std::endl;
+		std::cout << std::endl << "  baselines:" << std::endl;
+		bench("std::strtod", [&](int i){ gSink += static_cast<int>(std::strtod(dblStrs[i % N].c_str(), nullptr)); });
+		bench("std::strtof", [&](int i){ gSink += static_cast<int>(std::strtof(fltStrs[i % N].c_str(), nullptr)); });
+		{
+			double v;
+			bench("sscanf(%lf)", [&](int i){ std::sscanf(dblStrs[i % N].c_str(), "%lf", &v); gSink += static_cast<int>(v); });
+		}
+	}
 }
 
 

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1043,7 +1043,7 @@ void StringTest::testIntToString()
 	{
 		char pResult[POCO_MAX_INT_STRING_LEN];
 		std::size_t sz = POCO_MAX_INT_STRING_LEN;
-		intToStr(0, 10, pResult, sz, false, (int) sz + 1, ' ');
+		(void) intToStr(0, 10, pResult, sz, false, (int) sz + 1, ' ');
 		fail ("must throw RangeException");
 	} catch (RangeException&) { }
 }

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -76,7 +76,6 @@ using Poco::Stopwatch;
 using Poco::RangeException;
 using Poco::isIntOverflow;
 using Poco::safeMultiply;
-using Poco::isSafeIntCast;
 using Poco::safeIntCast;
 using Poco::FPEnvironment;
 
@@ -1100,9 +1099,10 @@ void StringTest::testNumericStringLimit()
 	catch(Poco::BadCastException&){}
 
 	signed char sc = 0, st = -1;
+	char ct = -1;
 	assertTrue(!isIntOverflow<signed char>(sc));
-	assertTrue(safeIntCast<char>(sc, st) == sc);
-	assertTrue(st == sc);
+	assertTrue(safeIntCast<char>(sc, ct) == sc);
+	assertTrue(ct == sc);
 
 	short ss = SHRT_MAX;
 	assertTrue(isIntOverflow<signed char>(ss));
@@ -1127,10 +1127,11 @@ void StringTest::testNumericStringLimit()
 	assertTrue(safeIntCast<signed char>(sc, st) == c);
 	assertTrue(st == sc);
 
-	unsigned char uc = 0, ut = -1;
+	unsigned char uc = 0;
+	ct = -1;
 	assertTrue(!isIntOverflow<unsigned char>(uc));
-	assertTrue(safeIntCast<char>(uc, ut) == uc);
-	assertTrue(ut == uc);
+	assertTrue(safeIntCast<char>(uc, ct) == uc);
+	assertTrue(ct == static_cast<char>(uc));
 
 	ss = SHRT_MAX;
 	assertTrue(isIntOverflow<unsigned char>(ss));
@@ -1456,7 +1457,7 @@ void StringTest::benchmarkStrToInt()
 		char hbuf[32]; std::snprintf(hbuf, sizeof(hbuf), "%X", v);
 		hexStrs[i] = hbuf;
 		hexPrefStrs[i] = std::string("0x") + hbuf;
-		negStrs[i] = std::to_string(-static_cast<int>(v));
+		negStrs[i] = std::to_string(static_cast<int>(-(static_cast<long long>(v) % INT_MAX)));
 		const auto big = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
 		bigStrs[i] = std::to_string(big);
 	}
@@ -1527,7 +1528,7 @@ void StringTest::benchmarkIntToStr()
 	{
 		ivals[i] = static_cast<int>(rng());
 		uvals[i] = static_cast<unsigned>(rng());
-		i64vals[i] = (static_cast<Poco::Int64>(rng()) << 32) | rng();
+		i64vals[i] = static_cast<Poco::Int64>((static_cast<Poco::UInt64>(rng()) << 32) | rng());
 		u64vals[i] = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
 		ismall[i] = static_cast<int>(rng() % 1000);
 		usmall[i] = static_cast<unsigned>(rng() % 1000);
@@ -1562,7 +1563,7 @@ void StringTest::benchmarkIntToStr()
 	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
 	bench("format(int, width=15)", [&](int i){ str = NumberFormatter::format(ivals[i], 15); });
 	bench("format0(int, width=15)", [&](int i){ str = NumberFormatter::format0(ivals[i], 15); });
-	bench("format(-int)", [&](int i){ str = NumberFormatter::format(-std::abs(ivals[i])); });
+	bench("format(-int)", [&](int i){ str = NumberFormatter::format(ivals[i] > 0 ? -ivals[i] : ivals[i]); });
 	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
 	bench("formatHex(int, width=10)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10); });
 	bench("formatHex(int, prefix)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], true); });

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1457,12 +1457,13 @@ void StringTest::benchmarkStrToInt()
 	};
 
 	// Pre-generate string test data
-	std::vector<std::string> decStrs(N), hexStrs(N), negStrs(N), bigStrs(N);
+	std::vector<std::string> smallStrs(N), decStrs(N), hexStrs(N), negStrs(N), bigStrs(N);
 	{
 		std::mt19937 rng(42);
 		for (int i = 0; i < N; ++i)
 		{
 			unsigned v = rng();
+			smallStrs[i] = std::to_string(v % 1000);
 			decStrs[i] = std::to_string(v);
 			char hbuf[32]; std::snprintf(hbuf, sizeof(hbuf), "%X", v);
 			hexStrs[i] = hbuf;
@@ -1475,44 +1476,17 @@ void StringTest::benchmarkStrToInt()
 	std::cout << std::endl << "strToInt parsing benchmark (" << N << " iterations)" << std::endl;
 	std::cout << std::string(55, '-') << std::endl;
 
-	// Per-case with constant strings
-	std::cout << std::endl << "Constant strings:" << std::endl;
-	{
-		int r; unsigned ur; Poco::Int64 r64; Poco::UInt64 ur64;
-		benchParse("strToInt(\"42\", int, 10)", [&]{ strToInt("42", r, 10); });
-		benchParse("strToInt(\"1234567890\", int, 10)", [&]{ strToInt("1234567890", r, 10); });
-		benchParse("strToInt(\"-1234567890\", int, 10)", [&]{ strToInt("-1234567890", r, 10); });
-		benchParse("strToInt(\"DEADBEEF\", uint, 16)", [&]{ strToInt("DEADBEEF", ur, 16); });
-		benchParse("strToInt(\"1,234,567\", int, 10, ',')", [&]{ strToInt("1,234,567", r, 10, ','); });
-		benchParse("strToInt(int64_max, int64, 10)", [&]{ strToInt("9223372036854775807", r64, 10); });
-		benchParse("strToInt(uint64_max, uint64, 10)", [&]{ strToInt("18446744073709551615", ur64, 10); });
-		benchParse("strToInt(\"0\", int, 10)", [&]{ strToInt("0", r, 10); });
-		benchParse("strToInt(\"10101010\", int, 2)", [&]{ strToInt("10101010", r, 2); });
-		benchParse("strToInt(\"777\", uint, 8)", [&]{ strToInt("777", ur, 8); });
-	}
-
-	// Random data
-	std::cout << std::endl << "Random strings:" << std::endl;
 	{
 		int r; unsigned ur; Poco::UInt64 ur64;
-		benchParse("strToInt(random_dec, int, 10)", [&]{ static int idx = 0; strToInt(decStrs[idx++ % N].c_str(), ur, 10); });
-		benchParse("strToInt(random_neg, int, 10)", [&]{ static int idx = 0; strToInt(negStrs[idx++ % N].c_str(), r, 10); });
-		benchParse("strToInt(random_hex, uint, 16)", [&]{ static int idx = 0; strToInt(hexStrs[idx++ % N].c_str(), ur, 16); });
-		benchParse("strToInt(random_uint64, uint64, 10)", [&]{ static int idx = 0; strToInt(bigStrs[idx++ % N].c_str(), ur64, 10); });
-	}
 
-	// Comparison with std::strtol and std::from_chars
-	std::cout << std::endl << "Comparison (\"1234567890\"):" << std::endl;
-	{
-		static volatile int sink = 0;
-		int r;
-		const char* s = "1234567890";
-		char* pEnd;
-		benchParse("strToInt", [&]{ strToInt(s, r, 10); sink = r; });
-		benchParse("std::strtol", [&]{ r = static_cast<int>(std::strtol(s, &pEnd, 10)); sink = r; });
-		benchParse("std::from_chars", [&]{
-			std::from_chars(s, s + 10, r, 10); sink = r;
-		});
+		std::cout << std::endl << "Small strings (0-999, random):" << std::endl;
+		benchParse("strToInt(small, uint, 10)", [&]{ static int idx = 0; strToInt(smallStrs[idx++ % N], ur, 10); });
+
+		std::cout << std::endl << "Random strings:" << std::endl;
+		benchParse("strToInt(dec, uint, 10)", [&]{ static int idx = 0; strToInt(decStrs[idx++ % N], ur, 10); });
+		benchParse("strToInt(neg, int, 10)", [&]{ static int idx = 0; strToInt(negStrs[idx++ % N], r, 10); });
+		benchParse("strToInt(hex, uint, 16)", [&]{ static int idx = 0; strToInt(hexStrs[idx++ % N], ur, 16); });
+		benchParse("strToInt(uint64, uint64, 10)", [&]{ static int idx = 0; strToInt(bigStrs[idx++ % N], ur64, 10); });
 	}
 }
 
@@ -1528,10 +1502,12 @@ void StringTest::benchmarkIntToStr()
 	static volatile int gSink = 0;
 
 	// Pre-generate random test data to avoid constant-folding
-	std::vector<int> ivals(N);
-	std::vector<unsigned> uvals(N);
+	std::vector<int> ivals(N);        // full-range int
+	std::vector<unsigned> uvals(N);   // full-range unsigned
 	std::vector<Poco::Int64> i64vals(N);
 	std::vector<Poco::UInt64> u64vals(N);
+	std::vector<int> ismall(N);       // small values 0-999
+	std::vector<unsigned> usmall(N);  // small unsigned 0-999
 	{
 		std::mt19937 rng(42); // fixed seed for reproducibility
 		for (int i = 0; i < N; ++i)
@@ -1540,6 +1516,8 @@ void StringTest::benchmarkIntToStr()
 			uvals[i] = static_cast<unsigned>(rng());
 			i64vals[i] = (static_cast<Poco::Int64>(rng()) << 32) | rng();
 			u64vals[i] = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
+			ismall[i] = static_cast<int>(rng() % 1000);
+			usmall[i] = static_cast<unsigned>(rng() % 1000);
 		}
 	}
 
@@ -1561,6 +1539,10 @@ void StringTest::benchmarkIntToStr()
 
 	std::cout << std::endl << "intToStr(char*) with random data (" << N << " values)" << std::endl;
 	std::cout << std::string(62, '-') << std::endl;
+
+	std::cout << std::endl << "small int (0-999, random):" << std::endl;
+	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ismall[i], 10, b, s); gSink += b[0]; });
+	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(usmall[i], 0x10, b, s); gSink += b[0]; });
 
 	std::cout << std::endl << "int (random):" << std::endl;
 	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s); gSink += b[0]; });
@@ -1584,6 +1566,10 @@ void StringTest::benchmarkIntToStr()
 
 	std::cout << std::endl << "NumberFormatter throughput (" << N << " random values)" << std::endl;
 	std::cout << std::string(62, '-') << std::endl;
+
+	std::cout << std::endl << "small int (0-999):" << std::endl;
+	bench("format(small)", [&](int i){ str = NumberFormatter::format(ismall[i]); });
+	bench("formatHex(small)", [&](int i){ str = NumberFormatter::formatHex(static_cast<unsigned>(usmall[i])); });
 
 	std::cout << std::endl << "int:" << std::endl;
 	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1471,11 +1471,11 @@ void StringTest::benchmarkStrToInt()
 		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
 	};
 
-	// Validate that parse() agrees with strtol/strtoul for all test data
+	// Validate that parse() agrees with strtoul/strtol for all test data
 	for (int i = 0; i < N; ++i)
 	{
-		assertEqual(static_cast<int>(std::strtol(decStrs[i].c_str(), nullptr, 10)),
-			static_cast<int>(NumberParser::parseUnsigned(decStrs[i])));
+		assertEqual(static_cast<unsigned>(std::strtoul(decStrs[i].c_str(), nullptr, 10)),
+			NumberParser::parseUnsigned(decStrs[i]));
 		assertEqual(static_cast<int>(std::strtol(negStrs[i].c_str(), nullptr, 10)),
 			NumberParser::parse(negStrs[i]));
 	}

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1500,7 +1500,7 @@ void StringTest::benchmarkStrToInt()
 		bench("std::strtoul(hex)", [&](int i){ gSink += static_cast<int>(std::strtoul(hexStrs[i % N].c_str(), nullptr, 16)); });
 		bench("std::strtoull(uint64)", [&](int i){ gSink += static_cast<int>(std::strtoull(bigStrs[i % N].c_str(), nullptr, 10)); });
 		{
-			int v; double d;
+			int v;
 			bench("sscanf(%d)", [&](int i){ std::sscanf(decStrs[i % N].c_str(), "%d", &v); gSink += v; });
 			bench("sscanf(%x)", [&](int i){ std::sscanf(hexStrs[i % N].c_str(), "%x", reinterpret_cast<unsigned*>(&v)); gSink += v; });
 		}

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -1443,63 +1443,89 @@ void StringTest::benchmarkFloatToStr()
 
 void StringTest::benchmarkStrToInt()
 {
+	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
-	std::string num = "123456789";
-	int res[4] = {};
-	sw.start();
-	for (int i = 0; i < 1000000; ++i) parseStream(num, res[0]);
-	sw.stop();
-	std::cout << "parseStream Number: " << res[0] << std::endl;
-	double timeStream = sw.elapsed() / 1000.0;
 
-	char* pC = nullptr;
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) res[1] = std::strtol(num.c_str(), &pC, 10);
-	sw.stop();
-	std::cout << "std::strtol Number: " << res[1] << std::endl;
-	double timeStrtol = sw.elapsed() / 1000.0;
+	auto benchParse = [&](const char* label, auto fn) {
+		for (int i = 0; i < 1000; ++i) fn();
+		sw.restart();
+		for (int i = 0; i < N; ++i) fn();
+		sw.stop();
+		double ms = sw.elapsed() / 1000.0;
+		std::cout << std::setw(40) << std::setfill(' ') << label
+		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
+	};
 
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) strToInt(num.c_str(), res[2], 10);
-	sw.stop();
-	std::cout << "strToInt Number: " << res[2] << std::endl;
-	double timeStrToInt = sw.elapsed() / 1000.0;
+	// Pre-generate string test data
+	std::vector<std::string> decStrs(N), hexStrs(N), negStrs(N), bigStrs(N);
+	{
+		std::mt19937 rng(42);
+		for (int i = 0; i < N; ++i)
+		{
+			unsigned v = rng();
+			decStrs[i] = std::to_string(v);
+			char hbuf[32]; std::snprintf(hbuf, sizeof(hbuf), "%X", v);
+			hexStrs[i] = hbuf;
+			negStrs[i] = std::to_string(-static_cast<int>(v));
+			auto big = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
+			bigStrs[i] = std::to_string(big);
+		}
+	}
 
-	sw.restart();
-	for (int i = 0; i < 1000000; ++i) std::sscanf(num.c_str(), "%d", &res[3]);
-	sw.stop();
-	std::cout << "sscanf Number: " << res[3] << std::endl;
-	double timeScanf = sw.elapsed() / 1000.0;
+	std::cout << std::endl << "strToInt parsing benchmark (" << N << " iterations)" << std::endl;
+	std::cout << std::string(55, '-') << std::endl;
 
-	assertEqual (res[0], res[1]);
-	assertEqual (res[1], res[2]);
-	assertEqual (res[2], res[3]);
+	// Per-case with constant strings
+	std::cout << std::endl << "Constant strings:" << std::endl;
+	{
+		int r; unsigned ur; Poco::Int64 r64; Poco::UInt64 ur64;
+		benchParse("strToInt(\"42\", int, 10)", [&]{ strToInt("42", r, 10); });
+		benchParse("strToInt(\"1234567890\", int, 10)", [&]{ strToInt("1234567890", r, 10); });
+		benchParse("strToInt(\"-1234567890\", int, 10)", [&]{ strToInt("-1234567890", r, 10); });
+		benchParse("strToInt(\"DEADBEEF\", uint, 16)", [&]{ strToInt("DEADBEEF", ur, 16); });
+		benchParse("strToInt(\"1,234,567\", int, 10, ',')", [&]{ strToInt("1,234,567", r, 10, ','); });
+		benchParse("strToInt(int64_max, int64, 10)", [&]{ strToInt("9223372036854775807", r64, 10); });
+		benchParse("strToInt(uint64_max, uint64, 10)", [&]{ strToInt("18446744073709551615", ur64, 10); });
+		benchParse("strToInt(\"0\", int, 10)", [&]{ strToInt("0", r, 10); });
+		benchParse("strToInt(\"10101010\", int, 2)", [&]{ strToInt("10101010", r, 2); });
+		benchParse("strToInt(\"777\", uint, 8)", [&]{ strToInt("777", ur, 8); });
+	}
 
-	int graph;
-	std::cout << std::endl << "Timing and speedup relative to I/O stream:" << std::endl << std::endl;
-	std::cout << std::setw(14) << "Stream:\t" << std::setw(10) << std::setfill(' ') << timeStream << "[ms]" << std::endl;
+	// Random data
+	std::cout << std::endl << "Random strings:" << std::endl;
+	{
+		int r; unsigned ur; Poco::UInt64 ur64;
+		benchParse("strToInt(random_dec, int, 10)", [&]{ static int idx = 0; strToInt(decStrs[idx++ % N].c_str(), ur, 10); });
+		benchParse("strToInt(random_neg, int, 10)", [&]{ static int idx = 0; strToInt(negStrs[idx++ % N].c_str(), r, 10); });
+		benchParse("strToInt(random_hex, uint, 16)", [&]{ static int idx = 0; strToInt(hexStrs[idx++ % N].c_str(), ur, 16); });
+		benchParse("strToInt(random_uint64, uint64, 10)", [&]{ static int idx = 0; strToInt(bigStrs[idx++ % N].c_str(), ur64, 10); });
+	}
 
-	std::cout << std::setw(14) << "std::strtol:\t" << std::setw(10) << std::setfill(' ') << timeStrtol << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeStrtol) << '\t' ;
-	graph = (int) (timeStream / timeStrtol); for (int i = 0; i < graph; ++i) std::cout << '|';
-
-	std::cout << std::endl << std::setw(14) << "strToInt:\t" << std::setw(10) << std::setfill(' ') << timeStrToInt << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeStrToInt) << '\t' ;
-	graph = (int) (timeStream / timeStrToInt); for (int i = 0; i < graph; ++i) std::cout << '|';
-
-	std::cout << std::endl << std::setw(14) << "std::sscanf:\t" << std::setw(10) << std::setfill(' ')  << timeScanf << "[ms]" <<
-	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeScanf) << '\t' ;
-	graph = (int) (timeStream / timeScanf); for (int i = 0; i < graph; ++i) std::cout << '|';
-	std::cout << std::endl;
+	// Comparison with std::strtol and std::from_chars
+	std::cout << std::endl << "Comparison (\"1234567890\"):" << std::endl;
+	{
+		static volatile int sink = 0;
+		int r;
+		const char* s = "1234567890";
+		char* pEnd;
+		benchParse("strToInt", [&]{ strToInt(s, r, 10); sink = r; });
+		benchParse("std::strtol", [&]{ r = static_cast<int>(std::strtol(s, &pEnd, 10)); sink = r; });
+		benchParse("std::from_chars", [&]{
+			std::from_chars(s, s + 10, r, 10); sink = r;
+		});
+	}
 }
 
 
 void StringTest::benchmarkIntToStr()
 {
 	using Poco::NumberFormatter;
+	using Poco::intToStr;
+
 	constexpr int N = 1000000;
 	Poco::Stopwatch sw;
 	std::string str;
+	static volatile int gSink = 0;
 
 	// Pre-generate random test data to avoid constant-folding
 	std::vector<int> ivals(N);
@@ -1517,8 +1543,9 @@ void StringTest::benchmarkIntToStr()
 		}
 	}
 
+	// Benchmark helper for random-data tests (indexed access)
 	auto bench = [&](const char* label, auto fn) -> double {
-		for (int i = 0; i < 1000; ++i) fn(i % N);  // warmup
+		for (int i = 0; i < 1000; ++i) fn(i % N);
 		sw.restart();
 		for (int i = 0; i < N; ++i) fn(i);
 		sw.stop();
@@ -1528,103 +1555,60 @@ void StringTest::benchmarkIntToStr()
 		return ms;
 	};
 
-	std::cout << std::endl << "NumberFormatter/intToStr benchmark (" << N << " iterations)" << std::endl;
+	// ====================================================================
+	// Part 1: intToStr(char*) with random data across formatting options
+	// ====================================================================
+
+	std::cout << std::endl << "intToStr(char*) with random data (" << N << " values)" << std::endl;
 	std::cout << std::string(62, '-') << std::endl;
 
-	// ---- int ----
+	std::cout << std::endl << "int (random):" << std::endl;
+	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s); gSink += b[0]; });
+	bench("dec, width=15", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s, false, 15); gSink += b[0]; });
+	bench("dec, width=15, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(ivals[i], 10, b, s, false, 15, '0'); gSink += b[0]; });
+	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s); gSink += b[0]; });
+	bench("hex, prefix", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s, true); gSink += b[0]; });
+	bench("hex, prefix, width=10, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<unsigned>(ivals[i]), 0x10, b, s, true, 10, '0'); gSink += b[0]; });
+
+#ifdef POCO_HAVE_INT64
+	std::cout << std::endl << "Int64 (random):" << std::endl;
+	bench("dec", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(i64vals[i], 10, b, s); gSink += b[0]; });
+	bench("dec, width=25, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(i64vals[i], 10, b, s, false, 25, '0'); gSink += b[0]; });
+	bench("hex", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<Poco::UInt64>(i64vals[i]), 0x10, b, s); gSink += b[0]; });
+	bench("hex, prefix, width=20, '0'", [&](int i){ char b[POCO_MAX_INT_STRING_LEN]; std::size_t s = sizeof(b); intToStr(static_cast<Poco::UInt64>(i64vals[i]), 0x10, b, s, true, 20, '0'); gSink += b[0]; });
+#endif
+
+	// ====================================================================
+	// Part 2: NumberFormatter throughput with random data
+	// ====================================================================
+
+	std::cout << std::endl << "NumberFormatter throughput (" << N << " random values)" << std::endl;
+	std::cout << std::string(62, '-') << std::endl;
+
 	std::cout << std::endl << "int:" << std::endl;
 	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
 	bench("format(int, width)", [&](int i){ str = NumberFormatter::format(ivals[i], 15); });
 	bench("format0(int, width)", [&](int i){ str = NumberFormatter::format0(ivals[i], 15); });
 	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
-	bench("formatHex(int, lower)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], NumberFormatter::Options::HEX_LOWERCASE); });
-	bench("formatHex(int, lower, width)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10, NumberFormatter::Options::HEX_LOWERCASE); });
 	bench("formatHex(int, width)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10); });
 	bench("format(-int)", [&](int i){ str = NumberFormatter::format(-std::abs(ivals[i])); });
 	bench("format0(-int, width)", [&](int i){ str = NumberFormatter::format0(-std::abs(ivals[i]), 15); });
 
-	// ---- unsigned ----
 	std::cout << std::endl << "unsigned:" << std::endl;
 	bench("format(unsigned)", [&](int i){ str = NumberFormatter::format(uvals[i]); });
-	bench("format(unsigned, width)", [&](int i){ str = NumberFormatter::format(uvals[i], 15); });
-	bench("format0(unsigned, width)", [&](int i){ str = NumberFormatter::format0(uvals[i], 15); });
 	bench("formatHex(unsigned)", [&](int i){ str = NumberFormatter::formatHex(uvals[i]); });
-	bench("formatHex(unsigned, width)", [&](int i){ str = NumberFormatter::formatHex(uvals[i], 10); });
-
-	// ---- long ----
-	std::cout << std::endl << "long:" << std::endl;
-	bench("format(long)", [&](int i){ str = NumberFormatter::format(static_cast<long>(ivals[i])); });
-	bench("formatHex(long)", [&](int i){ str = NumberFormatter::formatHex(static_cast<long>(ivals[i])); });
-
-	// ---- unsigned long ----
-	std::cout << std::endl << "unsigned long:" << std::endl;
-	bench("format(unsigned long)", [&](int i){ str = NumberFormatter::format(static_cast<unsigned long>(uvals[i])); });
-	bench("formatHex(unsigned long)", [&](int i){ str = NumberFormatter::formatHex(static_cast<unsigned long>(uvals[i])); });
-
-	// ---- hex deep-dive ----
-	std::cout << std::endl << "hex formatting approaches (int):" << std::endl;
-	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
-	bench("appendHex(str, int)", [&](int i){ str.clear(); NumberFormatter::appendHex(str, ivals[i]); });
-	bench("intToStr(int, 16, string)", [&](int i){ intToStr(uvals[i], 0x10, str); });
-	bench("intToStr(int, 16, char*)", [&](int i){
-		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
-		intToStr(uvals[i], 0x10, buf, sz);
-	});
-	{
-		char buf[32];
-		bench("std::to_chars hex", [&](int i){
-			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), uvals[i], 16);
-			static volatile char sink; sink = *buf;
-		});
-	}
-
-	std::cout << std::endl << "hex formatting approaches (UInt64):" << std::endl;
-	bench("formatHex(UInt64)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i]); });
-	bench("appendHex(str, UInt64)", [&](int i){ str.clear(); NumberFormatter::appendHex(str, u64vals[i]); });
-	bench("intToStr(UInt64, 16, char*)", [&](int i){
-		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
-		intToStr(u64vals[i], 0x10, buf, sz);
-	});
-	{
-		char buf[32];
-		bench("std::to_chars hex UInt64", [&](int i){
-			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), u64vals[i], 16);
-			static volatile char sink; sink = *buf;
-		});
-	}
-
-	std::cout << std::endl << "decimal formatting approaches (int):" << std::endl;
-	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
-	bench("append(str, int)", [&](int i){ str.clear(); NumberFormatter::append(str, ivals[i]); });
-	bench("intToStr(int, 10, char*)", [&](int i){
-		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
-		intToStr(ivals[i], 10, buf, sz);
-	});
-	{
-		char buf[32];
-		bench("std::to_chars dec", [&](int i){
-			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), ivals[i]);
-			static volatile char sink; sink = *buf;
-		});
-	}
 
 #ifdef POCO_HAVE_INT64
-
-	// ---- Int64 ----
 	std::cout << std::endl << "Int64:" << std::endl;
 	bench("format(Int64)", [&](int i){ str = NumberFormatter::format(i64vals[i]); });
-	bench("format(Int64, width)", [&](int i){ str = NumberFormatter::format(i64vals[i], 25); });
-	bench("format0(Int64, width)", [&](int i){ str = NumberFormatter::format0(i64vals[i], 25); });
 	bench("formatHex(Int64)", [&](int i){ str = NumberFormatter::formatHex(i64vals[i]); });
 	bench("format(-Int64)", [&](int i){ str = NumberFormatter::format(-std::abs(i64vals[i])); });
 
-	// ---- UInt64 ----
 	std::cout << std::endl << "UInt64:" << std::endl;
 	bench("format(UInt64)", [&](int i){ str = NumberFormatter::format(u64vals[i]); });
 	bench("formatHex(UInt64)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i]); });
 	bench("formatHex(UInt64, width)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i], 20); });
-
-#endif // POCO_HAVE_INT64
+#endif
 }
 
 

--- a/Foundation/testsuite/src/StringTest.cpp
+++ b/Foundation/testsuite/src/StringTest.cpp
@@ -23,9 +23,14 @@
 #include "Poco/Stopwatch.h"
 #include "Poco/FPEnvironment.h"
 #include "Poco/Exception.h"
+#include "Poco/NumberFormatter.h"
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <charconv>
+#include <cstdint>
+#include <random>
+#include <vector>
 #include <cstdio>
 #include <climits>
 #include <map>
@@ -1373,6 +1378,9 @@ void StringTest::conversionBenchmarks()
 	std::cout << "===================" << std::endl;
 	benchmarkStrToInt();
 	std::cout << "===================" << std::endl << std::endl;
+	std::cout << "===================" << std::endl;
+	benchmarkIntToStr();
+	std::cout << "===================" << std::endl << std::endl;
 }
 
 
@@ -1483,6 +1491,140 @@ void StringTest::benchmarkStrToInt()
 	std::setw(10) << std::setfill(' ')  << "Speedup: " << (timeStream / timeScanf) << '\t' ;
 	graph = (int) (timeStream / timeScanf); for (int i = 0; i < graph; ++i) std::cout << '|';
 	std::cout << std::endl;
+}
+
+
+void StringTest::benchmarkIntToStr()
+{
+	using Poco::NumberFormatter;
+	constexpr int N = 1000000;
+	Poco::Stopwatch sw;
+	std::string str;
+
+	// Pre-generate random test data to avoid constant-folding
+	std::vector<int> ivals(N);
+	std::vector<unsigned> uvals(N);
+	std::vector<Poco::Int64> i64vals(N);
+	std::vector<Poco::UInt64> u64vals(N);
+	{
+		std::mt19937 rng(42); // fixed seed for reproducibility
+		for (int i = 0; i < N; ++i)
+		{
+			ivals[i] = static_cast<int>(rng());
+			uvals[i] = static_cast<unsigned>(rng());
+			i64vals[i] = (static_cast<Poco::Int64>(rng()) << 32) | rng();
+			u64vals[i] = (static_cast<Poco::UInt64>(rng()) << 32) | rng();
+		}
+	}
+
+	auto bench = [&](const char* label, auto fn) -> double {
+		for (int i = 0; i < 1000; ++i) fn(i % N);  // warmup
+		sw.restart();
+		for (int i = 0; i < N; ++i) fn(i);
+		sw.stop();
+		double ms = sw.elapsed() / 1000.0;
+		std::cout << std::setw(46) << std::setfill(' ') << label
+		          << std::setw(10) << std::fixed << std::setprecision(2) << ms << " ms" << std::endl;
+		return ms;
+	};
+
+	std::cout << std::endl << "NumberFormatter/intToStr benchmark (" << N << " iterations)" << std::endl;
+	std::cout << std::string(62, '-') << std::endl;
+
+	// ---- int ----
+	std::cout << std::endl << "int:" << std::endl;
+	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
+	bench("format(int, width)", [&](int i){ str = NumberFormatter::format(ivals[i], 15); });
+	bench("format0(int, width)", [&](int i){ str = NumberFormatter::format0(ivals[i], 15); });
+	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
+	bench("formatHex(int, lower)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], NumberFormatter::Options::HEX_LOWERCASE); });
+	bench("formatHex(int, lower, width)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10, NumberFormatter::Options::HEX_LOWERCASE); });
+	bench("formatHex(int, width)", [&](int i){ str = NumberFormatter::formatHex(ivals[i], 10); });
+	bench("format(-int)", [&](int i){ str = NumberFormatter::format(-std::abs(ivals[i])); });
+	bench("format0(-int, width)", [&](int i){ str = NumberFormatter::format0(-std::abs(ivals[i]), 15); });
+
+	// ---- unsigned ----
+	std::cout << std::endl << "unsigned:" << std::endl;
+	bench("format(unsigned)", [&](int i){ str = NumberFormatter::format(uvals[i]); });
+	bench("format(unsigned, width)", [&](int i){ str = NumberFormatter::format(uvals[i], 15); });
+	bench("format0(unsigned, width)", [&](int i){ str = NumberFormatter::format0(uvals[i], 15); });
+	bench("formatHex(unsigned)", [&](int i){ str = NumberFormatter::formatHex(uvals[i]); });
+	bench("formatHex(unsigned, width)", [&](int i){ str = NumberFormatter::formatHex(uvals[i], 10); });
+
+	// ---- long ----
+	std::cout << std::endl << "long:" << std::endl;
+	bench("format(long)", [&](int i){ str = NumberFormatter::format(static_cast<long>(ivals[i])); });
+	bench("formatHex(long)", [&](int i){ str = NumberFormatter::formatHex(static_cast<long>(ivals[i])); });
+
+	// ---- unsigned long ----
+	std::cout << std::endl << "unsigned long:" << std::endl;
+	bench("format(unsigned long)", [&](int i){ str = NumberFormatter::format(static_cast<unsigned long>(uvals[i])); });
+	bench("formatHex(unsigned long)", [&](int i){ str = NumberFormatter::formatHex(static_cast<unsigned long>(uvals[i])); });
+
+	// ---- hex deep-dive ----
+	std::cout << std::endl << "hex formatting approaches (int):" << std::endl;
+	bench("formatHex(int)", [&](int i){ str = NumberFormatter::formatHex(ivals[i]); });
+	bench("appendHex(str, int)", [&](int i){ str.clear(); NumberFormatter::appendHex(str, ivals[i]); });
+	bench("intToStr(int, 16, string)", [&](int i){ intToStr(uvals[i], 0x10, str); });
+	bench("intToStr(int, 16, char*)", [&](int i){
+		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
+		intToStr(uvals[i], 0x10, buf, sz);
+	});
+	{
+		char buf[32];
+		bench("std::to_chars hex", [&](int i){
+			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), uvals[i], 16);
+			static volatile char sink; sink = *buf;
+		});
+	}
+
+	std::cout << std::endl << "hex formatting approaches (UInt64):" << std::endl;
+	bench("formatHex(UInt64)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i]); });
+	bench("appendHex(str, UInt64)", [&](int i){ str.clear(); NumberFormatter::appendHex(str, u64vals[i]); });
+	bench("intToStr(UInt64, 16, char*)", [&](int i){
+		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
+		intToStr(u64vals[i], 0x10, buf, sz);
+	});
+	{
+		char buf[32];
+		bench("std::to_chars hex UInt64", [&](int i){
+			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), u64vals[i], 16);
+			static volatile char sink; sink = *buf;
+		});
+	}
+
+	std::cout << std::endl << "decimal formatting approaches (int):" << std::endl;
+	bench("format(int)", [&](int i){ str = NumberFormatter::format(ivals[i]); });
+	bench("append(str, int)", [&](int i){ str.clear(); NumberFormatter::append(str, ivals[i]); });
+	bench("intToStr(int, 10, char*)", [&](int i){
+		char buf[POCO_MAX_INT_STRING_LEN]; std::size_t sz = POCO_MAX_INT_STRING_LEN;
+		intToStr(ivals[i], 10, buf, sz);
+	});
+	{
+		char buf[32];
+		bench("std::to_chars dec", [&](int i){
+			auto [p, ec] = std::to_chars(buf, buf + sizeof(buf), ivals[i]);
+			static volatile char sink; sink = *buf;
+		});
+	}
+
+#ifdef POCO_HAVE_INT64
+
+	// ---- Int64 ----
+	std::cout << std::endl << "Int64:" << std::endl;
+	bench("format(Int64)", [&](int i){ str = NumberFormatter::format(i64vals[i]); });
+	bench("format(Int64, width)", [&](int i){ str = NumberFormatter::format(i64vals[i], 25); });
+	bench("format0(Int64, width)", [&](int i){ str = NumberFormatter::format0(i64vals[i], 25); });
+	bench("formatHex(Int64)", [&](int i){ str = NumberFormatter::formatHex(i64vals[i]); });
+	bench("format(-Int64)", [&](int i){ str = NumberFormatter::format(-std::abs(i64vals[i])); });
+
+	// ---- UInt64 ----
+	std::cout << std::endl << "UInt64:" << std::endl;
+	bench("format(UInt64)", [&](int i){ str = NumberFormatter::format(u64vals[i]); });
+	bench("formatHex(UInt64)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i]); });
+	bench("formatHex(UInt64, width)", [&](int i){ str = NumberFormatter::formatHex(u64vals[i], 20); });
+
+#endif // POCO_HAVE_INT64
 }
 
 

--- a/Foundation/testsuite/src/StringTest.h
+++ b/Foundation/testsuite/src/StringTest.h
@@ -16,7 +16,6 @@
 
 #include "Poco/Foundation.h"
 #include "CppUnit/TestCase.h"
-#include "Poco/NumericString.h"
 #include "Poco/MemoryStream.h"
 #include "Poco/NumberFormatter.h"
 #include <limits>
@@ -62,6 +61,7 @@ public:
 	void benchmarkFloatToStr();
 	void benchmarkStrToFloat();
 	void benchmarkStrToInt();
+	void benchmarkIntToStr();
 
 	void testJSONString();
 

--- a/Foundation/testsuite/src/StringTest.h
+++ b/Foundation/testsuite/src/StringTest.h
@@ -16,7 +16,6 @@
 
 #include "Poco/Foundation.h"
 #include "CppUnit/TestCase.h"
-#include "Poco/MemoryStream.h"
 #include "Poco/NumberFormatter.h"
 #include <limits>
 
@@ -165,16 +164,6 @@ private:
 		assertFalse (Poco::safeMultiply(t, f, m));
 	}
 
-	template <typename T>
-	bool parseStream(const std::string& s, T& value)
-	{
-		Poco::MemoryInputStream istr(s.data(), s.size());
-#if !defined(POCO_NO_LOCALE)
-		istr.imbue(std::locale::classic());
-#endif
-		istr >> value;
-		return istr.eof() && !istr.fail();
-	}
 };
 
 


### PR DESCRIPTION
## Summary

Rewrites integer and floating-point conversion in `NumericString.h`/`.cpp` for
significantly improved performance, using modern C++17/C++20 techniques while
maintaining full API compatibility.

### Integer formatting (`intToStr`)

Based on the [implementation suggested by @aleks-f](https://gist.github.com/aleks-f/d2ea39a465a3ea1dde5ebcbcc1a159d2),
replaces the old division-based loop with the **two-digits-at-a-time** algorithm
using a 200-byte digit-pairs lookup table (as used by {fmt}, jemalloc, Facebook Folly).
Shift-and-mask for hex and power-of-2 bases. Writes directly into the result buffer
in reverse, then reverses in-place -- no intermediate buffer copy.

### Integer parsing (`strToInt`)

Replaced the manual digit loop with `std::from_chars` (C++17). Range-based
`(begin, end)` core overload avoids `strlen`. Thousand-separator slow path only
triggers when `from_chars` stops at a non-digit character.

### Float/double formatting (`floatToStr`, `doubleToStr`)

When `POCO_HAS_FLOAT_CHARCONV` is defined (GCC 11+, MSVC 19.24+, non-Apple
libc++ 20+, or Apple Clang with macOS 26.0+ deployment target), uses
`std::to_chars` for shortest representation and `std::to_chars(fixed) +
adjustPrecision` for fixed-precision formatting. Falls back to bundled
double-conversion library on older compilers.

To enable on Apple Clang, set the deployment target:
\`\`\`bash
cmake -B build -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0
\`\`\`

**Caveat**: `std::to_chars(fixed)` + manual precision adjustment is slower than
double-conversion's integrated `ToFixed` for fixed-precision formatting on macOS
Apple Clang (0.6x for `format(double, prec=2)`). This is a tradeoff: the
`std::to_chars` path eliminates ~6800 lines of bundled double-conversion dependency
when the feature is available. As stdlib implementations improve, this gap should
close. The double-conversion fallback remains available for older compilers where
it is the only option.

### Float/double parsing (`strToFloat`, `strToDouble`)

When `POCO_HAS_FLOAT_CHARCONV` is defined, uses `std::from_chars` with manual
inf/nan handling (matching double-conversion's exact-match semantics).
Falls back to `strtod` for out-of-range values (extreme underflow/overflow)
where `from_chars` reports `errc::result_out_of_range`.

### Other changes

- `POCO_HAS_FLOAT_CHARCONV` feature detection macro in `Config.h`
- Float/double functions in `NumericString.h` remain `Foundation_API` exported
  (required by inline `NumberFormatter` methods compiled into other libraries)
- `if constexpr` in `isIntOverflow` and `safeMultiply` (C++17 consistency)
- `[[nodiscard]]` on `strToInt`, `intToStr`, `safeMultiply`
- `intToStr` uses `size` parameter as buffer capacity for bounds checking
- `poco_bugcheck()` in unreachable switch default
- Removed obsolete MSVC `#pragma warning(disable: 4146)`
- Moved `<cmath>` from header to .cpp, removed unused `<memory>`
- `tryParseHex`/`tryParseHex64` now skip leading whitespace before 0x prefix
- Benchmarks rewritten to use `NumberFormatter`/`NumberParser` public API with
  baselines (std::to_string, snprintf, strtol, strtod, sscanf) and round-trip
  correctness validation

## Performance (5M random values, macOS Apple Clang arm64 / Linux GCC arm64)

### NumberFormatter -- Integer

| Operation | macOS speedup | Linux speedup |
|---|---|---|
| format(small 0-999) | 1.2x | 1.2x |
| format(int) | **1.7x** | **2.3x** |
| format(int, w=15) | **1.5x** | **1.9x** |
| format(-int) | **1.5x** | **1.9x** |
| formatHex(int) | **1.4x** | **1.7x** |
| format(Int64) | **2.7x** | **1.7x** |
| format(UInt64) | **2.3x** | **1.6x** |
| formatHex(Int64) | **2.3x** | 1.4x |

### NumberFormatter -- Float/Double

| Operation | macOS speedup | Linux speedup |
|---|---|---|
| format(float) shortest | **1.8x** | **2.5x** |
| format(double) shortest | ~same | ~same |
| format(double, prec=2) | **0.6x** (regression) | 0.9x |
| format(double, w=15, prec=4) | ~same | ~same |

### NumberParser -- Integer

| Operation | macOS speedup | Linux speedup |
|---|---|---|
| parse(uint dec) | **1.4x** | **2.2x** |
| parseHex(uint) | 1.2x | **3.7x** |
| parseUnsigned64 | **1.9x** | **2.8x** |

### NumberParser -- Float/Double

| Operation | macOS speedup | Linux speedup |
|---|---|---|
| tryParseFloat(double) | 1.2x | **1.5x** |

### vs standard library

| vs snprintf | Integer | Float |
|---|---|---|
| macOS | **2.5-4x faster** | **2-3x faster** |
| Linux | **2.8-4.3x faster** | **2.5-4.3x faster** |

| vs sscanf | Integer | Float |
|---|---|---|
| macOS | **3-5x faster** | **1.9x faster** |
| Linux | **3-5x faster** | **2.7x faster** |

## Known regressions

- `format(double, prec=2)` on macOS: 0.6x vs main. Root cause: `std::to_chars(fixed)` +
  `adjustPrecision` is slower than double-conversion's `ToFixed`. This is the cost of
  eliminating the double-conversion dependency when `POCO_HAS_FLOAT_CHARCONV` is available.
  On compilers without charconv support, the double-conversion path is unchanged.

## Test plan

- [x] Foundation tests: 946 pass on macOS C++20, macOS C++17 (fallback), Linux GCC
- [x] JSON tests: 48 pass on macOS and Linux (including extreme underflow 123e-10000000)
- [x] Benchmarks on macOS arm64 and Linux arm64 with 5M random values
- [x] Round-trip correctness validation (format -> parse, parse -> strtol/strtod)
