### PR TITLE
[fix] Only allow use atomic when C++20 is properly configured

### DIFF
--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -251,7 +251,7 @@
 
 #if defined(__APPLE__) && __has_include(<Availability.h>)
 	#include <Availability.h>
-	#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
+	#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000 && POCO_HAVE_CPP20_COMPILER
 		 #define POCO_HAVE_ATOMIC_WAIT 1
 	#endif
 #elif defined(__cpp_lib_atomic_wait)

--- a/Foundation/include/Poco/Config.h
+++ b/Foundation/include/Poco/Config.h
@@ -249,14 +249,16 @@
 	#define POCO_ENABLE_FASTLOGGER
 #endif
 
-#if defined(__APPLE__) && __has_include(<Availability.h>)
-	#include <Availability.h>
-	#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000 && POCO_HAVE_CPP20_COMPILER
-		 #define POCO_HAVE_ATOMIC_WAIT 1
+#if defined(__cpp_lib_atomic_wait)
+	#if defined(__APPLE__) && __has_include(<Availability.h>)
+		#include <Availability.h>
+		#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
+			#define POCO_HAVE_ATOMIC_WAIT 1
+		#endif
+	#else
+		// Standard feature test macro (C++20)
+		#define POCO_HAVE_ATOMIC_WAIT 1
 	#endif
-#elif defined(__cpp_lib_atomic_wait)
-	// Standard feature test macro (C++20)
-	#define POCO_HAVE_ATOMIC_WAIT 1
 #endif
 
 #endif // Foundation_Config_INCLUDED


### PR DESCRIPTION
Hello! :wave:

### Summary

When building Poco 1.15.2 using Apple Clang + C++17 in a modern OSX version, we have the following error:

```
/Users/jenkins/workspace/cci_prod_PR-29722/conan-home/p/b/poco95560bfbd94f7/b/src/Foundation/src/IOLock.cpp:31:15: error: no member named 'notify_one' in 'std::atomic<bool>'
   31 |                 _inProgress.notify_one();
      |                 ~~~~~~~~~~~ ^
/Users/jenkins/workspace/cci_prod_PR-29722/conan-home/p/b/poco95560bfbd94f7/b/src/Foundation/src/IOLock.cpp:43:14: error: no member named 'notify_one' in 'std::atomic<bool>'
   43 |         _inProgress.notify_one();
      |         ~~~~~~~~~~~ ^
/Users/jenkins/workspace/cci_prod_PR-29722/conan-home/p/b/poco95560bfbd94f7/b/src/Foundation/src/IOLock.cpp:67:15: error: no member named 'wait' in 'std::atomic<bool>'
   67 |                 _inProgress.wait(old, std::memory_order_relaxed);
      |                 ~~~~~~~~~~~ ^
3 errors generated.
```

The full build log can be found here: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-29722/10/package_build_logs/build_log_poco_1_15_2_76ab17b1c4e1079f6f0e70399fe19cd2_82348e27cd52c0bd6c190c5b1dda35def7c923ca.txt

### Root Cause

It happens because the condition does not check for C++20, but assumes it's supported based on the OSX version only: https://github.com/pocoproject/poco/blob/poco-1.15.2-release/Foundation/include/Poco/Config.h#L231

```cpp
#if defined(__APPLE__) && __has_include(<Availability.h>)
	#include <Availability.h>
	#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
		 #define POCO_HAVE_ATOMIC_WAIT 1
	#endif
#elif defined(__cpp_lib_atomic_wait)
	// Standard feature test macro (C++20)
	#define POCO_HAVE_ATOMIC_WAIT 1
#endif
```

### Proposed Fix 

In order to fix it, we can check `POCO_HAVE_CPP20_COMPILER`, configured in `Config.h` as well: https://github.com/pocoproject/poco/blob/poco-1.15.2-release/Foundation/include/Poco/Config.h#L189

After applying this proposed patch, I can build Poco 1.15.2 with C++17 without errors. My patched build log can be read here: [poco-1.15.2-osx-armv8-clang21-cppstd17-rel-shared.log](https://github.com/user-attachments/files/27953771/poco-1.15.2-osx-armv8-clang21-cppstd17-rel-shared.log)

Regards! 

#### Affected Configuration

Poco version: 1.15.0 and later (https://github.com/pocoproject/poco/commit/24b1fc16b64cf930a1a2a0581b311118812cfd05)
OS: Apple OSX 26.3
Arch: Apple M1 Max
Compiler: Apple Clang 21.0.0
C++ Standard: C++17
Build Type: Release