### PR TITLE
enh(Crypto,NetSSL): build with OPENSSL_NO_DEPRECATED

### DIFF
--- a/Crypto/include/Poco/Crypto/Crypto.h
+++ b/Crypto/include/Poco/Crypto/Crypto.h
@@ -20,14 +20,6 @@
 #define Crypto_Crypto_INCLUDED
 
 
-//
-// Temporarily suppress deprecation warnings coming
-// from OpenSSL 3.0, until we have updated our code.
-//
-#if !defined(POCO_DONT_SUPPRESS_OPENSSL_DEPRECATED)
-#define OPENSSL_SUPPRESS_DEPRECATED
-#endif
-
 
 #include "Poco/Foundation.h"
 #include <openssl/opensslv.h>

--- a/Crypto/include/Poco/Crypto/ECKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/ECKeyImpl.h
@@ -70,11 +70,27 @@ public:
 	~ECKeyImpl();
 		/// Destroys the ECKeyImpl.
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY* getEVPPKey();
+		/// Returns the OpenSSL EVP_PKEY object.
+
+	const EVP_PKEY* getEVPPKey() const;
+		/// Returns the OpenSSL EVP_PKEY object.
+#endif
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	POCO_DEPRECATED("use getEVPPKey() instead")
+#endif
 	EC_KEY* getECKey();
 		/// Returns the OpenSSL EC key.
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	POCO_DEPRECATED("use getEVPPKey() instead")
+#endif
 	const EC_KEY* getECKey() const;
 		/// Returns the OpenSSL EC key.
+#endif
 
 	int size() const;
 		/// Returns the EC key length in bits.
@@ -124,13 +140,71 @@ private:
 	void checkEC(const std::string& method, const std::string& func) const;
 	void freeEC();
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY* _pEVPPKey;
+#else
 	EC_KEY* _pEC;
+#endif
 };
 
 
 //
 // inlines
 //
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+inline EVP_PKEY* ECKeyImpl::getEVPPKey()
+{
+	return _pEVPPKey;
+}
+
+
+inline const EVP_PKEY* ECKeyImpl::getEVPPKey() const
+{
+	return _pEVPPKey;
+}
+
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+
+inline EC_KEY* ECKeyImpl::getECKey()
+{
+	return const_cast<EC_KEY*>(EVP_PKEY_get0_EC_KEY(_pEVPPKey));
+}
+
+
+inline const EC_KEY* ECKeyImpl::getECKey() const
+{
+	return EVP_PKEY_get0_EC_KEY(_pEVPPKey);
+}
+
+#endif // !OPENSSL_NO_DEPRECATED_3_0
+
+
+inline std::string ECKeyImpl::groupName() const
+{
+	return OBJ_nid2sn(groupId());
+}
+
+
+inline void ECKeyImpl::save(const std::string& publicKeyFile,
+	const std::string& privateKeyFile,
+	const std::string& privateKeyPassphrase) const
+{
+	EVPPKey(_pEVPPKey).save(publicKeyFile, privateKeyFile, privateKeyPassphrase);
+}
+
+
+inline void ECKeyImpl::save(std::ostream* pPublicKeyStream,
+	std::ostream* pPrivateKeyStream,
+	const std::string& privateKeyPassphrase) const
+{
+	EVPPKey(_pEVPPKey).save(pPublicKeyStream, pPrivateKeyStream, privateKeyPassphrase);
+}
+
+#else // !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
 inline EC_KEY* ECKeyImpl::getECKey()
 {
 	return _pEC;
@@ -163,6 +237,8 @@ inline void ECKeyImpl::save(std::ostream* pPublicKeyStream,
 {
 	EVPPKey(_pEC).save(pPublicKeyStream, pPrivateKeyStream, privateKeyPassphrase);
 }
+
+#endif // POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 
 
 } // namespace Poco::Crypto

--- a/Crypto/include/Poco/Crypto/ECKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/ECKeyImpl.h
@@ -141,6 +141,9 @@ private:
 	void freeEC();
 
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	void safeCheckEC(const std::string& method, const std::string& func);
+		/// Calls checkEC(); frees _pEVPPKey and rethrows on failure.
+		/// Use in constructors where destructor will not run.
 	EVP_PKEY* _pEVPPKey;
 #else
 	EC_KEY* _pEC;

--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -85,8 +85,8 @@ public:
 		/// Constructs EVPPKey from EVP_PKEY pointer.
 		/// The content behind the supplied pointer is internally duplicated.
 
+#if !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	template<typename K>
-	//[[deprecated]] explicit EVPPKey(K* pKey): _pEVPPKey(EVP_PKEY_new())
 	explicit EVPPKey(K* pKey): _pEVPPKey(EVP_PKEY_new())
 		/// Constructs EVPPKey from a "native" OpenSSL (RSA or EC_KEY),
 		/// or a Poco wrapper (RSAKey, ECKey) key pointer.
@@ -94,6 +94,7 @@ public:
 		if (!_pEVPPKey) throw OpenSSLException();
 		setKey(pKey);
 	}
+#endif
 
 	EVPPKey(const std::string& publicKeyFile, const std::string& privateKeyFile, const std::string& privateKeyPassphrase = "");
 		/// Creates the EVPPKey, by reading public and private key from the given files and
@@ -177,17 +178,12 @@ private:
 	void newECKey(const char* group);
 	void duplicate(EVP_PKEY* pEVPPKey);
 
-	//[[deprecated]]
+#if !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	void setKey(ECKey* pKey);
-
-	//[[deprecated]]
 	void setKey(RSAKey* pKey);
-
-	//[[deprecated]]
 	void setKey(EC_KEY* pKey);
-
-	//[[deprecated]]
 	void setKey(RSA* pKey);
+#endif
 
 	static int passCB(char* buf, int size, int, void* pass);
 

--- a/Crypto/include/Poco/Crypto/RSAKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/RSAKeyImpl.h
@@ -133,6 +133,12 @@ private:
 	void freeRSA();
 
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	static void ensureRSAKey(EVP_PKEY* pKey, const std::string& context);
+		/// Verifies pKey is an RSA key; frees pKey and throws if not.
+
+	ByteVec keyParam(const char* name, bool clearFree = false) const;
+		/// Extracts a BIGNUM parameter from _pEVPPKey and returns it as ByteVec.
+
 	EVP_PKEY* _pEVPPKey;
 #else
 	static ByteVec convertToByteVec(const BIGNUM* bn);

--- a/Crypto/include/Poco/Crypto/RSAKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/RSAKeyImpl.h
@@ -165,6 +165,19 @@ inline const EVP_PKEY* RSAKeyImpl::getEVPPKey() const
 	return _pEVPPKey;
 }
 
+#else
+
+inline RSA* RSAKeyImpl::getRSA()
+{
+	return _pRSA;
+}
+
+
+inline const RSA* RSAKeyImpl::getRSA() const
+{
+	return _pRSA;
+}
+
 #endif
 
 

--- a/Crypto/include/Poco/Crypto/RSAKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/RSAKeyImpl.h
@@ -29,10 +29,12 @@
 #include <vector>
 
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 struct bignum_st;
 struct rsa_st;
 typedef struct bignum_st BIGNUM;
 typedef struct rsa_st RSA;
+#endif
 
 
 namespace Poco::Crypto {
@@ -75,11 +77,27 @@ public:
 	~RSAKeyImpl();
 		/// Destroys the RSAKeyImpl.
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY* getEVPPKey();
+		/// Returns the OpenSSL EVP_PKEY object.
+
+	const EVP_PKEY* getEVPPKey() const;
+		/// Returns the OpenSSL EVP_PKEY object.
+#endif
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	POCO_DEPRECATED("use getEVPPKey() instead")
+#endif
 	RSA* getRSA();
 		/// Returns the OpenSSL RSA object.
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	POCO_DEPRECATED("use getEVPPKey() instead")
+#endif
 	const RSA* getRSA() const;
 		/// Returns the OpenSSL RSA object.
+#endif
 
 	int size() const;
 		/// Returns the RSA modulus size.
@@ -113,25 +131,35 @@ private:
 	RSAKeyImpl();
 
 	void freeRSA();
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY* _pEVPPKey;
+#else
 	static ByteVec convertToByteVec(const BIGNUM* bn);
 
 	RSA* _pRSA;
+#endif
 };
 
 
 //
 // inlines
 //
-inline RSA* RSAKeyImpl::getRSA()
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+inline EVP_PKEY* RSAKeyImpl::getEVPPKey()
 {
-	return _pRSA;
+	return _pEVPPKey;
 }
 
 
-inline const RSA* RSAKeyImpl::getRSA() const
+inline const EVP_PKEY* RSAKeyImpl::getEVPPKey() const
 {
-	return _pRSA;
+	return _pEVPPKey;
 }
+
+#endif
 
 
 } // namespace Poco::Crypto

--- a/Crypto/src/DigestEngine.cpp
+++ b/Crypto/src/DigestEngine.cpp
@@ -21,7 +21,7 @@ namespace Poco::Crypto {
 
 DigestEngine::DigestEngine(const std::string& name):
 	_name(name),
-	_pContext(EVP_MD_CTX_create())
+	_pContext(EVP_MD_CTX_new())
 {
 	const EVP_MD* md = EVP_get_digestbyname(_name.c_str());
 	if (!md) throw Poco::NotFoundException(_name);
@@ -31,7 +31,7 @@ DigestEngine::DigestEngine(const std::string& name):
 
 DigestEngine::~DigestEngine()
 {
-	EVP_MD_CTX_destroy(_pContext);
+	EVP_MD_CTX_free(_pContext);
 }
 
 int DigestEngine::nid() const
@@ -52,7 +52,7 @@ std::size_t DigestEngine::digestLength() const
 void DigestEngine::reset()
 {
 	EVP_MD_CTX_free(_pContext);
-	_pContext = EVP_MD_CTX_create();
+	_pContext = EVP_MD_CTX_new();
 	const EVP_MD* md = EVP_get_digestbyname(_name.c_str());
 	if (!md) throw Poco::NotFoundException(_name);
 	EVP_DigestInit_ex(_pContext, md, nullptr);

--- a/Crypto/src/ECDSADigestEngine.cpp
+++ b/Crypto/src/ECDSADigestEngine.cpp
@@ -16,6 +16,7 @@
 #include "Poco/Crypto/ECDSADigestEngine.h"
 #include "Poco/Crypto/CryptoException.h"
 #include <openssl/ecdsa.h>
+#include <openssl/evp.h>
 #include <openssl/bn.h>
 
 
@@ -68,6 +69,17 @@ const DigestEngine::Digest& ECDSADigestEngine::signature()
 	if (_signature.empty())
 	{
 		digest();
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
+		if (!pCtx) throw OpenSSLException("ECDSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign_init()"); }
+		size_t sigLen = 0;
+		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		_signature.resize(sigLen);
+		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		_signature.resize(sigLen);
+		EVP_PKEY_CTX_free(pCtx);
+#else
 		_signature.resize(_key.size());
 		unsigned sigLen = static_cast<unsigned>(_signature.size());
 		if (!ECDSA_sign(0, &_digest[0], static_cast<unsigned>(_digest.size()),
@@ -76,6 +88,7 @@ const DigestEngine::Digest& ECDSADigestEngine::signature()
 			throw OpenSSLException();
 		}
 		if (sigLen < _signature.size()) _signature.resize(sigLen);
+#endif
 	}
 	return _signature;
 }
@@ -84,6 +97,14 @@ const DigestEngine::Digest& ECDSADigestEngine::signature()
 bool ECDSADigestEngine::verify(const DigestEngine::Digest& sig)
 {
 	digest();
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
+	if (!pCtx) throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_verify_init()"); }
+	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
+	EVP_PKEY_CTX_free(pCtx);
+	return ret == 1;
+#else
 	EC_KEY* pKey = _key.impl()->getECKey();
 	if (pKey)
 	{
@@ -94,6 +115,7 @@ bool ECDSADigestEngine::verify(const DigestEngine::Digest& sig)
 		else if (0 == ret) return false;
 	}
 	throw OpenSSLException();
+#endif
 }
 
 

--- a/Crypto/src/ECDSADigestEngine.cpp
+++ b/Crypto/src/ECDSADigestEngine.cpp
@@ -121,7 +121,9 @@ bool ECDSADigestEngine::verify(const DigestEngine::Digest& sig)
 	}
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);
-	return ret == 1;
+	if (ret == 1) return true;
+	if (ret == 0) return false;
+	throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_verify()");
 #else
 	EC_KEY* pKey = _key.impl()->getECKey();
 	if (pKey)

--- a/Crypto/src/ECDSADigestEngine.cpp
+++ b/Crypto/src/ECDSADigestEngine.cpp
@@ -71,7 +71,7 @@ const DigestEngine::Digest& ECDSADigestEngine::signature()
 		digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-		if (!pCtx) throw OpenSSLException("ECDSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (pCtx == nullptr) throw OpenSSLException("ECDSADigestEngine::signature(): EVP_PKEY_CTX_new()");
 		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign_init()"); }
 		size_t sigLen = 0;
 		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
@@ -99,7 +99,7 @@ bool ECDSADigestEngine::verify(const DigestEngine::Digest& sig)
 	digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-	if (!pCtx) throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (pCtx == nullptr) throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_CTX_new()");
 	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_verify_init()"); }
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);

--- a/Crypto/src/ECDSADigestEngine.cpp
+++ b/Crypto/src/ECDSADigestEngine.cpp
@@ -71,12 +71,25 @@ const DigestEngine::Digest& ECDSADigestEngine::signature()
 		digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-		if (pCtx == nullptr) throw OpenSSLException("ECDSADigestEngine::signature(): EVP_PKEY_CTX_new()");
-		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign_init()"); }
+		if (pCtx == nullptr)
+			throw OpenSSLException("ECDSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (EVP_PKEY_sign_init(pCtx) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign_init()");
+		}
 		size_t sigLen = 0;
-		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign()");
+		}
 		_signature.resize(sigLen);
-		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign()");
+		}
 		_signature.resize(sigLen);
 		EVP_PKEY_CTX_free(pCtx);
 #else
@@ -99,8 +112,13 @@ bool ECDSADigestEngine::verify(const DigestEngine::Digest& sig)
 	digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-	if (pCtx == nullptr) throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_CTX_new()");
-	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_verify_init()"); }
+	if (pCtx == nullptr)
+		throw OpenSSLException("ECDSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (EVP_PKEY_verify_init(pCtx) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("EVP_PKEY_verify_init()");
+	}
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);
 	return ret == 1;

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -43,7 +43,7 @@ ECKeyImpl::ECKeyImpl(const EVPPKey& key):
 	_pEVPPKey(nullptr)
 {
 	EVPPKey::duplicate(const_cast<EVP_PKEY*>((const EVP_PKEY*)key), &_pEVPPKey);
-	checkEC("ECKeyImpl(const EVPPKey&)", "EVP_PKEY_dup()");
+	safeCheckEC("ECKeyImpl(const EVPPKey&)", "EVP_PKEY_dup()");
 }
 
 
@@ -57,7 +57,7 @@ ECKeyImpl::ECKeyImpl(const X509Certificate& cert):
 		_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
 		if (_pEVPPKey != nullptr)
 		{
-			checkEC("ECKeyImpl(const X509Certificate&)", "X509_get_pubkey()");
+			safeCheckEC("ECKeyImpl(const X509Certificate&)", "X509_get_pubkey()");
 			return;
 		}
 	}
@@ -71,7 +71,7 @@ ECKeyImpl::ECKeyImpl(const PKCS12Container& cont):
 {
 	EVPPKey key = cont.getKey();
 	EVPPKey::duplicate(static_cast<EVP_PKEY*>(key), &_pEVPPKey);
-	checkEC("ECKeyImpl(const PKCS12Container&)", "EVP_PKEY_dup()");
+	safeCheckEC("ECKeyImpl(const PKCS12Container&)", "EVP_PKEY_dup()");
 }
 
 
@@ -98,7 +98,7 @@ ECKeyImpl::ECKeyImpl(int curve):
 		throw OpenSSLException("ECKeyImpl(int curve): EVP_PKEY_generate()");
 	}
 	EVP_PKEY_CTX_free(pCtx);
-	checkEC("ECKeyImpl(int curve)", "EVP_PKEY_generate()");
+	safeCheckEC("ECKeyImpl(int curve)", "EVP_PKEY_generate()");
 }
 
 
@@ -110,7 +110,7 @@ ECKeyImpl::ECKeyImpl(const std::string& publicKeyFile,
 	if (EVPPKey::loadKey(&pKey, PEM_read_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, privateKeyFile, privateKeyPassphrase))
 	{
 		_pEVPPKey = pKey;
-		checkEC(Poco::format("ECKeyImpl(%s, %s, %s)",
+		safeCheckEC(Poco::format("ECKeyImpl(%s, %s, %s)",
 			publicKeyFile, privateKeyFile, privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
 			"PEM_read_PrivateKey()");
 		return;
@@ -121,7 +121,7 @@ ECKeyImpl::ECKeyImpl(const std::string& publicKeyFile,
 		throw OpenSSLException("ECKeyImpl(const string&, const string&, const string&");
 	}
 	_pEVPPKey = pKey;
-	checkEC(Poco::format("ECKeyImpl(%s, %s, %s)",
+	safeCheckEC(Poco::format("ECKeyImpl(%s, %s, %s)",
 		publicKeyFile, privateKeyFile, privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
 		"PEM_read_PUBKEY()");
 }
@@ -135,7 +135,7 @@ ECKeyImpl::ECKeyImpl(std::istream* pPublicKeyStream,
 	if (EVPPKey::loadKey(&pKey, PEM_read_bio_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, pPrivateKeyStream, privateKeyPassphrase))
 	{
 		_pEVPPKey = pKey;
-		checkEC(Poco::format("ECKeyImpl(stream, stream, %s)",
+		safeCheckEC(Poco::format("ECKeyImpl(stream, stream, %s)",
 			privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
 			"PEM_read_bio_PrivateKey()");
 		return;
@@ -146,7 +146,7 @@ ECKeyImpl::ECKeyImpl(std::istream* pPublicKeyStream,
 		throw OpenSSLException("ECKeyImpl(istream*, istream*, const string&");
 	}
 	_pEVPPKey = pKey;
-	checkEC(Poco::format("ECKeyImpl(stream, stream, %s)",
+	safeCheckEC(Poco::format("ECKeyImpl(stream, stream, %s)",
 		privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
 		"PEM_read_bio_PUBKEY()");
 }
@@ -172,6 +172,20 @@ void ECKeyImpl::checkEC(const std::string& method, const std::string& func) cons
 	EVP_PKEY_CTX_free(pCtx);
 	if (rc != 1)
 		throw OpenSSLException(Poco::format("%s: EVP_PKEY_check()", method));
+}
+
+
+void ECKeyImpl::safeCheckEC(const std::string& method, const std::string& func)
+{
+	try
+	{
+		checkEC(method, func);
+	}
+	catch (...)
+	{
+		freeEC();
+		throw;
+	}
 }
 
 

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -52,10 +52,10 @@ ECKeyImpl::ECKeyImpl(const X509Certificate& cert):
 	_pEVPPKey(nullptr)
 {
 	const X509* pCert = cert.certificate();
-	if (pCert)
+	if (pCert != nullptr)
 	{
 		_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
-		if (_pEVPPKey)
+		if (_pEVPPKey != nullptr)
 		{
 			checkEC("ECKeyImpl(const X509Certificate&)", "X509_get_pubkey()");
 			return;
@@ -80,7 +80,7 @@ ECKeyImpl::ECKeyImpl(int curve):
 	_pEVPPKey(nullptr)
 {
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr);
-	if (!pCtx)
+	if (pCtx == nullptr)
 		throw OpenSSLException("ECKeyImpl: EVP_PKEY_CTX_new_id()");
 	if (EVP_PKEY_keygen_init(pCtx) != 1)
 	{
@@ -160,9 +160,9 @@ ECKeyImpl::~ECKeyImpl()
 
 void ECKeyImpl::checkEC(const std::string& method, const std::string& func) const
 {
-	if (!_pEVPPKey) throw OpenSSLException(Poco::format("%s: %s", method, func));
+	if (_pEVPPKey == nullptr) throw OpenSSLException(Poco::format("%s: %s", method, func));
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pEVPPKey, nullptr);
-	if (!pCtx) throw OpenSSLException(Poco::format("%s: EVP_PKEY_CTX_new()", method));
+	if (pCtx == nullptr) throw OpenSSLException(Poco::format("%s: EVP_PKEY_CTX_new()", method));
 	int rc = EVP_PKEY_check(pCtx);
 	if (rc != 1)
 	{
@@ -177,7 +177,7 @@ void ECKeyImpl::checkEC(const std::string& method, const std::string& func) cons
 
 void ECKeyImpl::freeEC()
 {
-	if (_pEVPPKey)
+	if (_pEVPPKey != nullptr)
 	{
 		EVP_PKEY_free(_pEVPPKey);
 		_pEVPPKey = nullptr;
@@ -193,7 +193,7 @@ int ECKeyImpl::size() const
 
 int ECKeyImpl::groupId() const
 {
-	if (_pEVPPKey)
+	if (_pEVPPKey != nullptr)
 	{
 		char groupName[80];
 		size_t len = 0;

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -24,8 +24,193 @@
 #include <openssl/evp.h>
 #include <openssl/bn.h>
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+#include <openssl/core_names.h>
+#endif
+
 
 namespace Poco::Crypto {
+
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+// OpenSSL 3.0+ implementation using EVP_PKEY
+
+
+ECKeyImpl::ECKeyImpl(const EVPPKey& key):
+	KeyPairImpl("ec", KT_EC_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVPPKey::duplicate(const_cast<EVP_PKEY*>((const EVP_PKEY*)key), &_pEVPPKey);
+	checkEC("ECKeyImpl(const EVPPKey&)", "EVP_PKEY_dup()");
+}
+
+
+ECKeyImpl::ECKeyImpl(const X509Certificate& cert):
+	KeyPairImpl("ec", KT_EC_IMPL),
+	_pEVPPKey(nullptr)
+{
+	const X509* pCert = cert.certificate();
+	if (pCert)
+	{
+		_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
+		if (_pEVPPKey)
+		{
+			checkEC("ECKeyImpl(const X509Certificate&)", "X509_get_pubkey()");
+			return;
+		}
+	}
+	throw OpenSSLException("ECKeyImpl(const X509Certificate&)");
+}
+
+
+ECKeyImpl::ECKeyImpl(const PKCS12Container& cont):
+	KeyPairImpl("ec", KT_EC_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVPPKey key = cont.getKey();
+	EVPPKey::duplicate(static_cast<EVP_PKEY*>(key), &_pEVPPKey);
+	checkEC("ECKeyImpl(const PKCS12Container&)", "EVP_PKEY_dup()");
+}
+
+
+ECKeyImpl::ECKeyImpl(int curve):
+	KeyPairImpl("ec", KT_EC_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr);
+	if (!pCtx)
+		throw OpenSSLException("ECKeyImpl: EVP_PKEY_CTX_new_id()");
+	if (EVP_PKEY_keygen_init(pCtx) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("ECKeyImpl: EVP_PKEY_keygen_init()");
+	}
+	if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pCtx, curve) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("ECKeyImpl: EVP_PKEY_CTX_set_ec_paramgen_curve_nid()");
+	}
+	if (EVP_PKEY_generate(pCtx, &_pEVPPKey) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("ECKeyImpl(int curve): EVP_PKEY_generate()");
+	}
+	EVP_PKEY_CTX_free(pCtx);
+	checkEC("ECKeyImpl(int curve)", "EVP_PKEY_generate()");
+}
+
+
+ECKeyImpl::ECKeyImpl(const std::string& publicKeyFile,
+	const std::string& privateKeyFile,
+	const std::string& privateKeyPassphrase): KeyPairImpl("ec", KT_EC_IMPL), _pEVPPKey(nullptr)
+{
+	EVP_PKEY* pKey = nullptr;
+	if (EVPPKey::loadKey(&pKey, PEM_read_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, privateKeyFile, privateKeyPassphrase))
+	{
+		_pEVPPKey = pKey;
+		checkEC(Poco::format("ECKeyImpl(%s, %s, %s)",
+			publicKeyFile, privateKeyFile, privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
+			"PEM_read_PrivateKey()");
+		return;
+	}
+
+	if (!EVPPKey::loadKey(&pKey, PEM_read_PUBKEY, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, publicKeyFile))
+	{
+		throw OpenSSLException("ECKeyImpl(const string&, const string&, const string&");
+	}
+	_pEVPPKey = pKey;
+	checkEC(Poco::format("ECKeyImpl(%s, %s, %s)",
+		publicKeyFile, privateKeyFile, privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
+		"PEM_read_PUBKEY()");
+}
+
+
+ECKeyImpl::ECKeyImpl(std::istream* pPublicKeyStream,
+	std::istream* pPrivateKeyStream,
+	const std::string& privateKeyPassphrase): KeyPairImpl("ec", KT_EC_IMPL), _pEVPPKey(nullptr)
+{
+	EVP_PKEY* pKey = nullptr;
+	if (EVPPKey::loadKey(&pKey, PEM_read_bio_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, pPrivateKeyStream, privateKeyPassphrase))
+	{
+		_pEVPPKey = pKey;
+		checkEC(Poco::format("ECKeyImpl(stream, stream, %s)",
+			privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
+			"PEM_read_bio_PrivateKey()");
+		return;
+	}
+
+	if (!EVPPKey::loadKey(&pKey, PEM_read_bio_PUBKEY, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, pPublicKeyStream))
+	{
+		throw OpenSSLException("ECKeyImpl(istream*, istream*, const string&");
+	}
+	_pEVPPKey = pKey;
+	checkEC(Poco::format("ECKeyImpl(stream, stream, %s)",
+		privateKeyPassphrase.empty() ? privateKeyPassphrase : std::string("***")),
+		"PEM_read_bio_PUBKEY()");
+}
+
+
+ECKeyImpl::~ECKeyImpl()
+{
+	freeEC();
+}
+
+
+void ECKeyImpl::checkEC(const std::string& method, const std::string& func) const
+{
+	if (!_pEVPPKey) throw OpenSSLException(Poco::format("%s: %s", method, func));
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pEVPPKey, nullptr);
+	if (!pCtx) throw OpenSSLException(Poco::format("%s: EVP_PKEY_CTX_new()", method));
+	int rc = EVP_PKEY_check(pCtx);
+	if (rc != 1)
+	{
+		// public-key-only: EVP_PKEY_check may fail, try EVP_PKEY_public_check
+		rc = EVP_PKEY_public_check(pCtx);
+	}
+	EVP_PKEY_CTX_free(pCtx);
+	if (rc != 1)
+		throw OpenSSLException(Poco::format("%s: EVP_PKEY_check()", method));
+}
+
+
+void ECKeyImpl::freeEC()
+{
+	if (_pEVPPKey)
+	{
+		EVP_PKEY_free(_pEVPPKey);
+		_pEVPPKey = nullptr;
+	}
+}
+
+
+int ECKeyImpl::size() const
+{
+	return EVP_PKEY_bits(_pEVPPKey);
+}
+
+
+int ECKeyImpl::groupId() const
+{
+	if (_pEVPPKey)
+	{
+		char groupName[80];
+		size_t len = 0;
+		if (EVP_PKEY_get_utf8_string_param(_pEVPPKey, OSSL_PKEY_PARAM_GROUP_NAME, groupName, sizeof(groupName), &len))
+		{
+			return OBJ_sn2nid(groupName);
+		}
+		throw OpenSSLException("ECKeyImpl::groupId(): EVP_PKEY_get_utf8_string_param()");
+	}
+	throw NullPointerException("ECKeyImpl::groupId() => _pEVPPKey");
+}
+
+
+#else // !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+// OpenSSL 1.1.x implementation using EC_KEY
 
 
 ECKeyImpl::ECKeyImpl(const EVPPKey& key):
@@ -176,6 +361,12 @@ int ECKeyImpl::groupId() const
 	}
 	throw NullPointerException("ECKeyImpl::groupName() => _pEC");
 }
+
+
+#endif // POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+// Static methods (shared between versions -- EC_get_builtin_curves is not deprecated)
 
 
 std::string ECKeyImpl::getCurveName(int nid)

--- a/Crypto/src/EVPPKey.cpp
+++ b/Crypto/src/EVPPKey.cpp
@@ -311,7 +311,7 @@ EVPPKey& EVPPKey::operator = (EVPPKey&& other) noexcept
 
 EVPPKey::~EVPPKey()
 {
-	if (_pEVPPKey) EVP_PKEY_free(_pEVPPKey);
+	if (_pEVPPKey != nullptr) EVP_PKEY_free(_pEVPPKey);
 }
 
 
@@ -327,7 +327,7 @@ const std::string& EVPPKey::name() const
 
 void EVPPKey::checkType()
 {
-	if (_pEVPPKey)
+	if (_pEVPPKey != nullptr)
 	{
 		int t = type(_pEVPPKey);
 		if (KNOWN_TYPES.find(t) == KNOWN_TYPES.end())
@@ -474,12 +474,12 @@ void EVPPKey::save(std::ostream* pPublicKeyStream, std::ostream* pPrivateKeyStre
 
 EVP_PKEY* EVPPKey::duplicate(const EVP_PKEY* pFromKey, EVP_PKEY** pToKey)
 {
-	if (!pFromKey) throw NullPointerException("EVPPKey::duplicate(): "
+	if (pFromKey == nullptr) throw NullPointerException("EVPPKey::duplicate(): "
 		"provided key pointer is null.");
 
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	*pToKey = EVP_PKEY_dup(const_cast<EVP_PKEY*>(pFromKey));
-	if (!*pToKey)
+	if (*pToKey == nullptr)
 	{
 		std::string msg = "EVPPKey::duplicate():EVP_PKEY_dup()\n";
 		throw OpenSSLException(getError(msg));

--- a/Crypto/src/EVPPKey.cpp
+++ b/Crypto/src/EVPPKey.cpp
@@ -336,26 +336,6 @@ void EVPPKey::checkType()
 }
 
 
-void EVPPKey::setKey(EC_KEY* pKey)
-{
-	if (!EVP_PKEY_set1_EC_KEY(_pEVPPKey, pKey))
-	{
-		std::string msg = "EVPPKey::setKey('EC')\n";
-		throw OpenSSLException(getError(msg));
-	}
-}
-
-
-void EVPPKey::setKey(RSA* pKey)
-{
-	if (!EVP_PKEY_set1_RSA(_pEVPPKey, pKey))
-	{
-		std::string msg = "EVPPKey::setKey('RSA')\n";
-		throw OpenSSLException(getError(msg));
-	}
-}
-
-
 void EVPPKey::save(const std::string& publicKeyFile, const std::string& privateKeyFile, const std::string& privateKeyPassphrase) const
 {
 	if (!publicKeyFile.empty() && (publicKeyFile != privateKeyFile))
@@ -497,6 +477,14 @@ EVP_PKEY* EVPPKey::duplicate(const EVP_PKEY* pFromKey, EVP_PKEY** pToKey)
 	if (!pFromKey) throw NullPointerException("EVPPKey::duplicate(): "
 		"provided key pointer is null.");
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	*pToKey = EVP_PKEY_dup(const_cast<EVP_PKEY*>(pFromKey));
+	if (!*pToKey)
+	{
+		std::string msg = "EVPPKey::duplicate():EVP_PKEY_dup()\n";
+		throw OpenSSLException(getError(msg));
+	}
+#else
 	*pToKey = EVP_PKEY_new();
 	if (!*pToKey)
 	{
@@ -555,6 +543,7 @@ EVP_PKEY* EVPPKey::duplicate(const EVP_PKEY* pFromKey, EVP_PKEY** pToKey)
 			throw NotImplementedException("EVPPKey:duplicate(); Key type: " +
 				NumberFormatter::format(keyType));
 	}
+#endif
 
 	return *pToKey;
 }
@@ -562,6 +551,34 @@ EVP_PKEY* EVPPKey::duplicate(const EVP_PKEY* pFromKey, EVP_PKEY** pToKey)
 
 void EVPPKey::newECKey(const char* ecCurveName)
 {
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	int curveID = OBJ_txt2nid(ecCurveName);
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr);
+	if (!pCtx)
+	{
+		std::string msg = "EVPPKey::newECKey():EVP_PKEY_CTX_new_id()\n";
+		throw OpenSSLException(getError(msg));
+	}
+	if (EVP_PKEY_keygen_init(pCtx) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		std::string msg = "EVPPKey::newECKey():EVP_PKEY_keygen_init()\n";
+		throw OpenSSLException(getError(msg));
+	}
+	if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pCtx, curveID) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		std::string msg = "EVPPKey::newECKey():EVP_PKEY_CTX_set_ec_paramgen_curve_nid()\n";
+		throw OpenSSLException(getError(msg));
+	}
+	if (EVP_PKEY_generate(pCtx, &_pEVPPKey) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		std::string msg = "EVPPKey::newECKey():EVP_PKEY_generate()\n";
+		throw OpenSSLException(getError(msg));
+	}
+	EVP_PKEY_CTX_free(pCtx);
+#else
 	int curveID = OBJ_txt2nid(ecCurveName);
 	EC_KEY* pEC = EC_KEY_new_by_curve_name(curveID);
 	if (!pEC) goto err;
@@ -574,6 +591,29 @@ void EVPPKey::newECKey(const char* ecCurveName)
 err:
 	std::string msg = "EVPPKey::newECKey()\n";
 	throw OpenSSLException(getError(msg));
+#endif
+}
+
+
+#if !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+void EVPPKey::setKey(EC_KEY* pKey)
+{
+	if (!EVP_PKEY_set1_EC_KEY(_pEVPPKey, pKey))
+	{
+		std::string msg = "EVPPKey::setKey('EC')\n";
+		throw OpenSSLException(getError(msg));
+	}
+}
+
+
+void EVPPKey::setKey(RSA* pKey)
+{
+	if (!EVP_PKEY_set1_RSA(_pEVPPKey, pKey))
+	{
+		std::string msg = "EVPPKey::setKey('RSA')\n";
+		throw OpenSSLException(getError(msg));
+	}
 }
 
 
@@ -591,6 +631,8 @@ void EVPPKey::setKey(RSAKey* pKey)
 	poco_check_ptr(pKey->impl());
 	setKey(pKey->impl()->getRSA());
 }
+
+#endif
 
 
 int EVPPKey::passCB(char* buf, int size, int, void* pass)

--- a/Crypto/src/EVPPKey.cpp
+++ b/Crypto/src/EVPPKey.cpp
@@ -78,7 +78,11 @@ void pushBuildParamBignum(OSSL_PARAM_BLD* paramBld, const char* key, const std::
 		throw OpenSSLException(getError(msg));
 	}
 
-	OSSL_PARAM_BLD_push_BN(paramBld, key, *pBigNum);
+	if (!OSSL_PARAM_BLD_push_BN(paramBld, key, *pBigNum))
+	{
+		std::string msg = "pushBuildParamBignum(): OSSL_PARAM_BLD_push_BN()\n";
+		throw OpenSSLException(getError(msg));
+	}
 }
 
 
@@ -103,18 +107,24 @@ OSSL_PARAM* getKeyParameters(const std::vector<unsigned char>* publicKey, const 
 			pushBuildParamBignum(paramBld, "d", *privateKey, &pBigNum2);
 
 		// default rsa exponent
-		OSSL_PARAM_BLD_push_ulong(paramBld, "e", RSA_F4);
+		if (!OSSL_PARAM_BLD_push_ulong(paramBld, "e", RSA_F4))
+		{
+			std::string msg = "getKeyParameters(): OSSL_PARAM_BLD_push_ulong()\n";
+			throw OpenSSLException(getError(msg));
+		}
 
 		parameters = OSSL_PARAM_BLD_to_param(paramBld);
-		if (!parameters)
+		if (parameters == nullptr)
 		{
 			std::string msg = "getKeyParameters(): OSSL_PARAM_BLD_to_param()\n";
 			throw OpenSSLException(getError(msg));
 		}
 	}
-	catch(OpenSSLException&)
+	catch(...)
 	{
 		OSSL_PARAM_BLD_free(paramBld);
+		BN_clear_free(pBigNum1);
+		BN_clear_free(pBigNum2);
 		throw;
 	}
 
@@ -129,6 +139,11 @@ OSSL_PARAM* getKeyParameters(const std::vector<unsigned char>* publicKey, const 
 void EVPPKey::setKeyFromParameters(OSSL_PARAM* parameters)
 {
 	auto ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
+	if (ctx == nullptr)
+	{
+		OSSL_PARAM_free(parameters);
+		throw OpenSSLException("EVPPKey::setKeyFromParameters(): EVP_PKEY_CTX_new_id()");
+	}
 	if (EVP_PKEY_fromdata_init(ctx) <= 0)
 	{
 		OSSL_PARAM_free(parameters);
@@ -184,6 +199,7 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 	int ret = EVP_PKEY_keygen_init(pCtx);
 	if (ret != 1)
 	{
+		EVP_PKEY_CTX_free(pCtx);
 		std::string msg = Poco::format(
 			"EVPPKey(%d, %d):EVP_PKEY_keygen_init()\n", type, param);
 		throw OpenSSLException(getError(msg));
@@ -194,6 +210,7 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 		ret = EVP_PKEY_CTX_set_rsa_keygen_bits(pCtx, param);
 		if (ret != 1)
 		{
+			EVP_PKEY_CTX_free(pCtx);
 			std::string msg = Poco::format(
 				"EVPPKey(%d, %d):EVP_PKEY_CTX_set_rsa_keygen_bits()\n", type, param);
 			throw OpenSSLException(getError(msg));
@@ -204,6 +221,7 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 		ret = EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pCtx, param);
 		if (ret != 1)
 		{
+			EVP_PKEY_CTX_free(pCtx);
 			std::string msg = Poco::format(
 				"EVPPKey(%d, %d):EVP_PKEY_CTX_set_ec_paramgen_curve_nid()\n", type, param);
 			throw OpenSSLException(getError(msg));
@@ -213,6 +231,7 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 	ret = EVP_PKEY_generate(pCtx, &_pEVPPKey);
 	if (ret != 1)
 	{
+		EVP_PKEY_CTX_free(pCtx);
 		std::string msg = Poco::format(
 			"EVPPKey(%d, %d):EVP_PKEY_generate()\n", type, param);
 		throw OpenSSLException(getError(msg));
@@ -221,6 +240,7 @@ EVPPKey::EVPPKey(int type, int param) : _pEVPPKey(nullptr)
 	ret = EVP_PKEY_keygen(pCtx, &_pEVPPKey);
 	if (ret != 1)
 	{
+		EVP_PKEY_CTX_free(pCtx);
 		std::string msg = Poco::format(
 			"EVPPKey(%d, %d):EVP_PKEY_keygen()\n", type, param);
 		throw OpenSSLException(getError(msg));
@@ -581,14 +601,15 @@ void EVPPKey::newECKey(const char* ecCurveName)
 #else
 	int curveID = OBJ_txt2nid(ecCurveName);
 	EC_KEY* pEC = EC_KEY_new_by_curve_name(curveID);
-	if (!pEC) goto err;
+	if (pEC == nullptr) goto err;
 	if (!EC_KEY_generate_key(pEC)) goto err;
 	_pEVPPKey = EVP_PKEY_new();
-	if (!_pEVPPKey) goto err;
+	if (_pEVPPKey == nullptr) goto err;
 	if (!EVP_PKEY_set1_EC_KEY(_pEVPPKey, pEC)) goto err;
 	EC_KEY_free(pEC);
 	return;
 err:
+	if (pEC != nullptr) EC_KEY_free(pEC);
 	std::string msg = "EVPPKey::newECKey()\n";
 	throw OpenSSLException(getError(msg));
 #endif

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -98,9 +98,18 @@ namespace
 			_pBuf(nullptr)
 	{
 		if (_pCtx == nullptr) throwError();
-		if (EVP_PKEY_encrypt_init(_pCtx) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
-		if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
-		_pBuf = new unsigned char[blockSize()];
+		try
+		{
+			if (EVP_PKEY_encrypt_init(_pCtx) != 1) throwError();
+			if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) throwError();
+			_pBuf = new unsigned char[blockSize()];
+		}
+		catch (...)
+		{
+			EVP_PKEY_CTX_free(_pCtx);
+			_pCtx = nullptr;
+			throw;
+		}
 	}
 
 
@@ -240,9 +249,18 @@ namespace
 			_pBuf(nullptr)
 	{
 		if (_pCtx == nullptr) throwError();
-		if (EVP_PKEY_decrypt_init(_pCtx) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
-		if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
-		_pBuf = new unsigned char[blockSize()];
+		try
+		{
+			if (EVP_PKEY_decrypt_init(_pCtx) != 1) throwError();
+			if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) throwError();
+			_pBuf = new unsigned char[blockSize()];
+		}
+		catch (...)
+		{
+			EVP_PKEY_CTX_free(_pCtx);
+			_pCtx = nullptr;
+			throw;
+		}
 	}
 
 

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -83,6 +83,7 @@ namespace
 
 	private:
 		EVP_PKEY*       _pKey;
+		EVP_PKEY_CTX*   _pCtx;
 		RSAPaddingMode  _paddingMode;
 		std::streamsize _pos;
 		unsigned char*  _pBuf;
@@ -91,10 +92,14 @@ namespace
 
 	RSAEncryptImpl::RSAEncryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode):
 			_pKey(pKey),
+			_pCtx(EVP_PKEY_CTX_new(pKey, nullptr)),
 			_paddingMode(paddingMode),
 			_pos(0),
 			_pBuf(nullptr)
 	{
+		if (_pCtx == nullptr) throwError();
+		if (EVP_PKEY_encrypt_init(_pCtx) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
+		if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
 		_pBuf = new unsigned char[blockSize()];
 	}
 
@@ -102,6 +107,7 @@ namespace
 	RSAEncryptImpl::~RSAEncryptImpl()
 	{
 		delete [] _pBuf;
+		if (_pCtx != nullptr) EVP_PKEY_CTX_free(_pCtx);
 	}
 
 
@@ -158,17 +164,9 @@ namespace
 			if (missing == 0)
 			{
 				poco_assert (outputLength >= rsaSize);
-				EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
-				if (!pCtx) throwError();
-				if (EVP_PKEY_encrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
-				if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
 				size_t outLen = static_cast<size_t>(rsaSize);
-				if (EVP_PKEY_encrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(maxSize)) != 1)
-				{
-					EVP_PKEY_CTX_free(pCtx);
+				if (EVP_PKEY_encrypt(_pCtx, output, &outLen, _pBuf, static_cast<size_t>(maxSize)) != 1)
 					throwError();
-				}
-				EVP_PKEY_CTX_free(pCtx);
 				rc += static_cast<int>(outLen);
 				output += outLen;
 				outputLength -= outLen;
@@ -196,17 +194,9 @@ namespace
 		int rc = 0;
 		if (_pos > 0)
 		{
-			EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
-			if (!pCtx) throwError();
-			if (EVP_PKEY_encrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
-			if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
 			size_t outLen = static_cast<size_t>(length);
-			if (EVP_PKEY_encrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos)) != 1)
-			{
-				EVP_PKEY_CTX_free(pCtx);
+			if (EVP_PKEY_encrypt(_pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos)) != 1)
 				throwError();
-			}
-			EVP_PKEY_CTX_free(pCtx);
 			rc = static_cast<int>(outLen);
 		}
 		return rc;
@@ -235,6 +225,7 @@ namespace
 
 	private:
 		EVP_PKEY*       _pKey;
+		EVP_PKEY_CTX*   _pCtx;
 		RSAPaddingMode  _paddingMode;
 		std::streamsize _pos;
 		unsigned char*  _pBuf;
@@ -243,10 +234,14 @@ namespace
 
 	RSADecryptImpl::RSADecryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode):
 			_pKey(pKey),
+			_pCtx(EVP_PKEY_CTX_new(pKey, nullptr)),
 			_paddingMode(paddingMode),
 			_pos(0),
 			_pBuf(nullptr)
 	{
+		if (_pCtx == nullptr) throwError();
+		if (EVP_PKEY_decrypt_init(_pCtx) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
+		if (EVP_PKEY_CTX_set_rsa_padding(_pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(_pCtx); _pCtx = nullptr; throwError(); }
 		_pBuf = new unsigned char[blockSize()];
 	}
 
@@ -254,6 +249,7 @@ namespace
 	RSADecryptImpl::~RSADecryptImpl()
 	{
 		delete [] _pBuf;
+		if (_pCtx != nullptr) EVP_PKEY_CTX_free(_pCtx);
 	}
 
 
@@ -290,14 +286,9 @@ namespace
 			std::streamsize missing = rsaSize - _pos;
 			if (missing == 0)
 			{
-				EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
-				if (!pCtx) throwError();
-				if (EVP_PKEY_decrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
-				if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
 				size_t outLen = static_cast<size_t>(rsaSize);
-				int tmp = EVP_PKEY_decrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(rsaSize));
-				EVP_PKEY_CTX_free(pCtx);
-				if (tmp != 1) throwError();
+				if (EVP_PKEY_decrypt(_pCtx, output, &outLen, _pBuf, static_cast<size_t>(rsaSize)) != 1)
+					throwError();
 				rc += static_cast<int>(outLen);
 				output += outLen;
 				outputLength -= outLen;
@@ -324,14 +315,9 @@ namespace
 		int rc = 0;
 		if (_pos > 0)
 		{
-			EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
-			if (!pCtx) throwError();
-			if (EVP_PKEY_decrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
-			if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
 			size_t outLen = static_cast<size_t>(length);
-			int tmp = EVP_PKEY_decrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos));
-			EVP_PKEY_CTX_free(pCtx);
-			if (tmp != 1) throwError();
+			if (EVP_PKEY_decrypt(_pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos)) != 1)
+				throwError();
 			rc = static_cast<int>(outLen);
 		}
 		return rc;

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -17,6 +17,7 @@
 #include "Poco/Exception.h"
 #include <openssl/err.h>
 #include <openssl/rsa.h>
+#include <openssl/evp.h>
 #include <cstring>
 
 
@@ -56,6 +57,288 @@ namespace
 			return RSA_NO_PADDING;
 		}
 	}
+
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+	class RSAEncryptImpl: public CryptoTransform
+	{
+	public:
+		RSAEncryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode);
+		~RSAEncryptImpl();
+
+		std::size_t blockSize() const;
+		std::size_t maxDataSize() const;
+		std::string getTag(std::size_t);
+		void setTag(const std::string&);
+
+		std::streamsize transform(
+			const unsigned char* input,
+			std::streamsize		 inputLength,
+			unsigned char*		 output,
+			std::streamsize		 outputLength);
+
+		std::streamsize finalize(unsigned char* output, std::streamsize length);
+
+	private:
+		EVP_PKEY*       _pKey;
+		RSAPaddingMode  _paddingMode;
+		std::streamsize _pos;
+		unsigned char*  _pBuf;
+	};
+
+
+	RSAEncryptImpl::RSAEncryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode):
+			_pKey(pKey),
+			_paddingMode(paddingMode),
+			_pos(0),
+			_pBuf(nullptr)
+	{
+		_pBuf = new unsigned char[blockSize()];
+	}
+
+
+	RSAEncryptImpl::~RSAEncryptImpl()
+	{
+		delete [] _pBuf;
+	}
+
+
+	std::size_t RSAEncryptImpl::blockSize() const
+	{
+		return EVP_PKEY_get_size(_pKey);
+	}
+
+
+	std::size_t RSAEncryptImpl::maxDataSize() const
+	{
+		std::size_t size = blockSize();
+		switch (_paddingMode)
+		{
+		case RSA_PADDING_PKCS1:
+			size -= 11;
+			break;
+		case RSA_PADDING_PKCS1_OAEP:
+			size -= 41;
+			break;
+		default:
+			break;
+		}
+		return size;
+	}
+
+
+	std::string RSAEncryptImpl::getTag(std::size_t)
+	{
+		return std::string();
+	}
+
+
+	void RSAEncryptImpl::setTag(const std::string&)
+	{
+	}
+
+
+	std::streamsize RSAEncryptImpl::transform(
+		const unsigned char* input,
+		std::streamsize		 inputLength,
+		unsigned char*		 output,
+		std::streamsize		 outputLength)
+	{
+		std::streamsize maxSize = static_cast<std::streamsize>(maxDataSize());
+		std::streamsize rsaSize = static_cast<std::streamsize>(blockSize());
+		poco_assert_dbg(_pos <= maxSize);
+		poco_assert (outputLength >= rsaSize);
+		int rc = 0;
+		while (inputLength > 0)
+		{
+			poco_assert_dbg (maxSize >= _pos);
+			std::streamsize missing = maxSize - _pos;
+			if (missing == 0)
+			{
+				poco_assert (outputLength >= rsaSize);
+				EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
+				if (!pCtx) throwError();
+				if (EVP_PKEY_encrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+				if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+				size_t outLen = static_cast<size_t>(rsaSize);
+				if (EVP_PKEY_encrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(maxSize)) != 1)
+				{
+					EVP_PKEY_CTX_free(pCtx);
+					throwError();
+				}
+				EVP_PKEY_CTX_free(pCtx);
+				rc += static_cast<int>(outLen);
+				output += outLen;
+				outputLength -= outLen;
+				_pos = 0;
+			}
+			else
+			{
+				if (missing > inputLength)
+					missing = inputLength;
+
+				std::memcpy(_pBuf + _pos, input, static_cast<std::size_t>(missing));
+				input += missing;
+				_pos += missing;
+				inputLength -= missing;
+			}
+		}
+		return rc;
+	}
+
+
+	std::streamsize RSAEncryptImpl::finalize(unsigned char* output, std::streamsize length)
+	{
+		poco_assert (length >= static_cast<std::streamsize>(blockSize()));
+		poco_assert (static_cast<std::size_t>(_pos) <= maxDataSize());
+		int rc = 0;
+		if (_pos > 0)
+		{
+			EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
+			if (!pCtx) throwError();
+			if (EVP_PKEY_encrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+			if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+			size_t outLen = static_cast<size_t>(length);
+			if (EVP_PKEY_encrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos)) != 1)
+			{
+				EVP_PKEY_CTX_free(pCtx);
+				throwError();
+			}
+			EVP_PKEY_CTX_free(pCtx);
+			rc = static_cast<int>(outLen);
+		}
+		return rc;
+	}
+
+
+	class RSADecryptImpl: public CryptoTransform
+	{
+	public:
+		RSADecryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode);
+		~RSADecryptImpl();
+
+		std::size_t blockSize() const;
+		std::string getTag(std::size_t);
+		void setTag(const std::string&);
+
+		std::streamsize transform(
+			const unsigned char* input,
+			std::streamsize		 inputLength,
+			unsigned char*		 output,
+			std::streamsize		 outputLength);
+
+		std::streamsize finalize(
+			unsigned char*	output,
+			std::streamsize length);
+
+	private:
+		EVP_PKEY*       _pKey;
+		RSAPaddingMode  _paddingMode;
+		std::streamsize _pos;
+		unsigned char*  _pBuf;
+	};
+
+
+	RSADecryptImpl::RSADecryptImpl(EVP_PKEY* pKey, RSAPaddingMode paddingMode):
+			_pKey(pKey),
+			_paddingMode(paddingMode),
+			_pos(0),
+			_pBuf(nullptr)
+	{
+		_pBuf = new unsigned char[blockSize()];
+	}
+
+
+	RSADecryptImpl::~RSADecryptImpl()
+	{
+		delete [] _pBuf;
+	}
+
+
+	std::size_t RSADecryptImpl::blockSize() const
+	{
+		return EVP_PKEY_get_size(_pKey);
+	}
+
+
+	std::string RSADecryptImpl::getTag(std::size_t)
+	{
+		return std::string();
+	}
+
+
+	void RSADecryptImpl::setTag(const std::string&)
+	{
+	}
+
+
+	std::streamsize RSADecryptImpl::transform(
+		const unsigned char* input,
+		std::streamsize		 inputLength,
+		unsigned char*		 output,
+		std::streamsize		 outputLength)
+	{
+		std::streamsize rsaSize = static_cast<std::streamsize>(blockSize());
+		poco_assert_dbg(_pos <= rsaSize);
+		poco_assert (outputLength >= rsaSize);
+		int rc = 0;
+		while (inputLength > 0)
+		{
+			poco_assert_dbg (rsaSize >= _pos);
+			std::streamsize missing = rsaSize - _pos;
+			if (missing == 0)
+			{
+				EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
+				if (!pCtx) throwError();
+				if (EVP_PKEY_decrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+				if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+				size_t outLen = static_cast<size_t>(rsaSize);
+				int tmp = EVP_PKEY_decrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(rsaSize));
+				EVP_PKEY_CTX_free(pCtx);
+				if (tmp != 1) throwError();
+				rc += static_cast<int>(outLen);
+				output += outLen;
+				outputLength -= outLen;
+				_pos = 0;
+			}
+			else
+			{
+				if (missing > inputLength)
+					missing = inputLength;
+
+				std::memcpy(_pBuf + _pos, input, static_cast<std::size_t>(missing));
+				input += missing;
+				_pos += missing;
+				inputLength -= missing;
+			}
+		}
+		return rc;
+	}
+
+
+	std::streamsize RSADecryptImpl::finalize(unsigned char* output, std::streamsize length)
+	{
+		poco_assert (length >= static_cast<std::streamsize>(blockSize()));
+		int rc = 0;
+		if (_pos > 0)
+		{
+			EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_pKey, nullptr);
+			if (!pCtx) throwError();
+			if (EVP_PKEY_decrypt_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+			if (EVP_PKEY_CTX_set_rsa_padding(pCtx, mapPaddingMode(_paddingMode)) != 1) { EVP_PKEY_CTX_free(pCtx); throwError(); }
+			size_t outLen = static_cast<size_t>(length);
+			int tmp = EVP_PKEY_decrypt(pCtx, output, &outLen, _pBuf, static_cast<size_t>(_pos));
+			EVP_PKEY_CTX_free(pCtx);
+			if (tmp != 1) throwError();
+			rc = static_cast<int>(outLen);
+		}
+		return rc;
+	}
+
+
+#else // !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 
 
 	class RSAEncryptImpl: public CryptoTransform
@@ -310,6 +593,10 @@ namespace
 		}
 		return rc;
 	}
+
+
+#endif // POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
 }
 
 
@@ -327,13 +614,21 @@ RSACipherImpl::~RSACipherImpl()
 
 CryptoTransform::Ptr RSACipherImpl::createEncryptor()
 {
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	return new RSAEncryptImpl(_key.impl()->getEVPPKey(), _paddingMode);
+#else
 	return new RSAEncryptImpl(_key.impl()->getRSA(), _paddingMode);
+#endif
 }
 
 
 CryptoTransform::Ptr RSACipherImpl::createDecryptor()
 {
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	return new RSADecryptImpl(_key.impl()->getEVPPKey(), _paddingMode);
+#else
 	return new RSADecryptImpl(_key.impl()->getRSA(), _paddingMode);
+#endif
 }
 
 

--- a/Crypto/src/RSADigestEngine.cpp
+++ b/Crypto/src/RSADigestEngine.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/Crypto/RSADigestEngine.h"
+#include "Poco/Crypto/CryptoException.h"
 #include <openssl/rsa.h>
 #include <openssl/evp.h>
 
@@ -69,15 +70,15 @@ const DigestEngine::Digest& RSADigestEngine::signature()
 		digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-		if (!pCtx) throw Poco::IOException("RSADigestEngine::signature(): EVP_PKEY_CTX_new()");
-		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign_init()"); }
-		if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_rsa_padding()"); }
+		if (pCtx == nullptr) throw OpenSSLException("RSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign_init()"); }
+		if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()"); }
 		const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
-		if (md && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_signature_md()"); }
+		if (md != nullptr && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()"); }
 		size_t sigLen = 0;
-		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
 		_signature.resize(sigLen);
-		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
 		_signature.resize(sigLen);
 		EVP_PKEY_CTX_free(pCtx);
 #else
@@ -98,16 +99,16 @@ bool RSADigestEngine::verify(const DigestEngine::Digest& sig)
 	digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-	if (!pCtx) throw Poco::IOException("RSADigestEngine::verify(): EVP_PKEY_CTX_new()");
-	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_verify_init()"); }
-	if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_rsa_padding()"); }
+	if (pCtx == nullptr) throw OpenSSLException("RSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_verify_init()"); }
+	if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()"); }
 	const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
-	if (md && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_signature_md()"); }
+	if (md != nullptr && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()"); }
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);
 	return ret == 1;
 #else
-	DigestEngine::Digest sigCpy = sig; // copy becausse RSA_verify can modify sigCpy
+	DigestEngine::Digest sigCpy = sig; // copy because RSA_verify can modify sigCpy
 	int ret = RSA_verify(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &sigCpy[0], static_cast<unsigned>(sigCpy.size()), _key.impl()->getRSA());
 	return ret != 0;
 #endif

--- a/Crypto/src/RSADigestEngine.cpp
+++ b/Crypto/src/RSADigestEngine.cpp
@@ -150,11 +150,15 @@ bool RSADigestEngine::verify(const DigestEngine::Digest& sig)
 	}
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);
-	return ret == 1;
+	if (ret == 1) return true;
+	if (ret == 0) return false;
+	throw OpenSSLException("RSADigestEngine::verify(): EVP_PKEY_verify()");
 #else
 	DigestEngine::Digest sigCpy = sig; // copy because RSA_verify can modify sigCpy
 	int ret = RSA_verify(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &sigCpy[0], static_cast<unsigned>(sigCpy.size()), _key.impl()->getRSA());
-	return ret != 0;
+	if (ret == 1) return true;
+	if (ret == 0) return false;
+	throw OpenSSLException("RSADigestEngine::verify(): RSA_verify()");
 #endif
 }
 

--- a/Crypto/src/RSADigestEngine.cpp
+++ b/Crypto/src/RSADigestEngine.cpp
@@ -70,22 +70,48 @@ const DigestEngine::Digest& RSADigestEngine::signature()
 		digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-		if (pCtx == nullptr) throw OpenSSLException("RSADigestEngine::signature(): EVP_PKEY_CTX_new()");
-		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign_init()"); }
-		if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()"); }
+		if (pCtx == nullptr)
+			throw OpenSSLException("RSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (EVP_PKEY_sign_init(pCtx) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign_init()");
+		}
+		if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()");
+		}
 		const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
-		if (md != nullptr && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()"); }
+		if (md == nullptr)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("RSADigestEngine: unknown digest: " + _engine.algorithm());
+		}
+		if (EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()");
+		}
 		size_t sigLen = 0;
-		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign()");
+		}
 		_signature.resize(sigLen);
-		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_sign()"); }
+		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("EVP_PKEY_sign()");
+		}
 		_signature.resize(sigLen);
 		EVP_PKEY_CTX_free(pCtx);
 #else
 		_signature.resize(_key.size());
 		unsigned sigLen = static_cast<unsigned>(_signature.size());
-		RSA_sign(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &_signature[0], &sigLen, _key.impl()->getRSA());
-		// truncate _sig to sigLen
+		if (!RSA_sign(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &_signature[0], &sigLen, _key.impl()->getRSA()))
+			throw OpenSSLException("RSADigestEngine::signature(): RSA_sign()");
 		if (sigLen < _signature.size())
 			_signature.resize(sigLen);
 #endif
@@ -99,11 +125,29 @@ bool RSADigestEngine::verify(const DigestEngine::Digest& sig)
 	digest();
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
-	if (pCtx == nullptr) throw OpenSSLException("RSADigestEngine::verify(): EVP_PKEY_CTX_new()");
-	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_verify_init()"); }
-	if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()"); }
+	if (pCtx == nullptr)
+		throw OpenSSLException("RSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (EVP_PKEY_verify_init(pCtx) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("EVP_PKEY_verify_init()");
+	}
+	if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("EVP_PKEY_CTX_set_rsa_padding()");
+	}
 	const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
-	if (md != nullptr && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()"); }
+	if (md == nullptr)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("RSADigestEngine: unknown digest: " + _engine.algorithm());
+	}
+	if (EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("EVP_PKEY_CTX_set_signature_md()");
+	}
 	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
 	EVP_PKEY_CTX_free(pCtx);
 	return ret == 1;

--- a/Crypto/src/RSADigestEngine.cpp
+++ b/Crypto/src/RSADigestEngine.cpp
@@ -14,6 +14,7 @@
 
 #include "Poco/Crypto/RSADigestEngine.h"
 #include <openssl/rsa.h>
+#include <openssl/evp.h>
 
 
 namespace Poco::Crypto {
@@ -66,12 +67,27 @@ const DigestEngine::Digest& RSADigestEngine::signature()
 	if (_signature.empty())
 	{
 		digest();
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+		EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
+		if (!pCtx) throw Poco::IOException("RSADigestEngine::signature(): EVP_PKEY_CTX_new()");
+		if (EVP_PKEY_sign_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign_init()"); }
+		if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_rsa_padding()"); }
+		const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
+		if (md && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_signature_md()"); }
+		size_t sigLen = 0;
+		if (EVP_PKEY_sign(pCtx, nullptr, &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign()"); }
+		_signature.resize(sigLen);
+		if (EVP_PKEY_sign(pCtx, _signature.data(), &sigLen, _digest.data(), _digest.size()) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_sign()"); }
+		_signature.resize(sigLen);
+		EVP_PKEY_CTX_free(pCtx);
+#else
 		_signature.resize(_key.size());
 		unsigned sigLen = static_cast<unsigned>(_signature.size());
 		RSA_sign(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &_signature[0], &sigLen, _key.impl()->getRSA());
 		// truncate _sig to sigLen
 		if (sigLen < _signature.size())
 			_signature.resize(sigLen);
+#endif
 	}
 	return _signature;
 }
@@ -80,9 +96,21 @@ const DigestEngine::Digest& RSADigestEngine::signature()
 bool RSADigestEngine::verify(const DigestEngine::Digest& sig)
 {
 	digest();
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new(_key.impl()->getEVPPKey(), nullptr);
+	if (!pCtx) throw Poco::IOException("RSADigestEngine::verify(): EVP_PKEY_CTX_new()");
+	if (EVP_PKEY_verify_init(pCtx) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_verify_init()"); }
+	if (EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PADDING) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_rsa_padding()"); }
+	const EVP_MD* md = EVP_get_digestbyname(_engine.algorithm().c_str());
+	if (md && EVP_PKEY_CTX_set_signature_md(pCtx, md) != 1) { EVP_PKEY_CTX_free(pCtx); throw Poco::IOException("EVP_PKEY_CTX_set_signature_md()"); }
+	int ret = EVP_PKEY_verify(pCtx, sig.data(), sig.size(), _digest.data(), _digest.size());
+	EVP_PKEY_CTX_free(pCtx);
+	return ret == 1;
+#else
 	DigestEngine::Digest sigCpy = sig; // copy becausse RSA_verify can modify sigCpy
 	int ret = RSA_verify(_engine.nid(), &_digest[0], static_cast<unsigned>(_digest.size()), &sigCpy[0], static_cast<unsigned>(sigCpy.size()), _key.impl()->getRSA());
 	return ret != 0;
+#endif
 }
 
 

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -42,7 +42,7 @@ RSAKeyImpl::RSAKeyImpl(const EVPPKey& key):
 	_pEVPPKey(nullptr)
 {
 	EVPPKey::duplicate(const_cast<EVP_PKEY*>((const EVP_PKEY*)key), &_pEVPPKey);
-	if (!_pEVPPKey) throw OpenSSLException();
+	if (_pEVPPKey == nullptr) throw OpenSSLException();
 }
 
 
@@ -52,7 +52,7 @@ RSAKeyImpl::RSAKeyImpl(const X509Certificate& cert):
 {
 	const X509* pCert = cert.certificate();
 	_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
-	if (!_pEVPPKey)
+	if (_pEVPPKey == nullptr)
 		throw OpenSSLException("RSAKeyImpl(const X509Certificate&)");
 }
 
@@ -63,7 +63,7 @@ RSAKeyImpl::RSAKeyImpl(const PKCS12Container& cont):
 {
 	EVPPKey key = cont.getKey();
 	EVPPKey::duplicate(static_cast<EVP_PKEY*>(key), &_pEVPPKey);
-	if (!_pEVPPKey) throw OpenSSLException();
+	if (_pEVPPKey == nullptr) throw OpenSSLException();
 }
 
 
@@ -72,7 +72,7 @@ RSAKeyImpl::RSAKeyImpl(int keyLength, unsigned long exponent):
 	_pEVPPKey(nullptr)
 {
 	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
-	if (!pCtx)
+	if (pCtx == nullptr)
 		throw OpenSSLException("RSAKeyImpl: EVP_PKEY_CTX_new_id()");
 	if (EVP_PKEY_keygen_init(pCtx) != 1)
 	{
@@ -112,14 +112,14 @@ RSAKeyImpl::RSAKeyImpl(const std::string& publicKeyFile, const std::string& priv
 	if (!privateKeyFile.empty())
 	{
 		BIO* bio = BIO_new(BIO_s_file());
-		if (!bio) throw Poco::IOException("Cannot create BIO for reading private key", privateKeyFile);
+		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading private key", privateKeyFile);
 		int rc = BIO_read_filename(bio, privateKeyFile.c_str());
 		if (rc)
 		{
 			EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
 				privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
 			BIO_free(bio);
-			if (!pKey)
+			if (pKey == nullptr)
 				throw Poco::FileException("Failed to load private key", privateKeyFile);
 			_pEVPPKey = pKey;
 		}
@@ -133,13 +133,13 @@ RSAKeyImpl::RSAKeyImpl(const std::string& publicKeyFile, const std::string& priv
 	if (!publicKeyFile.empty() && _pEVPPKey == nullptr)
 	{
 		BIO* bio = BIO_new(BIO_s_file());
-		if (!bio) throw Poco::IOException("Cannot create BIO for reading public key", publicKeyFile);
+		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading public key", publicKeyFile);
 		int rc = BIO_read_filename(bio, publicKeyFile.c_str());
 		if (rc)
 		{
 			EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
 			BIO_free(bio);
-			if (!pKey)
+			if (pKey == nullptr)
 				throw Poco::FileException("Failed to load public key", publicKeyFile);
 			_pEVPPKey = pKey;
 		}
@@ -161,24 +161,24 @@ RSAKeyImpl::RSAKeyImpl(std::istream* pPublicKeyStream, std::istream* pPrivateKey
 		std::string privateKeyData;
 		Poco::StreamCopier::copyToString(*pPrivateKeyStream, privateKeyData);
 		BIO* bio = BIO_new_mem_buf(const_cast<char*>(privateKeyData.data()), static_cast<int>(privateKeyData.size()));
-		if (!bio) throw Poco::IOException("Cannot create BIO for reading private key");
+		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading private key");
 		EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
 			privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
 		BIO_free(bio);
-		if (!pKey)
+		if (pKey == nullptr)
 			throw Poco::FileException("Failed to load private key");
 		_pEVPPKey = pKey;
 	}
 
-	if (pPublicKeyStream && _pEVPPKey == nullptr)
+	if (pPublicKeyStream != nullptr && _pEVPPKey == nullptr)
 	{
 		std::string publicKeyData;
 		Poco::StreamCopier::copyToString(*pPublicKeyStream, publicKeyData);
 		BIO* bio = BIO_new_mem_buf(const_cast<char*>(publicKeyData.data()), static_cast<int>(publicKeyData.size()));
-		if (!bio) throw Poco::IOException("Cannot create BIO for reading public key");
+		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading public key");
 		EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
 		BIO_free(bio);
-		if (!pKey)
+		if (pKey == nullptr)
 			throw Poco::FileException("Failed to load public key");
 		_pEVPPKey = pKey;
 	}
@@ -193,7 +193,7 @@ RSAKeyImpl::~RSAKeyImpl()
 
 void RSAKeyImpl::freeRSA()
 {
-	if (_pEVPPKey) EVP_PKEY_free(_pEVPPKey);
+	if (_pEVPPKey != nullptr) EVP_PKEY_free(_pEVPPKey);
 	_pEVPPKey = nullptr;
 }
 

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -17,12 +17,268 @@
 #include "Poco/Crypto/PKCS12Container.h"
 #include "Poco/StreamCopier.h"
 #include <openssl/pem.h>
-#include <openssl/rsa.h>
 #include <openssl/evp.h>
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+#include <openssl/core_names.h>
+#include <openssl/param_build.h>
+#else
+#include <openssl/rsa.h>
 #include <openssl/bn.h>
+#endif
 
 
 namespace Poco::Crypto {
+
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+// OpenSSL 3.0+ implementation using EVP_PKEY
+
+
+RSAKeyImpl::RSAKeyImpl(const EVPPKey& key):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVPPKey::duplicate(const_cast<EVP_PKEY*>((const EVP_PKEY*)key), &_pEVPPKey);
+	if (!_pEVPPKey) throw OpenSSLException();
+}
+
+
+RSAKeyImpl::RSAKeyImpl(const X509Certificate& cert):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	const X509* pCert = cert.certificate();
+	_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
+	if (!_pEVPPKey)
+		throw OpenSSLException("RSAKeyImpl(const X509Certificate&)");
+}
+
+
+RSAKeyImpl::RSAKeyImpl(const PKCS12Container& cont):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVPPKey key = cont.getKey();
+	EVPPKey::duplicate(static_cast<EVP_PKEY*>(key), &_pEVPPKey);
+	if (!_pEVPPKey) throw OpenSSLException();
+}
+
+
+RSAKeyImpl::RSAKeyImpl(int keyLength, unsigned long exponent):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	EVP_PKEY_CTX* pCtx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
+	if (!pCtx)
+		throw OpenSSLException("RSAKeyImpl: EVP_PKEY_CTX_new_id()");
+	if (EVP_PKEY_keygen_init(pCtx) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("RSAKeyImpl: EVP_PKEY_keygen_init()");
+	}
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(pCtx, keyLength) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw OpenSSLException("RSAKeyImpl: EVP_PKEY_CTX_set_rsa_keygen_bits()");
+	}
+	if (exponent != RSA_F4)
+	{
+		BIGNUM* bn = BN_new();
+		BN_set_word(bn, exponent);
+		if (EVP_PKEY_CTX_set1_rsa_keygen_pubexp(pCtx, bn) != 1)
+		{
+			BN_free(bn);
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("RSAKeyImpl: EVP_PKEY_CTX_set1_rsa_keygen_pubexp()");
+		}
+		BN_free(bn);
+	}
+	if (EVP_PKEY_generate(pCtx, &_pEVPPKey) != 1)
+	{
+		EVP_PKEY_CTX_free(pCtx);
+		throw Poco::InvalidArgumentException("Failed to create RSA context");
+	}
+	EVP_PKEY_CTX_free(pCtx);
+}
+
+
+RSAKeyImpl::RSAKeyImpl(const std::string& publicKeyFile, const std::string& privateKeyFile, const std::string& privateKeyPassphrase):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	if (!privateKeyFile.empty())
+	{
+		BIO* bio = BIO_new(BIO_s_file());
+		if (!bio) throw Poco::IOException("Cannot create BIO for reading private key", privateKeyFile);
+		int rc = BIO_read_filename(bio, privateKeyFile.c_str());
+		if (rc)
+		{
+			EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
+				privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
+			BIO_free(bio);
+			if (!pKey)
+				throw Poco::FileException("Failed to load private key", privateKeyFile);
+			_pEVPPKey = pKey;
+		}
+		else
+		{
+			BIO_free(bio);
+			throw Poco::FileNotFoundException("Private key file", privateKeyFile);
+		}
+	}
+
+	if (!publicKeyFile.empty() && _pEVPPKey == nullptr)
+	{
+		BIO* bio = BIO_new(BIO_s_file());
+		if (!bio) throw Poco::IOException("Cannot create BIO for reading public key", publicKeyFile);
+		int rc = BIO_read_filename(bio, publicKeyFile.c_str());
+		if (rc)
+		{
+			EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
+			BIO_free(bio);
+			if (!pKey)
+				throw Poco::FileException("Failed to load public key", publicKeyFile);
+			_pEVPPKey = pKey;
+		}
+		else
+		{
+			BIO_free(bio);
+			throw Poco::FileNotFoundException("Public key file", publicKeyFile);
+		}
+	}
+}
+
+
+RSAKeyImpl::RSAKeyImpl(std::istream* pPublicKeyStream, std::istream* pPrivateKeyStream, const std::string& privateKeyPassphrase):
+	KeyPairImpl("rsa", KT_RSA_IMPL),
+	_pEVPPKey(nullptr)
+{
+	if (pPrivateKeyStream)
+	{
+		std::string privateKeyData;
+		Poco::StreamCopier::copyToString(*pPrivateKeyStream, privateKeyData);
+		BIO* bio = BIO_new_mem_buf(const_cast<char*>(privateKeyData.data()), static_cast<int>(privateKeyData.size()));
+		if (!bio) throw Poco::IOException("Cannot create BIO for reading private key");
+		EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
+			privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
+		BIO_free(bio);
+		if (!pKey)
+			throw Poco::FileException("Failed to load private key");
+		_pEVPPKey = pKey;
+	}
+
+	if (pPublicKeyStream && _pEVPPKey == nullptr)
+	{
+		std::string publicKeyData;
+		Poco::StreamCopier::copyToString(*pPublicKeyStream, publicKeyData);
+		BIO* bio = BIO_new_mem_buf(const_cast<char*>(publicKeyData.data()), static_cast<int>(publicKeyData.size()));
+		if (!bio) throw Poco::IOException("Cannot create BIO for reading public key");
+		EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
+		BIO_free(bio);
+		if (!pKey)
+			throw Poco::FileException("Failed to load public key");
+		_pEVPPKey = pKey;
+	}
+}
+
+
+RSAKeyImpl::~RSAKeyImpl()
+{
+	freeRSA();
+}
+
+
+void RSAKeyImpl::freeRSA()
+{
+	if (_pEVPPKey) EVP_PKEY_free(_pEVPPKey);
+	_pEVPPKey = nullptr;
+}
+
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+
+RSA* RSAKeyImpl::getRSA()
+{
+	return const_cast<RSA*>(EVP_PKEY_get0_RSA(_pEVPPKey));
+}
+
+
+const RSA* RSAKeyImpl::getRSA() const
+{
+	return EVP_PKEY_get0_RSA(_pEVPPKey);
+}
+
+#endif
+
+
+int RSAKeyImpl::size() const
+{
+	return EVP_PKEY_get_size(_pEVPPKey);
+}
+
+
+RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
+{
+	BIGNUM* bn = nullptr;
+	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_N, &bn))
+		throw OpenSSLException("RSAKeyImpl::modulus()");
+	int numBytes = BN_num_bytes(bn);
+	ByteVec byteVector(numBytes);
+	BN_bn2bin(bn, byteVector.data());
+	BN_free(bn);
+	return byteVector;
+}
+
+
+RSAKeyImpl::ByteVec RSAKeyImpl::encryptionExponent() const
+{
+	BIGNUM* bn = nullptr;
+	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_E, &bn))
+		throw OpenSSLException("RSAKeyImpl::encryptionExponent()");
+	int numBytes = BN_num_bytes(bn);
+	ByteVec byteVector(numBytes);
+	BN_bn2bin(bn, byteVector.data());
+	BN_free(bn);
+	return byteVector;
+}
+
+
+RSAKeyImpl::ByteVec RSAKeyImpl::decryptionExponent() const
+{
+	BIGNUM* bn = nullptr;
+	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_D, &bn))
+		return ByteVec();
+	int numBytes = BN_num_bytes(bn);
+	ByteVec byteVector(numBytes);
+	BN_bn2bin(bn, byteVector.data());
+	BN_free(bn);
+	return byteVector;
+}
+
+
+void RSAKeyImpl::save(const std::string& publicKeyFile,
+	const std::string& privateKeyFile,
+	const std::string& privateKeyPassphrase) const
+{
+	EVPPKey(_pEVPPKey).save(publicKeyFile, privateKeyFile, privateKeyPassphrase);
+}
+
+
+void RSAKeyImpl::save(std::ostream* pPublicKeyStream,
+	std::ostream* pPrivateKeyStream,
+	const std::string& privateKeyPassphrase) const
+{
+	EVPPKey(_pEVPPKey).save(pPublicKeyStream, pPrivateKeyStream, privateKeyPassphrase);
+}
+
+
+#else // !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+
+
+// OpenSSL 1.1.x implementation using RSA
 
 
 RSAKeyImpl::RSAKeyImpl(const EVPPKey& key):
@@ -358,6 +614,9 @@ RSAKeyImpl::ByteVec RSAKeyImpl::convertToByteVec(const BIGNUM* bn)
 
 	return byteVector;
 }
+
+
+#endif // POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 
 
 } // namespace Poco::Crypto

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -42,7 +42,7 @@ RSAKeyImpl::RSAKeyImpl(const EVPPKey& key):
 	_pEVPPKey(nullptr)
 {
 	EVPPKey::duplicate(const_cast<EVP_PKEY*>((const EVP_PKEY*)key), &_pEVPPKey);
-	if (_pEVPPKey == nullptr) throw OpenSSLException();
+	ensureRSAKey(_pEVPPKey, "EVPPKey");
 }
 
 
@@ -52,8 +52,7 @@ RSAKeyImpl::RSAKeyImpl(const X509Certificate& cert):
 {
 	const X509* pCert = cert.certificate();
 	_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
-	if (_pEVPPKey == nullptr)
-		throw OpenSSLException("RSAKeyImpl(const X509Certificate&)");
+	ensureRSAKey(_pEVPPKey, "X509Certificate");
 }
 
 
@@ -63,7 +62,7 @@ RSAKeyImpl::RSAKeyImpl(const PKCS12Container& cont):
 {
 	EVPPKey key = cont.getKey();
 	EVPPKey::duplicate(static_cast<EVP_PKEY*>(key), &_pEVPPKey);
-	if (_pEVPPKey == nullptr) throw OpenSSLException();
+	ensureRSAKey(_pEVPPKey, "PKCS12Container");
 }
 
 
@@ -87,6 +86,11 @@ RSAKeyImpl::RSAKeyImpl(int keyLength, unsigned long exponent):
 	if (exponent != RSA_F4)
 	{
 		BIGNUM* bn = BN_new();
+		if (bn == nullptr)
+		{
+			EVP_PKEY_CTX_free(pCtx);
+			throw OpenSSLException("RSAKeyImpl: BN_new()");
+		}
 		BN_set_word(bn, exponent);
 		if (EVP_PKEY_CTX_set1_rsa_keygen_pubexp(pCtx, bn) != 1)
 		{
@@ -99,7 +103,7 @@ RSAKeyImpl::RSAKeyImpl(int keyLength, unsigned long exponent):
 	if (EVP_PKEY_generate(pCtx, &_pEVPPKey) != 1)
 	{
 		EVP_PKEY_CTX_free(pCtx);
-		throw Poco::InvalidArgumentException("Failed to create RSA context");
+		throw OpenSSLException("RSAKeyImpl: EVP_PKEY_generate()");
 	}
 	EVP_PKEY_CTX_free(pCtx);
 }
@@ -109,46 +113,17 @@ RSAKeyImpl::RSAKeyImpl(const std::string& publicKeyFile, const std::string& priv
 	KeyPairImpl("rsa", KT_RSA_IMPL),
 	_pEVPPKey(nullptr)
 {
-	if (!privateKeyFile.empty())
+	if (EVPPKey::loadKey(&_pEVPPKey, PEM_read_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, privateKeyFile, privateKeyPassphrase))
 	{
-		BIO* bio = BIO_new(BIO_s_file());
-		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading private key", privateKeyFile);
-		int rc = BIO_read_filename(bio, privateKeyFile.c_str());
-		if (rc)
-		{
-			EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
-				privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
-			BIO_free(bio);
-			if (pKey == nullptr)
-				throw Poco::FileException("Failed to load private key", privateKeyFile);
-			_pEVPPKey = pKey;
-		}
-		else
-		{
-			BIO_free(bio);
-			throw Poco::FileNotFoundException("Private key file", privateKeyFile);
-		}
+		ensureRSAKey(_pEVPPKey, "file");
+		return;
 	}
 
-	if (!publicKeyFile.empty() && _pEVPPKey == nullptr)
+	if (!EVPPKey::loadKey(&_pEVPPKey, PEM_read_PUBKEY, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, publicKeyFile))
 	{
-		BIO* bio = BIO_new(BIO_s_file());
-		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading public key", publicKeyFile);
-		int rc = BIO_read_filename(bio, publicKeyFile.c_str());
-		if (rc)
-		{
-			EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
-			BIO_free(bio);
-			if (pKey == nullptr)
-				throw Poco::FileException("Failed to load public key", publicKeyFile);
-			_pEVPPKey = pKey;
-		}
-		else
-		{
-			BIO_free(bio);
-			throw Poco::FileNotFoundException("Public key file", publicKeyFile);
-		}
+		throw OpenSSLException("RSAKeyImpl(const string&, const string&, const string&)");
 	}
+	ensureRSAKey(_pEVPPKey, "file");
 }
 
 
@@ -156,32 +131,17 @@ RSAKeyImpl::RSAKeyImpl(std::istream* pPublicKeyStream, std::istream* pPrivateKey
 	KeyPairImpl("rsa", KT_RSA_IMPL),
 	_pEVPPKey(nullptr)
 {
-	if (pPrivateKeyStream)
+	if (EVPPKey::loadKey(&_pEVPPKey, PEM_read_bio_PrivateKey, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, pPrivateKeyStream, privateKeyPassphrase))
 	{
-		std::string privateKeyData;
-		Poco::StreamCopier::copyToString(*pPrivateKeyStream, privateKeyData);
-		BIO* bio = BIO_new_mem_buf(const_cast<char*>(privateKeyData.data()), static_cast<int>(privateKeyData.size()));
-		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading private key");
-		EVP_PKEY* pKey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr,
-			privateKeyPassphrase.empty() ? nullptr : const_cast<char*>(privateKeyPassphrase.c_str()));
-		BIO_free(bio);
-		if (pKey == nullptr)
-			throw Poco::FileException("Failed to load private key");
-		_pEVPPKey = pKey;
+		ensureRSAKey(_pEVPPKey, "stream");
+		return;
 	}
 
-	if (pPublicKeyStream != nullptr && _pEVPPKey == nullptr)
+	if (!EVPPKey::loadKey(&_pEVPPKey, PEM_read_bio_PUBKEY, (EVPPKey::EVP_PKEY_get_Key_fn) nullptr, pPublicKeyStream))
 	{
-		std::string publicKeyData;
-		Poco::StreamCopier::copyToString(*pPublicKeyStream, publicKeyData);
-		BIO* bio = BIO_new_mem_buf(const_cast<char*>(publicKeyData.data()), static_cast<int>(publicKeyData.size()));
-		if (bio == nullptr) throw Poco::IOException("Cannot create BIO for reading public key");
-		EVP_PKEY* pKey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
-		BIO_free(bio);
-		if (pKey == nullptr)
-			throw Poco::FileException("Failed to load public key");
-		_pEVPPKey = pKey;
+		throw OpenSSLException("RSAKeyImpl(istream*, istream*, const string&)");
 	}
+	ensureRSAKey(_pEVPPKey, "stream");
 }
 
 
@@ -220,42 +180,55 @@ int RSAKeyImpl::size() const
 }
 
 
-RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
+void RSAKeyImpl::ensureRSAKey(EVP_PKEY* pKey, const std::string& context)
+{
+	if (pKey == nullptr)
+		throw OpenSSLException("RSAKeyImpl(" + context + ")");
+	if (EVP_PKEY_base_id(pKey) != EVP_PKEY_RSA)
+	{
+		EVP_PKEY_free(pKey);
+		throw OpenSSLException("RSAKeyImpl(" + context + "): not an RSA key");
+	}
+}
+
+
+RSAKeyImpl::ByteVec RSAKeyImpl::keyParam(const char* name, bool clearFree) const
 {
 	BIGNUM* bn = nullptr;
-	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_N, &bn))
-		throw OpenSSLException("RSAKeyImpl::modulus()");
+	if (!EVP_PKEY_get_bn_param(_pEVPPKey, name, &bn))
+		return ByteVec();
 	int numBytes = BN_num_bytes(bn);
 	ByteVec byteVector(numBytes);
 	BN_bn2bin(bn, byteVector.data());
-	BN_free(bn);
+	if (clearFree)
+		BN_clear_free(bn);
+	else
+		BN_free(bn);
 	return byteVector;
+}
+
+
+RSAKeyImpl::ByteVec RSAKeyImpl::modulus() const
+{
+	ByteVec result = keyParam(OSSL_PKEY_PARAM_RSA_N);
+	if (result.empty())
+		throw OpenSSLException("RSAKeyImpl::modulus()");
+	return result;
 }
 
 
 RSAKeyImpl::ByteVec RSAKeyImpl::encryptionExponent() const
 {
-	BIGNUM* bn = nullptr;
-	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_E, &bn))
+	ByteVec result = keyParam(OSSL_PKEY_PARAM_RSA_E);
+	if (result.empty())
 		throw OpenSSLException("RSAKeyImpl::encryptionExponent()");
-	int numBytes = BN_num_bytes(bn);
-	ByteVec byteVector(numBytes);
-	BN_bn2bin(bn, byteVector.data());
-	BN_free(bn);
-	return byteVector;
+	return result;
 }
 
 
 RSAKeyImpl::ByteVec RSAKeyImpl::decryptionExponent() const
 {
-	BIGNUM* bn = nullptr;
-	if (!EVP_PKEY_get_bn_param(_pEVPPKey, OSSL_PKEY_PARAM_RSA_D, &bn))
-		return ByteVec();
-	int numBytes = BN_num_bytes(bn);
-	ByteVec byteVector(numBytes);
-	BN_bn2bin(bn, byteVector.data());
-	BN_free(bn);
-	return byteVector;
+	return keyParam(OSSL_PKEY_PARAM_RSA_D, true);
 }
 
 

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -51,6 +51,8 @@ RSAKeyImpl::RSAKeyImpl(const X509Certificate& cert):
 	_pEVPPKey(nullptr)
 {
 	const X509* pCert = cert.certificate();
+	if (pCert == nullptr)
+		throw OpenSSLException("RSAKeyImpl(const X509Certificate&): null certificate");
 	_pEVPPKey = X509_get_pubkey(const_cast<X509*>(pCert));
 	ensureRSAKey(_pEVPPKey, "X509Certificate");
 }

--- a/Crypto/testsuite/src/EVPTest.cpp
+++ b/Crypto/testsuite/src/EVPTest.cpp
@@ -30,6 +30,35 @@
 #include <cstring>
 
 
+namespace {
+
+// Helper to construct EVPPKey from RSAKey or ECKey.
+// On OpenSSL 3.0+, uses getEVPPKey() to avoid deprecated template constructor.
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+inline Poco::Crypto::EVPPKey evpPKeyFromKey(const Poco::Crypto::RSAKey& key)
+{
+	return Poco::Crypto::EVPPKey(key.impl()->getEVPPKey());
+}
+
+inline Poco::Crypto::EVPPKey evpPKeyFromKey(const Poco::Crypto::ECKey& key)
+{
+	return Poco::Crypto::EVPPKey(key.impl()->getEVPPKey());
+}
+#else
+inline Poco::Crypto::EVPPKey evpPKeyFromKey(Poco::Crypto::RSAKey& key)
+{
+	return Poco::Crypto::EVPPKey(&key);
+}
+
+inline Poco::Crypto::EVPPKey evpPKeyFromKey(Poco::Crypto::ECKey& key)
+{
+	return Poco::Crypto::EVPPKey(&key);
+}
+#endif
+
+} // namespace
+
+
 using namespace Poco::Crypto;
 using Poco::TemporaryFile;
 using Poco::StreamCopier;
@@ -103,8 +132,8 @@ void EVPTest::testRSAEVPPKey()
 	{
 		std::unique_ptr<RSAKey> key(new RSAKey(RSAKey::KL_1024, RSAKey::EXP_SMALL));
 		assertTrue(key->type() == Poco::Crypto::KeyPair::KT_RSA);
-		// construct EVPPKey from RSAKey*
-		EVPPKey* pKey = new EVPPKey(key.get());
+		// construct EVPPKey from RSAKey
+		EVPPKey* pKey = new EVPPKey(evpPKeyFromKey(*key));
 		// EVPPKey increments reference count, so freeing the original must be ok
 		key.reset();
 
@@ -117,8 +146,8 @@ void EVPTest::testRSAEVPPKey()
 		key.reset(new RSAKey(*pKey));
 		delete pKey;
 		assertTrue(key->type() == Poco::Crypto::KeyPair::KT_RSA);
-		// construct EVPPKey from RSAKey*
-		pKey = new EVPPKey(key.get());
+		// construct EVPPKey from RSAKey
+		pKey = new EVPPKey(evpPKeyFromKey(*key));
 		assertTrue (pKey->type() == EVP_PKEY_RSA);
 
 		BIO* bioPriv1 = BIO_new(BIO_s_mem());
@@ -202,7 +231,7 @@ void EVPTest::testRSAEVPPKey()
 void EVPTest::testRSAEVPSaveLoadStream()
 {
 	RSAKey rsaKey(RSAKey::KL_1024, RSAKey::EXP_SMALL);
-	EVPPKey key(&rsaKey);
+	EVPPKey key(evpPKeyFromKey(rsaKey));
 	std::ostringstream strPub;
 	std::ostringstream strPriv;
 	key.save(&strPub, &strPriv, "testpwd");
@@ -217,7 +246,7 @@ void EVPTest::testRSAEVPSaveLoadStream()
 	assertTrue (key == key2);
 	assertTrue (!(key != key2));
 	RSAKey rsaKeyNE(RSAKey::KL_1024, RSAKey::EXP_LARGE);
-	EVPPKey keyNE(&rsaKeyNE);
+	EVPPKey keyNE(evpPKeyFromKey(rsaKeyNE));
 	assertTrue (key != keyNE);
 	assertTrue (!(key == keyNE));
 	assertTrue (key2 != keyNE);;
@@ -239,7 +268,7 @@ void EVPTest::testRSAEVPSaveLoadStream()
 void EVPTest::testRSAEVPSaveLoadStreamNoPass()
 {
 	RSAKey rsaKey(RSAKey::KL_1024, RSAKey::EXP_SMALL);
-	EVPPKey key(&rsaKey);
+	EVPPKey key(evpPKeyFromKey(rsaKey));
 	std::ostringstream strPub;
 	std::ostringstream strPriv;
 	key.save(&strPub, &strPriv);
@@ -254,7 +283,7 @@ void EVPTest::testRSAEVPSaveLoadStreamNoPass()
 	assertTrue (key == key2);
 	assertTrue (!(key != key2));
 	RSAKey rsaKeyNE(RSAKey::KL_1024, RSAKey::EXP_LARGE);
-	EVPPKey keyNE(&rsaKeyNE);
+	EVPPKey keyNE(evpPKeyFromKey(rsaKeyNE));
 	assertTrue (key != keyNE);
 	assertTrue (!(key == keyNE));
 	assertTrue (key2 != keyNE);;
@@ -390,7 +419,7 @@ void EVPTest::testECEVPSaveLoadStream()
 			assertTrue (key == key2);
 			assertTrue (!(key != key2));
 			ECKey ecKeyNE(curveName);
-			EVPPKey keyNE(&ecKeyNE);
+			EVPPKey keyNE(evpPKeyFromKey(ecKeyNE));
 			assertTrue (key != keyNE);
 			assertTrue (!(key == keyNE));
 			assertTrue (key2 != keyNE);
@@ -445,7 +474,7 @@ void EVPTest::testECEVPSaveLoadStreamNoPass()
 			assertTrue (key == key2);
 			assertTrue (!(key != key2));
 			ECKey ecKeyNE(curveName);
-			EVPPKey keyNE(&ecKeyNE);
+			EVPPKey keyNE(evpPKeyFromKey(ecKeyNE));
 			assertTrue (key != keyNE);
 			assertTrue (!(key == keyNE));
 			assertTrue (key2 != keyNE);
@@ -502,7 +531,7 @@ void EVPTest::testECEVPSaveLoadFile()
 			assertTrue (key == key2);
 			assertTrue (!(key != key2));
 			ECKey ecKeyNE(curveName);
-			EVPPKey keyNE(&ecKeyNE);
+			EVPPKey keyNE(evpPKeyFromKey(ecKeyNE));
 			assertTrue (key != keyNE);
 			assertTrue (!(key == keyNE));
 			assertTrue (key2 != keyNE);

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -309,7 +309,11 @@ void Context::addCertificateAuthority(const std::string& caLocation)
 
 void Context::usePrivateKey(const Poco::Crypto::RSAKey& key)
 {
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	int errCode = SSL_CTX_use_PrivateKey(_pSSLContext, key.impl()->getEVPPKey());
+#else
 	int errCode = SSL_CTX_use_RSAPrivateKey(_pSSLContext, key.impl()->getRSA());
+#endif
 	if (errCode != 1)
 	{
 		std::string msg = Utility::getLastError();
@@ -405,7 +409,11 @@ void Context::flushSessionCache()
 	poco_assert (isForServerUse());
 
 	Poco::Timestamp now;
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	SSL_CTX_flush_sessions_ex(_pSSLContext, static_cast<time_t>(now.epochTime()));
+#else
 	SSL_CTX_flush_sessions(_pSSLContext, static_cast<long>(now.epochTime()));
+#endif
 }
 
 

--- a/NetSSL_OpenSSL/src/Context.cpp
+++ b/NetSSL_OpenSSL/src/Context.cpp
@@ -409,7 +409,7 @@ void Context::flushSessionCache()
 	poco_assert (isForServerUse());
 
 	Poco::Timestamp now;
-#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+#if POCO_OPENSSL_VERSION_PREREQ(3, 4, 0)
 	SSL_CTX_flush_sessions_ex(_pSSLContext, static_cast<time_t>(now.epochTime()));
 #else
 	SSL_CTX_flush_sessions(_pSSLContext, static_cast<long>(now.epochTime()));


### PR DESCRIPTION
## Summary

- Replace deprecated OpenSSL RSA/EC_KEY/DH low-level APIs with EVP_PKEY equivalents on OpenSSL 3.0+, enabling builds with `OPENSSL_NO_DEPRECATED`
- On 3.0+, `RSAKeyImpl` and `ECKeyImpl` store `EVP_PKEY*` internally; new `getEVPPKey()` accessor replaces `getRSA()`/`getECKey()`
- Legacy `getRSA()`/`getECKey()` remain available on default 3.0+ builds (guarded by `OPENSSL_NO_DEPRECATED_3_0`), marked `POCO_DEPRECATED`
- OpenSSL 1.1.1 code paths fully preserved in `#else` branches
- Remove global `OPENSSL_SUPPRESS_DEPRECATED` from `Crypto.h`
- Security hardening: RSA key-type validation, private key scrubbing, resource leak fixes, error checking improvements

## API changes

**OpenSSL 1.1.x: no changes.** All exported interfaces are unchanged.

**OpenSSL 3.0+ (default build):**
- New `RSAKeyImpl::getEVPPKey()` and `ECKeyImpl::getEVPPKey()` accessors.
- `RSAKeyImpl::getRSA()` and `ECKeyImpl::getECKey()` remain available but are marked `POCO_DEPRECATED`.
- `RSAKeyImpl::save()` output changes from PKCS#1 format (`BEGIN RSA PUBLIC KEY`) to X.509 SPKI format (`BEGIN PUBLIC KEY`). Loading still accepts both formats.
- `OPENSSL_SUPPRESS_DEPRECATED` is no longer defined by `Crypto.h`. Downstream code using deprecated OpenSSL APIs directly will now see deprecation warnings.

No other exported interfaces change. The `EVPPKey(K*)` template constructor for raw `RSA*`/`EC_KEY*` was already unavailable on 3.0+ before this PR.

**OpenSSL 3.0+ with `OPENSSL_NO_DEPRECATED`:** builds successfully (previously did not compile at all).

## Test plan

- [x] All 47 Crypto tests pass on macOS (OpenSSL 3.6)
- [x] All 47 Crypto tests pass on Linux via OrbStack (OpenSSL 3.x)
- [x] Zero deprecation warnings with `-DPOCO_DONT_SUPPRESS_OPENSSL_DEPRECATED`
- [x] NetSSL builds cleanly
- [x] CI passes on all platforms
- [x] Test with OpenSSL 1.1.1 build (1.1.x code paths unchanged, but verify)

Closes #5296
Related: #4846, #4602
Follow-up: #5312 (code deduplication for 1.16.0)