### PR TITLE
fix(Redis,XML,CppParser): replace dynamic_cast with static_cast for hidden visibility

### DIFF
--- a/CppParser/src/Function.cpp
+++ b/CppParser/src/Function.cpp
@@ -62,9 +62,9 @@ Function::Function(const std::string& decl, NameSpace* pNameSpace):
 
 Function::~Function()
 {
-	for (Parameters::iterator it = _params.begin(); it != _params.end(); ++it)
+	for (const auto* pParam : _params)
 	{
-		delete *it;
+		delete pParam;
 	}
 }
 
@@ -173,31 +173,31 @@ Symbol::Kind Function::kind() const
 
 std::string Function::signature() const
 {
-	std::string signature(declaration());
-	if (signature.compare(0, 8, "virtual ") == 0)
-		signature.erase(0, 8);
-	else if (signature.compare(0, 7, "static ") == 0)
-		signature.erase(0, 8);
-	if (signature.compare(0, 7, "inline ") == 0)
-		signature.erase(0, 7);
-	signature += "(";
+	std::string sig(declaration());
+	if (sig.compare(0, 8, "virtual ") == 0)
+		sig.erase(0, 8);
+	else if (sig.compare(0, 7, "static ") == 0)
+		sig.erase(0, 8);
+	if (sig.compare(0, 7, "inline ") == 0)
+		sig.erase(0, 7);
+	sig += "(";
 	bool isFirst = true;
-	for (Iterator it = begin(); it != end(); ++it)
+	for (const auto* pParam : _params)
 	{
 		if (isFirst)
 			isFirst = false;
 		else
-			signature += ", ";
-		std::string arg = (*it)->declaration();
-		std::string::size_type pos = arg.size() - 1;
+			sig += ", ";
+		const auto arg = pParam->declaration();
+		auto pos = arg.size() - 1;
 		while (pos > 0 && !std::isspace(arg[pos])) --pos;
 		while (pos > 0 && std::isspace(arg[pos])) --pos;
-		signature.append(arg, 0, pos + 1);
+		sig.append(arg, 0, pos + 1);
 	}
-	signature += ")";
+	sig += ")";
 	if (_flags & FN_CONST)
-		signature += " const";
-	return signature;
+		sig += " const";
+	return sig;
 }
 
 
@@ -209,8 +209,9 @@ bool Function::isVirtual() const
 	}
 	else if (isDestructor())
 	{
-		Struct* pClass = dynamic_cast<Struct*>(nameSpace());
-		return pClass && pClass->hasVirtualDestructor();
+		// isDestructor() implies nameSpace()->kind() == SYM_STRUCT
+		const auto* pClass = static_cast<const Struct*>(nameSpace());
+		return pClass->hasVirtualDestructor();
 	}
 	else return getOverridden() != nullptr;
 }
@@ -220,17 +221,15 @@ Function* Function::getOverridden() const
 {
 	if (isMethod() && !(_flags & FN_STATIC))
 	{
-		Struct* pClass = dynamic_cast<Struct*>(nameSpace());
-		if (pClass)
+		// isMethod() guarantees nameSpace()->kind() == SYM_STRUCT
+		const auto* pClass = static_cast<const Struct*>(nameSpace());
+		for (auto it = pClass->baseBegin(); it != pClass->baseEnd(); ++it)
 		{
-			for (Struct::BaseIterator it = pClass->baseBegin(); it != pClass->baseEnd(); ++it)
+			if (it->pClass)
 			{
-				if (it->pClass)
-				{
-					Function* pOverridden = it->pClass->findFunction(signature());
-					if (pOverridden && pOverridden->isVirtual())
-						return pOverridden;
-				}
+				auto* pOverridden = it->pClass->findFunction(signature());
+				if (pOverridden && pOverridden->isVirtual())
+					return pOverridden;
 			}
 		}
 	}
@@ -242,9 +241,9 @@ std::string Function::toString() const
 {
 	std::ostringstream ostr;
 	ostr << Decl::toString() << "(\n";
-	for (Iterator it = begin(); it != end(); ++it)
+	for (const auto* pParam : _params)
 	{
-		ostr << "\t" << (*it)->toString() << "\n";
+		ostr << "\t" << pParam->toString() << "\n";
 	}
 	ostr << ");";
 	return ostr.str();

--- a/CppParser/src/NameSpace.cpp
+++ b/CppParser/src/NameSpace.cpp
@@ -39,9 +39,9 @@ NameSpace::NameSpace(const std::string& name, NameSpace* pNameSpace, bool isInli
 
 NameSpace::~NameSpace()
 {
-	for (SymbolTable::iterator it = _symbols.begin(); it != _symbols.end(); ++it)
+	for (const auto& [name, pSym] : _symbols)
 	{
-		delete it->second;
+		delete pSym;
 	}
 }
 
@@ -63,10 +63,10 @@ void NameSpace::addSymbol(Symbol* pSymbol)
 
 void NameSpace::importSymbol(const std::string& fullName)
 {
-	std::string localName;
-	std::string::size_type pos = fullName.find_last_of(':');
+	const auto pos = fullName.find_last_of(':');
 	if (pos != std::string::npos && pos < fullName.size() - 1)
 	{
+		std::string localName;
 		localName.assign(fullName, pos + 1, fullName.size() - pos - 1);
 		_importedSymbols[localName] = fullName;
 	}
@@ -120,15 +120,16 @@ Symbol* NameSpace::lookup(const std::string& name, std::set<const NameSpace*>& a
 		alreadyVisited.insert(this);
 		return root()->lookup(tail, alreadyVisited);
 	}
-	SymbolTable::const_iterator it = _symbols.find(head);
+	const auto it = _symbols.find(head);
 	if (it != _symbols.end())
 	{
 		pSymbol = it->second;
 		if (!tail.empty())
 		{
 			alreadyVisited.insert(this);
-			NameSpace* pNS = dynamic_cast<NameSpace*>(pSymbol);
-			if (pNS)
+			// kind() discriminator: SYM_NAMESPACE and SYM_STRUCT both derive
+			// from NameSpace, so accept either for nested lookup.
+			if (pSymbol->kind() == Symbol::SYM_NAMESPACE || pSymbol->kind() == Symbol::SYM_STRUCT)
 				pSymbol = static_cast<NameSpace*>(pSymbol)->lookup(tail, alreadyVisited);
 			else
 				pSymbol = nullptr;
@@ -136,14 +137,15 @@ Symbol* NameSpace::lookup(const std::string& name, std::set<const NameSpace*>& a
 	}
 	else if (tail.empty())
 	{
-		AliasMap::const_iterator itAlias = _importedSymbols.find(head);
+		const auto itAlias = _importedSymbols.find(head);
 		if (itAlias != _importedSymbols.end())
 			pSymbol = lookup(itAlias->second, alreadyVisited);
 		else
 		{
-			for (NameSpaceVec::const_iterator itns = _importedNameSpaces.begin(); !pSymbol && itns != _importedNameSpaces.end(); ++itns)
+			for (const auto& ns : _importedNameSpaces)
 			{
-				Symbol* pNS = lookup(*itns, alreadyVisited);
+				if (pSymbol) break;
+				auto* pNS = lookup(ns, alreadyVisited);
 				if (pNS && pNS->kind() == Symbol::SYM_NAMESPACE)
 				{
 					pSymbol = static_cast<NameSpace*>(pNS)->lookup(name, alreadyVisited);
@@ -151,7 +153,7 @@ Symbol* NameSpace::lookup(const std::string& name, std::set<const NameSpace*>& a
 			}
 		}
 	}
-	NameSpace* pNS = nameSpace();
+	auto* pNS = nameSpace();
 	if (!pSymbol && pNS && (alreadyVisited.find(pNS) == alreadyVisited.end()))
 	{
 		// if we have to go up, never push the NS!
@@ -217,10 +219,10 @@ std::string NameSpace::toString() const
 	if (_isInline)
 		ostr << "inline ";
 	ostr << "namespace " << name() << "\n{\n";
-	for (Iterator it = begin(); it != end(); ++it)
+	for (const auto& [symName, pSym] : *this)
 	{
-		ostr << it->second->fullName() << "\n";
-		ostr << it->second->toString() << "\n";
+		ostr << pSym->fullName() << "\n";
+		ostr << pSym->toString() << "\n";
 	}
 	ostr << "}\n";
 	return ostr.str();
@@ -229,13 +231,13 @@ std::string NameSpace::toString() const
 
 void NameSpace::splitName(const std::string& name, std::string& head, std::string& tail)
 {
-	std::string::size_type pos = name.find(':');
+	const auto pos = name.find(':');
 	if (pos != std::string::npos)
 	{
 		head.assign(name, 0, pos);
-		pos += 2;
-		poco_assert (pos < name.length());
-		tail.assign(name, pos, name.length() - pos); 
+		const auto tailPos = pos + 2;
+		poco_assert (tailPos < name.length());
+		tail.assign(name, tailPos, name.length() - tailPos);
 	}
 	else head = name;
 }
@@ -250,10 +252,10 @@ NameSpace* NameSpace::root()
 
 void NameSpace::extract(Symbol::Kind kind, SymbolTable& table) const
 {
-	for (SymbolTable::const_iterator it = _symbols.begin(); it != _symbols.end(); ++it)
+	for (const auto& entry : _symbols)
 	{
-		if (it->second->kind() == kind)
-			table.insert(*it);
+		if (entry.second->kind() == kind)
+			table.insert(entry);
 	}
 }
 

--- a/CppParser/src/Parser.cpp
+++ b/CppParser/src/Parser.cpp
@@ -270,8 +270,10 @@ const Token* Parser::parseNameSpace(const Token* pNext)
 		int nestLevel = 0;
 		for (size_t i = 0; i < namespaceNames.size(); ++i)
 		{
-			NameSpace* pNS = dynamic_cast<NameSpace*>(currentNameSpace()->lookup(namespaceNames[i]));
-			bool undefined = (pNS == nullptr);
+			auto* pSym = currentNameSpace()->lookup(namespaceNames[i]);
+			auto* pNS = (pSym && (pSym->kind() == Symbol::SYM_NAMESPACE || pSym->kind() == Symbol::SYM_STRUCT))
+				? static_cast<NameSpace*>(pSym) : nullptr;
+			const bool undefined = (pNS == nullptr);
 			if (undefined) 
 				pNS = new NameSpace(namespaceNames[i], currentNameSpace(), inlineFlags[i]);
 			else if (inlineFlags[i])
@@ -835,7 +837,11 @@ const Token* Parser::parseFunc(const Token* pNext, const std::string& attrs, std
 
 		pNext = parseBlock(pNext);
 		if (!pFunc)
-			pFunc = dynamic_cast<Function*>(currentNameSpace()->lookup(name));
+		{
+			auto* pSym = currentNameSpace()->lookup(name);
+			if (pSym && pSym->kind() == Symbol::SYM_FUNCTION)
+				pFunc = static_cast<Function*>(pSym);
+		}
 		if (pFunc)
 			pFunc->makeInline();
 	}
@@ -859,7 +865,11 @@ const Token* Parser::parseFunc(const Token* pNext, const std::string& attrs, std
 			else syntaxError("expected catch block");
 
 			if (!pFunc)
-				pFunc = dynamic_cast<Function*>(currentNameSpace()->lookup(name));
+			{
+				auto* pSym = currentNameSpace()->lookup(name);
+				if (pSym && pSym->kind() == Symbol::SYM_FUNCTION)
+					pFunc = static_cast<Function*>(pSym);
+			}
 			if (pFunc)
 				pFunc->makeInline();
 		}

--- a/CppParser/src/Struct.cpp
+++ b/CppParser/src/Struct.cpp
@@ -84,11 +84,12 @@ void Struct::addDerived(Struct* pClass)
 
 void Struct::fixupBases()
 {
-	for (BaseClasses::iterator it = _bases.begin(); it != _bases.end(); ++it)
+	for (auto& base : _bases)
 	{
-		it->pClass = dynamic_cast<Struct*>(lookup(it->name));
-		if (it->pClass)
-			it->pClass->addDerived(this);
+		auto* pSym = lookup(base.name);
+		base.pClass = (pSym && pSym->kind() == Symbol::SYM_STRUCT) ? static_cast<Struct*>(pSym) : nullptr;
+		if (base.pClass)
+			base.pClass->addDerived(this);
 	}
 }
 
@@ -121,11 +122,14 @@ namespace
 
 void Struct::constructors(Functions& functions) const
 {
-	for (NameSpace::Iterator it = begin(); it != end(); ++it)
+	for (const auto& [name, pSym] : *this)
 	{
-		Function* pFunc = dynamic_cast<Function*>(it->second);
-		if (pFunc && pFunc->isConstructor())
-			functions.push_back(pFunc);
+		if (pSym->kind() == Symbol::SYM_FUNCTION)
+		{
+			auto* pFunc = static_cast<Function*>(pSym);
+			if (pFunc->isConstructor())
+				functions.push_back(pFunc);
+		}
 	}
 	std::sort(functions.begin(), functions.end(), CPLT());
 }
@@ -133,25 +137,28 @@ void Struct::constructors(Functions& functions) const
 
 void Struct::bases(std::set<std::string>& bases) const
 {
-	for (BaseIterator it = baseBegin(); it != baseEnd(); ++it)
+	for (const auto& base : _bases)
 	{
-		if (it->pClass)
+		if (base.pClass)
 		{
-			bases.insert(it->pClass->fullName());
-			it->pClass->bases(bases);
+			bases.insert(base.pClass->fullName());
+			base.pClass->bases(bases);
 		}
-		else bases.insert(it->name);
+		else bases.insert(base.name);
 	}
 }
 
 
 Function* Struct::destructor() const
 {
-	for (NameSpace::Iterator it = begin(); it != end(); ++it)
+	for (const auto& [name, pSym] : *this)
 	{
-		Function* pFunc = dynamic_cast<Function*>(it->second);
-		if (pFunc && pFunc->isDestructor())
-			return pFunc;
+		if (pSym->kind() == Symbol::SYM_FUNCTION)
+		{
+			auto* pFunc = static_cast<Function*>(pSym);
+			if (pFunc->isDestructor())
+				return pFunc;
+		}
 	}
 	return nullptr;
 }
@@ -159,27 +166,33 @@ Function* Struct::destructor() const
 
 void Struct::methods(Symbol::Access access, Functions& functions) const
 {
-	for (NameSpace::Iterator it = begin(); it != end(); ++it)
+	for (const auto& [name, pSym] : *this)
 	{
-		Function* pFunc = dynamic_cast<Function*>(it->second);
-		if (pFunc && pFunc->getAccess() == access && pFunc->isMethod())
-			functions.push_back(pFunc);
+		if (pSym->kind() == Symbol::SYM_FUNCTION)
+		{
+			auto* pFunc = static_cast<Function*>(pSym);
+			if (pFunc->getAccess() == access && pFunc->isMethod())
+				functions.push_back(pFunc);
+		}
 	}
 }
 
 
 void Struct::inheritedMethods(FunctionSet& functions) const
 {
-	for (BaseIterator it = baseBegin(); it != baseEnd(); ++it)
+	for (const auto& base : _bases)
 	{
-		Struct* pBase = it->pClass;
+		const auto* pBase = base.pClass;
 		if (pBase)
 		{
-			for (NameSpace::Iterator itm = pBase->begin(); itm != pBase->end(); ++itm)
+			for (const auto& [name, pSym] : *pBase)
 			{
-				Function* pFunc = dynamic_cast<Function*>(itm->second);
-				if (pFunc && pFunc->getAccess() != Symbol::ACC_PRIVATE && pFunc->isMethod())
-					functions.insert(pFunc);
+				if (pSym->kind() == Symbol::SYM_FUNCTION)
+				{
+					auto* pFunc = static_cast<Function*>(pSym);
+					if (pFunc->getAccess() != Symbol::ACC_PRIVATE && pFunc->isMethod())
+						functions.insert(pFunc);
+				}
 			}
 			pBase->inheritedMethods(functions);
 		}
@@ -189,10 +202,10 @@ void Struct::inheritedMethods(FunctionSet& functions) const
 
 void Struct::derived(StructSet& derived) const
 {
-	for (DerivedIterator it = derivedBegin(); it != derivedEnd(); ++it)
+	for (auto* pDerived : _derived)
 	{
-		derived.insert(*it);
-		(*it)->derived(derived);
+		derived.insert(pDerived);
+		pDerived->derived(derived);
 	}
 }
 
@@ -205,17 +218,20 @@ Symbol::Kind Struct::kind() const
 
 Function* Struct::findFunction(const std::string& signature) const
 {
-	for (NameSpace::Iterator it = begin(); it != end(); ++it)
+	for (const auto& [name, pSym] : *this)
 	{
-		Function* pFunc = dynamic_cast<Function*>(it->second);
-		if (pFunc && pFunc->signature() == signature)
-			return pFunc;
-	}
-	for (BaseIterator it = baseBegin(); it != baseEnd(); ++it)
-	{
-		if (it->pClass)
+		if (pSym->kind() == Symbol::SYM_FUNCTION)
 		{
-			Function* pFunc = it->pClass->findFunction(signature);
+			auto* pFunc = static_cast<Function*>(pSym);
+			if (pFunc->signature() == signature)
+				return pFunc;
+		}
+	}
+	for (const auto& base : _bases)
+	{
+		if (base.pClass)
+		{
+			auto* pFunc = base.pClass->findFunction(signature);
 			if (pFunc) return pFunc;
 		}
 	}
@@ -225,12 +241,12 @@ Function* Struct::findFunction(const std::string& signature) const
 
 bool Struct::hasVirtualDestructor() const
 {
-	Function* pFunc = destructor();
+	const auto* pFunc = destructor();
 	if (pFunc && (pFunc->flags() & Function::FN_VIRTUAL))
 		return true;
-	for (BaseIterator it = baseBegin(); it != baseEnd(); ++it)
+	for (const auto& base : _bases)
 	{
-		if (it->pClass && it->pClass->hasVirtualDestructor())
+		if (base.pClass && base.pClass->hasVirtualDestructor())
 			return true;
 	}
 	return false;
@@ -241,10 +257,10 @@ std::string Struct::toString() const
 {
 	std::ostringstream ostr;
 	ostr << declaration() << "\n{\n";
-	for (Iterator it = begin(); it != end(); ++it)
+	for (const auto& [name, pSym] : *this)
 	{
-		ostr << it->second->fullName() << "\n";
-		ostr << it->second->toString() << "\n";
+		ostr << pSym->fullName() << "\n";
+		ostr << pSym->toString() << "\n";
 	}
 	ostr << "};\n";
 	return ostr.str();
@@ -253,16 +269,16 @@ std::string Struct::toString() const
 
 Symbol* Struct::lookup(const std::string& name) const
 {
-	Symbol* pSymbol = NameSpace::lookup(name);
+	auto* pSymbol = NameSpace::lookup(name);
 	if (!pSymbol)
 	{
-		for (BaseIterator it = baseBegin(); it != baseEnd(); ++it)
+		for (const auto& base : _bases)
 		{
-			if (it->access != Symbol::ACC_PRIVATE)
+			if (base.access != Symbol::ACC_PRIVATE)
 			{
-				if (it->pClass)
+				if (base.pClass)
 				{
-					pSymbol = it->pClass->lookup(name);
+					pSymbol = base.pClass->lookup(name);
 					if (pSymbol)
 					{
 						return pSymbol;

--- a/CppParser/src/Utility.cpp
+++ b/CppParser/src/Utility.cpp
@@ -41,13 +41,13 @@ using Poco::Exception;
 namespace Poco::CppParser {
 
 
-void Utility::parseDir(const std::vector <std::string>& includePattern, const std::vector <std::string>& excludePattern, NameSpace::SymbolTable& st, const std::string& exec, const std::string& options, const std::string& path)
+void Utility::parseDir(const std::vector<std::string>& includePattern, const std::vector<std::string>& excludePattern, NameSpace::SymbolTable& st, const std::string& exec, const std::string& options, const std::string& path)
 {
 	std::set<std::string> files;
 	Utility::buildFileList(files, includePattern, excludePattern);
-	for (std::set<std::string>::const_iterator it = files.begin(); it != files.end(); ++it)
+	for (const auto& file : files)
 	{
-		Utility::parse(*it, st, exec, options, path);
+		Utility::parse(file, st, exec, options, path);
 	}
 	Utility::fixup(st);
 }
@@ -62,12 +62,11 @@ void Utility::parse(const std::string& file, NameSpace::SymbolTable& st, const s
 
 void Utility::fixup(NameSpace::SymbolTable& st)
 {
-	for (NameSpace::SymbolTable::iterator it = st.begin(); it != st.end(); ++it)
+	for (auto& [name, pSym] : st)
 	{
-		Struct* pStruct = dynamic_cast<Struct*>(it->second);
-		if (pStruct)
+		if (pSym->kind() == Symbol::SYM_STRUCT)
 		{
-			pStruct->fixupBases();
+			static_cast<Struct*>(pSym)->fixupBases();
 		}
 	}
 }
@@ -170,12 +169,12 @@ std::string Utility::preprocessFile(const std::string& file, const std::string& 
 	pp.setExtension("i");
 
 	std::string popts;
-	for (std::string::const_iterator it = options.begin(); it != options.end(); ++it)
+	for (const auto ch : options)
 	{
-		if (*it == '%')
+		if (ch == '%')
 			popts += pp.getBaseName();
 		else
-			popts += *it;
+			popts += ch;
 	}
 	StringTokenizer tokenizer(popts, ",;\n", StringTokenizer::TOK_IGNORE_EMPTY | StringTokenizer::TOK_TRIM);
 	std::vector<std::string> args(tokenizer.begin(), tokenizer.end());
@@ -195,8 +194,8 @@ std::string Utility::preprocessFile(const std::string& file, const std::string& 
 		Environment::set("PATH", path);
 	}
 
-	ProcessHandle proc = Process::launch(exec, args);
-	int rc = Process::wait(proc);
+	auto proc = Process::launch(exec, args);
+	const int rc = Process::wait(proc);
 	if (rc != 0)
 	{
 		throw Poco::RuntimeException("Failed to process file");
@@ -247,33 +246,29 @@ void Utility::removeFile(const std::string& preprocessedfile)
 void Utility::buildFileList(std::set<std::string>& files, const std::vector<std::string>& includePattern, const std::vector<std::string>& excludePattern)
 {
 	std::set<std::string> temp;
-	std::vector <std::string>::const_iterator itInc = includePattern.begin();
-	std::vector <std::string>::const_iterator itIncEnd = includePattern.end();
 
-	int options(0);
+	int options = 0;
 #if defined(_WIN32)
 	options |= Glob::GLOB_CASELESS;
 #endif
 
-	for (; itInc != itIncEnd; ++itInc)
+	for (const auto& pattern : includePattern)
 	{
-		Glob::glob(*itInc, temp, options);
+		Glob::glob(pattern, temp, options);
 	}
 
-	for (std::set<std::string>::const_iterator it = temp.begin(); it != temp.end(); ++it)
+	for (const auto& file : temp)
 	{
-		Path p(*it);
+		const Path p(file);
 		bool include = true;
-		std::vector <std::string>::const_iterator itExc = excludePattern.begin();
-		std::vector <std::string>::const_iterator itExcEnd = excludePattern.end();
-		for (; itExc != itExcEnd; ++itExc)
+		for (const auto& excPattern : excludePattern)
 		{
-			Glob glob(*itExc, options);
+			Glob glob(excPattern, options);
 			if (glob.match(p.toString()))
 				include = false;
 		}
 		if (include)
-			files.insert(*it);
+			files.insert(file);
 	}
 }
 

--- a/Redis/include/Poco/Redis/Array.h
+++ b/Redis/include/Poco/Redis/Array.h
@@ -157,10 +157,12 @@ public:
 		///
 		/// Note: this can throw a NullValueException when this is a Null array.
 
-private:
 	void checkNull();
-		/// Checks for null array and sets a new vector if true.
+		/// Ensures the array is not null by initializing an empty
+		/// vector if necessary. Call this to transition from a null
+		/// array to an empty (but non-null) array.
 
+private:
 	Nullable<std::vector<RedisType::Ptr>> _elements;
 };
 
@@ -297,18 +299,19 @@ struct RedisTypeTraits<Array>
 
 	static void read(RedisInputStream& input, Array& value)
 	{
-		value.clear();
+		value.makeNull();
 
 		const Int64 length = NumberParser::parse64(input.getline());
 
-		if ( length != -1 )
+		if (length >= 0)
 		{
-			for(int i = 0; i < length; ++i)
+			value.checkNull();
+			for (Int64 i = 0; i < length; ++i)
 			{
 				const char marker = input.get();
 				RedisType::Ptr element = RedisType::createRedisType(marker);
 
-				if ( element.isNull() )
+				if (element.isNull())
 					throw RedisException("Wrong answer received from Redis server");
 
 				element->read(input);

--- a/Redis/include/Poco/Redis/Array.h
+++ b/Redis/include/Poco/Redis/Array.h
@@ -125,11 +125,13 @@ public:
 
 		if ( pos >= _elements.value().size() ) throw InvalidArgumentException();
 
-		RedisType::Ptr element = _elements.value().at(pos);
+		const RedisType::Ptr element = _elements.value().at(pos);
 		if ( RedisTypeTraits<T>::TypeId == element->type() )
 		{
-			auto* concrete = dynamic_cast<Type<T>* >(element.get());
-			if ( concrete != nullptr ) return concrete->value();
+			// TypeId check guarantees runtime type; static_cast avoids
+			// hidden-visibility RTTI mismatch across DSOs on macOS.
+			const auto* concrete = static_cast<const Type<T>*>(element.get());
+			return concrete->value();
 		}
 		throw BadCastException();
 	}
@@ -205,9 +207,9 @@ inline Array& Array::add(const char* s)
 
 inline Array& Array::add(const std::vector<std::string>& strings)
 {
-	for(std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it)
+	for (const auto& s : strings)
 	{
-		add(*it);
+		add(s);
 	}
 	return *this;
 }
@@ -285,10 +287,9 @@ struct RedisTypeTraits<Array>
 		else
 		{
 			result << value.size() << LineEnding::NEWLINE_CRLF;
-			for(std::vector<RedisType::Ptr>::const_iterator it = value.begin();
-				it != value.end(); ++it)
+			for (const auto& element : value)
 			{
-				result << (*it)->toString();
+				result << element->toString();
 			}
 		}
 		return result.str();
@@ -304,7 +305,7 @@ struct RedisTypeTraits<Array>
 		{
 			for(int i = 0; i < length; ++i)
 			{
-				char marker = input.get();
+				const char marker = input.get();
 				RedisType::Ptr element = RedisType::createRedisType(marker);
 
 				if ( element.isNull() )

--- a/Redis/include/Poco/Redis/Client.h
+++ b/Redis/include/Poco/Redis/Client.h
@@ -178,14 +178,16 @@ public:
 		RedisType::Ptr redisResult = readReply();
 		if (redisResult->type() == RedisTypeTraits<Error>::TypeId)
 		{
-			Type<Error>* error = dynamic_cast<Type<Error>*>(redisResult.get());
+			// TypeId check guarantees runtime type; static_cast avoids
+			// hidden-visibility RTTI mismatch across DSOs on macOS.
+			const auto* error = static_cast<const Type<Error>*>(redisResult.get());
 			throw RedisException(error->value().getMessage());
 		}
 
 		if (redisResult->type() == RedisTypeTraits<T>::TypeId)
 		{
-			Type<T>* type = dynamic_cast<Type<T>*>(redisResult.get());
-			if (type != nullptr) result = type->value();
+			const auto* type = static_cast<const Type<T>*>(redisResult.get());
+			result = type->value();
 		}
 		else throw BadCastException();
 	}

--- a/Redis/include/Poco/Redis/Command.h
+++ b/Redis/include/Poco/Redis/Command.h
@@ -116,7 +116,7 @@ public:
 	static Command hmget(const std::string& hash, const StringVec& fields);
 		/// Creates and returns an HMGET command.
 
-	static Command hmset(const std::string& hash, std::map<std::string, std::string>& fields);
+	static Command hmset(const std::string& hash, const std::map<std::string, std::string>& fields);
 		/// Creates and returns a HMSET command.
 
 	static Command hset(const std::string& hash, const std::string& field, const std::string& value, bool create = true);

--- a/Redis/include/Poco/Redis/Error.h
+++ b/Redis/include/Poco/Redis/Error.h
@@ -34,7 +34,7 @@ public:
 	Error(const std::string& message);
 		/// Creates an Error with the given message.
 
-	virtual ~Error();
+	~Error();
 		/// Destroys the Error.
 
 	const std::string& getMessage() const;

--- a/Redis/include/Poco/Redis/PoolableConnectionFactory.h
+++ b/Redis/include/Poco/Redis/PoolableConnectionFactory.h
@@ -49,7 +49,7 @@ public:
 
 	bool validateObject(Redis::Client::Ptr pObject)
 	{
-		return true;
+		return pObject->isConnected();
 	}
 
 	void activateObject(Redis::Client::Ptr pObject)

--- a/Redis/include/Poco/Redis/RedisStream.h
+++ b/Redis/include/Poco/Redis/RedisStream.h
@@ -46,10 +46,7 @@ protected:
 	std::streamsize writeToDevice(const char* buffer, std::streamsize length);
 
 private:
-	enum
-	{
-		STREAM_BUFFER_SIZE = 1024
-	};
+	static constexpr int STREAM_BUFFER_SIZE = 1024;
 
 	Net::StreamSocket& _redis;
 };

--- a/Redis/include/Poco/Redis/Type.h
+++ b/Redis/include/Poco/Redis/Type.h
@@ -209,17 +209,17 @@ struct RedisTypeTraits<BulkString>
 	{
 		value.clear();
 
-		std::string line = input.getline();
-		int length = NumberParser::parse(line);
+		const std::string line = input.getline();
+		const Int64 length = NumberParser::parse64(line);
 
-		if ( length >= 0 )
+		if (length >= 0)
 		{
 			std::string s;
-			s.resize(length, ' ');
-			input.read(&*s.begin(), length);
+			s.resize(static_cast<std::size_t>(length), ' ');
+			input.read(s.data(), static_cast<std::streamsize>(length));
 			value.assign(s);
 
-			input.getline(); // Read and ignore /r/n
+			input.getline(); // Read and ignore \r\n
 		}
 	}
 };

--- a/Redis/src/Array.cpp
+++ b/Redis/src/Array.cpp
@@ -58,7 +58,7 @@ int Array::getType(size_t pos) const
 
 	if (pos >= _elements.value().size()) throw InvalidArgumentException();
 
-	RedisType::Ptr element = _elements.value().at(pos);
+	const RedisType::Ptr element = _elements.value().at(pos);
 	return element->type();
 }
 

--- a/Redis/src/Array.cpp
+++ b/Redis/src/Array.cpp
@@ -1,5 +1,5 @@
 //
-// Array.h
+// Array.cpp
 //
 // Library: Redis
 // Package: Redis

--- a/Redis/src/AsyncReader.cpp
+++ b/Redis/src/AsyncReader.cpp
@@ -39,12 +39,14 @@ void AsyncReader::runActivity()
 	{
 		try
 		{
+			// readReply() blocks on the socket read, so no sleep is needed
+			// between iterations -- the blocking read yields the CPU naturally.
 			RedisType::Ptr reply = _client.readReply();
 
 			RedisEventArgs args(reply);
 			redisResponse.notify(this, args);
 
-			if ( args.isStopped() ) stop();
+			if (args.isStopped()) stop();
 		}
 		catch (Exception& e)
 		{
@@ -52,7 +54,6 @@ void AsyncReader::runActivity()
 			redisException.notify(this, args);
 			stop();
 		}
-		if (!_activity.isStopped()) Thread::trySleep(100);
 	}
 }
 

--- a/Redis/src/Client.cpp
+++ b/Redis/src/Client.cpp
@@ -204,7 +204,7 @@ void Client::writeCommand(const Array& command, bool doFlush)
 {
 	poco_assert(_pOutput);
 
-	std::string commandStr = command.toString();
+	const std::string commandStr = command.toString();
 
 	_pOutput->write(commandStr.c_str(), commandStr.length());
 	if (doFlush) _pOutput->flush();
@@ -215,7 +215,7 @@ RedisType::Ptr Client::readReply()
 {
 	poco_assert(_pInput);
 
-	int c = _pInput->get();
+	const int c = _pInput->get();
 	if (c == -1)
 	{
 		disconnect();
@@ -244,9 +244,9 @@ Array Client::sendCommands(const std::vector<Array>& commands)
 {
 	Array results;
 
-	for (std::vector<Array>::const_iterator it = commands.begin(); it != commands.end(); ++it)
+	for (const auto& cmd : commands)
 	{
-		writeCommand(*it, false);
+		writeCommand(cmd, false);
 	}
 	_pOutput->flush();
 

--- a/Redis/src/Command.cpp
+++ b/Redis/src/Command.cpp
@@ -88,7 +88,7 @@ Command Command::decr(const std::string& key, Int64 by)
 	Command cmd(by == 0 ? "DECR" : "DECRBY");
 
 	cmd << key;
-	if ( by > 0 ) cmd << NumberFormatter::format(by);
+	if (by != 0) cmd << NumberFormatter::format(by);
 
 	return cmd;
 }
@@ -289,7 +289,7 @@ Command Command::incr(const std::string& key, Int64 by)
 	Command cmd(by == 0 ? "INCR" : "INCRBY");
 
 	cmd << key;
-	if ( by > 0 ) cmd << NumberFormatter::format(by);
+	if (by != 0) cmd << NumberFormatter::format(by);
 
 	return cmd;
 }
@@ -489,11 +489,13 @@ Command Command::sdiffstore(const std::string& set, const StringVec& sets)
 
 Command Command::set(const std::string& key, const std::string& value, bool overwrite, const Poco::Timespan& expireTime, bool create)
 {
+	poco_assert_msg(overwrite || create, "overwrite=false and create=false are mutually exclusive (NX + XX)");
+
 	Command cmd("SET");
 
 	cmd << key << value;
-	if (! overwrite) cmd << "NX";
-	if (! create) cmd << "XX";
+	if (!overwrite) cmd << "NX";
+	if (!create) cmd << "XX";
 	if (expireTime.totalMicroseconds() > 0) cmd << "PX" << NumberFormatter::format(expireTime.totalMilliseconds());
 
 	return cmd;

--- a/Redis/src/Command.cpp
+++ b/Redis/src/Command.cpp
@@ -224,14 +224,14 @@ Command Command::hmget(const std::string& hash, const StringVec& fields)
 }
 
 
-Command Command::hmset(const std::string& hash, std::map<std::string, std::string>& fields)
+Command Command::hmset(const std::string& hash, const std::map<std::string, std::string>& fields)
 {
 	Command cmd("HMSET");
 
 	cmd << hash;
-	for(std::map<std::string, std::string>::const_iterator it = fields.begin(); it != fields.end(); ++it)
+	for (const auto& [key, value] : fields)
 	{
-		cmd << it->first << it->second;
+		cmd << key << value;
 	}
 
 	return cmd;
@@ -408,9 +408,9 @@ Command Command::mset(const std::map<std::string, std::string>& keyvalues, bool 
 {
 	Command cmd(create ? "MSET" : "MSETNX");
 
-	for(std::map<std::string, std::string>::const_iterator it = keyvalues.begin(); it != keyvalues.end(); ++it)
+	for (const auto& [key, value] : keyvalues)
 	{
-		cmd << it->first << it->second;
+		cmd << key << value;
 	}
 
 	return cmd;

--- a/Redis/src/Exception.cpp
+++ b/Redis/src/Exception.cpp
@@ -1,5 +1,5 @@
 //
-// Exception.h
+// Exception.cpp
 //
 // Library: Redis
 // Package: Redis

--- a/Redis/src/RedisStream.cpp
+++ b/Redis/src/RedisStream.cpp
@@ -138,7 +138,7 @@ std::string RedisInputStream::getline()
 {
 	std::string line;
 	std::getline(*this, line);
-	if ( line.size() > 0 ) line.erase(line.end() - 1);
+	if (!line.empty()) line.erase(line.end() - 1);
 	return line;
 }
 

--- a/Redis/src/RedisStream.cpp
+++ b/Redis/src/RedisStream.cpp
@@ -15,6 +15,7 @@
 
 
 #include "Poco/Redis/RedisStream.h"
+#include "Poco/Exception.h"
 #include <iostream>
 
 
@@ -96,7 +97,8 @@ RedisStreamBuf* RedisIOS::rdbuf()
 
 void RedisIOS::close()
 {
-	_buf.sync();
+	if (_buf.sync() == -1)
+		throw Poco::IOException("Failed to flush Redis stream buffer");
 }
 
 
@@ -138,7 +140,7 @@ std::string RedisInputStream::getline()
 {
 	std::string line;
 	std::getline(*this, line);
-	if (!line.empty()) line.erase(line.end() - 1);
+	if (!line.empty() && line.back() == '\r') line.pop_back();
 	return line;
 }
 

--- a/Redis/testsuite/src/RedisTest.cpp
+++ b/Redis/testsuite/src/RedisTest.cpp
@@ -1587,9 +1587,11 @@ public:
 	{
 		if (!args.message().isNull())
 		{
-			Type<Array>* arrayType = dynamic_cast<Type<Array>*>(args.message().get());
-			if (arrayType != nullptr)
+			// Use TypeId check + static_cast (not dynamic_cast) to avoid
+			// hidden-visibility RTTI mismatch across DSOs on macOS.
+			if (args.message()->type() == RedisTypeTraits<Array>::TypeId)
 			{
+				auto* arrayType = static_cast<Type<Array>*>(args.message().get());
 				Array& array = arrayType->value();
 				if (array.size() == 3)
 				{

--- a/Util/src/XMLConfiguration.cpp
+++ b/Util/src/XMLConfiguration.cpp
@@ -277,7 +277,7 @@ void XMLConfiguration::removeRaw(const std::string& key)
 		}
 		else if (pNode->nodeType() == Node::ATTRIBUTE_NODE)
 		{
-			auto pAttr = dynamic_cast<Attr*>(pNode);
+			auto* pAttr = static_cast<Attr*>(pNode);
 			Element* pOwner = pAttr->ownerElement();
 			if (pOwner)
 			{
@@ -291,7 +291,7 @@ void XMLConfiguration::removeRaw(const std::string& key)
 const XMLConfiguration::Node* XMLConfiguration::findNode(const std::string& key) const
 {
 	auto it = key.begin();
-	auto pRoot = const_cast<Node*>(_pRoot.get());
+	auto* const pRoot = const_cast<Node*>(_pRoot.get());
 	return findNode(it, key.end(), pRoot);
 }
 
@@ -299,7 +299,7 @@ const XMLConfiguration::Node* XMLConfiguration::findNode(const std::string& key)
 XMLConfiguration::Node* XMLConfiguration::findNode(const std::string& key)
 {
 	auto it = key.begin();
-	auto pRoot = _pRoot.get();
+	auto* const pRoot = _pRoot.get();
 	return findNode(it, key.end(), pRoot);
 }
 
@@ -380,7 +380,7 @@ XMLConfiguration::Node* XMLConfiguration::findElement(const std::string& name, N
 
 XMLConfiguration::Node* XMLConfiguration::findElement(int index, Node* pNode, bool create)
 {
-	auto pRefNode = pNode;
+	const auto* pRefNode = pNode;
 	if (index > 0)
 	{
 		pNode = pNode->nextSibling();
@@ -409,8 +409,8 @@ XMLConfiguration::Node* XMLConfiguration::findElement(int index, Node* pNode, bo
 
 XMLConfiguration::Node* XMLConfiguration::findElement(const std::string& attr, const std::string& value, Node* pNode)
 {
-	auto pRefNode = pNode;
-	auto pElem = dynamic_cast<Element*>(pNode);
+	const auto* pRefNode = pNode;
+	auto* pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<Element*>(pNode) : nullptr;
 	if (!(pElem && pElem->getAttribute(attr) == value))
 	{
 		pNode = pNode->nextSibling();
@@ -418,7 +418,7 @@ XMLConfiguration::Node* XMLConfiguration::findElement(const std::string& attr, c
 		{
 			if (pNode->nodeName() == pRefNode->nodeName())
 			{
-				pElem = dynamic_cast<Element*>(pNode);
+				pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<Element*>(pNode) : nullptr;
 				if (pElem && pElem->getAttribute(attr) == value) break;
 			}
 			pNode = pNode->nextSibling();
@@ -431,7 +431,7 @@ XMLConfiguration::Node* XMLConfiguration::findElement(const std::string& attr, c
 XMLConfiguration::Node* XMLConfiguration::findAttribute(const std::string& name, Node* pNode, bool create)
 {
 	Node* pResult(nullptr);
-	auto pElem = dynamic_cast<Element*>(pNode);
+	auto* pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<Element*>(pNode) : nullptr;
 	if (pElem)
 	{
 		pResult = pElem->getAttributeNode(name);

--- a/XML/include/Poco/DOM/EventDispatcher.h
+++ b/XML/include/Poco/DOM/EventDispatcher.h
@@ -85,6 +85,12 @@ private:
 
 	typedef std::list<EventListenerItem> EventListenerList;
 
+	void removeDeadListeners();
+		/// Removes all entries with null listeners from the list.
+		/// Only performs cleanup when called from the outermost dispatch
+		/// (i.e., _inDispatch == 1), to avoid invalidating iterators
+		/// of any enclosing dispatch loop.
+
 	int               _inDispatch;
 	EventListenerList _listeners;
 };

--- a/XML/src/AbstractContainerNode.cpp
+++ b/XML/src/AbstractContainerNode.cpp
@@ -156,74 +156,74 @@ Node* AbstractContainerNode::insertBefore(Node* newChild, Node* refChild)
 
 Node* AbstractContainerNode::insertAfterNP(Node* newChild, Node* refChild)
 {
-    poco_check_ptr (newChild);
+	poco_check_ptr (newChild);
 
-    if (static_cast<AbstractNode*>(newChild)->_pOwner != _pOwner && static_cast<AbstractNode*>(newChild)->_pOwner != this)
-        throw DOMException(DOMException::WRONG_DOCUMENT_ERR);
-    if (refChild && static_cast<AbstractNode*>(refChild)->_pParent != this)
-        throw DOMException(DOMException::NOT_FOUND_ERR);
-    if (newChild == refChild)
-        return nullptr;
-    if (this == newChild)
-        throw DOMException(DOMException::HIERARCHY_REQUEST_ERR);
+	if (static_cast<AbstractNode*>(newChild)->_pOwner != _pOwner && static_cast<AbstractNode*>(newChild)->_pOwner != this)
+		throw DOMException(DOMException::WRONG_DOCUMENT_ERR);
+	if (refChild && static_cast<AbstractNode*>(refChild)->_pParent != this)
+		throw DOMException(DOMException::NOT_FOUND_ERR);
+	if (newChild == refChild)
+		return newChild;
+	if (this == newChild)
+		throw DOMException(DOMException::HIERARCHY_REQUEST_ERR);
 
-    AbstractNode* pFirst = nullptr;
-    AbstractNode* pLast  = nullptr;
-    if (newChild->nodeType() == Node::DOCUMENT_FRAGMENT_NODE)
-    {
-        AbstractContainerNode* pFrag = static_cast<AbstractContainerNode*>(newChild);
-        pFirst = pFrag->_pFirstChild;
-        pLast  = pFirst;
-        if (pFirst)
-        {
-            while (pLast->_pNext)
-            {
-                pLast->_pParent = this;
-                pLast = pLast->_pNext;
-            }
-            pLast->_pParent = this;
-        }
-        pFrag->_pFirstChild = nullptr;
-    }
-    else
-    {
-        newChild->duplicate();
-        AbstractContainerNode* pParent = static_cast<AbstractNode*>(newChild)->_pParent;
-        if (pParent) pParent->removeChild(newChild);
-        pFirst = static_cast<AbstractNode*>(newChild);
-        pLast  = pFirst;
-        pFirst->_pParent = this;
-    }
-    if (_pFirstChild && pFirst)
-    {
-        AbstractNode* pCur = _pFirstChild;
-        while (pCur && pCur != refChild)
-        {
-            pCur = pCur->_pNext;
-        }
-        if (pCur)
-        {
-            pLast->_pNext = pCur->_pNext;
-            pCur->_pNext = pFirst;
-        }
-        else throw DOMException(DOMException::NOT_FOUND_ERR);
-    }
-    else
-    {
-        _pFirstChild = pFirst;
-    }
+	AbstractNode* pFirst = nullptr;
+	AbstractNode* pLast  = nullptr;
+	if (newChild->nodeType() == Node::DOCUMENT_FRAGMENT_NODE)
+	{
+		AbstractContainerNode* pFrag = static_cast<AbstractContainerNode*>(newChild);
+		pFirst = pFrag->_pFirstChild;
+		pLast  = pFirst;
+		if (pFirst)
+		{
+			while (pLast->_pNext)
+			{
+				pLast->_pParent = this;
+				pLast = pLast->_pNext;
+			}
+			pLast->_pParent = this;
+		}
+		pFrag->_pFirstChild = nullptr;
+	}
+	else
+	{
+		newChild->duplicate();
+		AbstractContainerNode* pParent = static_cast<AbstractNode*>(newChild)->_pParent;
+		if (pParent) pParent->removeChild(newChild);
+		pFirst = static_cast<AbstractNode*>(newChild);
+		pLast  = pFirst;
+		pFirst->_pParent = this;
+	}
+	if (_pFirstChild && pFirst)
+	{
+		AbstractNode* pCur = _pFirstChild;
+		while (pCur && pCur != refChild)
+		{
+			pCur = pCur->_pNext;
+		}
+		if (pCur)
+		{
+			pLast->_pNext = pCur->_pNext;
+			pCur->_pNext = pFirst;
+		}
+		else throw DOMException(DOMException::NOT_FOUND_ERR);
+	}
+	else
+	{
+		_pFirstChild = pFirst;
+	}
 
-    if (events())
-    {
-        while (pFirst && pFirst != pLast->_pNext)
-        {
-            pFirst->dispatchNodeInserted();
-            pFirst->dispatchNodeInsertedIntoDocument();
-            pFirst = pFirst->_pNext;
-        }
-        dispatchSubtreeModified();
-    }
-    return newChild;
+	if (events())
+	{
+		while (pFirst && pFirst != pLast->_pNext)
+		{
+			pFirst->dispatchNodeInserted();
+			pFirst->dispatchNodeInsertedIntoDocument();
+			pFirst = pFirst->_pNext;
+		}
+		dispatchSubtreeModified();
+	}
+	return newChild;
 }
 
 
@@ -249,6 +249,7 @@ Node* AbstractContainerNode::replaceChild(Node* newChild, Node* oldChild)
 	}
 	else
 	{
+		newChild->duplicate();
 		AbstractContainerNode* pParent = static_cast<AbstractNode*>(newChild)->_pParent;
 		if (pParent) pParent->removeChild(newChild);
 
@@ -296,7 +297,6 @@ Node* AbstractContainerNode::replaceChild(Node* newChild, Node* oldChild)
 			}
 			else throw DOMException(DOMException::NOT_FOUND_ERR);
 		}
-		newChild->duplicate();
 		oldChild->autoRelease();
 	}
 	if (doEvents) dispatchSubtreeModified();
@@ -387,7 +387,7 @@ bool AbstractContainerNode::hasAttributes() const
 
 Node* AbstractContainerNode::getNodeByPath(const XMLString& path) const
 {
-	bool indexBound;
+	bool indexBound = false;
 	XMLString::const_iterator it = path.begin();
 	if (it != path.end() && *it == '/')
 	{
@@ -416,7 +416,7 @@ Node* AbstractContainerNode::getNodeByPath(const XMLString& path) const
 
 Node* AbstractContainerNode::getNodeByPathNS(const XMLString& path, const NSMap& nsMap) const
 {
-	bool indexBound;
+	bool indexBound = false;
 	XMLString::const_iterator it = path.begin();
 	if (it != path.end() && *it == '/')
 	{
@@ -568,7 +568,7 @@ const Node* AbstractContainerNode::findElement(int index, const Node* pNode, con
 const Node* AbstractContainerNode::findElement(const XMLString& attr, const XMLString& value, const Node* pNode, const NSMap* pNSMap)
 {
 	const Node* pRefNode = pNode;
-	const Element* pElem = dynamic_cast<const Element*>(pNode);
+	const auto* pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<const Element*>(pNode) : nullptr;
 	if (!(pElem && pElem->hasAttributeValue(attr, value, pNSMap)))
 	{
 		pNode = pNode->nextSibling();
@@ -576,7 +576,7 @@ const Node* AbstractContainerNode::findElement(const XMLString& attr, const XMLS
 		{
 			if (namesAreEqual(pNode, pRefNode, pNSMap))
 			{
-				pElem = dynamic_cast<const Element*>(pNode);
+				pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<const Element*>(pNode) : nullptr;
 				if (pElem && pElem->hasAttributeValue(attr, value, pNSMap)) break;
 			}
 			pNode = pNode->nextSibling();
@@ -589,7 +589,7 @@ const Node* AbstractContainerNode::findElement(const XMLString& attr, const XMLS
 const Attr* AbstractContainerNode::findAttribute(const XMLString& name, const Node* pNode, const NSMap* pNSMap)
 {
 	const Attr* pResult(nullptr);
-	const Element* pElem = dynamic_cast<const Element*>(pNode);
+	const auto* pElem = pNode->nodeType() == Node::ELEMENT_NODE ? static_cast<const Element*>(pNode) : nullptr;
 	if (pElem)
 	{
 		if (pNSMap)

--- a/XML/src/AbstractNode.cpp
+++ b/XML/src/AbstractNode.cpp
@@ -58,7 +58,8 @@ AbstractNode::~AbstractNode()
 
 void AbstractNode::autoRelease()
 {
-	_pOwner->autoReleasePool().add(this);
+	if (_pOwner != nullptr)
+		_pOwner->autoReleasePool().add(this);
 }
 
 

--- a/XML/src/AttrMap.cpp
+++ b/XML/src/AttrMap.cpp
@@ -114,7 +114,9 @@ Node* AttrMap::removeNamedItemNS(const XMLString& namespaceURI, const XMLString&
 
 void AttrMap::autoRelease()
 {
-	_pElement->ownerDocument()->autoReleasePool().add(this);
+	auto* pOwner = _pElement->ownerDocument();
+	if (pOwner != nullptr)
+		pOwner->autoReleasePool().add(this);
 }
 
 

--- a/XML/src/ChildNodesList.cpp
+++ b/XML/src/ChildNodesList.cpp
@@ -62,7 +62,9 @@ unsigned long ChildNodesList::length() const
 
 void ChildNodesList::autoRelease()
 {
-	_pParent->ownerDocument()->autoReleasePool().add(this);
+	auto* pOwner = _pParent->ownerDocument();
+	if (pOwner != nullptr)
+		pOwner->autoReleasePool().add(this);
 }
 
 

--- a/XML/src/DOMBuilder.cpp
+++ b/XML/src/DOMBuilder.cpp
@@ -195,7 +195,7 @@ void DOMBuilder::startElement(const XMLString& uri, const XMLString& localName, 
 
 	AutoPtr<Element> pElem = _namespaces ? _pDocument->createElementNS(uri, qname.empty() ? localName : qname) : _pDocument->createElement(qname);
 
-	const AttributesImpl& attrs = dynamic_cast<const AttributesImpl&>(attributes);
+	const auto& attrs = static_cast<const AttributesImpl&>(attributes);
 	Attr* pPrevAttr = nullptr;
 	for (const auto& attr: attrs)
 	{
@@ -212,6 +212,7 @@ void DOMBuilder::endElement(const XMLString& uri, const XMLString& localName, co
 	--_depth;
 
 	_pPrevious = _pParent;
+	poco_assert_dbg (_pParent->parentNode() != nullptr);
 	_pParent   = static_cast<AbstractContainerNode*>(_pParent->parentNode());
 }
 

--- a/XML/src/DTDMap.cpp
+++ b/XML/src/DTDMap.cpp
@@ -109,7 +109,9 @@ Node* DTDMap::removeNamedItemNS(const XMLString& namespaceURI, const XMLString& 
 
 void DTDMap::autoRelease()
 {
-	_pDocumentType->ownerDocument()->autoReleasePool().add(this);
+	auto* pOwner = _pDocumentType->ownerDocument();
+	if (pOwner != nullptr)
+		pOwner->autoReleasePool().add(this);
 }
 
 

--- a/XML/src/Document.cpp
+++ b/XML/src/Document.cpp
@@ -144,7 +144,7 @@ Element* Document::documentElement() const
 	Node* pCur = firstChild();
 	while (pCur)
 	{
-		if (dynamic_cast<Element*>(pCur))
+		if (pCur->nodeType() == Node::ELEMENT_NODE)
 			return static_cast<Element*>(pCur);
 		pCur = pCur->nextSibling();
 	}

--- a/XML/src/Element.cpp
+++ b/XML/src/Element.cpp
@@ -135,8 +135,8 @@ Attr* Element::removeAttributeNode(Attr* oldAttr)
 	if (oldAttr != _pFirstAttr)
 	{
 		Attr* pCur = _pFirstAttr;
-		while (pCur->_pNext != oldAttr) pCur = static_cast<Attr*>(pCur->_pNext);
-		if (pCur)
+		while (pCur != nullptr && pCur->_pNext != oldAttr) pCur = static_cast<Attr*>(pCur->_pNext);
+		if (pCur != nullptr)
 		{
 			pCur->_pNext = static_cast<Attr*>(pCur->_pNext->_pNext);
 		}

--- a/XML/src/ElementsByTagNameList.cpp
+++ b/XML/src/ElementsByTagNameList.cpp
@@ -76,13 +76,15 @@ Node* ElementsByTagNameList::find(const Node* pParent, unsigned long index) cons
 		if (pNode) return pNode;
 		pCur = pCur->nextSibling();
 	}
-	return pCur;
+	return nullptr;
 }
 
 
 void ElementsByTagNameList::autoRelease()
 {
-	_pParent->ownerDocument()->autoReleasePool().add(this);
+	auto* pOwner = _pParent->ownerDocument();
+	if (pOwner != nullptr)
+		pOwner->autoReleasePool().add(this);
 }
 
 
@@ -137,13 +139,15 @@ Node* ElementsByTagNameListNS::find(const Node* pParent, unsigned long index) co
 		if (pNode) return pNode;
 		pCur = pCur->nextSibling();
 	}
-	return pCur;
+	return nullptr;
 }
 
 
 void ElementsByTagNameListNS::autoRelease()
 {
-	_pParent->ownerDocument()->autoReleasePool().add(this);
+	auto* pOwner = _pParent->ownerDocument();
+	if (pOwner != nullptr)
+		pOwner->autoReleasePool().add(this);
 }
 
 

--- a/XML/src/EventDispatcher.cpp
+++ b/XML/src/EventDispatcher.cpp
@@ -92,13 +92,9 @@ void EventDispatcher::dispatchEvent(Event* evt)
 		{
 			it->pListener->handleEvent(evt);
 		}
-		if (!it->pListener)
-		{
-			EventListenerList::iterator del = it++;
-			_listeners.erase(del);
-		}
-		else ++it;
+		++it;
 	}
+	removeDeadListeners();
 }
 
 
@@ -112,13 +108,9 @@ void EventDispatcher::captureEvent(Event* evt)
 		{
 			it->pListener->handleEvent(evt);
 		}
-		if (!it->pListener)
-		{
-			EventListenerList::iterator del = it++;
-			_listeners.erase(del);
-		}
-		else ++it;
+		++it;
 	}
+	removeDeadListeners();
 }
 
 
@@ -132,12 +124,26 @@ void EventDispatcher::bubbleEvent(Event* evt)
 		{
 			it->pListener->handleEvent(evt);
 		}
-		if (!it->pListener)
+		++it;
+	}
+	removeDeadListeners();
+}
+
+
+void EventDispatcher::removeDeadListeners()
+{
+	if (_inDispatch == 1)
+	{
+		EventListenerList::iterator it = _listeners.begin();
+		while (it != _listeners.end())
 		{
-			EventListenerList::iterator del = it++;
-			_listeners.erase(del);
+			if (!it->pListener)
+			{
+				EventListenerList::iterator del = it++;
+				_listeners.erase(del);
+			}
+			else ++it;
 		}
-		else ++it;
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `dynamic_cast` with TypeId-check + `static_cast` across Redis, XML DOM, CppParser, and Util to fix hidden-visibility RTTI mismatches across DSOs on macOS
- Fix correctness bugs in Redis (null array deserialization, BulkString overflow, `incr`/`decr` with negative values, pool validation) and XML DOM (const-correctness, range-based loops, robustness)
- Fix remaining `dynamic_cast` in Redis test subscriber that caused `testPubSub` to corrupt the shared connection, failing all subsequent tests under hidden visibility

Issues discovered via the new macOS hidden-visibility + ASan CI build added in #5307.

## Commits to merge to this branch

The following recent commits on `main` should also be included in `Release 1.15.2`:
- 07f3f253e fix(cpptrace): pin hidden visibility on bundled target to match upstream
- e8eacf3c0 fix(MongoDB): use static_cast in Document::get<T> to avoid hidden-visibility RTTI failure
- 90adf53ea fix(Redis): fix Windows build failures

## Test plan

- [x] CI passes on macOS hidden-visibility + ASan build (the previously failing configuration)
- [x] Redis tests pass on all platforms
- [x] XML and CppParser tests pass