### PR TITLE
fix(Net): handle connect refusal correctly in SocketProactor

### DIFF
--- a/Net/src/SocketProactor.cpp
+++ b/Net/src/SocketProactor.cpp
@@ -296,6 +296,11 @@ int SocketProactor::poll(int* pHandled)
 		auto end = sm.end();
 		for (; it != end; ++it)
 		{
+			if (it->second & PollSet::POLL_ERROR)
+			{
+				Socket sock = it->first;
+				handled += error(sock);
+			}
 			if (it->second & PollSet::POLL_READ)
 			{
 				Socket sock = it->first;
@@ -307,11 +312,6 @@ int SocketProactor::poll(int* pHandled)
 				Socket sock = it->first;
 				if (hasHandlers(_writeHandlers, static_cast<int>(sock.impl()->sockfd())))
 					handled += send(sock);
-			}
-			if (it->second & PollSet::POLL_ERROR)
-			{
-				Socket sock = it->first;
-				handled += error(sock);
 			}
 		}
 	}
@@ -531,6 +531,15 @@ void SocketProactor::send(SocketImpl& sock, IOHandlerIt& it)
 		catch(std::exception&)
 		{
 			err = Socket::lastError();
+		}
+		if (n == 0 && err == 0)
+		{
+			// TCP never completes a non-empty send with zero bytes;
+			// this means the socket is in an error state (e.g. refused
+			// non-blocking connect) -- read SO_ERROR for the real code.
+			unsigned soErr = 0;
+			sock.getOption(SOL_SOCKET, SO_ERROR, soErr);
+			err = soErr;
 		}
 		enqueueIONotification(std::move((*it)->_onCompletion), n, err);
 	}


### PR DESCRIPTION
## Summary

- Reorder poll dispatch in `SocketProactor::poll()` so `POLL_ERROR` is processed before `POLL_READ`/`POLL_WRITE`, preventing send handlers from running on sockets with failed non-blocking connects
- Add `SO_ERROR` post-check in the stream send path when `sendBytes()` returns 0 without throwing, to detect the real socket error regardless of dispatch order

Closes #5308

## Test plan

- [x] `Net-testrunner SocketProactorTest` passes (all 5 tests)
- [x] 20 consecutive runs with no flakes on macOS