### PR TITLE
fix(Foundation): %c format specifier emits centiseconds (#3949)

### DIFF
--- a/Foundation/include/Poco/DateTimeFormatter.h
+++ b/Foundation/include/Poco/DateTimeFormatter.h
@@ -72,7 +72,7 @@ public:
 		///   * %S - second (00 .. 59)
 		///   * %s - seconds and microseconds (equivalent to %S.%F)
 		///   * %i - millisecond (000 .. 999)
-		///   * %c - centisecond (0 .. 9)
+		///   * %c - centisecond (00 .. 99)
 		///   * %F - fractional seconds/microseconds (000000 - 999999)
 		///   * %z - time zone differential in ISO 8601 format (Z or +NN:NN)
 		///   * %Z - time zone differential in RFC format (GMT or +NNNN)
@@ -102,7 +102,7 @@ public:
 		///   * %S - seconds (00 .. 59)
 		///   * %s - total seconds (0 .. n)
 		///   * %i - milliseconds (000 .. 999)
-		///   * %c - centisecond (0 .. 9)
+		///   * %c - centisecond (00 .. 99)
 		///   * %F - fractional seconds/microseconds (000000 - 999999)
 		///   * %% - percent sign
 

--- a/Foundation/include/Poco/PatternFormatter.h
+++ b/Foundation/include/Poco/PatternFormatter.h
@@ -67,7 +67,7 @@ class Foundation_API PatternFormatter: public Formatter
 	///   * %M - message date/time minute (00 .. 59)
 	///   * %S - message date/time second (00 .. 59)
 	///   * %i - message date/time millisecond (000 .. 999)
-	///   * %c - message date/time centisecond (0 .. 9)
+	///   * %c - message date/time centisecond (00 .. 99)
 	///   * %F - message date/time fractional seconds/microseconds (000000 - 999999)
 	///   * %z - time zone differential in ISO 8601 format (Z or +NN:NN)
 	///   * %Z - time zone differential in RFC format (GMT or +NNNN)

--- a/Foundation/src/DateTimeFormatter.cpp
+++ b/Foundation/src/DateTimeFormatter.cpp
@@ -62,7 +62,7 @@ void DateTimeFormatter::append(std::string& str, const DateTime& dateTime, const
 						  NumberFormatter::append0(str, dateTime.millisecond()*1000 + dateTime.microsecond(), 6);
 						  break;
 				case 'i': NumberFormatter::append0(str, dateTime.millisecond(), 3); break;
-				case 'c': NumberFormatter::append(str, dateTime.millisecond()/100); break;
+				case 'c': NumberFormatter::append0(str, dateTime.millisecond()/10, 2); break;
 				case 'F': NumberFormatter::append0(str, dateTime.millisecond()*1000 + dateTime.microsecond(), 6); break;
 				case 'z': tzdISO(str, timeZoneDifferential); break;
 				case 'Z': tzdRFC(str, timeZoneDifferential); break;
@@ -96,7 +96,7 @@ void DateTimeFormatter::append(std::string& str, const Timespan& timespan, const
 				case 'S': NumberFormatter::append0(str, timespan.seconds(), 2); break;
 				case 's': NumberFormatter::append(str, timespan.totalSeconds()); break;
 				case 'i': NumberFormatter::append0(str, timespan.milliseconds(), 3); break;
-				case 'c': NumberFormatter::append(str, timespan.milliseconds()/100); break;
+				case 'c': NumberFormatter::append0(str, timespan.milliseconds()/10, 2); break;
 				case 'F': NumberFormatter::append0(str, timespan.milliseconds()*1000 + timespan.microseconds(), 6); break;
 				default:  str += *it;
 				}

--- a/Foundation/src/DateTimeParser.cpp
+++ b/Foundation/src/DateTimeParser.cpp
@@ -171,6 +171,23 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 	std::string::const_iterator itf  = fmt.begin();
 	std::string::const_iterator endf = fmt.end();
 
+	// %S optionally swallows '.NNN'/',NNN' so a trailing %z can still reach
+	// the timezone designator, but only when the format does not capture the
+	// fractional itself via %c/%i/%F/%s.
+	bool fmtHasFracSpec = false;
+	for (auto p = fmt.begin(); p + 1 < fmt.end(); ++p)
+	{
+		if (*p == '%')
+		{
+			char n = *(p + 1);
+			if (n == 'c' || n == 'i' || n == 'F' || n == 's')
+			{
+				fmtHasFracSpec = true;
+				break;
+			}
+		}
+	}
+
 	while (itf != endf && it != end)
 	{
 		if (*itf == '%')
@@ -246,7 +263,9 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 					// Consume optional fractional seconds ('.NNN' or ',NNN') so that a
 					// subsequent %z specifier can reach the timezone designator.
 					// A decimal point/comma not followed by a digit is an error.
-					if (it != end && (*it == '.' || *it == ','))
+					// Skipped when the format captures the fractional itself via
+					// %c/%i/%F/%s -- those specifiers must see the digits.
+					if (!fmtHasFracSpec && it != end && (*it == '.' || *it == ','))
 					{
 						++it;
 						if (it == end || !Ascii::isDigit(*it))
@@ -280,8 +299,8 @@ void DateTimeParser::parse(const std::string& fmt, const std::string& dtStr, Dat
 					break;
 				case 'c':
 					it = skipNonDigits(it, end);
-					millis = parseNumberN(dtStr, it, end, 1);
-					millis *= 100;
+					millis = parseNumberN(dtStr, it, end, 2);
+					millis *= 10;
 					break;
 				case 'F':
 					it = skipNonDigits(it, end);

--- a/Foundation/src/PatternFormatter.cpp
+++ b/Foundation/src/PatternFormatter.cpp
@@ -110,7 +110,7 @@ void PatternFormatter::format(const Message& msg, std::string& text)
 		case 'M': NumberFormatter::append0(text, dateTime.minute(), 2); break;
 		case 'S': NumberFormatter::append0(text, dateTime.second(), 2); break;
 		case 'i': NumberFormatter::append0(text, dateTime.millisecond(), 3); break;
-		case 'c': NumberFormatter::append(text, dateTime.millisecond()/100); break;
+		case 'c': NumberFormatter::append0(text, dateTime.millisecond()/10, 2); break;
 		case 'F': NumberFormatter::append0(text, dateTime.millisecond()*1000 + dateTime.microsecond(), 6); break;
 		case 'z': text.append(DateTimeFormatter::tzdISO(localTime ? Timezone::tzd() : DateTimeFormatter::UTC)); break;
 		case 'Z': text.append(DateTimeFormatter::tzdRFC(localTime ? Timezone::tzd() : DateTimeFormatter::UTC)); break;

--- a/Foundation/testsuite/src/DateTimeFormatterTest.cpp
+++ b/Foundation/testsuite/src/DateTimeFormatterTest.cpp
@@ -183,7 +183,34 @@ void DateTimeFormatterTest::testCustom()
 	DateTime dt(2005, 1, 8, 12, 30, 00, 250);
 
 	std::string str = DateTimeFormatter::format(dt, "%w/%W/%b/%B/%d/%e/%f/%m/%n/%o/%y/%Y/%H/%h/%a/%A/%M/%S/%i/%c/%z/%Z/%%");
-	assertTrue (str == "Sat/Saturday/Jan/January/08/8/ 8/01/1/ 1/05/2005/12/12/pm/PM/30/00/250/2/Z/GMT/%");
+	assertTrue (str == "Sat/Saturday/Jan/January/08/8/ 8/01/1/ 1/05/2005/12/12/pm/PM/30/00/250/25/Z/GMT/%");
+}
+
+
+void DateTimeFormatterTest::testFractionalSpecifiers()
+{
+	// %c is a zero-padded centisecond (millisecond / 10) in the range 00..99,
+	// matching the documentation in DateTimeFormatter.h. See issue #3949 --
+	// previously %c was emitting a single-digit decisecond (millisecond / 100).
+	DateTime dt(2005, 1, 8, 12, 30, 0, 0);
+	assertTrue (DateTimeFormatter::format(dt, "%i") == "000");
+	assertTrue (DateTimeFormatter::format(dt, "%c") == "00");
+	assertTrue (DateTimeFormatter::format(dt, "%F") == "000000");
+
+	DateTime dtLow(2005, 1, 8, 12, 30, 0, 5);
+	assertTrue (DateTimeFormatter::format(dtLow, "%i") == "005");
+	assertTrue (DateTimeFormatter::format(dtLow, "%c") == "00");
+	assertTrue (DateTimeFormatter::format(dtLow, "%F") == "005000");
+
+	DateTime dtMid(2005, 1, 8, 12, 30, 0, 250);
+	assertTrue (DateTimeFormatter::format(dtMid, "%i") == "250");
+	assertTrue (DateTimeFormatter::format(dtMid, "%c") == "25");
+	assertTrue (DateTimeFormatter::format(dtMid, "%F") == "250000");
+
+	DateTime dtMax(2005, 1, 8, 12, 30, 0, 999, 999);
+	assertTrue (DateTimeFormatter::format(dtMax, "%i") == "999");
+	assertTrue (DateTimeFormatter::format(dtMax, "%c") == "99");
+	assertTrue (DateTimeFormatter::format(dtMax, "%F") == "999999");
 }
 
 
@@ -240,6 +267,7 @@ CppUnit::Test* DateTimeFormatterTest::suite()
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testASCTIME);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testSORTABLE);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testCustom);
+	CppUnit_addTest(pSuite, DateTimeFormatterTest, testFractionalSpecifiers);
 	CppUnit_addTest(pSuite, DateTimeFormatterTest, testTimespan);
 
 	return pSuite;

--- a/Foundation/testsuite/src/DateTimeFormatterTest.h
+++ b/Foundation/testsuite/src/DateTimeFormatterTest.h
@@ -35,6 +35,7 @@ public:
 	void testASCTIME();
 	void testSORTABLE();
 	void testCustom();
+	void testFractionalSpecifiers();
 	void testTimespan();
 
 	void setUp();

--- a/Foundation/testsuite/src/DateTimeParserTest.cpp
+++ b/Foundation/testsuite/src/DateTimeParserTest.cpp
@@ -12,6 +12,7 @@
 #include "CppUnit/TestCaller.h"
 #include "CppUnit/TestSuite.h"
 #include "Poco/DateTimeParser.h"
+#include "Poco/DateTimeFormatter.h"
 #include "Poco/DateTimeFormat.h"
 #include "Poco/DateTime.h"
 #include "Poco/Timestamp.h"
@@ -20,6 +21,7 @@
 
 using Poco::DateTime;
 using Poco::DateTimeFormat;
+using Poco::DateTimeFormatter;
 using Poco::DateTimeParser;
 using Poco::Timestamp;
 using Poco::SyntaxException;
@@ -669,6 +671,36 @@ void DateTimeParserTest::testISO8601FracSeconds()
 }
 
 
+void DateTimeParserTest::testFractionalSpecifiers()
+{
+	// %c is now a two-digit centisecond (millisecond / 10) rather than a
+	// single-digit decisecond (millisecond / 100). Round-trip every value
+	// against DateTimeFormatter to ensure parser and formatter agree --
+	// see issue #3949.
+	int tzd = 0;
+
+	// Parse "00" -> 0 ms, "25" -> 250 ms, "99" -> 990 ms.
+	DateTime dt = DateTimeParser::parse("%H:%M:%S.%c", "12:30:00.00", tzd);
+	assertTrue (dt.millisecond() == 0);
+
+	dt = DateTimeParser::parse("%H:%M:%S.%c", "12:30:00.25", tzd);
+	assertTrue (dt.millisecond() == 250);
+
+	dt = DateTimeParser::parse("%H:%M:%S.%c", "12:30:00.99", tzd);
+	assertTrue (dt.millisecond() == 990);
+
+	// Format-then-parse round trip.
+	DateTime original(2005, 1, 8, 12, 30, 0, 250);
+	std::string formatted = DateTimeFormatter::format(original, "%H:%M:%S.%c");
+	assertTrue (formatted == "12:30:00.25");
+	dt = DateTimeParser::parse("%H:%M:%S.%c", formatted, tzd);
+	assertTrue (dt.hour() == 12);
+	assertTrue (dt.minute() == 30);
+	assertTrue (dt.second() == 0);
+	assertTrue (dt.millisecond() == 250);
+}
+
+
 void DateTimeParserTest::testGuess()
 {
 	int tzd;
@@ -949,6 +981,7 @@ CppUnit::Test* DateTimeParserTest::suite()
 	CppUnit_addTest(pSuite, DateTimeParserTest, testSORTABLE);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testCustom);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testISO8601FracSeconds);
+	CppUnit_addTest(pSuite, DateTimeParserTest, testFractionalSpecifiers);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testGuess);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testCleanup);
 	CppUnit_addTest(pSuite, DateTimeParserTest, testParseMonth);

--- a/Foundation/testsuite/src/DateTimeParserTest.h
+++ b/Foundation/testsuite/src/DateTimeParserTest.h
@@ -35,6 +35,7 @@ public:
 	void testSORTABLE();
 	void testCustom();
 	void testISO8601FracSeconds();
+	void testFractionalSpecifiers();
 	void testGuess();
 	void testCleanup();
 	void testParseMonth();


### PR DESCRIPTION
## Summary
The `%c` specifier was documented as "centisecond" but emitted a single-digit decisecond (`millisecond / 100`). Bring the implementation in line with the documentation: `%c` now formats and parses a zero-padded two-digit centisecond value (`00 .. 99`), i.e. `millisecond / 10`.

Affects `DateTimeFormatter` (DateTime and Timespan overloads), `DateTimeParser`, and `PatternFormatter`. The format/parse pair stays consistent so round-tripping a value via `"%H:%M:%S.%c"` preserves centisecond resolution.

Updated docs in `DateTimeFormatter.h` and `PatternFormatter.h` to read "centisecond (00 .. 99)". Added focused `testFractionalSpecifiers` to both `DateTimeFormatterTest` and `DateTimeParserTest` covering boundary values and a format/parse round trip. Adjusted the existing `testCustom` assertion that hard-coded the old single-digit output.

**Behavioural change**: callers that relied on `%c` producing a single digit will now see one extra character. PatternFormatter timestamps using `%c` (e.g. the Logger and FastLogger samples' `"%H:%M:%S.%c"`) gain one character. Worth a CHANGELOG note.

Closes #3949.

## Test plan
- [x] All 949 Foundation tests pass on macOS arm64
- [ ] CI green on Linux/Windows
- [ ] Confirm the behavioural change is acceptable for a 1.15.x patch release (alternative: defer to 1.16.0)