### PR TITLE
fix(Foundation): propagate decoder exceptions through xsgetn (#5327)

### DIFF
--- a/Foundation/include/Poco/UnbufferedStreamBuf.h
+++ b/Foundation/include/Poco/UnbufferedStreamBuf.h
@@ -76,7 +76,7 @@ public:
 		}
 		else
 		{
-			int_type c = readFromDevice();
+			const int_type c = readFromDevice();
 			if (c != char_traits::eof())
 			{
 				_ispb = true;
@@ -95,7 +95,7 @@ public:
 		}
 		else
 		{
-			int_type c = readFromDevice();
+			const int_type c = readFromDevice();
 			if (c != char_traits::eof())
 			{
 				_pb = c;
@@ -127,16 +127,7 @@ public:
 		std::streamsize copied = 0;
 		while (count > 0)
 		{
-			int_type c;
-			try
-			{
-				c = uflow();
-			}
-			catch (...)
-			{
-				if (copied > 0) return copied;
-				throw;
-			}
+			const int_type c = uflow();
 			if (c == char_traits::eof()) break;
 			*p++ = char_traits::to_char_type(c);
 			++copied;

--- a/Foundation/testsuite/src/Base64Test.cpp
+++ b/Foundation/testsuite/src/Base64Test.cpp
@@ -195,6 +195,40 @@ void Base64Test::testDecoder()
 		}
 		assertTrue (!decoder.eof());
 	}
+	{
+		// istream::read() goes through xsgetn; badbit must be set
+		// when a mid-read decoder error occurs.
+		std::istringstream istr("QUJD#REVG");
+		Base64Decoder decoder(istr);
+		char buf[16];
+		try
+		{
+			decoder.read(buf, sizeof(buf));
+			assertTrue (decoder.bad());
+		}
+		catch (DataFormatException&)
+		{
+		}
+		assertTrue (!decoder.eof());
+	}
+	{
+		// exceptions(badbit) opt-in must still rethrow the decoder
+		// exception when the failure occurs mid-read via xsgetn.
+		std::istringstream istr("QUJD#REVG");
+		Base64Decoder decoder(istr);
+		decoder.exceptions(std::ios::badbit);
+		char buf[16];
+		bool threw = false;
+		try
+		{
+			decoder.read(buf, sizeof(buf));
+		}
+		catch (DataFormatException&)
+		{
+			threw = true;
+		}
+		assertTrue (threw);
+	}
 }
 
 

--- a/Foundation/testsuite/src/HexBinaryTest.cpp
+++ b/Foundation/testsuite/src/HexBinaryTest.cpp
@@ -150,6 +150,40 @@ void HexBinaryTest::testDecoder()
 		}
 		assertTrue (!decoder.eof());
 	}
+	{
+		// istream::read() goes through xsgetn; badbit must be set
+		// when a mid-read decoder error occurs.
+		std::istringstream istr("AABB#CCDD");
+		HexBinaryDecoder decoder(istr);
+		char buf[16];
+		try
+		{
+			decoder.read(buf, sizeof(buf));
+			assertTrue (decoder.bad());
+		}
+		catch (DataFormatException&)
+		{
+		}
+		assertTrue (!decoder.eof());
+	}
+	{
+		// exceptions(badbit) opt-in must still rethrow the decoder
+		// exception when the failure occurs mid-read via xsgetn.
+		std::istringstream istr("AABB#CCDD");
+		HexBinaryDecoder decoder(istr);
+		decoder.exceptions(std::ios::badbit);
+		char buf[16];
+		bool threw = false;
+		try
+		{
+			decoder.read(buf, sizeof(buf));
+		}
+		catch (DataFormatException&)
+		{
+			threw = true;
+		}
+		assertTrue (threw);
+	}
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #5327. Reverts the mid-read `try/catch` added to `BasicUnbufferedStreamBuf::xsgetn` in #5290. Swallowing `uflow()` exceptions after a partial copy left `istream::read` unable to set `badbit`, so `Base64Decoder` / `HexBinaryDecoder` errors became silent no-ops on any `read()`-based consumer (including `StreamCopier::copyToString`).

`BasicBufferedStreamBuf::xsgetn` is unaffected -- `underflow()` propagates naturally, and no test in Foundation or Net relied on the partial-data preservation that #5290 aimed for (verified by running the `MailMessage` suite, including `testReadMultiPartNoFinalBoundaryFromFile` and all six #5290-era `testReadMultiPart*` tests).

Also adds `const` to the local `int_type c` in `underflow()` / `uflow()` / `xsgetn` for clarity.

## Regression tests

- `Base64Test::testDecoder` now additionally exercises `istream::read()` (goes through `xsgetn`) with invalid input, and the `exceptions(std::ios::badbit)` opt-in rethrow path.
- `HexBinaryTest::testDecoder` gets the same two blocks.

The pre-existing invalid-input blocks only used `operator>>` (which dispatches via `sbumpc`, not `xsgetn`), which is why #5290's regression slipped past CI.

## Test plan
- [x] `Foundation-testrunner -all` (946/946 pass on macOS)
- [x] `Net-testrunner MailMessageTest` (23/23 pass, including truncated multipart + all #5290 tests)
- [x] `Net-testrunner HTTPCredentialsTest HTMLFormTest MessageHeaderTest` (51/51)
- [x] CI full matrix