### PR TITLE
fix(Foundation): handle INTERFACE_LIBRARY Pcre2::Pcre2 from CONFIG-mode packages

### DIFF
--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -35,6 +35,9 @@ if(POCO_UNBUNDLED)
 
 	# pcre2 source files are linked with Foundation when shared library pcre2 is linked.
 	# When linking pcre2 as static library the symbols are accessible.
+	# CONFIG-mode packages (e.g. Conan, vcpkg) may expose Pcre2::Pcre2 as an
+	# INTERFACE_LIBRARY aggregator; the PCRE2_STATIC compile definition is the
+	# canonical marker that the underlying build is static.
 	get_target_property(_PCRE2TYPE Pcre2::Pcre2 TYPE)
 	if("${_PCRE2TYPE}" STREQUAL "SHARED_LIBRARY")
 		# HACK: Unicode.cpp requires functions from these files.
@@ -42,6 +45,15 @@ if(POCO_UNBUNDLED)
 		POCO_SOURCES(SRCS RegExp ${EMBEDDED_PCRE2_SOURCES} )
 	elseif ("${_PCRE2TYPE}" STREQUAL "STATIC_LIBRARY")
 		message(STATUS "PCRE2: linking static library.")
+	elseif("${_PCRE2TYPE}" STREQUAL "INTERFACE_LIBRARY" OR "${_PCRE2TYPE}" STREQUAL "UNKNOWN_LIBRARY")
+		get_target_property(_PCRE2DEFS Pcre2::Pcre2 INTERFACE_COMPILE_DEFINITIONS)
+		if(_PCRE2DEFS MATCHES "PCRE2_STATIC")
+			message(STATUS "PCRE2: linking ${_PCRE2TYPE} (PCRE2_STATIC set).")
+		else()
+			message(STATUS "PCRE2: ${_PCRE2TYPE} without PCRE2_STATIC; embedding internal sources.")
+			POCO_SOURCES(SRCS RegExp ${EMBEDDED_PCRE2_SOURCES})
+		endif()
+		unset(_PCRE2DEFS)
 	else()
 		message(WARNING "PCRE2: unknown library type: ${_PCRE2TYPE}")
 	endif()


### PR DESCRIPTION
## Summary

Follow-up to #5331 (issue #5330).

When \`find_package(PCRE2 REQUIRED)\` resolves via a CONFIG-mode package file (typical with Conan or vcpkg), \`Pcre2::Pcre2\` is created as an \`INTERFACE_LIBRARY\` aggregator around concrete sub-targets (\`PCRE2::8BIT\`, etc.). \`Foundation/CMakeLists.txt\` only handled \`SHARED_LIBRARY\` / \`STATIC_LIBRARY\`, so every CONFIG-mode user saw:

\`\`\`
CMake Warning at Foundation/CMakeLists.txt:46 (message):
  PCRE2: unknown library type: INTERFACE_LIBRARY
\`\`\`

In addition to being noisy, silently falling through is unsafe: if the INTERFACE target wraps a *shared* PCRE2 build, \`Unicode.cpp\` fails to link because \`pcre2_ucd\` / \`pcre2_tables\` are not exported from the shared library. The current build succeeds for issue #5330's Conan reporter only because their PCRE2 happens to be static.

## Fix

Treat \`INTERFACE_LIBRARY\` (and \`UNKNOWN_LIBRARY\`) explicitly. Use the \`PCRE2_STATIC\` compile definition -- the canonical marker set by PCRE2's own build system for static linking -- to decide whether to embed \`pcre2_ucd.c\` / \`pcre2_tables.c\`:

- \`PCRE2_STATIC\` present on \`INTERFACE_COMPILE_DEFINITIONS\`: underlying build is static; skip embedding.
- Otherwise: treat as shared and embed the internal sources, the same behaviour as the existing \`SHARED_LIBRARY\` branch.

This is a no-op on hosts where PCRE2 resolves to \`SHARED_LIBRARY\` / \`STATIC_LIBRARY\` (i.e. the module-mode \`FindPCRE2.cmake\` path).

## Test plan

- [x] Linux (OrbStack) unbundled static -- PCRE2 resolves to \`SHARED_LIBRARY\`, warning absent before and after.
- [x] macOS unbundled -- PCRE2 resolves to \`SHARED_LIBRARY\` (\`.tbd\`), warning absent before and after.
- [x] Conan / CONFIG-mode reproducer -- waiting on the original reporter to confirm the warning is gone and \`Unicode.cpp\` still links.

No regression in either host matrix point.