### PR TITLE
Fix C1021 fatal error when building DataSQLite with POCO_SQLITE_UNBUNDLED on MSVC

### DIFF
--- a/Data/SQLite/src/Utility.cpp
+++ b/Data/SQLite/src/Utility.cpp
@@ -38,7 +38,7 @@ const int Utility::THREAD_MODE_MULTI = SQLITE_CONFIG_MULTITHREAD;
 const int Utility::THREAD_MODE_SERIAL = SQLITE_CONFIG_SERIALIZED;
 
 #if defined(POCO_SQLITE_UNBUNDLED)
-	#warning "Utility::_threadMode is set based on SQLITE_THREADSAFE, which may not reflect the actual threading mode used by unbundled SQLite"
+	#pragma message("WARNING: Utility::_threadMode is set based on SQLITE_THREADSAFE, which may not reflect the actual threading mode used by unbundled SQLite")
 #endif
 
 int Utility::_threadMode =


### PR DESCRIPTION
Hello Poco maintainers! :wave: 

### Summary

When building Poco 1.15.2 on Conan via PR https://github.com/conan-io/conan-center-index/pull/29722, a new compilation error came when building on Windows with MSVC and `POCO_UNBUNDLED=ON`:

```
[603/669] Building CXX object Data\SQLite\CMakeFiles\DataSQLite.dir\src\Utility.cpp.obj
FAILED: Data/SQLite/CMakeFiles/DataSQLite.dir/src/Utility.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP -DPOCO_CMAKE -DPOCO_DLL -DPOCO_ENABLE_FASTLOGGER -DPOCO_NO_AUTOMATIC_LIBS=1 -DPOCO_OS_FAMILY_WINDOWS -DPOCO_SQLITE_UNBUNDLED -DPOCO_UNBUNDLED -DSQLITE_API=__declspec(dllimport) -DSQLITE_THREADSAFE=1 -DSQLParser_EXPORTS -DSQLite_EXPORTS -DUNICODE -DXML_DTD=1 -D_UNICODE -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\SQLite\include -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\SQLite\src -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\include -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\src -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\Foundation\include -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\dependencies\tessil\include -IC:\j\29722-6\b\pocoeaefe95cf9364\b\src\dependencies\quill\include -external:IC:\j\29722-6\sqlita6b10382efd94\p\include -external:W0 /DWIN32 /D_WINDOWS /EHsc /Zc:__cplusplus /O2 /Ob2 /DNDEBUG -std:c++20 -MD /showIncludes /FoData\SQLite\CMakeFiles\DataSQLite.dir\src\Utility.cpp.obj /FdData\SQLite\CMakeFiles\DataSQLite.dir\ /FS -c C:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\SQLite\src\Utility.cpp
C:\j\29722-6\b\pocoeaefe95cf9364\b\src\Data\SQLite\src\Utility.cpp(43): fatal error C1021: invalid preprocessor command 'warning'
```

Full build log: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-29722/6/package_build_logs/build_log_poco_1_15_2_0adc2f8480994b99f01861be3ca8abd7_7c1918cef109f6ba5d4f8f80693ced80922aa350.txt

Note that it was not seen for version 1.14.2, which is distributed/built by Conan. It could be related to https://github.com/pocoproject/poco/pull/4996, as we started to see it after 1.15.z only.

### Cause of the Problem

MSVC does not support the `#warning` preprocessor directive (it is a GCC/Clang extension). When building with `-DPOCO_SQLITE_UNBUNDLED` on Windows, the compiler emits a fatal error:

```
fatal error C1021: invalid preprocessor command 'warning'
```

References:
- https://learn.microsoft.com/en-us/cpp/preprocessor/warning?view=msvc-170
- https://gcc.gnu.org/onlinedocs/gcc-4.4.3/gcc/Diagnostic-Pragmas.html
- https://gcc.gnu.org/onlinedocs/cpp/Diagnostics.html
- https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas

### Proposed Fix

`#pragma message(...)` is supported by MSVC, GCC, and Clang, making it a portable drop-in replacement. The message text is preserved, prefixed with `WARNING:` to retain its intent.

I applied the proposed patch on Conan side, so we can validate it on the CI as well:

- The same patch overs 1.15.2: https://github.com/conan-io/conan-center-index/pull/29722/changes/871e92075e387986420f91bd64435a624fdda929
- Build log on Windows with that patch applied: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-29722/7/package_build_logs/build_log_poco_1_15_2_10e5cff93d1fde2e8d6a95ff0bf19527_7c1918cef109f6ba5d4f8f80693ced80922aa350.success.txt

### Affected configuration

- Platform: Windows
- Poco version: 1.15.2 (probably 1.15.0 and 1.15.1 as well)
- Compiler: Visual Studio 17 2022 - MSVC 19.44.35213.0 
- Build flag: `-DPOCO_SQLITE_UNBUNDLED`