### PR TITLE
Fix: DateTimeParser trailing timezone designators & Timezone UTC offset cache invalidation

### DIFF
--- a/Foundation/include/Poco/DateTimeParser.h
+++ b/Foundation/include/Poco/DateTimeParser.h
@@ -63,6 +63,12 @@ public:
 		/// Throws a SyntaxException if the string cannot be successfully parsed.
 		/// Please see DateTimeFormatter::format() for a description of the format string.
 		/// Class DateTimeFormat defines format strings for various standard date/time formats.
+		///
+		/// Note: The %S specifier parses whole seconds and then silently discards any
+		/// fractional-second suffix of the form '.DDD' or ',DDD' (including a bare decimal
+		/// point that is immediately followed by a non-digit is treated as a parse error).
+		/// Callers that need the fractional digits captured must use %s (millis+micros),
+		/// %i (milliseconds only), %c (centiseconds), or %F (six-digit fractional seconds).
 
 	static DateTime parse(const std::string& fmt, const std::string& str, int& timeZoneDifferential);
 		/// Parses a date and time in the given format from the given string.

--- a/Foundation/src/DateTimeParser.cpp
+++ b/Foundation/src/DateTimeParser.cpp
@@ -243,6 +243,18 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 				case 'S':
 					it = skipNonDigits(it, end);
 					second = parseNumberN(dtStr, it, end, 2);
+					// Consume optional fractional seconds ('.NNN' or ',NNN') so that a
+					// subsequent %z specifier can reach the timezone designator.
+					// A decimal point/comma not followed by a digit is an error.
+					if (it != end && (*it == '.' || *it == ','))
+					{
+						++it;
+						if (it == end || !Ascii::isDigit(*it))
+						{
+							throw SyntaxException("Invalid DateTimeString: " + dtStr + ", missing fractional digits");
+						}
+						it = skipDigits(it, end);
+					}
 					break;
 				case 's':
 					it = skipNonDigits(it, end);

--- a/Foundation/src/Timezone_UNIX.cpp
+++ b/Foundation/src/Timezone_UNIX.cpp
@@ -18,6 +18,7 @@
 #include <ctime>
 #include <cstdlib>
 #include <string>
+#include <sys/stat.h>
 
 
 namespace Poco {
@@ -66,13 +67,44 @@ private:
 	{
 		const char* tz = std::getenv("TZ");
 		_cachedTZ = tz ? tz : "";
+		// /etc/localtime is the system-wide zone source (updated by timedatectl etc.).
+		// Stat'ing it lets us detect zone changes that don't touch the TZ env var; we
+		// don't read its contents — tzset()/libc still resolves the actual zone data.
+		cacheLocaltimeStat();
 	}
 
 	bool tzChanged() const
 	{
 		const char* tz = std::getenv("TZ");
 		std::string currentTZ = tz ? tz : "";
-		return currentTZ != _cachedTZ;
+		if (currentTZ != _cachedTZ) return true;
+		return localtimeStatChanged();
+	}
+
+	void cacheLocaltimeStat()
+	{
+		struct stat st{};
+		if (::stat("/etc/localtime", &st) == 0)
+		{
+			_localtimeIno = st.st_ino;
+			_localtimeMtime = st.st_mtime;
+		}
+		else
+		{
+			_localtimeIno = 0;
+			_localtimeMtime = 0;
+		}
+	}
+
+	bool localtimeStatChanged() const
+	{
+		struct stat st{};
+		if (::stat("/etc/localtime", &st) == 0)
+		{
+			return st.st_ino != _localtimeIno || st.st_mtime != _localtimeMtime;
+		}
+		// /etc/localtime not accessible: treat as changed only if we had it before
+		return _localtimeIno != 0;
 	}
 
 	static int computeTimeZone()
@@ -112,6 +144,8 @@ private:
 	std::mutex _mutex;
 	int _tzOffset;
 	std::string _cachedTZ;
+	ino_t _localtimeIno = 0;
+	time_t _localtimeMtime = 0;
 };
 
 

--- a/Foundation/testsuite/src/DateTimeParserTest.cpp
+++ b/Foundation/testsuite/src/DateTimeParserTest.cpp
@@ -638,6 +638,37 @@ void DateTimeParserTest::testCustom()
 }
 
 
+void DateTimeParserTest::testISO8601FracSeconds()
+{
+	// ISO8601_FORMAT uses %S which silently discards a well-formed fractional-second
+	// suffix so that the trailing %z can still reach the timezone designator.
+	int tzd;
+
+	// Dot-separated fractional seconds with negative timezone offset
+	DateTime dt = DateTimeParser::parse(DateTimeFormat::ISO8601_FORMAT, "2013-10-07T08:23:19.120-04:00", tzd);
+	assertTrue (dt.year()   == 2013);
+	assertTrue (dt.month()  == 10);
+	assertTrue (dt.day()    == 7);
+	assertTrue (dt.hour()   == 8);
+	assertTrue (dt.minute() == 23);
+	assertTrue (dt.second() == 19);
+	assertTrue (tzd == -4*3600);
+
+	// Comma-separated fractional seconds (ISO 8601 allows ',' as the decimal sign)
+	dt = DateTimeParser::parse(DateTimeFormat::ISO8601_FORMAT, "2013-10-07T08:23:19,120-04:00", tzd);
+	assertTrue (dt.year()   == 2013);
+	assertTrue (dt.month()  == 10);
+	assertTrue (dt.day()    == 7);
+	assertTrue (dt.hour()   == 8);
+	assertTrue (dt.minute() == 23);
+	assertTrue (dt.second() == 19);
+	assertTrue (tzd == -4*3600);
+
+	// A bare decimal point not followed by any digit must be rejected
+	testBad(DateTimeFormat::ISO8601_FORMAT, "2013-10-07T08:23:19.-04:00", tzd);
+}
+
+
 void DateTimeParserTest::testGuess()
 {
 	int tzd;
@@ -917,6 +948,7 @@ CppUnit::Test* DateTimeParserTest::suite()
 	CppUnit_addTest(pSuite, DateTimeParserTest, testASCTIME);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testSORTABLE);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testCustom);
+	CppUnit_addTest(pSuite, DateTimeParserTest, testISO8601FracSeconds);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testGuess);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testCleanup);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testParseMonth);

--- a/Foundation/testsuite/src/DateTimeParserTest.h
+++ b/Foundation/testsuite/src/DateTimeParserTest.h
@@ -34,6 +34,7 @@ public:
 	void testASCTIME();
 	void testSORTABLE();
 	void testCustom();
+	void testISO8601FracSeconds();
 	void testGuess();
 	void testCleanup();
 	void testParseMonth();


### PR DESCRIPTION
Hi all,

After we update poco to new version our applications tests start failing. We identified these issues and fix it. Some of the issues are little specific, so we are interesting what you say about that. Here are quick summary of our changes.

Thanks.

## Summary

This MR contains two bug fixes for the `Foundation` library addressing datetime parsing and timezone handling regressions.

---

### Changes

#### 1. `fix(Foundation): DateTimeParser: %S consume optional fractional seconds`

Parsing ISO 8601 date strings that contain both fractional seconds and a timezone offset (e.g. "2013-10-07T08:23:19.120-04:00") with the format "%Y-%m-%dT%H:%M:%S%z" raises a SyntaxException:

- %S consumes the integer seconds but stops at ., leaving .120-04:00 unconsumed.
- %z (parseTZD) is called next but sees . and returns without consuming anything.
- The trailing-garbage check then raises SyntaxException.

**Fix:** Extend the %S case to consume and discard an optional fractional-second suffix (. or , followed by one or more digits) immediately after parsing the integer seconds. This mirrors the existing %s behaviour and allows %z to see the timezone designator directly, keeping the trailing-garbage check fully effective for truly invalid input.

---

#### 2. `fix(Foundation): Timezone: invalidate utcOffset cache when /etc/localtime changes`

The `TZInfo` UTC offset cache introduced in Poco commit `1850dc16` is only invalidated when the `TZ` environment variable changes. Since `TZ` is process-local, system timezone changes via `/etc/localtime` (symlink update) go undetected, causing `Timezone::utcOffset()` to return a stale value.

**Fix:** Extend `cacheTZ()`/`tzChanged()` to track the inode and `mtime` of `/etc/localtime` via `stat(2)`. Cache is invalidated when either changes.

---

### Testing

- Verified ISO 8601 strings with fractional seconds and UTC offsets parse correctly.
- Verified `utcOffset()` reflects timezone changes after localtime is updated without modifying `TZ`.