### PR TITLE
chore(deps): bundled third-party library updates for 1.15.3

### DIFF
--- a/dependencies/7zip/CMakeLists.txt
+++ b/dependencies/7zip/CMakeLists.txt
@@ -1,5 +1,5 @@
 # LZMA SDK (7-Zip)
-# Version: 26.00
+# Version: 26.01
 # Source: https://github.com/ip7z/7zip/releases/tag/26.00
 
 # Sources

--- a/dependencies/7zip/src/7zArcIn.c
+++ b/dependencies/7zip/src/7zArcIn.c
@@ -1,5 +1,5 @@
 /* 7zArcIn.c -- 7z Input functions
-2023-09-07 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #include "Precomp.h"
 
@@ -289,9 +289,9 @@ static SRes WaitId(CSzData *sd, UInt32 id)
   }
 }
 
-static SRes RememberBitVector(CSzData *sd, UInt32 numItems, const Byte **v)
+static SRes RememberBitVector(CSzData *sd, size_t numItems, const Byte **v)
 {
-  const UInt32 numBytes = (numItems + 7) >> 3;
+  const size_t numBytes = (numItems + 7) >> 3;
   if (numBytes > sd->Size)
     return SZ_ERROR_ARCHIVE;
   *v = sd->Data;
@@ -317,11 +317,11 @@ static UInt32 CountDefinedBits(const Byte *bits, UInt32 numItems)
   return sum;
 }
 
-static Z7_NO_INLINE SRes ReadBitVector(CSzData *sd, UInt32 numItems, Byte **v, ISzAllocPtr alloc)
+static Z7_NO_INLINE SRes ReadBitVector(CSzData *sd, size_t numItems, Byte **v, ISzAllocPtr alloc)
 {
   Byte allAreDefined;
   Byte *v2;
-  const UInt32 numBytes = (numItems + 7) >> 3;
+  const size_t numBytes = (numItems + 7) >> 3;
   *v = NULL;
   SZ_READ_BYTE(allAreDefined)
   if (numBytes == 0)
@@ -345,9 +345,9 @@ static Z7_NO_INLINE SRes ReadBitVector(CSzData *sd, UInt32 numItems, Byte **v, I
   return SZ_OK;
 }
 
-static Z7_NO_INLINE SRes ReadUi32s(CSzData *sd2, UInt32 numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
+static Z7_NO_INLINE SRes ReadUi32s(CSzData *sd2, size_t numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
 {
-  UInt32 i;
+  size_t i;
   CSzData sd;
   UInt32 *vals;
   const Byte *defs;
@@ -366,7 +366,7 @@ static Z7_NO_INLINE SRes ReadUi32s(CSzData *sd2, UInt32 numItems, CSzBitUi32s *c
   return SZ_OK;
 }
 
-static SRes ReadBitUi32s(CSzData *sd, UInt32 numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
+static SRes ReadBitUi32s(CSzData *sd, size_t numItems, CSzBitUi32s *crcs, ISzAllocPtr alloc)
 {
   SzBitUi32s_Free(crcs, alloc);
   RINOK(ReadBitVector(sd, numItems, &crcs->Defs, alloc))
@@ -1027,42 +1027,39 @@ static SRes SzReadAndDecodePackedStreams(
   return SZ_OK;
 }
 
+// (size & 1) == 0
+// (data) is aligned for 2-bytes
 static SRes SzReadFileNames(const Byte *data, size_t size, UInt32 numFiles, size_t *offsets)
 {
-  size_t pos = 0;
+  const Byte *p, *lim;
   *offsets++ = 0;
   if (numFiles == 0)
     return (size == 0) ? SZ_OK : SZ_ERROR_ARCHIVE;
   if (size < 2)
     return SZ_ERROR_ARCHIVE;
-  if (data[size - 2] != 0 || data[size - 1] != 0)
+  lim = data + size;
+  if (*(const UInt16 *)(const void *)(lim - 2))
     return SZ_ERROR_ARCHIVE;
+  p = data;
   do
   {
-    const Byte *p;
-    if (pos == size)
+    if (p >= lim)
       return SZ_ERROR_ARCHIVE;
-    for (p = data + pos;
-      #ifdef _WIN32
-      *(const UInt16 *)(const void *)p != 0
-      #else
-      p[0] != 0 || p[1] != 0
-      #endif
-      ; p += 2);
-    pos = (size_t)(p - data) + 2;
-    *offsets++ = (pos >> 1);
+    for (; *(const UInt16 *)(const void *)p; p += 2);
+    p += 2;
+    *offsets++ = (size_t)(p - data) >> 1;
   }
   while (--numFiles);
-  return (pos == size) ? SZ_OK : SZ_ERROR_ARCHIVE;
+  return (p == lim) ? SZ_OK : SZ_ERROR_ARCHIVE;
 }
 
-static Z7_NO_INLINE SRes ReadTime(CSzBitUi64s *p, UInt32 num,
+static Z7_NO_INLINE SRes ReadTime(CSzBitUi64s *p, size_t num,
     CSzData *sd2,
     const CBuf *tempBufs, UInt32 numTempBufs,
     ISzAllocPtr alloc)
 {
   CSzData sd;
-  UInt32 i;
+  size_t i;
   CNtfsFileTime *vals;
   Byte *defs;
   Byte external;
@@ -1215,6 +1212,7 @@ static SRes SzReadHeader2(
         {
           namesSize = (size_t)size - 1;
           namesData = sd->Data;
+          SKIP_DATA(sd, namesSize)
         }
         else
         {
@@ -1226,15 +1224,11 @@ static SRes SzReadHeader2(
           namesSize = (tempBufs)[index].size;
         }
 
-        if ((namesSize & 1) != 0)
+        if (namesSize & 1)
           return SZ_ERROR_ARCHIVE;
         MY_ALLOC(size_t, p->FileNameOffsets, numFiles + 1, allocMain)
         MY_ALLOC_ZE_AND_CPY(p->FileNames, namesSize, namesData, allocMain)
         RINOK(SzReadFileNames(p->FileNames, namesSize, numFiles, p->FileNameOffsets))
-        if (external == 0)
-        {
-          SKIP_DATA(sd, namesSize)
-        }
         break;
       }
       case k7zIdEmptyStream:

--- a/dependencies/7zip/src/7zFile.h
+++ b/dependencies/7zip/src/7zFile.h
@@ -1,12 +1,11 @@
 /* 7zFile.h -- File IO
-2023-03-05 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #ifndef ZIP7_INC_FILE_H
 #define ZIP7_INC_FILE_H
 
 #ifdef _WIN32
 #define USE_WINDOWS_FILE
-// #include <windows.h>
 #endif
 
 #ifdef USE_WINDOWS_FILE

--- a/dependencies/7zip/src/7zTypes.h
+++ b/dependencies/7zip/src/7zTypes.h
@@ -1,5 +1,5 @@
 /* 7zTypes.h -- Basic types
-2024-01-24 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #ifndef ZIP7_7Z_TYPES_H
 #define ZIP7_7Z_TYPES_H
@@ -46,8 +46,9 @@ typedef int SRes;
 
 
 #ifdef _MSC_VER
+  #define MY_ALIGN_IN_STRUCT(n) __declspec(align(n))
   #if _MSC_VER > 1200
-    #define MY_ALIGN(n) __declspec(align(n))
+    #define MY_ALIGN(n) MY_ALIGN_IN_STRUCT(n)
   #else
     #define MY_ALIGN(n)
   #endif
@@ -58,6 +59,7 @@ typedef int SRes;
   #define MY_ALIGN(n) alignas(n)
   */
   #define MY_ALIGN(n) __attribute__ ((aligned(n)))
+  #define MY_ALIGN_IN_STRUCT(n) MY_ALIGN(n)
 #endif
 
 

--- a/dependencies/7zip/src/7zVersion.h
+++ b/dependencies/7zip/src/7zVersion.h
@@ -1,7 +1,7 @@
 #define MY_VER_MAJOR 26
-#define MY_VER_MINOR 0
+#define MY_VER_MINOR 1
 #define MY_VER_BUILD 0
-#define MY_VERSION_NUMBERS "26.00"
+#define MY_VERSION_NUMBERS "26.01"
 #define MY_VERSION MY_VERSION_NUMBERS
 
 #ifdef MY_CPU_NAME
@@ -10,7 +10,7 @@
   #define MY_VERSION_CPU MY_VERSION
 #endif
 
-#define MY_DATE "2026-02-12"
+#define MY_DATE "2026-04-27"
 #undef MY_COPYRIGHT
 #undef MY_VERSION_COPYRIGHT_DATE
 #define MY_AUTHOR_NAME "Igor Pavlov"

--- a/dependencies/7zip/src/Alloc.c
+++ b/dependencies/7zip/src/Alloc.c
@@ -1,5 +1,5 @@
 /* Alloc.c -- Memory allocation functions
-2024-02-18 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #include "Precomp.h"
 
@@ -24,8 +24,6 @@
 #endif
 
 // #define SZ_ALLOC_DEBUG
-/* #define SZ_ALLOC_DEBUG */
-
 /* use SZ_ALLOC_DEBUG to debug alloc/free operations */
 #ifdef SZ_ALLOC_DEBUG
 
@@ -34,9 +32,10 @@
 static int g_allocCount = 0;
 #ifdef _WIN32
 static int g_allocCountMid = 0;
+#ifdef Z7_LARGE_PAGES
 static int g_allocCountBig = 0;
 #endif
-
+#endif
 
 #define CONVERT_INT_TO_STR(charType, tempSize) \
   char temp[tempSize]; unsigned i = 0; \
@@ -140,7 +139,9 @@ static void PrintAddr(void *p)
 #else
 
 #ifdef _WIN32
+#ifdef Z7_LARGE_PAGES
 #define PRINT_ALLOC(name, cnt, size, ptr)
+#endif
 #endif
 #define PRINT_FREE(name, cnt, ptr)
 #define Print(s)
@@ -245,6 +246,7 @@ void MidFree(void *address)
 }
 
 #ifdef Z7_LARGE_PAGES
+// #pragma message("Z7_LARGE_PAGES")
 
 #ifdef MEM_LARGE_PAGES
   #define MY_MEM_LARGE_PAGES  MEM_LARGE_PAGES
@@ -253,32 +255,14 @@ void MidFree(void *address)
 #endif
 
 extern
-SIZE_T g_LargePageSize;
-SIZE_T g_LargePageSize = 0;
-typedef SIZE_T (WINAPI *Func_GetLargePageMinimum)(VOID);
-
-void SetLargePageSize(void)
-{
-  SIZE_T size;
-#ifdef Z7_USE_DYN_GetLargePageMinimum
-Z7_DIAGNOSTIC_IGNORE_CAST_FUNCTION
-
-  const
-   Func_GetLargePageMinimum fn =
-  (Func_GetLargePageMinimum) Z7_CAST_FUNC_C GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
-       "GetLargePageMinimum");
-  if (!fn)
-    return;
-  size = fn();
-#else
-  size = GetLargePageMinimum();
-#endif
-  if (size == 0 || (size & (size - 1)) != 0)
-    return;
-  g_LargePageSize = size;
-}
-
-#endif // Z7_LARGE_PAGES
+size_t g_LargePageSize;
+size_t g_LargePageSize = 0;
+extern
+size_t g_LargePageThresholdMin;
+size_t g_LargePageThresholdMin = 0;
+extern
+UInt32 g_LargePageFlags;
+UInt32 g_LargePageFlags = 0;
 
 void *BigAlloc(size_t size)
 {
@@ -289,12 +273,10 @@ void *BigAlloc(size_t size)
 
   #ifdef Z7_LARGE_PAGES
   {
-    SIZE_T ps = g_LargePageSize;
-    if (ps != 0 && ps <= (1 << 30) && size > (ps / 2))
+    const size_t ps = g_LargePageSize - 1;
+    if (ps < (1u << 30) && size > g_LargePageThresholdMin)
     {
-      size_t size2;
-      ps--;
-      size2 = (size + ps) & ~ps;
+      const size_t size2 = (size + ps) & ~ps;
       if (size2 >= size)
       {
         void *p = VirtualAlloc(NULL, size2, MEM_COMMIT | MY_MEM_LARGE_PAGES, PAGE_READWRITE);
@@ -303,6 +285,8 @@ void *BigAlloc(size_t size)
           PRINT_ALLOC("Alloc-BM ", g_allocCountMid, size2, p)
           return p;
         }
+        if (g_LargePageFlags & Z7_LARGE_PAGES_FLAG_FAIL_STOP)
+          return p;
       }
     }
   }
@@ -317,6 +301,7 @@ void BigFree(void *address)
   MidFree(address);
 }
 
+#endif // Z7_LARGE_PAGES
 #endif // _WIN32
 
 
@@ -327,9 +312,12 @@ const ISzAlloc g_Alloc = { SzAlloc, SzFree };
 #ifdef _WIN32
 static void *SzMidAlloc(ISzAllocPtr p, size_t size) { UNUSED_VAR(p)  return MidAlloc(size); }
 static void SzMidFree(ISzAllocPtr p, void *address) { UNUSED_VAR(p)  MidFree(address); }
+const ISzAlloc g_MidAlloc = { SzMidAlloc, SzMidFree };
+#endif
+
+#if defined(Z7_LARGE_PAGES)
 static void *SzBigAlloc(ISzAllocPtr p, size_t size) { UNUSED_VAR(p)  return BigAlloc(size); }
 static void SzBigFree(ISzAllocPtr p, void *address) { UNUSED_VAR(p)  BigFree(address); }
-const ISzAlloc g_MidAlloc = { SzMidAlloc, SzMidFree };
 const ISzAlloc g_BigAlloc = { SzBigAlloc, SzBigFree };
 #endif
 
@@ -371,10 +359,16 @@ typedef
 
 #endif
 
-#if !defined(_WIN32) \
-    && (defined(Z7_ALLOC_NO_OFFSET_ALLOCATOR) \
-        || defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L))
+#ifndef _WIN32
+#include <unistd.h> // for _POSIX_ADVISORY_INFO : for some linux
+#if (defined(Z7_ALLOC_NO_OFFSET_ALLOCATOR) \
+        || defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L) \
+        || defined(_POSIX_ADVISORY_INFO) && (_POSIX_ADVISORY_INFO >= 200112L) \
+        || defined(__APPLE__) \
+        /* || defined(__linux__) */)
   #define USE_posix_memalign
+  // #pragma message("USE_posix_memalign")
+#endif
 #endif
 
 #ifndef USE_posix_memalign
@@ -488,6 +482,181 @@ static void SzAlignedFree(ISzAllocPtr pp, void *address)
 #endif
 }
 
+#ifndef _WIN32
+
+#ifdef Z7_LARGE_PAGES
+
+#if 0 // 1 for debug
+  #include <stdio.h>
+  #include <string.h>  // for strerror()
+  #define PRF(x) x
+#else
+  #define PRF(x)
+#endif
+
+#ifdef USE_posix_memalign
+  /* madvise():
+     glibc <= 2.19 : _BSD_SOURCE
+     glibc  > 2.19 : _DEFAULT_SOURCE
+  */
+  /* && (defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)) */
+#if 1 && !defined(Z7_NO_MADVISE) && \
+  (defined(__linux__) || defined(__unix__) || defined(__APPLE__))
+#include <sys/mman.h> // for madvise
+// #pragma message("sys/mman.h")
+#if (defined(MADV_HUGEPAGE) && defined(MADV_NOHUGEPAGE))
+  #define Z7_USE_BIG_ALLOC_MADVISE
+  // #pragma message("Z7_USE_BIG_ALLOC_MADVISE")
+#endif
+#endif
+#endif // USE_posix_memalign
+
+#ifdef Z7_USE_BIG_ALLOC_MADVISE
+#define LARGE_PAGE_SIZE_DEFAULT (1 << 21)
+#else
+#define LARGE_PAGE_SIZE_DEFAULT 0
+#endif
+
+extern
+size_t g_LargePageSize;
+size_t g_LargePageSize = LARGE_PAGE_SIZE_DEFAULT;
+extern
+size_t g_LargePageThresholdMin;
+size_t g_LargePageThresholdMin = LARGE_PAGE_SIZE_DEFAULT / 2;
+extern
+UInt32 g_LargePageFlags;
+UInt32 g_LargePageFlags = 0;
+
+void *BigAlloc(size_t size)
+{
+  if (size == 0)
+    return NULL;
+#ifdef USE_posix_memalign
+  {
+    const size_t pageSize = g_LargePageSize;
+    void *buf = NULL; // on Linux (and other systems), posix_memalign() does not modify memptr on failure (POSIX.1-2008 TC2).
+    PRF(printf("\nBigAlloc 0x%08x=%5uMB", (unsigned)(size), (unsigned)(size >> 20));)
+    if (pageSize && size > g_LargePageThresholdMin)
+    {
+      int res;
+      const size_t mask = pageSize - 1;
+      /* we can allocate aligned size, so data at the end of buffer also will use huge page
+         if (size2 for madvise() is not aligned for huge page size)
+           { Last data block will use small pages. It reduces memory allocation,
+             but last data block with small pages can work slower.
+             It's useful, if we have very large HUGE_PAGE: 32MB or 512MB. }
+      */
+      size_t size2 = (size + mask) & ~mask;
+      if (size2 < size || (size & mask) <= g_LargePageThresholdMin)
+        size2 = size;
+      res = posix_memalign(&buf, pageSize, size2);
+      PRF(printf(" posix_memalign size=0x%08x=%5uMB align=%u",
+          (unsigned)(size2), (unsigned)(size2 >> 20), (unsigned)pageSize);)
+      PRF(printf(" buf=%p", (void *)buf);)
+      if (res == 0)
+      {
+#ifdef Z7_USE_BIG_ALLOC_MADVISE
+        if ((g_LargePageFlags & Z7_LARGE_PAGES_FLAG_NO_MADVISE) == 0)
+        {
+          // Advise the kernel to use huge pages for this memory range
+          // MADV_HUGEPAGE / MADV_NOHUGEPAGE : since Linux 2.6.38
+          // madvise() only operates on whole pages, therefore addr must be page-aligned (4KB/8KB/16KB/64KB).
+          // The value of size is rounded up to a multiple of page size.
+          PRF(printf(" madvise g_LargePageFlags=%x", (unsigned)g_LargePageFlags);)
+          res = madvise(buf, size2, (g_LargePageFlags & Z7_LARGE_PAGES_FLAG_NO_HUGEPAGE) ? MADV_NOHUGEPAGE : MADV_HUGEPAGE);
+          if (res)
+          {
+            PRF(printf("\nERROR res=%d, errno=%d=%s\n", res, (int)errno, strerror(errno));)
+            if (g_LargePageFlags & Z7_LARGE_PAGES_FLAG_FAIL_STOP)
+            {
+              free(buf);
+              return NULL;
+            }
+          }
+        }
+#endif // Z7_USE_BIG_ALLOC_MADVISE
+        PRF(printf("\n");)
+        return buf;
+      }
+      PRF(printf("\nERROR res=%d=%s\n", res, strerror(res));)
+      if (g_LargePageFlags & Z7_LARGE_PAGES_FLAG_FAIL_STOP)
+        return NULL;
+      // (res == ENOMEM) "Out of memory" is possible, if pageSize is too big.
+      // so we do second attempt with smaller alignment
+    }
+  }
+#endif // !USE_posix_memalign
+  PRF(printf(" z7_AlignedAlloc size=0x%08x=%5uMB\n", (unsigned)(size), (unsigned)(size >> 20));)
+  return z7_AlignedAlloc(size);
+}
+
+
+void BigFree(void *address)
+{
+  z7_AlignedFree(address);
+}
+#endif // Z7_LARGE_PAGES
+#endif // !_WIN32
+
+
+#ifdef Z7_LARGE_PAGES
+void z7_LargePage_Set(UInt32 flags, size_t pageSize, size_t threshold)
+{
+  g_LargePageFlags = flags;
+
+#ifdef _WIN32
+  if ((flags & Z7_LARGE_PAGES_FLAG_USE_HUGEPAGE) == 0)
+  {
+    g_LargePageSize = 0;
+    g_LargePageThresholdMin = 0;
+  }
+  else
+  {
+    if ((flags & Z7_LARGE_PAGES_FLAG_DIRECT_PAGE_SIZE) == 0)
+    {
+#ifdef Z7_USE_DYN_GetLargePageMinimum
+      Z7_DIAGNOSTIC_IGNORE_CAST_FUNCTION
+typedef SIZE_T (WINAPI *Func_GetLargePageMinimum)(VOID);
+      const
+        Func_GetLargePageMinimum fn =
+       (Func_GetLargePageMinimum) Z7_CAST_FUNC_C GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+            "GetLargePageMinimum");
+      if (fn)
+        pageSize = fn();
+      else
+        pageSize = 0;
+#else
+      pageSize = GetLargePageMinimum();
+#endif
+      if (pageSize & (pageSize - 1))
+        pageSize = 0;
+    }
+    g_LargePageSize = pageSize;
+    if ((flags & Z7_LARGE_PAGES_FLAG_DIRECT_THRESHOLD) == 0)
+      threshold = pageSize / 2;
+    g_LargePageThresholdMin = threshold;
+  }
+
+#else // !_WIN32
+
+  if (flags & Z7_LARGE_PAGES_FLAG_NO_PAGECODE)
+  {
+    g_LargePageSize = 0;
+    g_LargePageThresholdMin = 0;
+  }
+  else
+  {
+    if ((flags & Z7_LARGE_PAGES_FLAG_DIRECT_PAGE_SIZE) == 0)
+      pageSize = LARGE_PAGE_SIZE_DEFAULT;
+    g_LargePageSize = pageSize;
+    if ((flags & Z7_LARGE_PAGES_FLAG_DIRECT_THRESHOLD) == 0)
+      threshold = pageSize / 2;
+    g_LargePageThresholdMin = threshold;
+  }
+  // PRF(printf("\ng_LargePageSize=%x g_LargePageThresholdMin = %x g_LargePageFlags = %x", (unsigned)g_LargePageSize, (unsigned)g_LargePageThresholdMin, (unsigned)g_LargePageFlags);)
+#endif // !_WIN32
+}
+#endif // Z7_LARGE_PAGES
 
 const ISzAlloc g_AlignedAlloc = { SzAlignedAlloc, SzAlignedFree };
 

--- a/dependencies/7zip/src/Alloc.h
+++ b/dependencies/7zip/src/Alloc.h
@@ -1,5 +1,5 @@
 /* Alloc.h -- Memory allocation functions
-2024-01-22 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #ifndef ZIP7_INC_ALLOC_H
 #define ZIP7_INC_ALLOC_H
@@ -25,39 +25,39 @@ void *MyRealloc(void *address, size_t size);
 void *z7_AlignedAlloc(size_t size);
 void  z7_AlignedFree(void *p);
 
+extern const ISzAlloc g_Alloc;
+extern const ISzAlloc g_AlignedAlloc;
+
 #ifdef _WIN32
+  void *MidAlloc(size_t size);
+  void MidFree(void *address);
+  extern const ISzAlloc g_MidAlloc;
+#else
+  #define MidAlloc(size)    z7_AlignedAlloc(size)
+  #define MidFree(address)  z7_AlignedFree(address)
+  #define g_MidAlloc g_AlignedAlloc
+#endif
 
 #ifdef Z7_LARGE_PAGES
-void SetLargePageSize(void);
-#endif
 
-void *MidAlloc(size_t size);
-void MidFree(void *address);
-void *BigAlloc(size_t size);
-void BigFree(void *address);
+#define Z7_LARGE_PAGES_FLAG_USE_HUGEPAGE  (1 << 0)  //    PAGE_ALIGNED / MADV_HUGEPAGE
+#define Z7_LARGE_PAGES_FLAG_NO_PAGECODE   (1 << 1)  // no PAGE_ALIGNED / no madvise
+#define Z7_LARGE_PAGES_FLAG_NO_MADVISE    (1 << 2)  //    PAGE_ALIGNED / no madvise : for THP=always
+#define Z7_LARGE_PAGES_FLAG_NO_HUGEPAGE   (1 << 3)  //    PAGE_ALIGNED / MADV_NOHUGEPAGE
+#define Z7_LARGE_PAGES_FLAG_FAIL_STOP     (1 << 15) // for benchmarks
+#define Z7_LARGE_PAGES_FLAG_DIRECT_PAGE_SIZE  (1 << 16)
+#define Z7_LARGE_PAGES_FLAG_DIRECT_THRESHOLD  (1 << 17)
 
-/* #define Z7_BIG_ALLOC_IS_ZERO_FILLED */
-
+void z7_LargePage_Set(UInt32 flags, size_t pageSize, size_t threshold);
+  
+  void *BigAlloc(size_t size);
+  void BigFree(void *address);
+  extern const ISzAlloc g_BigAlloc;
 #else
-
-#define MidAlloc(size)    z7_AlignedAlloc(size)
-#define MidFree(address)  z7_AlignedFree(address)
-#define BigAlloc(size)    z7_AlignedAlloc(size)
-#define BigFree(address)  z7_AlignedFree(address)
-
+  #define BigAlloc(size)    MidAlloc(size)
+  #define BigFree(address)  MidFree(address)
+  #define g_BigAlloc g_MidAlloc
 #endif
-
-extern const ISzAlloc g_Alloc;
-
-#ifdef _WIN32
-extern const ISzAlloc g_BigAlloc;
-extern const ISzAlloc g_MidAlloc;
-#else
-#define g_BigAlloc g_AlignedAlloc
-#define g_MidAlloc g_AlignedAlloc
-#endif
-
-extern const ISzAlloc g_AlignedAlloc;
 
 
 typedef struct

--- a/dependencies/7zip/src/Compiler.h
+++ b/dependencies/7zip/src/Compiler.h
@@ -54,6 +54,12 @@
 #pragma GCC diagnostic ignored "-Wexcess-padding"
 #endif
 
+#if defined(Z7_APPLE_CLANG_VERSION) && __clang_major__ >= 21
+// warning: function MyAlloc might be an allocator wrapper
+// clang in xcode: clang 21.0.0
+#pragma GCC diagnostic ignored "-Wallocator-wrappers"
+#endif
+
 #if __clang_major__ >= 16
 #pragma GCC diagnostic ignored "-Wunsafe-buffer-usage"
 #endif
@@ -72,7 +78,7 @@
 
 #endif // __clang__
 
-#if defined(_WIN32) && defined(__clang__) && __clang_major__ >= 16
+#if defined(__clang__) && __clang_major__ >= 16
 // #pragma GCC diagnostic ignored "-Wcast-function-type-strict"
 #define Z7_DIAGNOSTIC_IGNORE_CAST_FUNCTION \
   _Pragma("GCC diagnostic ignored \"-Wcast-function-type-strict\"")

--- a/dependencies/7zip/src/CpuArch.h
+++ b/dependencies/7zip/src/CpuArch.h
@@ -254,11 +254,12 @@ MY_CPU_64BIT means that processor can work with 64-bit registers.
 #endif
 
 
+// _LITTLE_ENDIAN macro can be defined for big-endian platform with some compilers
+ 
 #if defined(MY_CPU_X86_OR_AMD64) \
     || defined(MY_CPU_ARM_LE) \
     || defined(MY_CPU_ARM64_LE) \
     || defined(MY_CPU_IA64_LE) \
-    || defined(_LITTLE_ENDIAN) \
     || defined(__LITTLE_ENDIAN__) \
     || defined(__ARMEL__) \
     || defined(__THUMBEL__) \

--- a/dependencies/7zip/src/LzmaEnc.c
+++ b/dependencies/7zip/src/LzmaEnc.c
@@ -2351,10 +2351,9 @@ static void LzmaEnc_Construct(CLzmaEnc *p)
 
 CLzmaEncHandle LzmaEnc_Create(ISzAllocPtr alloc)
 {
-  void *p;
-  p = ISzAlloc_Alloc(alloc, sizeof(CLzmaEnc));
+  CLzmaEncHandle p = (CLzmaEncHandle)ISzAlloc_Alloc(alloc, sizeof(CLzmaEnc));
   if (p)
-    LzmaEnc_Construct((CLzmaEnc *)p);
+    LzmaEnc_Construct(p);
   return p;
 }
 

--- a/dependencies/7zip/src/Precomp.h
+++ b/dependencies/7zip/src/Precomp.h
@@ -1,5 +1,5 @@
 /* Precomp.h -- precompilation file
-2024-01-25 : Igor Pavlov : Public domain */
+: Igor Pavlov : Public domain */
 
 #ifndef ZIP7_INC_PRECOMP_H
 #define ZIP7_INC_PRECOMP_H
@@ -40,17 +40,17 @@
 #endif
 */
 
+#ifndef Z7_LARGE_PAGES
+#if !defined(Z7_NO_LARGE_PAGES) && !defined(UNDER_CE)
+#define Z7_LARGE_PAGES 1
+#endif
+#endif
+
 #ifdef _WIN32
 /*
   this "Precomp.h" file must be included before <windows.h>,
   if we want to define _WIN32_WINNT before <windows.h>.
 */
-
-#ifndef Z7_LARGE_PAGES
-#ifndef Z7_NO_LARGE_PAGES
-#define Z7_LARGE_PAGES 1
-#endif
-#endif
 
 #ifndef Z7_LONG_PATH
 #ifndef Z7_NO_LONG_PATH

--- a/dependencies/7zip/src/Threads.c
+++ b/dependencies/7zip/src/Threads.c
@@ -153,6 +153,17 @@ static void PrintProcess_Info()
 #endif
 #endif
 
+/* if we send (stackSize=0) to CreateThread(), it will
+   use default value PE::SizeOfStackReserve from exe file.
+   PE::SizeOfStackReserve == 1 MiB in exe file with default linker options.
+   Windows aligns specified value to the next 64 KB range. */
+static const unsigned k_StackSize_ReserveSize =
+  #ifdef UNDER_CE
+    1 << 17;
+  #else
+    1 << 20;
+  #endif
+
 WRes Thread_Create(CThread *p, THREAD_FUNC_TYPE func, LPVOID param)
 {
   /* Windows Me/98/95: threadId parameter may not be NULL in _beginthreadex/CreateThread functions */
@@ -160,12 +171,15 @@ WRes Thread_Create(CThread *p, THREAD_FUNC_TYPE func, LPVOID param)
   #ifdef USE_THREADS_CreateThread
 
   DWORD threadId;
-  *p = CreateThread(NULL, 0, func, param, 0, &threadId);
+  *p = CreateThread(NULL, k_StackSize_ReserveSize, func, param, STACK_SIZE_PARAM_IS_A_RESERVATION, &threadId);
   
   #else
+
+#define CALL_beginthreadex(func2, param2, flags, threadIdPtr) \
+    ((HANDLE)(_beginthreadex(NULL, k_StackSize_ReserveSize, func2, param2, (flags) | STACK_SIZE_PARAM_IS_A_RESERVATION, threadIdPtr)))
   
   unsigned threadId;
-  *p = (HANDLE)(_beginthreadex(NULL, 0, func, param, 0, &threadId));
+  *p = CALL_beginthreadex(func, param, 0, &threadId);
 
 #if 0 // 1 : for debug
   {
@@ -223,7 +237,7 @@ WRes Thread_Create_With_Affinity(CThread *p, THREAD_FUNC_TYPE func, LPVOID param
   HANDLE h;
   WRes wres;
   unsigned threadId;
-  h = (HANDLE)(_beginthreadex(NULL, 0, func, param, CREATE_SUSPENDED, &threadId));
+  h = CALL_beginthreadex(func, param, CREATE_SUSPENDED, &threadId);
   *p = h;
   wres = HandleToWRes(h);
   if (h)
@@ -272,7 +286,7 @@ WRes Thread_Create_With_Group(CThread *p, THREAD_FUNC_TYPE func, LPVOID param, u
   HANDLE h;
   WRes wres;
   unsigned threadId;
-  h = (HANDLE)(_beginthreadex(NULL, 0, func, param, CREATE_SUSPENDED, &threadId));
+  h = CALL_beginthreadex(func, param, CREATE_SUSPENDED, &threadId);
   *p = h;
   wres = HandleToWRes(h);
   if (h)

--- a/dependencies/7zip/src/XzDec.c
+++ b/dependencies/7zip/src/XzDec.c
@@ -279,7 +279,7 @@ SRes Xz_StateCoder_Bc_SetFromMethod_Func(IStateCoder *p, UInt64 id,
     decoder = (CXzBcFilterState *)ISzAlloc_Alloc(alloc, sizeof(CXzBcFilterState));
     if (!decoder)
       return SZ_ERROR_MEM;
-    decoder->buf = ISzAlloc_Alloc(alloc, BRA_BUF_SIZE);
+    decoder->buf = (Byte *)ISzAlloc_Alloc(alloc, BRA_BUF_SIZE);
     if (!decoder->buf)
     {
       ISzAlloc_Free(alloc, decoder);
@@ -1243,7 +1243,7 @@ SRes XzUnpacker_Code(CXzUnpacker *p, Byte *dest, SizeT *destLen,
             UInt32 digest32[XZ_CHECK_SIZE_MAX / 4];
             p->state = XZ_STATE_BLOCK_HEADER;
             p->pos = 0;
-            if (XzCheck_Final(&p->check, (void *)digest32) && memcmp(digest32, p->buf, checkSize) != 0)
+            if (XzCheck_Final(&p->check, (Byte *)(void *)digest32) && memcmp(digest32, p->buf, checkSize) != 0)
               return SZ_ERROR_CRC;
             if (p->decodeOnlyOneBlock)
             {
@@ -1292,7 +1292,7 @@ SRes XzUnpacker_Code(CXzUnpacker *p, Byte *dest, SizeT *destLen,
             p->state = XZ_STATE_STREAM_INDEX_CRC;
             p->indexSize += 4;
             p->pos = 0;
-            Sha256_Final(&p->sha, (void *)digest32);
+            Sha256_Final(&p->sha, (Byte *)(void *)digest32);
             if (memcmp(digest32, p->shaDigest32, SHA256_DIGEST_SIZE) != 0)
               return SZ_ERROR_CRC;
           }

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -15,7 +15,7 @@ are replaced with system-installed versions via `find_package()` or `-l` flags.
 | [pcre2](pcre2/) | 10.47 | BSD-3-Clause | Foundation (regular expressions) | Yes | https://github.com/PCRE2Project/pcre2 |
 | [utf8proc](utf8proc/) | 2.11.3 | MIT | Foundation (Unicode normalization) | Yes | https://github.com/JuliaStrings/utf8proc |
 | [expat](expat/) | 2.8.1 | MIT | XML (SAX/DOM parser) | Yes | https://github.com/libexpat/libexpat |
-| [sqlite3](sqlite3/) | 3.53.0 | Public Domain | Data/SQLite (embedded database) | Yes | https://www.sqlite.org |
+| [sqlite3](sqlite3/) | 3.53.1 | Public Domain | Data/SQLite (embedded database) | Yes | https://www.sqlite.org |
 | [png](png/) | 1.6.57 | libpng License | PDF (PNG image support) | Yes | https://github.com/pnggroup/libpng |
 | [v8_double_conversion](v8_double_conversion/) | 3.4.0 | BSD-3-Clause | Foundation (float-to-string conversion) | No | https://github.com/google/double-conversion |
 | [pdjson](pdjson/) | n/a | Public Domain | JSON (streaming parser) | No | https://github.com/skeeto/pdjson |

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -16,7 +16,7 @@ are replaced with system-installed versions via `find_package()` or `-l` flags.
 | [utf8proc](utf8proc/) | 2.11.3 | MIT | Foundation (Unicode normalization) | Yes | https://github.com/JuliaStrings/utf8proc |
 | [expat](expat/) | 2.8.1 | MIT | XML (SAX/DOM parser) | Yes | https://github.com/libexpat/libexpat |
 | [sqlite3](sqlite3/) | 3.53.1 | Public Domain | Data/SQLite (embedded database) | Yes | https://www.sqlite.org |
-| [png](png/) | 1.6.57 | libpng License | PDF (PNG image support) | Yes | https://github.com/pnggroup/libpng |
+| [png](png/) | 1.6.58 | libpng License | PDF (PNG image support) | Yes | https://github.com/pnggroup/libpng |
 | [v8_double_conversion](v8_double_conversion/) | 3.4.0 | BSD-3-Clause | Foundation (float-to-string conversion) | No | https://github.com/google/double-conversion |
 | [pdjson](pdjson/) | n/a | Public Domain | JSON (streaming parser) | No | https://github.com/skeeto/pdjson |
 | [tessil](tessil/) | 1.2.0 | MIT | Foundation (insertion-order-preserving hash containers) | No | https://github.com/Tessil/ordered-map |

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -19,7 +19,7 @@ are replaced with system-installed versions via `find_package()` or `-l` flags.
 | [png](png/) | 1.6.57 | libpng License | PDF (PNG image support) | Yes | https://github.com/pnggroup/libpng |
 | [v8_double_conversion](v8_double_conversion/) | 3.4.0 | BSD-3-Clause | Foundation (float-to-string conversion) | No | https://github.com/google/double-conversion |
 | [pdjson](pdjson/) | n/a | Public Domain | JSON (streaming parser) | No | https://github.com/skeeto/pdjson |
-| [tessil](tessil/) | n/a | MIT | Foundation (insertion-order-preserving hash containers) | No | https://github.com/Tessil/ordered-map |
+| [tessil](tessil/) | 1.2.0 | MIT | Foundation (insertion-order-preserving hash containers) | No | https://github.com/Tessil/ordered-map |
 | [hpdf](hpdf/) (libharu) | 2.4.6 | Zlib-like | PDF (PDF document generation) | No | https://github.com/libharu/libharu |
 | [7zip](7zip/) (LZMA SDK) | 26.00 | Public Domain | SevenZip (7z archive support) | No | https://github.com/ip7z/7zip |
 | [cpptrace](cpptrace/) | 1.0.4 | MIT | Foundation (stack trace support, optional) | No | https://github.com/jeremy-rifkin/cpptrace |

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -14,7 +14,7 @@ are replaced with system-installed versions via `find_package()` or `-l` flags.
 | [zlib](zlib/) | 1.3.2 | Zlib | Foundation (compression/decompression streams) | Yes | https://github.com/madler/zlib |
 | [pcre2](pcre2/) | 10.47 | BSD-3-Clause | Foundation (regular expressions) | Yes | https://github.com/PCRE2Project/pcre2 |
 | [utf8proc](utf8proc/) | 2.11.3 | MIT | Foundation (Unicode normalization) | Yes | https://github.com/JuliaStrings/utf8proc |
-| [expat](expat/) | 2.7.5 | MIT | XML (SAX/DOM parser) | Yes | https://github.com/libexpat/libexpat |
+| [expat](expat/) | 2.8.1 | MIT | XML (SAX/DOM parser) | Yes | https://github.com/libexpat/libexpat |
 | [sqlite3](sqlite3/) | 3.53.0 | Public Domain | Data/SQLite (embedded database) | Yes | https://www.sqlite.org |
 | [png](png/) | 1.6.57 | libpng License | PDF (PNG image support) | Yes | https://github.com/pnggroup/libpng |
 | [v8_double_conversion](v8_double_conversion/) | 3.4.0 | BSD-3-Clause | Foundation (float-to-string conversion) | No | https://github.com/google/double-conversion |

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -21,7 +21,7 @@ are replaced with system-installed versions via `find_package()` or `-l` flags.
 | [pdjson](pdjson/) | n/a | Public Domain | JSON (streaming parser) | No | https://github.com/skeeto/pdjson |
 | [tessil](tessil/) | 1.2.0 | MIT | Foundation (insertion-order-preserving hash containers) | No | https://github.com/Tessil/ordered-map |
 | [hpdf](hpdf/) (libharu) | 2.4.6 | Zlib-like | PDF (PDF document generation) | No | https://github.com/libharu/libharu |
-| [7zip](7zip/) (LZMA SDK) | 26.00 | Public Domain | SevenZip (7z archive support) | No | https://github.com/ip7z/7zip |
+| [7zip](7zip/) (LZMA SDK) | 26.01 | Public Domain | SevenZip (7z archive support) | No | https://github.com/ip7z/7zip |
 | [cpptrace](cpptrace/) | 1.0.4 | MIT | Foundation (stack trace support, optional) | No | https://github.com/jeremy-rifkin/cpptrace |
 | [quill](quill/) | 11.1.0 | MIT | Foundation (high-performance async logging, optional) | No | https://github.com/odygrd/quill |
 | [wepoll](wepoll/) | 1.5.8 | BSD-2-Clause | Net (epoll emulation, Windows only) | No | https://github.com/piscisaureus/wepoll |

--- a/dependencies/expat/CMakeLists.txt
+++ b/dependencies/expat/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Expat XML parser library
-# Version: 2.7.5
-# Source: https://github.com/libexpat/libexpat/releases/tag/R_2_7_5
+# Version: 2.8.1
+# Source: https://github.com/libexpat/libexpat/releases/tag/R_2_8_1
 
 if(POCO_UNBUNDLED)
 	if (ENABLE_XML)
@@ -8,22 +8,41 @@ if(POCO_UNBUNDLED)
 		set_target_properties(EXPAT::EXPAT PROPERTIES IMPORTED_GLOBAL TRUE)
 	endif()
 else()
-	# Sources
+	# Core sources -- exclude the per-entropy-source random_*.c files;
+	# those are added conditionally below to mirror the upstream
+	# CMakeLists gating (see expat-2.8.1/CMakeLists.txt).
 	file(GLOB SRCS_G "src/*.c")
+	list(FILTER SRCS_G EXCLUDE REGEX "/random_.*\\.c$")
 	POCO_SOURCES(SRCS expat ${SRCS_G})
 
 	# Headers
 	file(GLOB_RECURSE HDRS_G "src/*.h")
 	POCO_HEADERS(SRCS expat ${HDRS_G})
 
+	# Platform-specific entropy source for Expat's hash salt generation.
+	# Each random_*.c file is only meaningful when its corresponding
+	# HAVE_* macro is defined; compiling otherwise yields undefined
+	# symbols (e.g. SYS_getrandom on macOS).
+	set(_BUNDLED_EXPAT_RANDOM_SRCS "")
+	if(WIN32)
+		# Windows uses rand_s() by default
+		list(APPEND _BUNDLED_EXPAT_RANDOM_SRCS src/random_rand_s.c)
+	elseif(APPLE OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
+		list(APPEND _BUNDLED_EXPAT_RANDOM_SRCS src/random_arc4random_buf.c)
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+		list(APPEND _BUNDLED_EXPAT_RANDOM_SRCS src/random_getrandom.c)
+	elseif(UNIX)
+		list(APPEND _BUNDLED_EXPAT_RANDOM_SRCS src/random_dev_urandom.c)
+	endif()
+
 	# NOTE: We use object library to be able to link it with static or shared libraries
-	add_library(_BUNDLED_EXPAT OBJECT EXCLUDE_FROM_ALL ${SRCS})
+	add_library(_BUNDLED_EXPAT OBJECT EXCLUDE_FROM_ALL ${SRCS} ${_BUNDLED_EXPAT_RANDOM_SRCS})
 
 	set_property(TARGET _BUNDLED_EXPAT PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-	# Platform-specific entropy source for Expat's hash salt generation
+	# Match each entropy source file with the macro its body checks for.
 	if(WIN32)
-		# Windows uses rand_s() by default
+		# random_rand_s.c body is unconditional
 	elseif(APPLE OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
 		target_compile_definitions(_BUNDLED_EXPAT PRIVATE HAVE_ARC4RANDOM_BUF)
 	elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/dependencies/expat/src/expat.h
+++ b/dependencies/expat/src/expat.h
@@ -45,6 +45,7 @@
 #ifndef Expat_INCLUDED
 #  define Expat_INCLUDED 1
 
+#  include <stdint.h> // for uint8_t
 #  include <stdlib.h>
 #  include "expat_external.h"
 
@@ -917,9 +918,20 @@ XML_SetParamEntityParsing(XML_Parser parser,
    function behavior. This must be called before parsing is started.
    Returns 1 if successful, 0 when called after parsing has started.
    Note: If parser == NULL, the function will do nothing and return 0.
+   DEPRECATED since Expat 2.8.0.
 */
 XMLPARSEAPI(int)
 XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt);
+
+/* Sets the hash salt to use for internal hash calculations.
+   Helps in preventing DoS attacks based on predicting hash function behavior.
+   This must be called before parsing is started.
+   Returns XML_TRUE if successful, XML_FALSE when called after parsing has
+   started or when parser is NULL.
+   Added in Expat 2.8.0.
+*/
+XMLPARSEAPI(XML_Bool)
+XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]);
 
 /* If XML_Parse or XML_ParseBuffer have returned XML_STATUS_ERROR, then
    XML_GetErrorCode returns information about the error.
@@ -1081,8 +1093,8 @@ XML_SetReparseDeferralEnabled(XML_Parser parser, XML_Bool enabled);
    See https://semver.org
 */
 #  define XML_MAJOR_VERSION 2
-#  define XML_MINOR_VERSION 7
-#  define XML_MICRO_VERSION 5
+#  define XML_MINOR_VERSION 8
+#  define XML_MICRO_VERSION 1
 
 #  ifdef __cplusplus
 }

--- a/dependencies/expat/src/expat_external.h
+++ b/dependencies/expat/src/expat_external.h
@@ -12,9 +12,10 @@
    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2016      Cristian Rodríguez <crrodriguez@opensuse.org>
-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2016-2025 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
+   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -45,7 +46,7 @@
 /* Expat tries very hard to make the API boundary very specifically
    defined.  There are two macros defined to control this boundary;
    each of these can be defined before including this header to
-   achieve some different behavior, but doing so it not recommended or
+   achieve some different behavior, but doing so is not recommended or
    tested frequently.
 
    XMLCALL    - The calling convention to use for all calls across the

--- a/dependencies/expat/src/internal.h
+++ b/dependencies/expat/src/internal.h
@@ -28,7 +28,7 @@
    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2003      Greg Stein <gstein@users.sourceforge.net>
-   Copyright (c) 2016-2025 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2023-2024 Sony Corporation / Snild Dolkow <snild@sony.com>
@@ -113,6 +113,7 @@
 #if defined(_WIN32)                                                            \
     && (! defined(__USE_MINGW_ANSI_STDIO)                                      \
         || (1 - __USE_MINGW_ANSI_STDIO - 1 == 0))
+#  define EXPAT_FMT_LLX(midpart) "%" midpart "I64x"
 #  define EXPAT_FMT_ULL(midpart) "%" midpart "I64u"
 #  if defined(_WIN64) // Note: modifiers "td" and "zu" do not work for MinGW
 #    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "I64d"
@@ -122,6 +123,7 @@
 #    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
 #  endif
 #else
+#  define EXPAT_FMT_LLX(midpart) "%" midpart "llx"
 #  define EXPAT_FMT_ULL(midpart) "%" midpart "llu"
 #  if ! defined(ULONG_MAX)
 #    error Compiler did not define ULONG_MAX for us

--- a/dependencies/expat/src/random_arc4random.c
+++ b/dependencies/expat/src/random_arc4random.c
@@ -1,0 +1,56 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_arc4random.h"
+
+#if ! defined(_DEFAULT_SOURCE)
+#  define _DEFAULT_SOURCE 1 /* for glibc */
+#endif
+
+#include <stdint.h> // for uint32_t
+#include <stdlib.h> // for arc4random
+#include <string.h> // for memcpy
+
+void
+writeRandomBytes_arc4random(void *target, size_t count) {
+  size_t bytesWrittenTotal = 0;
+
+  while (bytesWrittenTotal < count) {
+    const uint32_t random32 = arc4random();
+
+    size_t toUse = count - bytesWrittenTotal;
+    if (toUse > sizeof(random32))
+      toUse = sizeof(random32);
+    memcpy((char *)target + bytesWrittenTotal, &random32, toUse);
+    bytesWrittenTotal += toUse;
+  }
+}

--- a/dependencies/expat/src/random_arc4random.h
+++ b/dependencies/expat/src/random_arc4random.h
@@ -1,0 +1,39 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_ACR4RANDOM_H)
+#  define RANDOM_ACR4RANDOM_H 1
+
+#  include <stddef.h> // for size_t
+
+void writeRandomBytes_arc4random(void *target, size_t count);
+
+#endif // ! defined(RANDOM_ACR4RANDOM_H)

--- a/dependencies/expat/src/random_arc4random_buf.c
+++ b/dependencies/expat/src/random_arc4random_buf.c
@@ -1,0 +1,43 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_arc4random_buf.h"
+
+#if ! defined(_DEFAULT_SOURCE)
+#  define _DEFAULT_SOURCE 1 /* for glibc */
+#endif
+
+#include <stdlib.h> // for arc4random_buf
+
+void
+writeRandomBytes_arc4random_buf(void *target, size_t count) {
+  arc4random_buf(target, count);
+}

--- a/dependencies/expat/src/random_arc4random_buf.h
+++ b/dependencies/expat/src/random_arc4random_buf.h
@@ -1,0 +1,39 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_ACR4RANDOM_BUF_H)
+#  define RANDOM_ACR4RANDOM_BUF_H 1
+
+#  include <stddef.h> // for size_t
+
+void writeRandomBytes_arc4random_buf(void *target, size_t count);
+
+#endif // ! defined(RANDOM_ACR4RANDOM_BUF_H)

--- a/dependencies/expat/src/random_dev_urandom.c
+++ b/dependencies/expat/src/random_dev_urandom.c
@@ -1,0 +1,72 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_dev_urandom.h"
+
+#if ! defined(_POSIX_C_SOURCE)                                                 \
+    || (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE < 200809L))
+#  define _POSIX_C_SOURCE 200809L // for O_CLOEXEC
+#endif
+
+#include <errno.h>
+#include <fcntl.h>  // open
+#include <unistd.h> // close
+
+/* Extract entropy from /dev/urandom */
+bool
+writeRandomBytes_dev_urandom(void *target, size_t count) {
+  int success = false; /* full count bytes written? */
+  size_t bytesWrittenTotal = 0;
+
+  const int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    return 0;
+  }
+
+  do {
+    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
+    const size_t bytesToWrite = count - bytesWrittenTotal;
+
+    errno = 0;
+
+    const ssize_t bytesWrittenMore = read(fd, currentTarget, bytesToWrite);
+
+    if (bytesWrittenMore > 0) {
+      bytesWrittenTotal += bytesWrittenMore;
+      if (bytesWrittenTotal >= count)
+        success = true;
+    }
+  } while (! success && (errno == EINTR));
+
+  close(fd);
+  return success;
+}

--- a/dependencies/expat/src/random_dev_urandom.h
+++ b/dependencies/expat/src/random_dev_urandom.h
@@ -1,0 +1,40 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_DEV_URANDOM_H)
+#  define RANDOM_DEV_URANDOM_H 1
+
+#  include <stdbool.h>
+#  include <stddef.h> // for size_t
+
+bool writeRandomBytes_dev_urandom(void *target, size_t count);
+
+#endif // ! defined(RANDOM_DEV_URANDOM_H)

--- a/dependencies/expat/src/random_getentropy.c
+++ b/dependencies/expat/src/random_getentropy.c
@@ -1,0 +1,54 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_getentropy.h"
+
+// NOTE: Please keep this block in sync with its two siblings in files
+//       `configure.ac` and `ConfigureChecks.cmake`!
+#if defined(__APPLE__)
+#  include <sys/random.h>
+#else
+#  if defined(__GLIBC__) && ! defined(_DEFAULT_SOURCE)
+#    define _DEFAULT_SOURCE 1
+#  endif
+#  if ! defined(_GNU_SOURCE)
+#    define _GNU_SOURCE 1 /* for musl */
+#  endif
+#  include <unistd.h>
+#endif // ! defined(__APPLE__)
+
+#include <errno.h>
+
+bool
+writeRandomBytes_getentropy(void *target, size_t count) {
+  errno = 0;
+  return getentropy(target, count) == 0;
+}

--- a/dependencies/expat/src/random_getentropy.h
+++ b/dependencies/expat/src/random_getentropy.h
@@ -1,0 +1,40 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_GETENTROPY_H)
+#  define RANDOM_GETENTROPY_H 1
+
+#  include <stdbool.h>
+#  include <stddef.h> // for size_t
+
+bool writeRandomBytes_getentropy(void *target, size_t count);
+
+#endif // ! defined(RANDOM_GETENTROPY_H)

--- a/dependencies/expat/src/random_getrandom.c
+++ b/dependencies/expat/src/random_getrandom.c
@@ -1,0 +1,90 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2017      Chanho Park <chanho61.park@samsung.com>
+   Copyright (c) 2022      Sean McBride <sean@rogue-research.com>
+   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_getrandom.h"
+
+#include "expat_config.h" // for HAVE_GETRANDOM, HAVE_SYSCALL_GETRANDOM
+
+#if defined(HAVE_GETRANDOM)
+#  include <sys/random.h> /* getrandom */
+#endif
+
+#if defined(HAVE_SYSCALL_GETRANDOM)
+#  if ! defined(_GNU_SOURCE)
+#    define _GNU_SOURCE 1 /* syscall prototype */
+#  endif
+#  include <unistd.h>      /* syscall */
+#  include <sys/syscall.h> /* SYS_getrandom */
+#endif                     // defined(HAVE_SYSCALL_GETRANDOM)
+
+#if ! defined(GRND_NONBLOCK)
+#  define GRND_NONBLOCK 0x0001
+#endif /* defined(GRND_NONBLOCK) */
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h> // for INT_MAX
+
+/* Obtain entropy on Linux 3.17+ */
+bool
+writeRandomBytes_getrandom_nonblock(void *target, size_t count) {
+  int success = false; /* full count bytes written? */
+  size_t bytesWrittenTotal = 0;
+  const unsigned int getrandomFlags = GRND_NONBLOCK;
+
+  do {
+    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
+    const size_t bytesToWrite = count - bytesWrittenTotal;
+
+    assert(bytesToWrite <= INT_MAX);
+
+    errno = 0;
+
+    const int bytesWrittenMore =
+#if defined(HAVE_GETRANDOM)
+        (int)getrandom(currentTarget, bytesToWrite, getrandomFlags);
+#else
+        (int)syscall(SYS_getrandom, currentTarget, bytesToWrite,
+                     getrandomFlags);
+#endif
+
+    if (bytesWrittenMore > 0) {
+      bytesWrittenTotal += bytesWrittenMore;
+      if (bytesWrittenTotal >= count)
+        success = true;
+    }
+  } while (! success && (errno == EINTR));
+
+  return success;
+}

--- a/dependencies/expat/src/random_getrandom.h
+++ b/dependencies/expat/src/random_getrandom.h
@@ -1,0 +1,40 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_GETRANDOM_H)
+#  define RANDOM_GETRANDOM_H 1
+
+#  include <stdbool.h>
+#  include <stddef.h> // for size_t
+
+bool writeRandomBytes_getrandom_nonblock(void *target, size_t count);
+
+#endif // ! defined(RANDOM_GETRANDOM_H)

--- a/dependencies/expat/src/random_rand_s.c
+++ b/dependencies/expat/src/random_rand_s.c
@@ -1,0 +1,88 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2019-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2019      Ben Wagner <bungeman@chromium.org>
+   Copyright (c) 2019      Vadim Zeitlin <vadim@zeitlins.org>
+   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "random_rand_s.h"
+
+/* force stdlib to define rand_s() */
+#if ! defined(_CRT_RAND_S)
+#  define _CRT_RAND_S
+#endif
+
+// Workaround MinGW GCC trouble with recognizing `rand_s`, likely related
+// to return type `error_t`; the symptom was:
+// > error: implicit declaration of function ‘rand_s’
+#if defined(__MINGW32__)
+#  include <errno.h>
+#endif
+
+#include <stdlib.h> // for rand_s
+#include <string.h> // for memcpy
+
+// Help clang-tidy out with prototype of function `rand_s`
+#if defined(XML_CLANG_TIDY)
+int rand_s(unsigned int *);
+#endif
+
+/* Provide declaration of rand_s() for MinGW-32 (not 64, which has it),
+   as it didn't declare it in its header prior to version 5.3.0 of its
+   runtime package (mingwrt, containing stdlib.h).  The upstream fix
+   was introduced at https://osdn.net/projects/mingw/ticket/39658 . */
+#if defined(__MINGW32__) && defined(__MINGW32_VERSION)                         \
+    && __MINGW32_VERSION < 5003000L && ! defined(__MINGW64_VERSION_MAJOR)
+__declspec(dllimport) int rand_s(unsigned int *);
+#endif
+
+/* Obtain entropy on Windows using the rand_s() function which
+ * generates cryptographically secure random numbers.  Internally it
+ * uses RtlGenRandom API which is present in Windows XP and later.
+ */
+bool
+writeRandomBytes_rand_s(void *target, size_t count) {
+  size_t bytesWrittenTotal = 0;
+
+  while (bytesWrittenTotal < count) {
+    unsigned int random32 = 0;
+
+    if (rand_s(&random32))
+      return false; /* failure */
+
+    size_t toUse = count - bytesWrittenTotal;
+    if (toUse > sizeof(random32))
+      toUse = sizeof(random32);
+    memcpy((char *)target + bytesWrittenTotal, &random32, toUse);
+    bytesWrittenTotal += toUse;
+  }
+  return true; /* success */
+}

--- a/dependencies/expat/src/random_rand_s.h
+++ b/dependencies/expat/src/random_rand_s.h
@@ -1,0 +1,41 @@
+/*
+                            __  __            _
+                         ___\ \/ /_ __   __ _| |_
+                        / _ \\  /| '_ \ / _` | __|
+                       |  __//  \| |_) | (_| | |_
+                        \___/_/\_\ .__/ \__,_|\__|
+                                 |_| XML parser
+
+   Copyright (c) 2019 David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#if ! defined(RANDOM_RAND_S_H)
+#  define RANDOM_RAND_S_H 1
+
+#  include <stdbool.h>
+#  include <stddef.h> // for size_t
+
+bool writeRandomBytes_rand_s(void *target, size_t count);
+
+#endif // ! defined(RANDOM_RAND_S_H)

--- a/dependencies/expat/src/xmlparse.c
+++ b/dependencies/expat/src/xmlparse.c
@@ -1,4 +1,4 @@
-/* 93c1caa66e2b0310459482516af05505b57c5cb7b96df777105308fc585c85d1 (2.7.5+)
+/* 75ef4224f81c052e9e5aeea2ac7de75357d2169ff9908e39edc08b9dc3052513 (2.8.1+)
                             __  __            _
                          ___\ \/ /_ __   __ _| |_
                         / _ \\  /| '_ \ / _` | __|
@@ -41,10 +41,12 @@
    Copyright (c) 2023-2024 Sony Corporation / Snild Dolkow <snild@sony.com>
    Copyright (c) 2024-2025 Berkay Eren Ürün <berkay.ueruen@siemens.com>
    Copyright (c) 2024      Hanno Böck <hanno@gentoo.org>
-   Copyright (c) 2025      Matthew Fernandez <matthew.fernandez@gmail.com>
+   Copyright (c) 2025-2026 Matthew Fernandez <matthew.fernandez@gmail.com>
    Copyright (c) 2025      Atrem Borovik <polzovatellllk@gmail.com>
    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
    Copyright (c) 2026      Rosen Penev <rosenp@gmail.com>
+   Copyright (c) 2026      Francesco Bertolaccini
+   Copyright (c) 2026      Christian Ng <christianrng@berkeley.edu>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -84,28 +86,16 @@
 #  error XML_CONTEXT_BYTES must be defined, non-empty and >=0 (0 to disable, >=1 to enable; 1024 is a common default)
 #endif
 
-#if defined(HAVE_SYSCALL_GETRANDOM)
-#  if ! defined(_GNU_SOURCE)
-#    define _GNU_SOURCE 1 /* syscall prototype */
-#  endif
-#endif
-
-#ifdef _WIN32
-/* force stdlib to define rand_s() */
-#  if ! defined(_CRT_RAND_S)
-#    define _CRT_RAND_S
-#  endif
-#endif
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h> /* memset(), memcpy() */
 #include <assert.h>
 #include <limits.h> /* INT_MAX, UINT_MAX */
 #include <stdio.h>  /* fprintf */
-#include <stdlib.h> /* getenv, rand_s */
+#include <stdlib.h> /* getenv */
 #include <stdint.h> /* SIZE_MAX, uintptr_t */
 #include <math.h>   /* isnan */
+#include <errno.h>
 
 #ifdef _WIN32
 #  define getpid GetCurrentProcessId
@@ -125,26 +115,34 @@
 #include "expat.h"
 #include "siphash.h"
 
-#if defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
-#  if defined(HAVE_GETRANDOM)
-#    include <sys/random.h> /* getrandom */
-#  else
-#    include <unistd.h>      /* syscall */
-#    include <sys/syscall.h> /* SYS_getrandom */
-#  endif
-#  if ! defined(GRND_NONBLOCK)
-#    define GRND_NONBLOCK 0x0001
-#  endif /* defined(GRND_NONBLOCK) */
-#endif   /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
+#if defined(HAVE_ARC4RANDOM)
+#  include "random_arc4random.h"
+#endif /* defined(HAVE_ARC4RANDOM) */
 
-#if defined(_WIN32) && ! defined(LOAD_LIBRARY_SEARCH_SYSTEM32)
-#  define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
-#endif
+#if defined(HAVE_ARC4RANDOM_BUF)
+#  include "random_arc4random_buf.h"
+#endif // defined(HAVE_ARC4RANDOM_BUF)
+
+#if defined(XML_DEV_URANDOM)
+#  include "random_dev_urandom.h"
+#endif /* defined(XML_DEV_URANDOM) */
+
+#if defined(HAVE_GETENTROPY)
+#  include "random_getentropy.h"
+#endif // defined(HAVE_GETENTROPY)
+
+#if defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
+#  include "random_getrandom.h"
+#endif /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
+
+#if defined(_WIN32)
+#  include "random_rand_s.h"
+#endif /* defined(_WIN32) */
 
 #if ! defined(HAVE_GETRANDOM) && ! defined(HAVE_SYSCALL_GETRANDOM)             \
     && ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)            \
-    && ! defined(XML_DEV_URANDOM) && ! defined(_WIN32)                         \
-    && ! defined(XML_POOR_ENTROPY)
+    && ! defined(HAVE_GETENTROPY) && ! defined(XML_DEV_URANDOM)                \
+    && ! defined(_WIN32) && ! defined(XML_POOR_ENTROPY)
 #  error You do not have support for any sources of high quality entropy \
     enabled.  For end user security, that is probably not what you want. \
     \
@@ -153,10 +151,11 @@
       * Linux >=3.17 + glibc (including <2.25) (syscall SYS_getrandom): HAVE_SYSCALL_GETRANDOM, \
       * BSD / macOS >=10.7 / glibc >=2.36 (arc4random_buf): HAVE_ARC4RANDOM_BUF, \
       * BSD / macOS (including <10.7) / glibc >=2.36 (arc4random): HAVE_ARC4RANDOM, \
+      * BSD / macOS >=10.12 / glibc >=2.25 (getentropy): HAVE_GETENTROPY, \
       * Linux (including <3.17) / BSD / macOS (including <10.7) / Solaris >=8 (/dev/urandom): XML_DEV_URANDOM, \
       * Windows >=Vista (rand_s): _WIN32. \
     \
-    If insist on not using any of these, bypass this error by defining \
+    If you insist on not using any of these, bypass this error by defining \
     XML_POOR_ENTROPY; you have been warned. \
     \
     If you have reasons to patch this detection code away or need changes \
@@ -388,6 +387,7 @@ typedef struct {
   int nDefaultAtts;
   int allocDefaultAtts;
   DEFAULT_ATTRIBUTE *defaultAtts;
+  HASH_TABLE defaultAttsNames;
 } ELEMENT_TYPE;
 
 typedef struct {
@@ -604,7 +604,7 @@ static ELEMENT_TYPE *getElementType(XML_Parser parser, const ENCODING *enc,
 
 static XML_Char *copyString(const XML_Char *s, XML_Parser parser);
 
-static unsigned long generate_hash_secret_salt(XML_Parser parser);
+static struct sipkey generate_hash_secret_salt(void);
 static XML_Bool startParsing(XML_Parser parser);
 
 static XML_Parser parserCreate(const XML_Char *encodingName,
@@ -777,7 +777,8 @@ struct XML_ParserStruct {
   XML_Bool m_useForeignDTD;
   enum XML_ParamEntityParsing m_paramEntityParsing;
 #endif
-  unsigned long m_hash_secret_salt;
+  struct sipkey m_hash_secret_salt_128;
+  XML_Bool m_hash_secret_salt_set;
 #if XML_GE == 1
   ACCOUNTING m_accounting;
   MALLOC_TRACKER m_alloc_tracker;
@@ -1036,135 +1037,6 @@ static const XML_Char implicitContext[]
        ASCII_s,     ASCII_p,     ASCII_a,      ASCII_c,      ASCII_e,
        '\0'};
 
-/* To avoid warnings about unused functions: */
-#if ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)
-
-#  if defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
-
-/* Obtain entropy on Linux 3.17+ */
-static int
-writeRandomBytes_getrandom_nonblock(void *target, size_t count) {
-  int success = 0; /* full count bytes written? */
-  size_t bytesWrittenTotal = 0;
-  const unsigned int getrandomFlags = GRND_NONBLOCK;
-
-  do {
-    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
-    const size_t bytesToWrite = count - bytesWrittenTotal;
-
-    assert(bytesToWrite <= INT_MAX);
-
-    const int bytesWrittenMore =
-#    if defined(HAVE_GETRANDOM)
-        (int)getrandom(currentTarget, bytesToWrite, getrandomFlags);
-#    else
-        (int)syscall(SYS_getrandom, currentTarget, bytesToWrite,
-                     getrandomFlags);
-#    endif
-
-    if (bytesWrittenMore > 0) {
-      bytesWrittenTotal += bytesWrittenMore;
-      if (bytesWrittenTotal >= count)
-        success = 1;
-    }
-  } while (! success && (errno == EINTR));
-
-  return success;
-}
-
-#  endif /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
-
-#  if ! defined(_WIN32) && defined(XML_DEV_URANDOM)
-
-/* Extract entropy from /dev/urandom */
-static int
-writeRandomBytes_dev_urandom(void *target, size_t count) {
-  int success = 0; /* full count bytes written? */
-  size_t bytesWrittenTotal = 0;
-
-  const int fd = open("/dev/urandom", O_RDONLY);
-  if (fd < 0) {
-    return 0;
-  }
-
-  do {
-    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
-    const size_t bytesToWrite = count - bytesWrittenTotal;
-
-    const ssize_t bytesWrittenMore = read(fd, currentTarget, bytesToWrite);
-
-    if (bytesWrittenMore > 0) {
-      bytesWrittenTotal += bytesWrittenMore;
-      if (bytesWrittenTotal >= count)
-        success = 1;
-    }
-  } while (! success && (errno == EINTR));
-
-  close(fd);
-  return success;
-}
-
-#  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
-
-#endif /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
-
-#if defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF)
-
-static void
-writeRandomBytes_arc4random(void *target, size_t count) {
-  size_t bytesWrittenTotal = 0;
-
-  while (bytesWrittenTotal < count) {
-    const uint32_t random32 = arc4random();
-    size_t i = 0;
-
-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
-         i++, bytesWrittenTotal++) {
-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
-    }
-  }
-}
-
-#endif /* defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF) */
-
-#ifdef _WIN32
-
-/* Provide declaration of rand_s() for MinGW-32 (not 64, which has it),
-   as it didn't declare it in its header prior to version 5.3.0 of its
-   runtime package (mingwrt, containing stdlib.h).  The upstream fix
-   was introduced at https://osdn.net/projects/mingw/ticket/39658 . */
-#  if defined(__MINGW32__) && defined(__MINGW32_VERSION)                       \
-      && __MINGW32_VERSION < 5003000L && ! defined(__MINGW64_VERSION_MAJOR)
-__declspec(dllimport) int rand_s(unsigned int *);
-#  endif
-
-/* Obtain entropy on Windows using the rand_s() function which
- * generates cryptographically secure random numbers.  Internally it
- * uses RtlGenRandom API which is present in Windows XP and later.
- */
-static int
-writeRandomBytes_rand_s(void *target, size_t count) {
-  size_t bytesWrittenTotal = 0;
-
-  while (bytesWrittenTotal < count) {
-    unsigned int random32 = 0;
-    size_t i = 0;
-
-    if (rand_s(&random32))
-      return 0; /* failure */
-
-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
-         i++, bytesWrittenTotal++) {
-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
-    }
-  }
-  return 1; /* success */
-}
-
-#endif /* _WIN32 */
-
 #if ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)
 
 static unsigned long
@@ -1192,67 +1064,68 @@ gather_time_entropy(void) {
 
 #endif /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
 
-static unsigned long
-ENTROPY_DEBUG(const char *label, unsigned long entropy) {
+static struct sipkey
+ENTROPY_DEBUG(const char *label, struct sipkey entropy_128) {
   if (getDebugLevel("EXPAT_ENTROPY_DEBUG", 0) >= 1u) {
-    fprintf(stderr, "expat: Entropy: %s --> 0x%0*lx (%lu bytes)\n", label,
-            (int)sizeof(entropy) * 2, entropy, (unsigned long)sizeof(entropy));
+    fprintf(stderr,
+            "expat: Entropy: %s --> [0x" EXPAT_FMT_LLX(
+                "016") ", 0x" EXPAT_FMT_LLX("016") "] (16 bytes)\n",
+            label, (unsigned long long)entropy_128.k[0],
+            (unsigned long long)entropy_128.k[1]);
   }
-  return entropy;
+  return entropy_128;
 }
 
-static unsigned long
-generate_hash_secret_salt(XML_Parser parser) {
-  unsigned long entropy;
-  (void)parser;
+static struct sipkey
+generate_hash_secret_salt(void) {
+  struct sipkey entropy;
 
   /* "Failproof" high quality providers: */
 #if defined(HAVE_ARC4RANDOM_BUF)
-  arc4random_buf(&entropy, sizeof(entropy));
+  writeRandomBytes_arc4random_buf(&entropy, sizeof(entropy));
   return ENTROPY_DEBUG("arc4random_buf", entropy);
 #elif defined(HAVE_ARC4RANDOM)
-  writeRandomBytes_arc4random((void *)&entropy, sizeof(entropy));
+  writeRandomBytes_arc4random(&entropy, sizeof(entropy));
   return ENTROPY_DEBUG("arc4random", entropy);
 #else
   /* Try high quality providers first .. */
 #  ifdef _WIN32
-  if (writeRandomBytes_rand_s((void *)&entropy, sizeof(entropy))) {
+  if (writeRandomBytes_rand_s(&entropy, sizeof(entropy))) {
     return ENTROPY_DEBUG("rand_s", entropy);
   }
+#  elif defined(HAVE_GETENTROPY)
+  if (writeRandomBytes_getentropy(&entropy, sizeof(entropy))) {
+    return ENTROPY_DEBUG("getentropy", entropy);
+  }
+  errno = 0;
 #  elif defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
-  if (writeRandomBytes_getrandom_nonblock((void *)&entropy, sizeof(entropy))) {
+  if (writeRandomBytes_getrandom_nonblock(&entropy, sizeof(entropy))) {
     return ENTROPY_DEBUG("getrandom", entropy);
   }
 #  endif
 #  if ! defined(_WIN32) && defined(XML_DEV_URANDOM)
-  if (writeRandomBytes_dev_urandom((void *)&entropy, sizeof(entropy))) {
+  if (writeRandomBytes_dev_urandom(&entropy, sizeof(entropy))) {
     return ENTROPY_DEBUG("/dev/urandom", entropy);
   }
 #  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
   /* .. and self-made low quality for backup: */
 
-  entropy = gather_time_entropy();
+  entropy.k[0] = 0;
+  entropy.k[1] = gather_time_entropy();
 #  if ! defined(__wasi__)
   /* Process ID is 0 bits entropy if attacker has local access */
-  entropy ^= getpid();
+  entropy.k[1] ^= getpid();
 #  endif
 
   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
   if (sizeof(unsigned long) == 4) {
-    return ENTROPY_DEBUG("fallback(4)", entropy * 2147483647);
+    entropy.k[1] *= 2147483647;
+    return ENTROPY_DEBUG("fallback(4)", entropy);
   } else {
-    return ENTROPY_DEBUG("fallback(8)",
-                         entropy * (unsigned long)2305843009213693951ULL);
+    entropy.k[1] *= 2305843009213693951ULL;
+    return ENTROPY_DEBUG("fallback(8)", entropy);
   }
 #endif
-}
-
-static unsigned long
-get_hash_secret_salt(XML_Parser parser) {
-  const XML_Parser rootParser = getRootParserOf(parser, NULL);
-  assert(! rootParser->m_parentParser);
-
-  return rootParser->m_hash_secret_salt;
 }
 
 static enum XML_Error
@@ -1323,8 +1196,10 @@ callProcessor(XML_Parser parser, const char *start, const char *end,
 static XML_Bool /* only valid for root parser */
 startParsing(XML_Parser parser) {
   /* hash functions must be initialized before setContext() is called */
-  if (parser->m_hash_secret_salt == 0)
-    parser->m_hash_secret_salt = generate_hash_secret_salt(parser);
+  if (parser->m_hash_secret_salt_set != XML_TRUE) {
+    parser->m_hash_secret_salt_128 = generate_hash_secret_salt();
+    parser->m_hash_secret_salt_set = XML_TRUE;
+  }
   if (parser->m_ns) {
     /* implicit context only set for root parser, since child
        parsers (i.e. external entity parsers) will inherit it
@@ -1612,7 +1487,9 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
   parser->m_useForeignDTD = XML_FALSE;
   parser->m_paramEntityParsing = XML_PARAM_ENTITY_PARSING_NEVER;
 #endif
-  parser->m_hash_secret_salt = 0;
+  parser->m_hash_secret_salt_128.k[0] = 0;
+  parser->m_hash_secret_salt_128.k[1] = 0;
+  parser->m_hash_secret_salt_set = XML_FALSE;
 
 #if XML_GE == 1
   memset(&parser->m_accounting, 0, sizeof(ACCOUNTING));
@@ -1779,7 +1656,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
      from hash tables associated with either parser without us having
      to worry which hash secrets each table has.
   */
-  unsigned long oldhash_secret_salt;
+  struct sipkey oldhash_secret_salt_128;
+  XML_Bool oldhash_secret_salt_set;
   XML_Bool oldReparseDeferralEnabled;
 
   /* Validate the oldParser parameter before we pull everything out of it */
@@ -1825,7 +1703,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
      from hash tables associated with either parser without us having
      to worry which hash secrets each table has.
   */
-  oldhash_secret_salt = parser->m_hash_secret_salt;
+  oldhash_secret_salt_128 = parser->m_hash_secret_salt_128;
+  oldhash_secret_salt_set = parser->m_hash_secret_salt_set;
   oldReparseDeferralEnabled = parser->m_reparseDeferralEnabled;
 
 #ifdef XML_DTD
@@ -1880,7 +1759,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
     parser->m_externalEntityRefHandlerArg = oldExternalEntityRefHandlerArg;
   parser->m_defaultExpandInternalEntities = oldDefaultExpandInternalEntities;
   parser->m_ns_triplets = oldns_triplets;
-  parser->m_hash_secret_salt = oldhash_secret_salt;
+  parser->m_hash_secret_salt_128 = oldhash_secret_salt_128;
+  parser->m_hash_secret_salt_set = oldhash_secret_salt_set;
   parser->m_reparseDeferralEnabled = oldReparseDeferralEnabled;
   parser->m_parentParser = oldParser;
 #ifdef XML_DTD
@@ -2324,6 +2204,7 @@ XML_SetParamEntityParsing(XML_Parser parser,
 #endif
 }
 
+// DEPRECATED since Expat 2.8.0.
 int XMLCALL
 XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
   if (parser == NULL)
@@ -2335,8 +2216,44 @@ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
   /* block after XML_Parse()/XML_ParseBuffer() has been called */
   if (parserBusy(rootParser))
     return 0;
-  rootParser->m_hash_secret_salt = hash_salt;
+
+  rootParser->m_hash_secret_salt_128.k[0] = 0;
+  rootParser->m_hash_secret_salt_128.k[1] = hash_salt;
+
+  if (hash_salt != 0) { // to remain backwards compatible
+    rootParser->m_hash_secret_salt_set = XML_TRUE;
+
+    if (sizeof(unsigned long) == 4)
+      ENTROPY_DEBUG("explicit(4)", rootParser->m_hash_secret_salt_128);
+    else
+      ENTROPY_DEBUG("explicit(8)", rootParser->m_hash_secret_salt_128);
+  }
+
   return 1;
+}
+
+XML_Bool XMLCALL
+XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]) {
+  if (parser == NULL)
+    return XML_FALSE;
+
+  if (entropy == NULL)
+    return XML_FALSE;
+
+  const XML_Parser rootParser = getRootParserOf(parser, NULL);
+  assert(! rootParser->m_parentParser);
+
+  /* block after XML_Parse()/XML_ParseBuffer() has been called */
+  if (parserBusy(rootParser))
+    return XML_FALSE;
+
+  sip_tokey(&(rootParser->m_hash_secret_salt_128), entropy);
+
+  rootParser->m_hash_secret_salt_set = XML_TRUE;
+
+  ENTROPY_DEBUG("explicit(16)", rootParser->m_hash_secret_salt_128);
+
+  return XML_TRUE;
 }
 
 enum XML_Status XMLCALL
@@ -3853,6 +3770,8 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
                                          sizeof(ELEMENT_TYPE));
     if (! elementType)
       return XML_ERROR_NO_MEMORY;
+    if (! elementType->defaultAttsNames.parser)
+      hashTableInit(&(elementType->defaultAttsNames), parser);
     if (parser->m_ns && ! setElementTypePrefix(parser, elementType))
       return XML_ERROR_NO_MEMORY;
   }
@@ -7186,10 +7105,10 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
   if (value || isId) {
     /* The handling of default attributes gets messed up if we have
        a default which duplicates a non-default. */
-    int i;
-    for (i = 0; i < type->nDefaultAtts; i++)
-      if (attId == type->defaultAtts[i].id)
-        return 1;
+    NAMED *const nameFound
+        = (NAMED *)lookup(parser, &(type->defaultAttsNames), attId->name, 0);
+    if (nameFound)
+      return 1;
     if (isId && ! type->idAtt && ! attId->xmlns)
       type->idAtt = attId;
   }
@@ -7236,6 +7155,12 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
   att->isCdata = isCdata;
   if (! isCdata)
     attId->maybeTokenized = XML_TRUE;
+
+  NAMED *const nameAddedOrFound = (NAMED *)lookup(
+      parser, &(type->defaultAttsNames), attId->name, sizeof(NAMED));
+  if (! nameAddedOrFound)
+    return 0;
+
   type->nDefaultAtts += 1;
   return 1;
 }
@@ -7561,6 +7486,7 @@ dtdReset(DTD *p, XML_Parser parser) {
     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
     if (! e)
       break;
+    hashTableDestroy(&(e->defaultAttsNames));
     if (e->allocDefaultAtts != 0)
       FREE(parser, e->defaultAtts);
   }
@@ -7602,6 +7528,7 @@ dtdDestroy(DTD *p, XML_Bool isDocEntity, XML_Parser parser) {
     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
     if (! e)
       break;
+    hashTableDestroy(&(e->defaultAttsNames));
     if (e->allocDefaultAtts != 0)
       FREE(parser, e->defaultAtts);
   }
@@ -7695,6 +7622,10 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
                                   sizeof(ELEMENT_TYPE));
     if (! newE)
       return 0;
+
+    if (! newE->defaultAttsNames.parser)
+      hashTableInit(&(newE->defaultAttsNames), parser);
+
     if (oldE->nDefaultAtts) {
       /* Detect and prevent integer overflow.
        * The preprocessor guard addresses the "always false" warning
@@ -7719,8 +7650,9 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
       newE->prefix = (PREFIX *)lookup(oldParser, &(newDtd->prefixes),
                                       oldE->prefix->name, 0);
     for (i = 0; i < newE->nDefaultAtts; i++) {
+      const XML_Char *const attributeName = oldE->defaultAtts[i].id->name;
       newE->defaultAtts[i].id = (ATTRIBUTE_ID *)lookup(
-          oldParser, &(newDtd->attributeIds), oldE->defaultAtts[i].id->name, 0);
+          oldParser, &(newDtd->attributeIds), attributeName, 0);
       newE->defaultAtts[i].isCdata = oldE->defaultAtts[i].isCdata;
       if (oldE->defaultAtts[i].value) {
         newE->defaultAtts[i].value
@@ -7729,6 +7661,12 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
           return 0;
       } else
         newE->defaultAtts[i].value = NULL;
+
+      NAMED *const nameAddedOrFound = (NAMED *)lookup(
+          parser, &(newE->defaultAttsNames), attributeName, sizeof(NAMED));
+      if (! nameAddedOrFound) {
+        return 0;
+      }
     }
   }
 
@@ -7842,8 +7780,10 @@ keylen(KEY s) {
 
 static void
 copy_salt_to_sipkey(XML_Parser parser, struct sipkey *key) {
-  key->k[0] = 0;
-  key->k[1] = get_hash_secret_salt(parser);
+  const XML_Parser rootParser = getRootParserOf(parser, NULL);
+  assert(! rootParser->m_parentParser);
+
+  *key = rootParser->m_hash_secret_salt_128;
 }
 
 static unsigned long FASTCALL
@@ -8473,6 +8413,8 @@ getElementType(XML_Parser parser, const ENCODING *enc, const char *ptr,
                                sizeof(ELEMENT_TYPE));
   if (! ret)
     return NULL;
+  if (! ret->defaultAttsNames.parser)
+    hashTableInit(&(ret->defaultAttsNames), getRootParserOf(parser, NULL));
   if (ret->name != name)
     poolDiscard(&dtd->pool);
   else {

--- a/dependencies/expat/src/xmlrole.c
+++ b/dependencies/expat/src/xmlrole.c
@@ -12,7 +12,7 @@
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2016-2023 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2021      Donghee Na <donghee.na@python.org>

--- a/dependencies/expat/src/xmltok.c
+++ b/dependencies/expat/src/xmltok.c
@@ -12,7 +12,7 @@
    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002-2016 Karl Waclawek <karl@waclawek.net>
    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2016-2024 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2016      Pascal Cuoq <cuoq@trust-in-soft.com>
    Copyright (c) 2016      Don Lewis <truckman@apache.org>
    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>

--- a/dependencies/expat/src/xmltok_ns.c
+++ b/dependencies/expat/src/xmltok_ns.c
@@ -11,7 +11,7 @@
    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
    Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
-   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2017-2021 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
    Licensed under the MIT license:
 

--- a/dependencies/png/CMakeLists.txt
+++ b/dependencies/png/CMakeLists.txt
@@ -1,6 +1,6 @@
 # libpng - PNG reference library
-# Version: 1.6.57
-# Source: https://github.com/pnggroup/libpng/releases/tag/v1.6.57
+# Version: 1.6.58
+# Source: https://github.com/pnggroup/libpng/releases/tag/v1.6.58
 
 if(POCO_UNBUNDLED)
 	if (ENABLE_PDF)

--- a/dependencies/png/src/png.c
+++ b/dependencies/png/src/png.c
@@ -13,7 +13,7 @@
 #include "pngpriv.h"
 
 /* Generate a compiler error if there is an old png.h in the search path. */
-typedef png_libpng_version_1_6_57 Your_png_h_is_not_version_1_6_57;
+typedef png_libpng_version_1_6_58 Your_png_h_is_not_version_1_6_58;
 
 /* Sanity check the chunks definitions - PNG_KNOWN_CHUNKS from pngpriv.h and the
  * corresponding macro definitions.  This causes a compile time failure if
@@ -820,7 +820,7 @@ png_get_copyright(png_const_structrp png_ptr)
    return PNG_STRING_COPYRIGHT
 #else
    return PNG_STRING_NEWLINE \
-      "libpng version 1.6.57" PNG_STRING_NEWLINE \
+      "libpng version 1.6.58" PNG_STRING_NEWLINE \
       "Copyright (c) 2018-2026 Cosmin Truta" PNG_STRING_NEWLINE \
       "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
       PNG_STRING_NEWLINE \

--- a/dependencies/png/src/png.h
+++ b/dependencies/png/src/png.h
@@ -1,6 +1,6 @@
 /* png.h - header file for PNG reference library
  *
- * libpng version 1.6.57
+ * libpng version 1.6.58
  *
  * Copyright (c) 2018-2026 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
@@ -14,7 +14,7 @@
  *   libpng versions 0.89, June 1996, through 0.96, May 1997: Andreas Dilger
  *   libpng versions 0.97, January 1998, through 1.6.35, July 2018:
  *     Glenn Randers-Pehrson
- *   libpng versions 1.6.36, December 2018, through 1.6.57, April 2026:
+ *   libpng versions 1.6.36, December 2018, through 1.6.58, April 2026:
  *     Cosmin Truta
  *   See also "Contributing Authors", below.
  */
@@ -238,7 +238,7 @@
  *    ...
  *    1.5.30                  15    10530  15.so.15.30[.0]
  *    ...
- *    1.6.57                  16    10657  16.so.16.57[.0]
+ *    1.6.58                  16    10658  16.so.16.58[.0]
  *
  *    Henceforth the source version will match the shared-library major and
  *    minor numbers; the shared-library major version number will be used for
@@ -274,7 +274,7 @@
  */
 
 /* Version information for png.h - this should match the version in png.c */
-#define PNG_LIBPNG_VER_STRING "1.6.57"
+#define PNG_LIBPNG_VER_STRING "1.6.58"
 #define PNG_HEADER_VERSION_STRING " libpng version " PNG_LIBPNG_VER_STRING "\n"
 
 /* The versions of shared library builds should stay in sync, going forward */
@@ -285,7 +285,7 @@
 /* These should match the first 3 components of PNG_LIBPNG_VER_STRING: */
 #define PNG_LIBPNG_VER_MAJOR   1
 #define PNG_LIBPNG_VER_MINOR   6
-#define PNG_LIBPNG_VER_RELEASE 57
+#define PNG_LIBPNG_VER_RELEASE 58
 
 /* This should be zero for a public release, or non-zero for a
  * development version.
@@ -316,7 +316,7 @@
  * From version 1.0.1 it is:
  * XXYYZZ, where XX=major, YY=minor, ZZ=release
  */
-#define PNG_LIBPNG_VER 10657 /* 1.6.57 */
+#define PNG_LIBPNG_VER 10658 /* 1.6.58 */
 
 /* Library configuration: these options cannot be changed after
  * the library has been built.
@@ -426,7 +426,7 @@ extern "C" {
 /* This triggers a compiler error in png.c, if png.c and png.h
  * do not agree upon the version number.
  */
-typedef char *png_libpng_version_1_6_57;
+typedef char *png_libpng_version_1_6_58;
 
 /* Basic control structions.  Read libpng-manual.txt or libpng.3 for more info.
  *

--- a/dependencies/png/src/pngconf.h
+++ b/dependencies/png/src/pngconf.h
@@ -1,6 +1,6 @@
 /* pngconf.h - machine-configurable file for libpng
  *
- * libpng version 1.6.57
+ * libpng version 1.6.58
  *
  * Copyright (c) 2018-2026 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson

--- a/dependencies/png/src/pngrtran.c
+++ b/dependencies/png/src/pngrtran.c
@@ -2070,19 +2070,15 @@ png_read_transform_info(png_structrp png_ptr, png_inforp info_ptr)
 {
    png_debug(1, "in png_read_transform_info");
 
-   if (png_ptr->transformations != 0)
+   if (info_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
+       info_ptr->palette != NULL && png_ptr->palette != NULL)
    {
-      if (info_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
-          info_ptr->palette != NULL && png_ptr->palette != NULL)
-      {
-         /* Sync info_ptr->palette with png_ptr->palette.
-          * The function png_init_read_transformations may have modified
-          * png_ptr->palette in place (e.g. for gamma correction or for
-          * background compositing).
-          */
-         memcpy(info_ptr->palette, png_ptr->palette,
-             PNG_MAX_PALETTE_LENGTH * (sizeof (png_color)));
-      }
+      /* Sync info_ptr->palette with png_ptr->palette, which may
+       * have been modified by png_init_read_transformations
+       * (e.g. for gamma correction or background compositing).
+       */
+      memcpy(info_ptr->palette, png_ptr->palette,
+          PNG_MAX_PALETTE_LENGTH * (sizeof (png_color)));
    }
 
 #ifdef PNG_READ_EXPAND_SUPPORTED

--- a/dependencies/png/src/pngtest.c
+++ b/dependencies/png/src/pngtest.c
@@ -49,9 +49,6 @@
  */
 #define STDERR stdout
 
-/* Generate a compiler error if there is an old png.h in the search path. */
-typedef png_libpng_version_1_6_57 Your_png_h_is_not_version_1_6_57;
-
 /* Ensure that all version numbers in png.h are consistent with one another. */
 #if (PNG_LIBPNG_VER != PNG_LIBPNG_VER_MAJOR * 10000 + \
                        PNG_LIBPNG_VER_MINOR * 100 + \

--- a/dependencies/sqlite3/CMakeLists.txt
+++ b/dependencies/sqlite3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SQLite database engine
-# Version: 3.53.0
-# Source: https://www.sqlite.org/2026/sqlite-amalgamation-3530000.zip
+# Version: 3.53.1
+# Source: https://www.sqlite.org/2026/sqlite-amalgamation-3530100.zip
 
 if(POCO_SQLITE_UNBUNDLED)
 	if (ENABLE_DATA_SQLITE)

--- a/dependencies/sqlite3/src/sqlite3.h
+++ b/dependencies/sqlite3/src/sqlite3.h
@@ -146,12 +146,12 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.53.0"
-#define SQLITE_VERSION_NUMBER 3053000
-#define SQLITE_SOURCE_ID      "2026-04-09 11:41:38 4525003a53a7fc63ca75c59b22c79608659ca12f0131f52c18637f829977f20b"
-#define SQLITE_SCM_BRANCH     "trunk"
-#define SQLITE_SCM_TAGS       "release major-release version-3.53.0"
-#define SQLITE_SCM_DATETIME   "2026-04-09T11:41:38.498Z"
+#define SQLITE_VERSION        "3.53.1"
+#define SQLITE_VERSION_NUMBER 3053001
+#define SQLITE_SOURCE_ID      "2026-05-05 10:34:17 c88b22011a54b4f6fbd149e9f8e4de77658ce58143a1af0e3785e4e6475127e9"
+#define SQLITE_SCM_BRANCH     "branch-3.53"
+#define SQLITE_SCM_TAGS       "release version-3.53.1"
+#define SQLITE_SCM_DATETIME   "2026-05-05T10:34:17.344Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/dependencies/tessil/CMakeLists.txt
+++ b/dependencies/tessil/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Tessil ordered-map - header-only ordered hash map/set
+# Version: 1.2.0
 # Source: https://github.com/Tessil/ordered-map
 
 add_library(_BUNDLED_TESSIL INTERFACE)


### PR DESCRIPTION
## Summary
Refresh four bundled third-party dependencies and record tessil's actual version. Five commits, one per dependency.

| Commit | Update | Notes |
|---|---|---|
| `9376f1a29` | tessil: record `1.2.0` in CMakeLists/README | Bundled snapshot already matches upstream v1.2.0 (verified by header diff). The local `static` removal on `numeric_cast`/`deserialize_value` remains, tracked by upstream PR #54. |
| `0f9fc99a1` | expat: 2.7.5 -> 2.8.1 | **CVE-2026-41080**, **CVE-2026-45186**. Required restoring POCO's portable `expat_config.h` after the update script clobbered it, plus adding the new `random_*.{c,h}` files and gating them per platform in CMakeLists to mirror upstream. |
| `bc56c38b9` | sqlite3: 3.53.0 -> 3.53.1 | Fix WAL-reset database corruption bug. |
| `2f8ef3a9c` | libpng: 1.6.57 -> 1.6.58 | Fix `png_get_PLTE()` returning stale palette data when gamma correction or alpha-compositing is the only transform applied (regression from 1.6.56). The bundled `pnglibconf.h` is preserved. |
| `afbc44fd2` | 7zip (LZMA SDK): 26.00 -> 26.01 | Linux huge-pages support, new `-spo[d|c|r]` switch, several bug fixes. |

After this PR, `dependencies/check-upstream-versions.sh` reports all bundled deps up to date.

## Test plan
- [x] expat: `XML-testrunner -all` (138 tests) on macOS arm64 + Linux arm64
- [x] sqlite3: `DataSQLite-testrunner -all` (100 tests) on macOS arm64 + Linux arm64
- [x] libpng: `PDF-testrunner -all` (8 tests) on macOS arm64 + Linux arm64
- [x] 7zip: SevenZip + un7zip sample build cleanly on macOS + Linux; un7zip smoke-tested against a real `.7z` archive (list + extract round-trip)
- [ ] CI green on all platforms (Windows MSVC for expat platform-gated entropy file selection in particular)

## CHANGELOG entries (suggested)
For the "Bundled Third-Party Library Upgrades" section of 1.15.3:

- expat: 2.7.5 -> 2.8.1 (CVE-2026-41080, CVE-2026-45186)
- sqlite3: 3.53.0 -> 3.53.1 (WAL-reset corruption fix)
- libpng: 1.6.57 -> 1.6.58 (png_get_PLTE regression fix)
- 7zip (LZMA SDK): 26.00 -> 26.01