### PR TITLE
enh(MongoDB): add wire version constants for MongoDB 6.1-8.0

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -121,7 +121,14 @@ public:
 		VER_51		= 14, ///< First wire version that supports *only* OP_MSG
 		VER_52		= 15,
 		VER_53		= 16,
-		VER_60		= 17
+		VER_60		= 17,
+		VER_61		= 18,
+		VER_62		= 19,
+		VER_70		= 21,
+		VER_71		= 22,
+		VER_72		= 23,
+		VER_73		= 24,
+		VER_80		= 25
 	};
 
 protected:


### PR DESCRIPTION
## Summary

- Extend `Poco::MongoDB::Database::WireVersion` with constants for the wire versions introduced since MongoDB 6.0: `VER_61` (18), `VER_62` (19), `VER_70` (21), `VER_71` (22), `VER_72` (23), `VER_73` (24) and `VER_80` (25).
- Values based on the authoritative list in [mongodb/specifications -- wireversion-featurelist.md](https://github.com/mongodb/specifications/blob/master/source/wireversion-featurelist/wireversion-featurelist.md).
- Gaps at 10, 11, 12 and 20 are left intentionally unassigned because MongoDB reserves those numbers for internal development releases and does not expose them as server wire versions.

Purely additive change -- no existing constants or values are modified, so downstream code using the existing `VER_*` names is unaffected.

## Test plan

- [x] Build MongoDB component and test runner to confirm the header compiles cleanly:
  ```
  cmake -B build-mongodb-wire -DENABLE_TESTS=ON -DPOCO_MINIMAL_BUILD=ON -DENABLE_FOUNDATION=ON -DENABLE_MONGODB=ON
  cmake --build build-mongodb-wire --target MongoDB-testrunner -j
  ```
- [x] Verified no other files in the tree depend on the previous maximum value (`VER_60`).