### PR TITLE
chore(Crypto): silence OpenSSL 3.x deprecation warnings for legacy key accessors

### DIFF
--- a/Crypto/include/Poco/Crypto/ECKeyImpl.h
+++ b/Crypto/include/Poco/Crypto/ECKeyImpl.h
@@ -169,22 +169,6 @@ inline const EVP_PKEY* ECKeyImpl::getEVPPKey() const
 }
 
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-
-inline EC_KEY* ECKeyImpl::getECKey()
-{
-	return const_cast<EC_KEY*>(EVP_PKEY_get0_EC_KEY(_pEVPPKey));
-}
-
-
-inline const EC_KEY* ECKeyImpl::getECKey() const
-{
-	return EVP_PKEY_get0_EC_KEY(_pEVPPKey);
-}
-
-#endif // !OPENSSL_NO_DEPRECATED_3_0
-
-
 inline std::string ECKeyImpl::groupName() const
 {
 	return OBJ_nid2sn(groupId());

--- a/Crypto/src/ECKeyImpl.cpp
+++ b/Crypto/src/ECKeyImpl.cpp
@@ -221,6 +221,36 @@ int ECKeyImpl::groupId() const
 }
 
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#	pragma warning(push)
+#	pragma warning(disable:4996)
+#endif
+
+EC_KEY* ECKeyImpl::getECKey()
+{
+	return const_cast<EC_KEY*>(EVP_PKEY_get0_EC_KEY(_pEVPPKey));
+}
+
+
+const EC_KEY* ECKeyImpl::getECKey() const
+{
+	return EVP_PKEY_get0_EC_KEY(_pEVPPKey);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#	pragma warning(pop)
+#endif
+
+#endif // !OPENSSL_NO_DEPRECATED_3_0
+
+
 #else // !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 
 

--- a/Crypto/src/RSAKeyImpl.cpp
+++ b/Crypto/src/RSAKeyImpl.cpp
@@ -162,6 +162,14 @@ void RSAKeyImpl::freeRSA()
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#	pragma warning(push)
+#	pragma warning(disable:4996)
+#endif
+
 RSA* RSAKeyImpl::getRSA()
 {
 	return const_cast<RSA*>(EVP_PKEY_get0_RSA(_pEVPPKey));
@@ -172,6 +180,12 @@ const RSA* RSAKeyImpl::getRSA() const
 {
 	return EVP_PKEY_get0_RSA(_pEVPPKey);
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#	pragma warning(pop)
+#endif
 
 #endif
 


### PR DESCRIPTION
## Summary

Linux and macOS builds against OpenSSL 3.x emit many
`-Wdeprecated-declarations` warnings coming from two legacy accessors
that POCO deliberately keeps for backwards-compatibility:

- `Poco::Crypto::ECKeyImpl::getECKey()` (was inline in
  `Crypto/include/Poco/Crypto/ECKeyImpl.h`)
- `Poco::Crypto::RSAKeyImpl::getRSA()` (out-of-line in
  `Crypto/src/RSAKeyImpl.cpp`)

Both forward to `EVP_PKEY_get0_EC_KEY` / `EVP_PKEY_get0_RSA`, which are
deprecated since OpenSSL 3.0. The methods themselves are already marked
`POCO_DEPRECATED` and guarded by `#ifndef OPENSSL_NO_DEPRECATED_3_0`;
they exist purely as a migration aid for downstream code that still
uses the legacy `EC_KEY*` / `RSA*` API. There is no non-deprecated
OpenSSL 3 equivalent that returns these types, so the warning cannot
be avoided by switching APIs.

Inside POCO itself, every call to these shims is already gated by
`#if !POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)`, so under OpenSSL 3.x the
warnings come only from the shim bodies.

## Changes

- Move the OpenSSL-3 branch inline bodies of `ECKeyImpl::getECKey()` /
  `const getECKey()` out of the header into the .cpp. Previously they
  were defined inline in `ECKeyImpl.h`, so every translation unit that
  (transitively) included `ECKey.h` re-emitted the deprecation warning
  across Crypto / NetSSL / Util / Net.
- Wrap the two deprecated-symbol call sites in
  `Crypto/src/ECKeyImpl.cpp` and `Crypto/src/RSAKeyImpl.cpp` with
  compiler diagnostic pragmas (`-Wdeprecated-declarations` for
  GCC/Clang, C4996 for MSVC). This silences the warning at the only
  place where it still fires, while keeping the public API unchanged
  and the `POCO_DEPRECATED` migration hint visible to external users.

The pre-OpenSSL-3 inline branch of the header is left untouched.
No functional change.

## Test plan

- [x] Linux build with OpenSSL 3.x (OrbStack, gcc): 0 deprecation
      warnings for `EVP_PKEY_get0_EC_KEY` / `EVP_PKEY_get0_RSA`
      (previously dozens per TU).
- [x] macOS build with OpenSSL 3.x (Homebrew, AppleClang): 0 OpenSSL
      deprecation warnings.
- [x] `Crypto-testrunner -all` on Linux: 47/47 tests pass, including
      the EVP / RSA / EC / PKCS12 / Envelope / OpenSSLInitializer
      suites.
- [x] CI coverage across remaining platforms (MSVC, older gcc/clang).