### PR TITLE
fix(Net): IPv6AddressImpl::isLoopback IPv4-mapped check (#5050)

### DIFF
--- a/Net/src/IPAddressImpl.cpp
+++ b/Net/src/IPAddressImpl.cpp
@@ -565,15 +565,20 @@ bool IPv6AddressImpl::isBroadcast() const
 
 bool IPv6AddressImpl::isLoopback() const
 {
+	const UInt16* words = reinterpret_cast<const UInt16*>(&_addr);
+
 	if (isIPv4Mapped())
 	{
 		// IPv4-mapped IPv6 address: ::ffff:a.b.c.d
-		// The IPv4 octets occupy s6_addr32[3] (the last 32 bits of the address).
-		// Loopback in IPv4 is 127.0.0.0/8, so the high byte must be 0x7F.
-		return (ByteOrder::fromNetwork(_addr.s6_addr32[3]) & 0xFF000000) == 0x7F000000;
+		// The IPv4 octets occupy the last 32 bits of the address; words[6]
+		// holds the (a, b) pair in network order. Loopback in IPv4 is
+		// 127.0.0.0/8, so the high byte (a) must be 0x7F.
+		// Note: s6_addr16 is non-portable (missing on Windows in6_addr),
+		// so reinterpret_cast over the whole struct, like the rest of
+		// this file does.
+		return (ByteOrder::fromNetwork(words[6]) & 0xFF00) == 0x7F00;
 	}
 
-	const UInt16* words = reinterpret_cast<const UInt16*>(&_addr);
 	return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&
 		words[4] == 0 && words[5] == 0 && words[6] == 0 && ByteOrder::fromNetwork(words[7]) == 0x0001;
 }

--- a/Net/src/IPAddressImpl.cpp
+++ b/Net/src/IPAddressImpl.cpp
@@ -566,7 +566,12 @@ bool IPv6AddressImpl::isBroadcast() const
 bool IPv6AddressImpl::isLoopback() const
 {
 	if (isIPv4Mapped())
-		return (ByteOrder::fromNetwork(_addr.s6_addr[6]) & 0xFF000000) == 0x7F000000;
+	{
+		// IPv4-mapped IPv6 address: ::ffff:a.b.c.d
+		// The IPv4 octets occupy s6_addr32[3] (the last 32 bits of the address).
+		// Loopback in IPv4 is 127.0.0.0/8, so the high byte must be 0x7F.
+		return (ByteOrder::fromNetwork(_addr.s6_addr32[3]) & 0xFF000000) == 0x7F000000;
+	}
 
 	const UInt16* words = reinterpret_cast<const UInt16*>(&_addr);
 	return words[0] == 0 && words[1] == 0 && words[2] == 0 && words[3] == 0 &&

--- a/Net/testsuite/src/IPAddressTest.cpp
+++ b/Net/testsuite/src/IPAddressTest.cpp
@@ -507,34 +507,44 @@ void IPAddressTest::testClassification6()
 	assertTrue (!ip7.isGlobalMC());
 
 	IPAddress ip8("::ffff:127.0.0.1"); // IPv4-mapped loopback
-	assertTrue (!ip3.isWildcard());
-	assertTrue (!ip3.isBroadcast());
-	assertTrue (ip3.isLoopback());
-	assertTrue (!ip3.isMulticast());
-	assertTrue (ip3.isUnicast());
-	assertTrue (!ip3.isLinkLocal());
-	assertTrue (!ip3.isSiteLocal());
-	assertTrue (!ip3.isWellKnownMC());
-	assertTrue (!ip3.isNodeLocalMC());
-	assertTrue (!ip3.isLinkLocalMC());
-	assertTrue (!ip3.isSiteLocalMC());
-	assertTrue (!ip3.isOrgLocalMC());
-	assertTrue (!ip3.isGlobalMC());
+	assertTrue (!ip8.isWildcard());
+	assertTrue (!ip8.isBroadcast());
+	assertTrue (ip8.isLoopback());
+	assertTrue (!ip8.isMulticast());
+	assertTrue (ip8.isUnicast());
+	assertTrue (!ip8.isLinkLocal());
+	assertTrue (!ip8.isSiteLocal());
+	assertTrue (!ip8.isWellKnownMC());
+	assertTrue (!ip8.isNodeLocalMC());
+	assertTrue (!ip8.isLinkLocalMC());
+	assertTrue (!ip8.isSiteLocalMC());
+	assertTrue (!ip8.isOrgLocalMC());
+	assertTrue (!ip8.isGlobalMC());
 
 	IPAddress ip9("::ffff:127.255.255.254"); // IPv4-mapped loopback
-	assertTrue (!ip3.isWildcard());
-	assertTrue (!ip3.isBroadcast());
-	assertTrue (ip3.isLoopback());
-	assertTrue (!ip3.isMulticast());
-	assertTrue (ip3.isUnicast());
-	assertTrue (!ip3.isLinkLocal());
-	assertTrue (!ip3.isSiteLocal());
-	assertTrue (!ip3.isWellKnownMC());
-	assertTrue (!ip3.isNodeLocalMC());
-	assertTrue (!ip3.isLinkLocalMC());
-	assertTrue (!ip3.isSiteLocalMC());
-	assertTrue (!ip3.isOrgLocalMC());
-	assertTrue (!ip3.isGlobalMC());
+	assertTrue (!ip9.isWildcard());
+	assertTrue (!ip9.isBroadcast());
+	assertTrue (ip9.isLoopback());
+	assertTrue (!ip9.isMulticast());
+	assertTrue (ip9.isUnicast());
+	assertTrue (!ip9.isLinkLocal());
+	assertTrue (!ip9.isSiteLocal());
+	assertTrue (!ip9.isWellKnownMC());
+	assertTrue (!ip9.isNodeLocalMC());
+	assertTrue (!ip9.isLinkLocalMC());
+	assertTrue (!ip9.isSiteLocalMC());
+	assertTrue (!ip9.isOrgLocalMC());
+	assertTrue (!ip9.isGlobalMC());
+
+	// IPv4-mapped non-loopback (regression guard for #5050: previous
+	// implementation always returned false here, but symmetrically
+	// could have always returned true depending on the byte read).
+	IPAddress ip13("::ffff:192.168.1.120");
+	assertTrue (!ip13.isWildcard());
+	assertTrue (!ip13.isBroadcast());
+	assertTrue (!ip13.isLoopback());
+	assertTrue (!ip13.isMulticast());
+	assertTrue (ip13.isUnicast());
 #endif
 }
 


### PR DESCRIPTION
## Summary
- Fix `IPv6AddressImpl::isLoopback` IPv4-mapped path: it read a single byte (`s6_addr[6]`, part of the 0xFFFF prefix word) and AND-ed it with `0xFF000000`, making the check always false. CodeQL flagged it as "comparison is always the same". Now reads `s6_addr32[3]` (the 32-bit IPv4 portion of `::ffff:a.b.c.d`) and tests the high byte against `0x7F` for the IPv4 loopback range 127/8.
- Fix pre-existing copy/paste bugs in `testClassification6`: the IPv4-mapped loopback test cases declared `ip8`/`ip9` but asserted on `ip3` (the `::1` address from earlier in the function), so the buggy code path was never actually exercised.
- Add a non-loopback IPv4-mapped regression guard (`::ffff:192.168.1.120`).

Closes #5050.

## Test plan
- [x] `Net-testrunner IPAddressTest` -- 16/16 tests pass on macOS arm64
- [x] CI green on Linux/Windows