### PR TITLE
fix(SSH): forward-declare libssh handles in public headers

### DIFF
--- a/SSH/CMakeLists.txt
+++ b/SSH/CMakeLists.txt
@@ -12,6 +12,8 @@ if(MSVC AND BUILD_SHARED_LIBS)
 	list(APPEND SRCS ${PROJECT_SOURCE_DIR}/DLLVersion.rc)
 endif()
 
+find_package(libssh CONFIG REQUIRED)
+
 add_library(SSH ${SRCS})
 add_library(Poco::SSH ALIAS SSH)
 set_target_properties(SSH

--- a/SSH/include/Poco/SSH/SSHChannelStream.h
+++ b/SSH/include/Poco/SSH/SSHChannelStream.h
@@ -19,7 +19,7 @@
 
 
 #include "Poco/SSH/SSH.h"
-#include <libssh/libssh.h>
+#include "Poco/SSH/SSHTypes.h"
 #include <streambuf>
 #include <ostream>
 #include <string>

--- a/SSH/include/Poco/SSH/SSHClient.h
+++ b/SSH/include/Poco/SSH/SSHClient.h
@@ -19,8 +19,8 @@
 
 
 #include "Poco/SSH/SSH.h"
+#include "Poco/SSH/SSHTypes.h"
 #include "Poco/Types.h"
-#include <libssh/libssh.h>
 #include <string>
 
 

--- a/SSH/include/Poco/SSH/SSHServer.h
+++ b/SSH/include/Poco/SSH/SSHServer.h
@@ -20,14 +20,13 @@
 
 #include "Poco/SSH/SSH.h"
 #include "Poco/SSH/SSHServerConfig.h"
+#include "Poco/SSH/SSHTypes.h"
 #include "Poco/Logger.h"
 #include "Poco/Thread.h"
 #include "Poco/ThreadPool.h"
 #include "Poco/RunnableAdapter.h"
 #include "Poco/Mutex.h"
 #include "Poco/Event.h"
-#include <libssh/libssh.h>
-#include <libssh/server.h>
 #include <atomic>
 #include <set>
 #include <functional>

--- a/SSH/include/Poco/SSH/SSHSession.h
+++ b/SSH/include/Poco/SSH/SSHSession.h
@@ -20,9 +20,9 @@
 
 #include "Poco/SSH/SSH.h"
 #include "Poco/SSH/SSHServerConfig.h"
+#include "Poco/SSH/SSHTypes.h"
 #include "Poco/Logger.h"
 #include "Poco/Runnable.h"
-#include <libssh/libssh.h>
 #include <string>
 
 

--- a/SSH/include/Poco/SSH/SSHTypes.h
+++ b/SSH/include/Poco/SSH/SSHTypes.h
@@ -1,0 +1,28 @@
+//
+// SSHTypes.h
+//
+// Forward declarations of libssh opaque handles. Lets Poco::SSH public headers
+// avoid <libssh/libssh.h>. Tags match upstream; safe to co-include with the
+// real libssh headers.
+//
+// Copyright (c) 2026, Aleph ONE Software Engineering LLC
+// SPDX-License-Identifier: BSL-1.0
+//
+
+
+#ifndef SSH_SSHTypes_INCLUDED
+#define SSH_SSHTypes_INCLUDED
+
+
+struct ssh_session_struct;
+struct ssh_channel_struct;
+struct ssh_key_struct;
+struct ssh_bind_struct;
+
+using ssh_session = ssh_session_struct*;
+using ssh_channel = ssh_channel_struct*;
+using ssh_key     = ssh_key_struct*;
+using ssh_bind    = ssh_bind_struct*;
+
+
+#endif // SSH_SSHTypes_INCLUDED

--- a/SSH/src/SSHChannelStream.cpp
+++ b/SSH/src/SSHChannelStream.cpp
@@ -13,6 +13,7 @@
 
 
 #include "Poco/SSH/SSHChannelStream.h"
+#include <libssh/libssh.h>
 
 
 namespace Poco {

--- a/SSH/src/SSHClient.cpp
+++ b/SSH/src/SSHClient.cpp
@@ -14,6 +14,7 @@
 
 #include "Poco/SSH/SSHClient.h"
 #include "Poco/SSH/SSHException.h"
+#include <libssh/libssh.h>
 
 
 namespace Poco {

--- a/SSH/src/SSHServer.cpp
+++ b/SSH/src/SSHServer.cpp
@@ -15,6 +15,7 @@
 #include "Poco/SSH/SSHServer.h"
 #include "Poco/SSH/SSHSession.h"
 #include "Poco/SSH/SSHException.h"
+#include <libssh/libssh.h>
 #include <libssh/server.h>
 
 #if !defined(POCO_OS_FAMILY_WINDOWS)

--- a/SSH/src/SSHSession.cpp
+++ b/SSH/src/SSHSession.cpp
@@ -27,6 +27,7 @@
 #include "Poco/SSH/SSHException.h"
 #include "Poco/Path.h"
 #include "Poco/File.h"
+#include <libssh/libssh.h>
 #include <libssh/server.h>
 #include <fstream>
 #include <sstream>

--- a/SSH/testsuite/src/SSHTest.cpp
+++ b/SSH/testsuite/src/SSHTest.cpp
@@ -22,6 +22,7 @@
 #include "Poco/TemporaryFile.h"
 #include "Poco/Thread.h"
 #include <libssh/libssh.h>
+#include <libssh/server.h>
 
 
 using namespace Poco::SSH;


### PR DESCRIPTION
## Summary

Move `ssh_session`/`ssh_channel`/`ssh_key`/`ssh_bind` opaque-pointer typedefs into a new `SSHTypes.h` so `Poco::SSH` public headers no longer `#include <libssh/libssh.h>`. Consumers of `Poco::SSH` now compile without libssh on the include path, making `target_link_libraries(SSH PRIVATE ssh)` truthful.

- New `SSH/include/Poco/SSH/SSHTypes.h` with forward declarations matching the upstream libssh tags.
- `SSHChannelStream.h`, `SSHClient.h`, `SSHServer.h`, `SSHSession.h` switched from `<libssh/libssh.h>` (and `<libssh/server.h>` for the server) to the new header.
- `.cpp` files (and the testsuite, which uses libssh APIs directly) now include `<libssh/libssh.h>` / `<libssh/server.h>` explicitly since they no longer get them transitively.
- `SSH/CMakeLists.txt`: added `find_package(libssh CONFIG REQUIRED)` so the SSH subdirectory can be built standalone.

Upstreamed from the macchina.io copy of Poco.

## Test plan

- [x] Linux build with `ENABLE_SSH=ON` (libssh from system) -- `SSH`, `SSH-testrunner`, `pocossh` sample all link clean.
- [x] `./SSH-testrunner -all` -- 10/10 tests pass.
- [ ] CI (Windows + Linux) green.