### PR TITLE
Foundation: make Logger::shutdown() channel-detach instead of map-reset (fix UAF)

### DIFF
--- a/Foundation/src/Logger.cpp
+++ b/Foundation/src/Logger.cpp
@@ -345,7 +345,24 @@ void Logger::shutdown()
 {
 	Mutex::ScopedLock lock(_mapMtx);
 
-	_pLoggerMap.reset();
+	if (_pLoggerMap)
+	{
+		// Detach the channel from every Logger instead of destroying the
+		// map. Long-lived objects frequently cache a Logger& obtained via
+		// Logger::get() during construction and may still dereference it
+		// from static destructors that run after LoggingSubsystem has
+		// called shutdown(); tearing the map down there would leave those
+		// references dangling (heap-use-after-free).
+		//
+		// logImpl() already guards channel writes with `if (_pChannel)`, so
+		// a Logger with a null channel is a safe no-op. The map (and the
+		// Logger objects it keeps alive) are released when the static
+		// _pLoggerMap is destroyed at process exit.
+		for (auto& p: *_pLoggerMap)
+		{
+			p.second->setChannel(nullptr);
+		}
+	}
 }
 
 


### PR DESCRIPTION
Fixes #5324.

`Logger::shutdown()` previously did:

```cpp
void Logger::shutdown()
{
    Mutex::ScopedLock lock(_mapMtx);
    _pLoggerMap.reset();
}
```

`shutdown()` is called from `LoggingSubsystem::uninitialize()`, which runs before the destruction of static singletons that registered via `atexit`. Those singletons frequently cache a `Logger&` obtained from `Logger::get()` during construction — the canonical pattern recommended in the Poco samples and used widely by downstream code. Once the logger map is torn down, every such cached reference is dangling, and the first log call from a static destructor hits a heap-use-after-free.

This switches `shutdown()` to detach the channel from every Logger rather than destroying them. `logImpl()` already short-circuits on `if (_pChannel)`, so once the channel is null all further logging from a Logger is a cheap no-op and the reference stays valid. The map itself is released at real program exit when the static `_pLoggerMap` is destroyed; no long-lived singleton can touch it between `shutdown()` and that point.