### PR TITLE
fix(cmake): resolve unbundled dependencies before find_package(OpenSSL) (#5330)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,56 @@ if (WIN32 AND CMAKE_VERSION VERSION_LESS  "4.1.0")
 	endif()
 endif()
 
+# -- Resolve bundled/unbundled dependencies before any find_package() for
+# packages that transitively depend on them (notably OpenSSL -> ZLIB in
+# static builds). Keeping this block ahead of find_package(OpenSSL ...) lets
+# dependencies/zlib/CMakeLists.txt create (and IMPORTED_GLOBAL-promote)
+# ZLIB::ZLIB in its own directory scope. See issue #5330.
+
+option(POCO_UNBUNDLED
+	"Set to OFF|ON (default is OFF) to control linking dependencies as external" OFF)
+
+option(POCO_SQLITE_UNBUNDLED
+	"Set to OFF|ON (default is OFF) to control linking sqlite dependency as external" OFF)
+
+if (POCO_UNBUNDLED)
+	set(POCO_SQLITE_UNBUNDLED ON CACHE BOOL "Enable Unbundled SQLite" FORCE)
+endif()
+
+option(ENABLE_TRACE "Enable stack tracing" OFF)
+option(ENABLE_FASTLOGGER "Enable FastLogger (Quill-based high-performance logger)" ON)
+
+# FastLogger uses Quill which only supports specific platforms.
+# Auto-disable on unsupported OS or CPU architecture.
+# Supported platforms are derived from quill source code:
+#   OS:   ThreadUtilities.h (get_thread_id), BackendWorkerLock.h
+#   Arch: Rdtsc.h
+set(_FASTLOGGER_SUPPORTED_OS FALSE)
+set(_FASTLOGGER_SUPPORTED_ARCH FALSE)
+
+if(CMAKE_SYSTEM_NAME MATCHES "^(Windows|Linux|Darwin|FreeBSD|NetBSD|OpenBSD|DragonFly|Android)$")
+	set(_FASTLOGGER_SUPPORTED_OS TRUE)
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^([xX]86_64|[aA][mM][dD]64|[xX]86|i[3-6]86|aarch64|[aA][rR][mM]64|[aA][rR][mM]|riscv|loongarch64|s390x)")
+	set(_FASTLOGGER_SUPPORTED_ARCH TRUE)
+endif()
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64|powerpc64)")
+	set(_FASTLOGGER_SUPPORTED_ARCH TRUE)
+endif()
+
+if(NOT _FASTLOGGER_SUPPORTED_OS OR NOT _FASTLOGGER_SUPPORTED_ARCH OR EMSCRIPTEN)
+	if(ENABLE_FASTLOGGER)
+		message(STATUS "FastLogger disabled: unsupported platform (${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR})")
+	endif()
+	set(ENABLE_FASTLOGGER OFF CACHE BOOL "Enable FastLogger" FORCE)
+endif()
+
+include(DefinePlatformSpecific)
+add_compile_definitions(POCO_CMAKE)
+
+add_subdirectory(dependencies)
+
 if (NOT POCO_MINIMAL_BUILD)
 	find_package(OpenSSL 1.1.1)
 	find_package(MySQL)
@@ -209,38 +259,13 @@ option(ENABLE_SEVENZIP "Enable SevenZip" OFF)
 option(ENABLE_CPPPARSER "Enable C++ parser" OFF)
 option(ENABLE_POCODOC "Enable Poco Documentation Generator" OFF)
 option(ENABLE_PDF "Enable PDF" OFF)
-option(ENABLE_TRACE "Enable stack tracing" OFF)
-option(ENABLE_FASTLOGGER "Enable FastLogger (Quill-based high-performance logger)" ON)
-
-# FastLogger uses Quill which only supports specific platforms.
-# Auto-disable on unsupported OS or CPU architecture.
-# Supported platforms are derived from quill source code:
-#   OS:   ThreadUtilities.h (get_thread_id), BackendWorkerLock.h
-#   Arch: Rdtsc.h
-set(_FASTLOGGER_SUPPORTED_OS FALSE)
-set(_FASTLOGGER_SUPPORTED_ARCH FALSE)
-
-if(CMAKE_SYSTEM_NAME MATCHES "^(Windows|Linux|Darwin|FreeBSD|NetBSD|OpenBSD|DragonFly|Android)$")
-	set(_FASTLOGGER_SUPPORTED_OS TRUE)
-endif()
-
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^([xX]86_64|[aA][mM][dD]64|[xX]86|i[3-6]86|aarch64|[aA][rR][mM]64|[aA][rR][mM]|riscv|loongarch64|s390x)")
-	set(_FASTLOGGER_SUPPORTED_ARCH TRUE)
-endif()
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64|powerpc64)")
-	set(_FASTLOGGER_SUPPORTED_ARCH TRUE)
-endif()
-
-if(NOT _FASTLOGGER_SUPPORTED_OS OR NOT _FASTLOGGER_SUPPORTED_ARCH OR EMSCRIPTEN)
-	if(ENABLE_FASTLOGGER)
-		message(STATUS "FastLogger disabled: unsupported platform (${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR})")
-	endif()
-	set(ENABLE_FASTLOGGER OFF CACHE BOOL "Enable FastLogger" FORCE)
-endif()
 
 if(POCO_ENABLE_CPP20)
 	option(ENABLE_MODULES "Build Poco.* C++ modules" OFF)
 endif()
+
+option(ENABLE_BENCHMARK
+	"Set to OFF|ON (default is OFF) to enable Benchmark application (requires Google Benchmark library)" OFF)
 
 option(ENABLE_CPPUNIT
 	"Set to OFF|ON (default is OFF) to enable CppUnit library" OFF)
@@ -265,18 +290,8 @@ option(ENABLE_SAMPLES
 option(ENABLE_FUZZING
 	"Set to OFF|ON (default is OFF) to control build of fuzzing targets for oss-fuzz (Clang compiler is required)" OFF)
 
-option(POCO_UNBUNDLED
-	"Set to OFF|ON (default is OFF) to control linking dependencies as external" OFF)
-
-option(POCO_SQLITE_UNBUNDLED
-	"Set to OFF|ON (default is OFF) to control linking sqlite dependency as external" OFF)
-
 option(POCO_SOO
 	"Set to OFF|ON (default is ON) to control small object optimization in Poco::Foundation" ON)
-
-if (POCO_UNBUNDLED)
-	set(POCO_SQLITE_UNBUNDLED ON CACHE BOOL "Enable Unbundled SQLite" FORCE)
-endif()
 
 if(ENABLE_TESTS)
 	include(CTest)
@@ -303,67 +318,6 @@ if(ENABLE_FUZZING)
 	endif()
 endif()
 
-# -- Dependency status summary --
-# Report which third-party libraries are bundled (internal) vs system (external).
-# Always present: zlib, pcre2, utf8proc.
-# Feature-gated: expat (XML), sqlite (Data/SQLite), libpng (PDF).
-set(_opt_deps "")
-if(ENABLE_XML)
-	string(APPEND _opt_deps ", expat")
-endif()
-if(ENABLE_DATA_SQLITE)
-	string(APPEND _opt_deps ", sqlite")
-endif()
-if(ENABLE_PDF)
-	string(APPEND _opt_deps ", libpng")
-endif()
-if(ENABLE_TRACE)
-	string(APPEND _opt_deps ", cpptrace")
-endif()
-
-if(POCO_UNBUNDLED)
-	# All bundled deps become external
-	message(STATUS "Using external zlib, pcre2, utf8proc${_opt_deps}")
-elseif(POCO_SQLITE_UNBUNDLED)
-	# Only sqlite is external; rebuild the internal list without it
-	if(ENABLE_DATA_SQLITE)
-		message(STATUS "Using external sqlite")
-	endif()
-	set(_int_deps "")
-	if(ENABLE_XML)
-		string(APPEND _int_deps ", expat")
-	endif()
-	if(ENABLE_PDF)
-		string(APPEND _int_deps ", libpng")
-	endif()
-	message(STATUS "Using internal zlib, pcre2, utf8proc${_int_deps}")
-else()
-	# Fully bundled
-	message(STATUS "Using internal zlib, pcre2, utf8proc${_opt_deps}")
-endif()
-
-# Always-external dependencies: these are never bundled, only report when enabled
-set(_ext_deps "")
-if(ENABLE_NETSSL OR ENABLE_CRYPTO OR ENABLE_JWT)
-	list(APPEND _ext_deps "OpenSSL")
-endif()
-if(ENABLE_DATA_MYSQL)
-	list(APPEND _ext_deps "MySQL")
-endif()
-if(ENABLE_DATA_POSTGRESQL)
-	list(APPEND _ext_deps "PostgreSQL")
-endif()
-if(ENABLE_DATA_ODBC)
-	list(APPEND _ext_deps "ODBC")
-endif()
-if(ENABLE_APACHECONNECTOR)
-	list(APPEND _ext_deps "APR" "Apache")
-endif()
-if(_ext_deps)
-	list(JOIN _ext_deps ", " _ext_deps_str)
-	message(STATUS "Using external ${_ext_deps_str}")
-endif()
-
 # Disable fork exec
 option(POCO_NO_FORK_EXEC "Set to OFF|ON (default is OFF) to disable use of fork() and exec*() which are not allowed on some Apple platforms (iOS, watchOS, iPadOS, tvOS)." OFF)
 
@@ -380,9 +334,6 @@ endif ()
 if(ENABLE_TRACE)
 	add_compile_definitions(POCO_ENABLE_TRACE)
 endif()
-
-include(DefinePlatformSpecific)
-add_compile_definitions(POCO_CMAKE)
 
 # Collect the built libraries and include dirs, the will be used to create the PocoConfig.cmake file
 set(Poco_COMPONENTS "")
@@ -527,10 +478,6 @@ endif()
 if(ENABLE_DATA_ODBC)
 	find_package(ODBC REQUIRED)
 endif()
-
-# - add required subdirectories
-
-add_subdirectory(dependencies)
 
 # Enable detailed compiler warnings for Poco code only (after dependencies to exclude them)
 poco_enable_detailed_compiler_warnings()
@@ -707,9 +654,6 @@ endif()
 #############################################################
 # Benchmark application (optional, requires Google Benchmark)
 
-option(ENABLE_BENCHMARK
-	"Set to OFF|ON (default is OFF) to enable Benchmark application (requires Google Benchmark library)" OFF)
-
 if(ENABLE_BENCHMARK)
 	find_package(benchmark QUIET)
 	if(benchmark_FOUND)
@@ -779,10 +723,75 @@ install(
 		Devel
 )
 
+message(STATUS " * CMake '${CMAKE_VERSION}' successfully configured '${PROJECT_NAME}'")
+message(STATUS " * ${PROJECT_NAME} package version: '${PROJECT_VERSION}'")
+
+# -- Dependency status summary --
+# Report which third-party libraries are bundled (internal) vs system (external).
+# Always present: zlib, pcre2, utf8proc.
+# Feature-gated: expat (XML), sqlite (Data/SQLite), libpng (PDF).
+# Printed after the enablement cascade and find_package() calls above so the
+# status reflects the final resolved state.
+set(_opt_deps "")
+if(ENABLE_XML)
+	string(APPEND _opt_deps ", expat")
+endif()
+if(ENABLE_DATA_SQLITE)
+	string(APPEND _opt_deps ", sqlite")
+endif()
+if(ENABLE_PDF)
+	string(APPEND _opt_deps ", libpng")
+endif()
+if(ENABLE_TRACE)
+	string(APPEND _opt_deps ", cpptrace")
+endif()
+
+if(POCO_UNBUNDLED)
+	# All bundled deps become external
+	message(STATUS "Using external zlib, pcre2, utf8proc${_opt_deps}")
+elseif(POCO_SQLITE_UNBUNDLED)
+	# Only sqlite is external; rebuild the internal list without it
+	if(ENABLE_DATA_SQLITE)
+		message(STATUS "Using external sqlite")
+	endif()
+	set(_int_deps "")
+	if(ENABLE_XML)
+		string(APPEND _int_deps ", expat")
+	endif()
+	if(ENABLE_PDF)
+		string(APPEND _int_deps ", libpng")
+	endif()
+	message(STATUS "Using internal zlib, pcre2, utf8proc${_int_deps}")
+else()
+	# Fully bundled
+	message(STATUS "Using internal zlib, pcre2, utf8proc${_opt_deps}")
+endif()
+
+# Always-external dependencies: these are never bundled, only report when enabled
+set(_ext_deps "")
+if(ENABLE_NETSSL OR ENABLE_CRYPTO OR ENABLE_JWT)
+	list(APPEND _ext_deps "OpenSSL")
+endif()
+if(ENABLE_DATA_MYSQL)
+	list(APPEND _ext_deps "MySQL")
+endif()
+if(ENABLE_DATA_POSTGRESQL)
+	list(APPEND _ext_deps "PostgreSQL")
+endif()
+if(ENABLE_DATA_ODBC)
+	list(APPEND _ext_deps "ODBC")
+endif()
+if(ENABLE_APACHECONNECTOR)
+	list(APPEND _ext_deps "APR" "Apache")
+endif()
+if(_ext_deps)
+	list(JOIN _ext_deps ", " _ext_deps_str)
+	message(STATUS "Using external ${_ext_deps_str}")
+endif()
+
+
 math(EXPR POCO_ARCH "${CMAKE_SIZEOF_VOID_P} * 8")
 
-message(STATUS "CMake '${CMAKE_VERSION}' successfully configured '${PROJECT_NAME}'")
-message(STATUS "${PROJECT_NAME} package version: '${PROJECT_VERSION}'")
 if(BUILD_SHARED_LIBS)
 	message(STATUS "Building dynamic libraries")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,16 @@ if (WIN32 AND CMAKE_VERSION VERSION_LESS  "4.1.0")
 	endif()
 endif()
 
-# -- Resolve bundled/unbundled dependencies before any find_package() for
-# packages that transitively depend on them (notably OpenSSL -> ZLIB in
-# static builds). Keeping this block ahead of find_package(OpenSSL ...) lets
-# dependencies/zlib/CMakeLists.txt create (and IMPORTED_GLOBAL-promote)
-# ZLIB::ZLIB in its own directory scope. See issue #5330.
+# Resolve zlib before find_package(OpenSSL ...): in static builds FindOpenSSL
+# transitively imports ZLIB::ZLIB non-globally at this scope, which would then
+# block dependencies/zlib from promoting it to IMPORTED_GLOBAL. The other dep
+# subdirs are feature-gated on ENABLE_XML / ENABLE_DATA_SQLITE / ENABLE_PDF
+# and stay at their original post-cascade position.
+#
+# POCO_UNBUNDLED / POCO_SQLITE_UNBUNDLED are declared here because
+# dependencies/zlib reads them. ENABLE_TRACE / ENABLE_FASTLOGGER and
+# DefinePlatformSpecific are pulled up so their directory-scope compile
+# definitions reach a bundled zlib object library.
 
 option(POCO_UNBUNDLED
 	"Set to OFF|ON (default is OFF) to control linking dependencies as external" OFF)
@@ -159,7 +164,9 @@ endif()
 include(DefinePlatformSpecific)
 add_compile_definitions(POCO_CMAKE)
 
-add_subdirectory(dependencies)
+if (POCO_UNBUNDLED)
+	add_subdirectory(dependencies/zlib)
+endif()
 
 if (NOT POCO_MINIMAL_BUILD)
 	find_package(OpenSSL 1.1.1)
@@ -478,6 +485,12 @@ endif()
 if(ENABLE_DATA_ODBC)
 	find_package(ODBC REQUIRED)
 endif()
+
+# Feature-gated dep subdirs must run after the enablement cascade so
+# ENABLE_XML / ENABLE_DATA_SQLITE / ENABLE_PDF etc. are finalised. zlib may
+# already have been added early; dependencies/CMakeLists.txt skips it in that
+# case.
+add_subdirectory(dependencies)
 
 # Enable detailed compiler warnings for Poco code only (after dependencies to exclude them)
 poco_enable_detailed_compiler_warnings()

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_subdirectory(zlib)
+# zlib may already have been added early at the top level to provide a global
+# ZLIB::ZLIB for FindOpenSSL's transitive find_dependency(ZLIB).
+if(NOT TARGET ZLIB::ZLIB)
+	add_subdirectory(zlib)
+endif()
 add_subdirectory(pcre2)
 add_subdirectory(v8_double_conversion)
 add_subdirectory(utf8proc)


### PR DESCRIPTION
## Summary

Fixes #5330.

With `POCO_UNBUNDLED=ON` and a static OpenSSL, the top-level `find_package(OpenSSL ...)` transitively calls `find_dependency(ZLIB)` from `FindOpenSSL.cmake`. That import creates `ZLIB::ZLIB` as a **non-global** imported target rooted in the top-level directory. When `add_subdirectory(dependencies)` later enters `dependencies/zlib/CMakeLists.txt`, the subsequent `set_target_properties(ZLIB::ZLIB PROPERTIES IMPORTED_GLOBAL TRUE)` fails because [CMake only allows `IMPORTED_GLOBAL` to be set from the directory that created the target](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_GLOBAL.html):

```
CMake Error at dependencies/zlib/CMakeLists.txt:12 (set_target_properties):
  Attempt to promote imported target "ZLIB::ZLIB" to global scope (by setting
  IMPORTED_GLOBAL) which is not built in this directory.
```

The reporter's one-liner suggestion (`find_package(ZLIB REQUIRED GLOBAL)` in the subdir) is not sufficient on its own: by the time control reaches `dependencies/zlib`, `ZLIB::ZLIB` already exists non-globally at the parent scope, and `FindZLIB.cmake`'s `if(NOT TARGET ZLIB::ZLIB)` guard makes the second `find_package` a no-op, so `GLOBAL` has no effect.

## Fix

Resolve unbundled dependencies **before** any `find_package(...)` that may pull them in transitively.

Move the following up in `CMakeLists.txt`, above the first `find_package(OpenSSL ...)`:

- `POCO_UNBUNDLED` / `POCO_SQLITE_UNBUNDLED` options + the `if(POCO_UNBUNDLED) set(POCO_SQLITE_UNBUNDLED ON ... FORCE) endif()` cascade.
- `ENABLE_TRACE` / `ENABLE_FASTLOGGER` options + the FastLogger platform fix-up (gates `dependencies/quill` and `dependencies/cpptrace`).
- `include(DefinePlatformSpecific)` (sets directory-scope `POCO_DLL` / `POCO_STATIC` compile definitions that bundled object libraries inherit).
- `add_subdirectory(dependencies)`.

`ZLIB::ZLIB` is now created and promoted to `IMPORTED_GLOBAL` inside the directory that created it. Later `find_package(OpenSSL/MySQL/PostgreSQL ...)` calls see the pre-existing global target via `FindZLIB`'s `if(NOT TARGET ZLIB::ZLIB)` guard and reuse it.

The **Dependency status summary** block is moved **down** to just after the REQUIRED `find_package(...)` calls, so its printed state reflects the post-enablement-cascade `ENABLE_*` values (e.g. `ENABLE_JWT` -> `ENABLE_CRYPTO`, `ENABLE_SAMPLES` -> `ENABLE_XML`).

`dependencies/zlib/CMakeLists.txt` itself is unchanged.

## Consequences considered

- Nothing inside `dependencies/*` reads component-level `ENABLE_*` options (only `POCO_UNBUNDLED` / `POCO_SQLITE_UNBUNDLED` / `ENABLE_FASTLOGGER` / `ENABLE_TRACE`), so the earlier dep resolution does not force premature decisions.
- `poco_enable_detailed_compiler_warnings()` stays where it was (intentionally after `add_subdirectory(dependencies)` to exclude bundled third-party code from strict warnings).
- `include(PocoMacros)` / `BUILD_SHARED_LIBS` / `CMAKE_CXX_STANDARD` / output dirs are already set before the new location.

## Test plan

Verified in four configurations:

- [x] **macOS, unbundled, shared** (Homebrew OpenSSL 3) -- configure + build clean.
- [x] **macOS, bundled** -- configure + build clean; `_BUNDLED_ZLIB`/`_BUNDLED_PCRE2` still inherit `POCO_DLL` / `POCO_STATIC` (confirms `DefinePlatformSpecific` ran early enough).
- [x] **Linux (OrbStack), unbundled, shared** -- configure + build clean.
- [x] **Linux (OrbStack), unbundled, static** (`-DBUILD_SHARED_LIBS=OFF -DOPENSSL_USE_STATIC_LIBS=ON`) -- original reproducer from #5330:
  - Before this patch: configure fails with the exact `Attempt to promote imported target "ZLIB::ZLIB" to global scope` error at `dependencies/zlib/CMakeLists.txt:12`.
  - With this patch: configure + full build clean, `libPocoNetSSL.a` links against static `libz.a` + static `libcrypto.a` / `libssl.a`.