### PR TITLE
test(Thread): deflake testTrySleep and prevent SEGFAULT on failure #5316

### DIFF
--- a/Foundation/testsuite/src/ThreadTest.cpp
+++ b/Foundation/testsuite/src/ThreadTest.cpp
@@ -423,25 +423,42 @@ void ThreadTest::testTrySleep()
 	assertTrue (!thread.isRunning());
 	assertTrue (r.counter() == 0);
 	thread.start(r);
-	assertTrue (thread.isRunning());
-	assertTrue (r.counter() == 0);
-	assertTrue (r.isSleepy());
-	Thread::sleep(100);
-	assertTrue (r.counter() == 0);
-	assertTrue (r.isSleepy());
-	thread.wakeUp(); Thread::sleep(10);
-	assertTrue (r.counter() == 1);
-	assertTrue (r.isSleepy());
-	Thread::sleep(100);
-	assertTrue (r.counter() == 1);
-	thread.wakeUp(); Thread::sleep(10);
-	assertTrue (r.counter() == 2);
-	assertTrue (r.isSleepy());
-	Thread::sleep(200);
-	assertTrue (r.counter() == 3);
-	assertTrue (!r.isSleepy());
-	assertTrue (!thread.isRunning());
+	auto waitForCounter = [&](int expected)
+	{
+		for (int i = 0; i < 500 && r.counter() < expected; ++i)
+			Thread::sleep(10);
+	};
+	try
+	{
+		assertTrue (thread.isRunning());
+		assertTrue (r.counter() == 0);
+		assertTrue (r.isSleepy());
+		Thread::sleep(100);
+		assertTrue (r.counter() == 0);
+		assertTrue (r.isSleepy());
+		thread.wakeUp();
+		waitForCounter(1);
+		assertTrue (r.counter() == 1);
+		assertTrue (r.isSleepy());
+		Thread::sleep(100);
+		assertTrue (r.counter() == 1);
+		thread.wakeUp();
+		waitForCounter(2);
+		assertTrue (r.counter() == 2);
+		assertTrue (r.isSleepy());
+		waitForCounter(3);
+		assertTrue (r.counter() == 3);
+		assertTrue (!r.isSleepy());
+		assertTrue (!thread.isRunning());
+	}
+	catch (...)
+	{
+		thread.wakeUp();
+		thread.join();
+		throw;
+	}
 	thread.wakeUp();
+	assertTrue (thread.tryJoin(5000));
 	assertTrue (!thread.isRunning());
 }
 


### PR DESCRIPTION
## Summary

Fixes #5316 -- `ThreadTest::testTrySleep` intermittently failed on the
`macos-clang-cmake-poco-soo-off` CI job, and the failure was followed
by a SEGFAULT that aborted the whole `Foundation-testrunner`.

- Poll the atomic counter with a 5 s budget instead of racing a 10 ms /
  200 ms wait after `wakeUp()` and natural `trySleep` expiry.
- Wrap the body in `try/catch` to join the worker on assertion failure,
  turning a SEGFAULT into a clean FAILURE.
- Replace the final unbounded `join()` with `tryJoin(5000)` so `wakeUp`
  regressions fail fast instead of hanging CI.

The 100 ms wait proving the worker goes back to sleep between wakeUps
is preserved -- a negative property requires a fixed-duration check.

## Test plan

- [x] `ThreadTest.testTrySleep` stress run 50/50 passes on macOS
- [x] Full `ThreadTest` suite passes (17/17)
- [ ] CI `macos-clang-cmake-poco-soo-off` job green
- [ ] Linux CI still green