### PR TITLE
fix(cmake): replace obsolete -s with -Wl,-x on Apple linker

### DIFF
--- a/cmake/DefinePlatformSpecific.cmake
+++ b/cmake/DefinePlatformSpecific.cmake
@@ -49,11 +49,14 @@ else(MSVC)
 	# Other compilers then MSVC don't have a static STATIC_POSTFIX at the moment
 	set(STATIC_POSTFIX "" CACHE STRING "Set static library postfix" FORCE)
 
-	# Strip debug symbols from Release binaries (reduces binary size significantly)
-	# On Windows, debug symbols go to separate .pdb files, so this is not needed
-	# NOTE: CMAKE_BUILD_TYPE must be set to Release for this to take effect
-	#       e.g., cmake -B build -DCMAKE_BUILD_TYPE=Release
-	add_link_options($<$<CONFIG:Release>:-s>)
+	# Strip symbols from Release binaries. Apple's ld deprecated `-s`;
+	# `-Wl,-x` is its documented replacement and keeps dynamic exports.
+	# MSVC has no equivalent — symbols live in the .pdb, not the binary.
+	if(APPLE)
+		add_link_options($<$<CONFIG:Release>:-Wl,-x>)
+	else()
+		add_link_options($<$<CONFIG:Release>:-s>)
+	endif()
 
 	# Dead-code stripping for macOS: Apple's -dead_strip works on Mach-O
 	# atoms without needing -ffunction-sections/-fdata-sections.


### PR DESCRIPTION
## Problem

Every Release link on macOS prints:

```
ld: warning: -s is obsolete
```

Apple's linker (ld64 / ld-prime, Xcode 15+) deprecated the `-s` flag introduced for size reduction in #5297. The link still strips, but the warning is emitted on every shared library and executable. LLVM's `lld` accepts `-s` silently — the warning is specific to Apple's `ld`.

## Change

Gate the strip flag by platform in [cmake/DefinePlatformSpecific.cmake](cmake/DefinePlatformSpecific.cmake):

- **Apple:** `-Wl,-x` — Apple's documented replacement. Strips local symbols while keeping dynamic exports needed for `.dylib`s.
- **Other Unix (GCC/Clang on Linux/BSD):** `-s` retained, unchanged.
- **MSVC:** intentionally no change. PE binaries do not carry a strippable symbol table — debug info lives in separate `.pdb` files. There is no `-s` equivalent on Windows.

## Verification

Local rebuild on macOS (Xcode 16, Apple clang) of the Foundation/Util chain:

- `ld: warning: -s is obsolete` — gone.
- `nm libPocoUtil.dylib` shows 640 global text symbols, 0 local (lowercase) symbols → strip is effective.
- Util test suite: **OK (244 tests)**.

## Notes

- Out of scope: the `/OPT:REF` and `/OPT:ICF` flags on MSVC are dead-code/folding parallels of `-Wl,-dead_strip` / `--gc-sections` / `--icf=safe`, not of `-s`. They are MSVC linker defaults for Release already; making them explicit can be a separate follow-up if desired.
- Bit-for-bit equivalence to GNU `-s` would also pass `-Wl,-S` (strip debug info) on Apple, but clang on macOS emits DWARF into object files and only collects it into a `.dSYM` on demand, so the linked output rarely carries debug info; `-Wl,-x` alone matches the size-reduction goal.