### PR TITLE
enh(MongoDB): MongoDB 6.0/7.0/8.0 compat -- partial indexes, Decimal128, SCRAM-SHA-256

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,28 @@ Release 1.15.3 (Unreleased)
 
 API Changes:
 
+- Poco::MongoDB::Database::authenticate() default mechanism changed from
+  "SCRAM-SHA-1" to "SCRAM-SHA-256", matching the MongoDB server default
+  for new users since 4.0 and the convention used by every official
+  MongoDB driver. Existing callers that rely on SCRAM-SHA-1 should pass
+  Database::AUTH_SCRAM_SHA1 explicitly. SCRAM-SHA-256 currently requires
+  ASCII passwords; non-ASCII passwords throw NotImplementedException
+  pending full SASLprep (RFC 4013) support.
+- Poco::MongoDB::Database::count() now uses aggregation [{$count: "n"}]
+  instead of the legacy "count" command. The signature is unchanged.
+  Aggregation $count is in the Stable API v1, returns accurate results
+  on sharded clusters (the legacy command over-reports due to orphans),
+  and is permitted in multi-document transactions. Operators watching
+  server-side query metrics will see "aggregate" commands where they
+  previously saw "count".
+- Poco::MongoDB::Database::INDEX_BACKGROUND is now marked POCO_DEPRECATED
+  (deprecated by MongoDB in 4.2; server-side no-op). The flag is kept
+  for source compatibility but its value is no longer forwarded to the
+  server.
+- Poco::MongoDB::OpMsgMessage::CMD_MAP_REDUCE is now marked
+  POCO_DEPRECATED (mapReduce deprecated by MongoDB in 5.0); use the
+  aggregation pipeline.
+
 - GH #5322 PropertyFileConfiguration: the optional parent-configuration
   parameter (added in 1.15.1 via #5253) is now an AbstractConfiguration*
   raw non-owning pointer instead of AbstractConfiguration::Ptr. Callers

--- a/Foundation/testsuite/src/SharedMemoryTest.cpp
+++ b/Foundation/testsuite/src/SharedMemoryTest.cpp
@@ -89,8 +89,11 @@ void SharedMemoryTest::testCreateLarge()
 	}
 	catch (Poco::SystemException& ex)
 	{
-		// no memory, quite posible to happen
-		assertEqual(ERROR_NOT_ENOUGH_MEMORY, ex.code());
+		// Windows returns either ERROR_NOT_ENOUGH_MEMORY or
+		// ERROR_NO_SYSTEM_RESOURCES depending on which allocation tier
+		// rejects the request.
+		assertTrue(ex.code() == ERROR_NOT_ENOUGH_MEMORY ||
+		           ex.code() == ERROR_NO_SYSTEM_RESOURCES);
 	}
 #endif
 }

--- a/MongoDB/Makefile
+++ b/MongoDB/Makefile
@@ -9,7 +9,7 @@ include $(POCO_BASE)/build/rules/global
 INCLUDE += -I $(POCO_BASE)/MongoDB/include/Poco/MongoDB
 
 objects = Array Binary Connection Cursor DeleteRequest  Database \
-	Document Element GetMoreRequest InsertRequest JavaScriptCode \
+	Decimal128 Document Element GetMoreRequest InsertRequest JavaScriptCode \
 	KillCursorsRequest Message MessageHeader ObjectId QueryRequest \
 	RegularExpression ReplicaSet RequestMessage ResponseMessage \
 	UpdateRequest OpMsgMessage OpMsgCursor

--- a/MongoDB/README.md
+++ b/MongoDB/README.md
@@ -1,0 +1,161 @@
+# Poco::MongoDB
+
+C++ client library for MongoDB. Speaks the OP_MSG wire protocol over
+`Poco::Net::StreamSocket` and exposes BSON documents, CRUD operations,
+cursors, indexes, and replica-set topology discovery.
+
+Minimum server version: MongoDB 3.6. Legacy opcodes (`OP_QUERY`,
+`OP_INSERT`, etc.) were removed in 1.14 (GH #4781); only `OP_MSG` and
+`OP_COMPRESSED` are sent on the wire. Servers from 3.6 through 8.x are
+supported at the protocol level. The "Server feature compatibility" section
+below details which features are exposed at the API level.
+
+Replica-set support (SDAM, automatic failover, read preferences, topology
+change notifications) is documented in [README-ReplicaSet.md](README-ReplicaSet.md).
+
+## Quick start
+
+```cpp
+#include "Poco/MongoDB/Connection.h"
+#include "Poco/MongoDB/Database.h"
+#include "Poco/MongoDB/OpMsgMessage.h"
+
+using namespace Poco::MongoDB;
+
+Connection connection;
+connection.connect("mongodb://localhost:27017/test");
+
+Database db("test");
+Poco::SharedPtr<OpMsgMessage> insert = db.createOpMsgMessage("users");
+insert->setCommandName(OpMsgMessage::CMD_INSERT);
+insert->documents().push_back(
+    db.createDocument().add("name", std::string("Alice")).add("age", 30));
+OpMsgMessage response;
+connection.sendRequest(*insert, response);
+```
+
+## Server feature compatibility
+
+The tables below list MongoDB 6.0 / 7.0 / 8.0 server features and their
+status in Poco::MongoDB:
+
+- **Supported**: dedicated API.
+- **Partial**: command-level access via `OpMsgMessage` (caller assembles
+  the BSON body); no typed helper.
+- **Missing**: no API and no helper; out of reach without library changes.
+- **Added 1.15.x**: introduced by the patch series that ships this document.
+
+`OpMsgMessage` is the universal escape hatch: any command can be issued by
+constructing its body manually, so "Missing" never means "impossible" -- it
+means there is no typed helper and the caller must read the server-side
+command reference.
+
+### A. Driver baseline (pre-6.0 specs)
+
+Capabilities expected of any modern MongoDB driver.
+
+| Capability | Status | Notes |
+|---|---|---|
+| Stable API (`apiVersion: "1"`, MongoDB 5.0+) | Missing | Set `apiVersion` manually on each command. |
+| SCRAM-SHA-256 (server default since 4.0) | Added 1.15.x | New `AUTH_SCRAM_SHA256`; default for `authenticate()`. |
+| SCRAM-SHA-1 | Supported | Pass `AUTH_SCRAM_SHA1` explicitly. |
+| x.509 / PLAIN / GSSAPI / MONGODB-AWS / MONGODB-OIDC | Missing | |
+| TLS / SSL | Partial | Default `SocketFactory` throws for secure; user must supply a `SocketFactory` returning a `Poco::Net::SecureStreamSocket`. |
+| `mongodb://` URI | Supported | |
+| `mongodb+srv://` DNS seedlist | Missing | Resolve the host list out of band. |
+| `tls=` URI option | Added 1.15.x | Alias for the historical `ssl=`. |
+| Retryable reads / writes | Missing | Transient network errors are not retried. |
+| Network compression (`zstd` / `zlib` / `snappy`) | Missing | `OP_COMPRESSED` opcode present; no codec or handshake. |
+| ClientSession, causal consistency, snapshot reads | Missing | No multi-document transactions. |
+
+### B. MongoDB 6.0
+
+| Feature | Status | Notes |
+|---|---|---|
+| OP_MSG-only wire protocol | Supported | Cleaned up in 1.14 (GH #4781). |
+| `$densify`, `$fill`, `$documents`, `$maxN`/`$minN`/`$lastN`/`$topN`/`$bottomN`, `$sortArray` | Partial | Hand-rolled aggregation pipeline. |
+| Change streams (`$changeStream`) with `fullDocumentBeforeChange` and DDL events | Missing | No `watch()`, no resume tokens. |
+| Clustered collections (`clusteredIndex`) | Partial | Raw `create` command. |
+| Time-series collections; secondary / compound indexes on them | Partial | Raw `create` command; new `createIndex(extraOptions)` covers the index side. |
+| **Partial indexes (`partialFilterExpression`, 3.2+)** | Added 1.15.x | Pass `partialFilterExpression` in the new `extraOptions` overload. |
+| Hidden indexes (4.4+) | Added 1.15.x | New `INDEX_HIDDEN` flag. |
+| Text / 2dsphere / hashed / wildcard indexes | Partial | Reachable via `extraOptions`; wildcard via `"$**"` field name. |
+| Collation on indexes | Added 1.15.x | Pass `collation` in `extraOptions`. |
+| Queryable Encryption (preview) | Missing | No `ClientEncryption` class. |
+
+### C. MongoDB 7.0
+
+| Feature | Status | Notes |
+|---|---|---|
+| Queryable Encryption (GA) | Missing | No `ClientEncryption` class, no key-vault helper. |
+| MONGODB-OIDC authentication | Missing | |
+| Compound wildcard indexes | Partial | Reachable via `extraOptions` and a `"$**"` field. |
+| `$median`, `$percentile`, `$bitAnd` / `$bitOr` / `$bitXor` / `$bitNot` | Partial | Hand-rolled aggregation pipeline. |
+| `$changeStreamSplitLargeEvent` | Missing | No change-stream helper. |
+| `analyzeShardKey`, `configureQueryAnalyzer` | Partial | Raw admin command. |
+| Time-series delete relaxations | Supported | Transparent on the wire. |
+
+### D. MongoDB 8.0
+
+| Feature | Status | Notes |
+|---|---|---|
+| Cross-collection `bulkWrite` | Missing | Per-collection batched writes already work via `OpMsgMessage`. |
+| Queryable Encryption range queries | Missing | Depends on QE. |
+| `moveCollection`, `unshardCollection`, config-shard transitions | Partial | Raw admin command. |
+| `setQuerySettings`, `removeQuerySettings` | Partial | Raw admin command. |
+| `$convert` to BinData, `$toUUID`, `$toBinData` | Partial | Hand-rolled aggregation pipeline; UUID binary subtype already supported. |
+| Majority write concern oplog optimization | Supported | Server-side only. |
+
+### E. BSON type coverage
+
+| Type | TypeId | Status |
+|---|---|---|
+| Double | 0x01 | Supported |
+| String | 0x02 | Supported |
+| Document | 0x03 | Supported |
+| Array | 0x04 | Supported |
+| Binary (incl. UUID subtype 0x04) | 0x05 | Supported |
+| ObjectId | 0x07 | Supported |
+| Boolean | 0x08 | Supported |
+| UTC DateTime | 0x09 | Supported |
+| Null | 0x0A | Supported |
+| Regex | 0x0B | Supported |
+| JavaScript | 0x0D | Supported |
+| Int32 | 0x10 | Supported |
+| Timestamp | 0x11 | Supported |
+| Int64 | 0x12 | Supported |
+| **Decimal128** | 0x13 | Added 1.15.x |
+| **MinKey** | 0xFF | Added 1.15.x |
+| **MaxKey** | 0x7F | Added 1.15.x |
+| Code-with-scope | 0x0F | Missing |
+| DBPointer (deprecated) | 0x0C | Missing |
+| Symbol (deprecated) | 0x0E | Missing |
+
+### F. Features obsolete in recent MongoDB
+
+These work against current servers but the listed replacement is preferred.
+Nothing has been removed.
+
+| Surface | Status | Replacement |
+|---|---|---|
+| `OpMsgMessage::CMD_MAP_REDUCE` | `POCO_DEPRECATED` (server deprecated in 5.0) | Aggregation pipeline with `$accumulator`, `$function`, `$out`, `$merge`. |
+| `OpMsgMessage::CMD_COUNT` | Outside Stable API v1; `Database::count()` no longer issues it directly | Aggregation `$count` (used internally by `Database::count()`). |
+| `Database::INDEX_BACKGROUND` | `POCO_DEPRECATED` (server no-op since 4.2) | Drop the flag; index builds are online by default. |
+| `Database::INDEX_SPARSE` | Superseded by `partialFilterExpression` since 3.2 | Pass `partialFilterExpression` in `createIndex(extraOptions)`. |
+| `Database::createIndex(..., int version)` | Explicit `v=1` is incompatible with several modern index types | Leave at 0; server picks v=2 (default since 3.4). |
+| URI option `ssl=true` | Replaced by `tls=true` (canonical since 4.2) | Either accepted. |
+
+### Top blockers
+
+The largest remaining gaps for users targeting MongoDB 6.0 / 7.0 / 8.0:
+
+  1. `mongodb+srv://` Atlas connection strings.
+  2. Transactions and `ClientSession`.
+  3. Change streams.
+  4. Queryable Encryption.
+  5. MONGODB-OIDC and other modern auth mechanisms.
+  6. Retryable reads / writes.
+  7. Built-in TLS factory.
+  8. Stable API opt-in.
+  9. Cross-collection `bulkWrite` command.
+  10. Aggregation pipeline builder.

--- a/MongoDB/README.md
+++ b/MongoDB/README.md
@@ -22,17 +22,23 @@ change notifications) is documented in [README-ReplicaSet.md](README-ReplicaSet.
 
 using namespace Poco::MongoDB;
 
-Connection connection;
-connection.connect("mongodb://localhost:27017/test");
-
+Connection connection("localhost", 27017);
 Database db("test");
-Poco::SharedPtr<OpMsgMessage> insert = db.createOpMsgMessage("users");
-insert->setCommandName(OpMsgMessage::CMD_INSERT);
-insert->documents().push_back(
-    db.createDocument().add("name", std::string("Alice")).add("age", 30));
+
+auto request = db.createOpMsgMessage("users");
+request->setCommandName(OpMsgMessage::CMD_INSERT);
+
+Document::Ptr user = new Document;
+user->add("name", "Alice").add("age", 30);
+request->documents().push_back(user);
+
 OpMsgMessage response;
-connection.sendRequest(*insert, response);
+connection.sendRequest(*request, response);
 ```
+
+For `mongodb://` URI connections (including authentication), use the
+`Connection::connect(uri, socketFactory)` overload with a user-provided
+`SocketFactory`.
 
 ## Server feature compatibility
 
@@ -45,10 +51,8 @@ status in Poco::MongoDB:
 - **Missing**: no API and no helper; out of reach without library changes.
 - **Added 1.15.x**: introduced by the patch series that ships this document.
 
-`OpMsgMessage` is the universal escape hatch: any command can be issued by
-constructing its body manually, so "Missing" never means "impossible" -- it
-means there is no typed helper and the caller must read the server-side
-command reference.
+Any command can be sent via `OpMsgMessage` with a hand-built body, so
+"Missing" means "no typed helper", not "unreachable".
 
 ### A. Driver baseline (pre-6.0 specs)
 
@@ -56,7 +60,7 @@ Capabilities expected of any modern MongoDB driver.
 
 | Capability | Status | Notes |
 |---|---|---|
-| Stable API (`apiVersion: "1"`, MongoDB 5.0+) | Missing | Set `apiVersion` manually on each command. |
+| Stable API (`apiVersion: "1"`, since 5.0) | Missing | Set `apiVersion` manually on each command. |
 | SCRAM-SHA-256 (server default since 4.0) | Added 1.15.x | New `AUTH_SCRAM_SHA256`; default for `authenticate()`. |
 | SCRAM-SHA-1 | Supported | Pass `AUTH_SCRAM_SHA1` explicitly. |
 | x.509 / PLAIN / GSSAPI / MONGODB-AWS / MONGODB-OIDC | Missing | |
@@ -77,8 +81,8 @@ Capabilities expected of any modern MongoDB driver.
 | Change streams (`$changeStream`) with `fullDocumentBeforeChange` and DDL events | Missing | No `watch()`, no resume tokens. |
 | Clustered collections (`clusteredIndex`) | Partial | Raw `create` command. |
 | Time-series collections; secondary / compound indexes on them | Partial | Raw `create` command; new `createIndex(extraOptions)` covers the index side. |
-| **Partial indexes (`partialFilterExpression`, 3.2+)** | Added 1.15.x | Pass `partialFilterExpression` in the new `extraOptions` overload. |
-| Hidden indexes (4.4+) | Added 1.15.x | New `INDEX_HIDDEN` flag. |
+| **Partial indexes (`partialFilterExpression`, since 3.2)** | Added 1.15.x | Pass `partialFilterExpression` in the new `extraOptions` overload. |
+| Hidden indexes (since 4.4) | Added 1.15.x | New `INDEX_HIDDEN` flag. |
 | Text / 2dsphere / hashed / wildcard indexes | Partial | Reachable via `extraOptions`; wildcard via `"$**"` field name. |
 | Collation on indexes | Added 1.15.x | Pass `collation` in `extraOptions`. |
 | Queryable Encryption (preview) | Missing | No `ClientEncryption` class. |
@@ -138,12 +142,12 @@ Nothing has been removed.
 
 | Surface | Status | Replacement |
 |---|---|---|
-| `OpMsgMessage::CMD_MAP_REDUCE` | `POCO_DEPRECATED` (server deprecated in 5.0) | Aggregation pipeline with `$accumulator`, `$function`, `$out`, `$merge`. |
-| `OpMsgMessage::CMD_COUNT` | Outside Stable API v1; `Database::count()` no longer issues it directly | Aggregation `$count` (used internally by `Database::count()`). |
-| `Database::INDEX_BACKGROUND` | `POCO_DEPRECATED` (server no-op since 4.2) | Drop the flag; index builds are online by default. |
-| `Database::INDEX_SPARSE` | Superseded by `partialFilterExpression` since 3.2 | Pass `partialFilterExpression` in `createIndex(extraOptions)`. |
-| `Database::createIndex(..., int version)` | Explicit `v=1` is incompatible with several modern index types | Leave at 0; server picks v=2 (default since 3.4). |
-| URI option `ssl=true` | Replaced by `tls=true` (canonical since 4.2) | Either accepted. |
+| `OpMsgMessage::CMD_MAP_REDUCE` | `POCO_DEPRECATED` (server-deprecated since 5.0). | Aggregation pipeline with `$accumulator`, `$function`, `$out`, `$merge`. |
+| `OpMsgMessage::CMD_COUNT` | Outside Stable API v1; `Database::count()` no longer issues it directly. | Aggregation `$count` (used internally by `Database::count()`). |
+| `Database::INDEX_BACKGROUND` | `POCO_DEPRECATED` (server no-op since 4.2). | Drop the flag; index builds are online by default. |
+| `Database::INDEX_SPARSE` | Superseded by `partialFilterExpression` since 3.2. | Pass `partialFilterExpression` in `createIndex(extraOptions)`. |
+| `Database::createIndex(..., int version)` | Explicit `v=1` is incompatible with several modern index types. | Leave at 0; server picks v=2 (default since 3.4). |
+| Connection URI option `ssl=true` | Replaced by `tls=true` (canonical since 4.2). | Either accepted. |
 
 ### Top blockers
 

--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -122,9 +122,7 @@ public:
 		///     accepted as a synonym.
 		///   - connectTimeoutMS: Socket connection timeout in milliseconds.
 		///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
-		///   - authMechanism: Authentication mechanism. Accepts "SCRAM-SHA-256"
-		///     (default since 4.0) and "SCRAM-SHA-1". Other mechanisms are
-		///     not yet implemented.
+		///   - authMechanism: "SCRAM-SHA-256" (default) or "SCRAM-SHA-1".
 		///
 		/// Unknown options are silently ignored.
 		///

--- a/MongoDB/include/Poco/MongoDB/Connection.h
+++ b/MongoDB/include/Poco/MongoDB/Connection.h
@@ -116,11 +116,15 @@ public:
 		///
 		/// The following options are supported:
 		///
-		///   - ssl: If ssl=true is specified, a custom SocketFactory subclass creating
-		///     a SecureStreamSocket must be supplied.
+		///   - tls (or ssl, historical alias): If true, a custom SocketFactory
+		///     subclass creating a SecureStreamSocket must be supplied. "tls"
+		///     is the canonical option name since MongoDB 4.2; "ssl" remains
+		///     accepted as a synonym.
 		///   - connectTimeoutMS: Socket connection timeout in milliseconds.
 		///   - socketTimeoutMS: Socket send/receive timeout in milliseconds.
-		///   - authMechanism: Authentication mechanism. Only "SCRAM-SHA-1" is supported.
+		///   - authMechanism: Authentication mechanism. Accepts "SCRAM-SHA-256"
+		///     (default since 4.0) and "SCRAM-SHA-1". Other mechanisms are
+		///     not yet implemented.
 		///
 		/// Unknown options are silently ignored.
 		///

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -37,19 +37,14 @@ public:
 
 	enum IndexOptions {
 		INDEX_UNIQUE        = 1 << 0,
+			///< For new indexes with conditional-inclusion semantics, prefer
+			///< partialFilterExpression (see createIndex with extraOptions)
+			///< over INDEX_SPARSE.
 		INDEX_SPARSE        = 1 << 1,
-			/// Not deprecated, but for new code partialFilterExpression
-			/// (see the createIndex() overload taking extraOptions) is preferred
-			/// over INDEX_SPARSE for indexes with conditional inclusion semantics.
-			/// Partial indexes are available since MongoDB 3.2.
 		INDEX_BACKGROUND POCO_DEPRECATED("Deprecated since MongoDB 4.2; index builds are online by default") = 1 << 2,
-			/// Background index builds were deprecated in MongoDB 4.2. The option
-			/// is a server-side no-op on 4.2+ deployments since all index builds
-			/// became hybrid (online) by default.
+			///< Hybrid online index builds since 4.2; no longer forwarded to the server.
 		INDEX_HIDDEN        = 1 << 3
-			/// Marks the index hidden from the query planner. Available since
-			/// MongoDB 4.4. The index is still maintained on writes and can be
-			/// unhidden without rebuilding.
+			///< Hide the index from the query planner (since MongoDB 4.4).
 	};
 
 	using FieldIndex = std::tuple<std::string, bool>;
@@ -69,25 +64,18 @@ public:
 
 	bool authenticate(Connection& connection, const std::string& username, const std::string& password, const std::string& method = AUTH_SCRAM_SHA256);
 		/// Authenticates against the database using the given connection,
-		/// username and password, as well as authentication method.
+		/// username and password, and authentication method:
 		///
-		/// Supported methods:
-		///   - "SCRAM-SHA-256" (default, MongoDB 4.0+ default for new users)
-		///   - "SCRAM-SHA-1"   (MongoDB 3.0+; pass AUTH_SCRAM_SHA1 explicitly)
+		///   - "SCRAM-SHA-256" (MongoDB 4.0+)
+		///   - "SCRAM-SHA-1"   (MongoDB 3.0+)
 		///
-		/// "MONGODB-CR" is no longer supported as it requires the legacy wire
-		/// protocol.
+		/// MONGODB-CR is not supported (requires the legacy wire protocol).
 		///
-		/// For SCRAM-SHA-256 the password is used directly after SASLprep
-		/// (RFC 4013). Currently only ASCII passwords are accepted on the
-		/// SCRAM-SHA-256 path; passing a password containing non-ASCII bytes
-		/// throws Poco::NotImplementedException. Use SCRAM-SHA-1 for non-ASCII
-		/// passwords until full SASLprep support is implemented.
+		/// SCRAM-SHA-256 accepts ASCII passwords only; SASLprep (RFC 4013)
+		/// is not implemented. Non-ASCII throws Poco::NotImplementedException.
 		///
-		/// Returns true if authentication was successful, otherwise false.
-		///
-		/// May throw a Poco::ProtocolException if authentication fails for a
-		/// reason other than invalid credentials.
+		/// Returns true on success, false on invalid credentials. Throws
+		/// Poco::ProtocolException on other failures.
 
 	[[nodiscard]] Document::Ptr queryBuildInfo(Connection& connection) const;
 		/// Queries server build info using OP_MSG protocol.
@@ -158,12 +146,10 @@ public:
 		/// The document returned is the createIndexes response body.
 
 	static const std::string AUTH_SCRAM_SHA1;
-		/// SCRAM-SHA-1 authentication mechanism (MongoDB 3.0 and later).
+		/// SCRAM-SHA-1 authentication mechanism (MongoDB 3.0+).
 
 	static const std::string AUTH_SCRAM_SHA256;
-		/// SCRAM-SHA-256 authentication mechanism. MongoDB 4.0 and later;
-		/// also the default mechanism for users created in 4.0+ without an
-		/// explicit mechanism specification. Default for Database::authenticate.
+		/// SCRAM-SHA-256 authentication mechanism (MongoDB 4.0+).
 
 	enum WireVersion
 		/// Wire version as reported by the command hello.
@@ -198,7 +184,7 @@ protected:
 		/// Performs SCRAM-SHA-1 authentication.
 
 	bool authSCRAM256(Connection& connection, const std::string& username, const std::string& password);
-		/// Performs SCRAM-SHA-256 authentication. ASCII-only password fast path.
+		/// Performs SCRAM-SHA-256 authentication. ASCII passwords only.
 
 private:
 	std::string _dbname;

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -96,7 +96,12 @@ public:
 		/// Queries hello response from server using OP_MSG protocol.
 
 	[[nodiscard]] Int64 count(Connection& connection, const std::string& collectionName) const;
-		/// Sends a count request for the given collection to MongoDB using OP_MSG protocol.
+		/// Counts documents in the given collection using the aggregation
+		/// framework ([{$count: "n"}]) over OP_MSG. Aggregation-based counting
+		/// is preferred over the legacy "count" command because it is part of
+		/// the Stable API v1 (since MongoDB 5.0), is accurate on sharded
+		/// clusters (the legacy command can over-report due to orphaned
+		/// documents), and is permitted in multi-document transactions.
 		///
 		/// If the command fails, -1 is returned.
 

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -67,18 +67,27 @@ public:
 	[[nodiscard]] const std::string& name() const;
 		/// Database name
 
-	bool authenticate(Connection& connection, const std::string& username, const std::string& password, const std::string& method = AUTH_SCRAM_SHA1);
+	bool authenticate(Connection& connection, const std::string& username, const std::string& password, const std::string& method = AUTH_SCRAM_SHA256);
 		/// Authenticates against the database using the given connection,
 		/// username and password, as well as authentication method.
 		///
-		/// "SCRAM-SHA-1" (default starting in MongoDB 3.0) is the only supported
-		/// authentication method. "MONGODB-CR" is no longer supported as it
-		/// requires the legacy wire protocol.
+		/// Supported methods:
+		///   - "SCRAM-SHA-256" (default, MongoDB 4.0+ default for new users)
+		///   - "SCRAM-SHA-1"   (MongoDB 3.0+; pass AUTH_SCRAM_SHA1 explicitly)
+		///
+		/// "MONGODB-CR" is no longer supported as it requires the legacy wire
+		/// protocol.
+		///
+		/// For SCRAM-SHA-256 the password is used directly after SASLprep
+		/// (RFC 4013). Currently only ASCII passwords are accepted on the
+		/// SCRAM-SHA-256 path; passing a password containing non-ASCII bytes
+		/// throws Poco::NotImplementedException. Use SCRAM-SHA-1 for non-ASCII
+		/// passwords until full SASLprep support is implemented.
 		///
 		/// Returns true if authentication was successful, otherwise false.
 		///
-		/// May throw a Poco::ProtocolException if authentication fails for a reason other than
-		/// invalid credentials.
+		/// May throw a Poco::ProtocolException if authentication fails for a
+		/// reason other than invalid credentials.
 
 	[[nodiscard]] Document::Ptr queryBuildInfo(Connection& connection) const;
 		/// Queries server build info using OP_MSG protocol.
@@ -144,7 +153,12 @@ public:
 		/// The document returned is the createIndexes response body.
 
 	static const std::string AUTH_SCRAM_SHA1;
-		/// Default authentication mechanism for MongoDB 3.0 and later.
+		/// SCRAM-SHA-1 authentication mechanism (MongoDB 3.0 and later).
+
+	static const std::string AUTH_SCRAM_SHA256;
+		/// SCRAM-SHA-256 authentication mechanism. MongoDB 4.0 and later;
+		/// also the default mechanism for users created in 4.0+ without an
+		/// explicit mechanism specification. Default for Database::authenticate.
 
 	enum WireVersion
 		/// Wire version as reported by the command hello.
@@ -176,6 +190,10 @@ public:
 
 protected:
 	bool authSCRAM(Connection& connection, const std::string& username, const std::string& password);
+		/// Performs SCRAM-SHA-1 authentication.
+
+	bool authSCRAM256(Connection& connection, const std::string& username, const std::string& password);
+		/// Performs SCRAM-SHA-256 authentication. ASCII-only password fast path.
 
 private:
 	std::string _dbname;

--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -38,7 +38,18 @@ public:
 	enum IndexOptions {
 		INDEX_UNIQUE        = 1 << 0,
 		INDEX_SPARSE        = 1 << 1,
-		INDEX_BACKGROUND    = 1 << 2
+			/// Not deprecated, but for new code partialFilterExpression
+			/// (see the createIndex() overload taking extraOptions) is preferred
+			/// over INDEX_SPARSE for indexes with conditional inclusion semantics.
+			/// Partial indexes are available since MongoDB 3.2.
+		INDEX_BACKGROUND POCO_DEPRECATED("Deprecated since MongoDB 4.2; index builds are online by default") = 1 << 2,
+			/// Background index builds were deprecated in MongoDB 4.2. The option
+			/// is a server-side no-op on 4.2+ deployments since all index builds
+			/// became hybrid (online) by default.
+		INDEX_HIDDEN        = 1 << 3
+			/// Marks the index hidden from the query planner. Available since
+			/// MongoDB 4.4. The index is still maintained on writes and can be
+			/// unhidden without rebuilding.
 	};
 
 	using FieldIndex = std::tuple<std::string, bool>;
@@ -97,8 +108,40 @@ public:
 		unsigned long options = 0,
 		int expirationSeconds = 0,
 		int version = 0);
-		/// Creates an index. The document returned is the response body..
-		/// For more info look at the createIndex information on the MongoDB website. (new wire protocol)
+		/// Creates an index. The document returned is the response body.
+		/// For more info look at the createIndex information on the MongoDB
+		/// website. (new wire protocol)
+		///
+		/// Leave version at 0 to use the server default (v=2 since MongoDB 3.4).
+		/// Setting v=1 is only for compatibility with pre-3.4 servers and is
+		/// incompatible with text, wildcard, and several other modern index
+		/// types.
+
+	Document::Ptr createIndex(
+		Connection& connection,
+		const std::string& collection,
+		const IndexedFields& indexedFields,
+		const std::string& indexName,
+		Document::Ptr extraOptions,
+		unsigned long options = 0,
+		int expirationSeconds = 0,
+		int version = 0);
+		/// Creates an index, allowing arbitrary additional fields in the
+		/// per-index spec via extraOptions. Every element of extraOptions
+		/// is added to the index spec document on top of the fields derived
+		/// from indexedFields, indexName, options, expirationSeconds and
+		/// version. Typical keys to pass in extraOptions include:
+		///
+		///   - "partialFilterExpression" (Document): partial indexes,
+		///     MongoDB 3.2+. Preferred over INDEX_SPARSE for new code.
+		///   - "collation" (Document): per-index collation, MongoDB 3.4+.
+		///   - "wildcardProjection" (Document): wildcard / compound-wildcard
+		///     indexes (the wildcard field itself is specified as "$**" or
+		///     "path.$**" in indexedFields).
+		///   - "weights", "default_language", "language_override" (text indexes).
+		///   - "2dsphereIndexVersion", "bits", "min", "max" (geo indexes).
+		///
+		/// The document returned is the createIndexes response body.
 
 	static const std::string AUTH_SCRAM_SHA1;
 		/// Default authentication mechanism for MongoDB 3.0 and later.

--- a/MongoDB/include/Poco/MongoDB/Decimal128.h
+++ b/MongoDB/include/Poco/MongoDB/Decimal128.h
@@ -75,19 +75,12 @@ public:
 	~Decimal128() = default;
 
 	[[nodiscard]] Poco::UInt64 low() const noexcept;
-		/// Returns the low 64 bits.
-
 	[[nodiscard]] Poco::UInt64 high() const noexcept;
-		/// Returns the high 64 bits.
 
 	[[nodiscard]] bool isNaN() const noexcept;
-		/// True if the value is NaN (any payload).
-
 	[[nodiscard]] bool isInfinite() const noexcept;
-		/// True if the value is +Infinity or -Infinity.
-
 	[[nodiscard]] bool isNegative() const noexcept;
-		/// True if the sign bit is set, including -0, -Inf and -NaN.
+		/// Includes -0, -Inf and -NaN.
 
 	[[nodiscard]] std::string toString() const;
 		/// Returns the canonical decimal string per IEEE 754-2008 Section
@@ -112,7 +105,6 @@ public:
 	static Decimal128 positiveInfinity();
 	static Decimal128 negativeInfinity();
 	static Decimal128 nan();
-		/// Convenience constructors for the standard special values.
 
 private:
 	Poco::UInt64 _low;

--- a/MongoDB/include/Poco/MongoDB/Decimal128.h
+++ b/MongoDB/include/Poco/MongoDB/Decimal128.h
@@ -1,0 +1,188 @@
+//
+// Decimal128.h
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  Decimal128
+//
+// Definition of the Decimal128 BSON value type.
+//
+// Copyright (c) 2025, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_Decimal128_INCLUDED
+#define MongoDB_Decimal128_INCLUDED
+
+
+#include "Poco/BinaryReader.h"
+#include "Poco/BinaryWriter.h"
+#include "Poco/MongoDB/Element.h"
+#include "Poco/MongoDB/MongoDB.h"
+#include "Poco/SharedPtr.h"
+#include <string>
+
+
+namespace Poco::MongoDB {
+
+
+// BSON Decimal128 specification:
+//   https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.md
+//
+// Encoding (IEEE 754-2008 BID format):
+//   bit 127        : sign
+//   bits 126..0    : combination field + biased exponent + coefficient
+//
+//   If bits 126..125 are not both 1:
+//     biased exponent = bits 126..113 (14 bits)
+//     coefficient     = bits 112..0   (113-bit unsigned integer)
+//   If bits 126..125 are both 1 and bits 124..123 are not both 1:
+//     biased exponent = bits 124..111 (14 bits)
+//     coefficient     = 0b100 || bits 110..0 (114 bits, but limited to <= 10^34 - 1)
+//   If bits 126..123 are all 1:
+//     bit 122 = 1 -> NaN; bit 122 = 0 -> Infinity
+//
+// Exponent bias = 6176. Maximum 34 significant decimal digits.
+
+
+class MongoDB_API Decimal128
+	/// Represents an IEEE 754-2008 decimal128 floating-point value (BSON
+	/// TypeId 0x13, available since MongoDB 3.4). Used wherever exact decimal
+	/// representation matters -- currency, ledger entries, scientific data --
+	/// since binary double cannot represent 0.1 exactly.
+	///
+	/// Storage is two Poco::UInt64 halves matching the BSON wire format
+	/// (16 bytes, little-endian, low half first then high half). The class
+	/// supports BSON serialization, canonical string conversion per
+	/// IEEE 754-2008 Section 5.12.4, parsing simple decimal literals, and
+	/// equality comparison. It does not implement decimal arithmetic; users
+	/// who need to operate on values are expected to round-trip through
+	/// std::string or use an external decimal-arithmetic library.
+{
+public:
+	using Ptr = Poco::SharedPtr<Decimal128>;
+
+	Decimal128();
+		/// Creates a Decimal128 representing positive zero (0E0).
+
+	Decimal128(Poco::UInt64 low, Poco::UInt64 high);
+		/// Creates a Decimal128 from the raw 128 bits, expressed as low and
+		/// high 64-bit halves matching the on-wire layout.
+
+	~Decimal128() = default;
+
+	[[nodiscard]] Poco::UInt64 low() const noexcept;
+		/// Returns the low 64 bits.
+
+	[[nodiscard]] Poco::UInt64 high() const noexcept;
+		/// Returns the high 64 bits.
+
+	[[nodiscard]] bool isNaN() const noexcept;
+		/// True if the value is NaN (any payload).
+
+	[[nodiscard]] bool isInfinite() const noexcept;
+		/// True if the value is +Infinity or -Infinity.
+
+	[[nodiscard]] bool isNegative() const noexcept;
+		/// True if the sign bit is set, including -0, -Inf and -NaN.
+
+	[[nodiscard]] std::string toString() const;
+		/// Returns the canonical decimal string per IEEE 754-2008 Section
+		/// 5.12.4: special values render as "NaN", "Infinity", "-Infinity";
+		/// finite values render in scientific or non-scientific notation
+		/// depending on the adjusted exponent.
+
+	bool operator == (const Decimal128& other) const noexcept;
+	bool operator != (const Decimal128& other) const noexcept;
+
+	static Decimal128 fromString(const std::string& s);
+		/// Parses a decimal string into a Decimal128. Accepts the canonical
+		/// forms produced by toString(): "NaN" (case insensitive), "Infinity"
+		/// / "-Infinity" / "Inf" / "-Inf", and finite decimal literals with
+		/// optional sign, optional fractional part, and optional exponent
+		/// ("E"/"e" prefix). Throws Poco::SyntaxException on malformed input
+		/// or Poco::RangeException when the coefficient exceeds 34 decimal
+		/// digits or the exponent is out of the decimal128 range.
+
+	static Decimal128 positiveZero();
+	static Decimal128 negativeZero();
+	static Decimal128 positiveInfinity();
+	static Decimal128 negativeInfinity();
+	static Decimal128 nan();
+		/// Convenience constructors for the standard special values.
+
+private:
+	Poco::UInt64 _low;
+	Poco::UInt64 _high;
+};
+
+
+//
+// inlines
+//
+inline Poco::UInt64 Decimal128::low() const noexcept
+{
+	return _low;
+}
+
+
+inline Poco::UInt64 Decimal128::high() const noexcept
+{
+	return _high;
+}
+
+
+inline bool Decimal128::operator == (const Decimal128& other) const noexcept
+{
+	return _low == other._low && _high == other._high;
+}
+
+
+inline bool Decimal128::operator != (const Decimal128& other) const noexcept
+{
+	return !(*this == other);
+}
+
+
+template<>
+struct ElementTraits<Decimal128::Ptr>
+{
+	enum { TypeId = 0x13 };
+
+	static std::string toString(const Decimal128::Ptr& value, int /*indent*/ = 0)
+	{
+		if (!value) return "null";
+		std::string result;
+		result.reserve(48);
+		result += "{\"$numberDecimal\": \"";
+		result += value->toString();
+		result += "\"}";
+		return result;
+	}
+};
+
+
+template<>
+inline void BSONReader::read<Decimal128::Ptr>(Decimal128::Ptr& to)
+{
+	Poco::UInt64 low;
+	Poco::UInt64 high;
+	_reader >> low >> high;
+	to = new Decimal128(low, high);
+}
+
+
+template<>
+inline void BSONWriter::write<Decimal128::Ptr>(const Decimal128::Ptr& from)
+{
+	_writer << from->low() << from->high();
+}
+
+
+} // namespace Poco::MongoDB
+
+
+#endif // MongoDB_Decimal128_INCLUDED

--- a/MongoDB/include/Poco/MongoDB/MaxKey.h
+++ b/MongoDB/include/Poco/MongoDB/MaxKey.h
@@ -1,0 +1,64 @@
+//
+// MaxKey.h
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  MaxKey
+//
+// Definition of the MaxKey sentinel type.
+//
+// Copyright (c) 2025, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_MaxKey_INCLUDED
+#define MongoDB_MaxKey_INCLUDED
+
+
+#include "Poco/MongoDB/Element.h"
+#include "Poco/MongoDB/MongoDB.h"
+
+
+namespace Poco::MongoDB {
+
+
+struct MaxKey
+	/// Sentinel BSON value (TypeId 0x7F) that compares higher than any other
+	/// BSON value. Used by the server for shard-key chunk upper bounds, for
+	/// open-ended index range queries, and in the output of administrative
+	/// commands such as $indexStats. Has no payload.
+{
+};
+
+
+template<>
+struct ElementTraits<MaxKey>
+{
+	enum { TypeId = 0x7F };
+
+	static std::string toString(const MaxKey& /*value*/, int /*indent*/ = 0)
+	{
+		return "{\"$maxKey\": 1}";
+	}
+};
+
+
+template<>
+inline void BSONReader::read<MaxKey>(MaxKey& /*to*/)
+{
+}
+
+
+template<>
+inline void BSONWriter::write<MaxKey>(const MaxKey& /*from*/)
+{
+}
+
+
+} // namespace Poco::MongoDB
+
+
+#endif // MongoDB_MaxKey_INCLUDED

--- a/MongoDB/include/Poco/MongoDB/MinKey.h
+++ b/MongoDB/include/Poco/MongoDB/MinKey.h
@@ -1,0 +1,64 @@
+//
+// MinKey.h
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  MinKey
+//
+// Definition of the MinKey sentinel type.
+//
+// Copyright (c) 2025, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MongoDB_MinKey_INCLUDED
+#define MongoDB_MinKey_INCLUDED
+
+
+#include "Poco/MongoDB/Element.h"
+#include "Poco/MongoDB/MongoDB.h"
+
+
+namespace Poco::MongoDB {
+
+
+struct MinKey
+	/// Sentinel BSON value (TypeId 0xFF) that compares lower than any other
+	/// BSON value. Used by the server for shard-key chunk lower bounds, for
+	/// open-ended index range queries, and in the output of administrative
+	/// commands such as $indexStats. Has no payload.
+{
+};
+
+
+template<>
+struct ElementTraits<MinKey>
+{
+	enum { TypeId = 0xFF };
+
+	static std::string toString(const MinKey& /*value*/, int /*indent*/ = 0)
+	{
+		return "{\"$minKey\": 1}";
+	}
+};
+
+
+template<>
+inline void BSONReader::read<MinKey>(MinKey& /*to*/)
+{
+}
+
+
+template<>
+inline void BSONWriter::write<MinKey>(const MinKey& /*from*/)
+{
+}
+
+
+} // namespace Poco::MongoDB
+
+
+#endif // MongoDB_MinKey_INCLUDED

--- a/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
@@ -50,13 +50,8 @@ public:
 	// Aggregation
 	static const std::string CMD_AGGREGATE;
 	static const std::string CMD_COUNT;
-		/// The legacy "count" command is supported by the server but is
-		/// outside the MongoDB Stable API v1 (since MongoDB 5.0), can be
-		/// inaccurate on sharded clusters (orphaned documents inflate the
-		/// count until balancer cleanup), and may not be permitted inside
-		/// multi-document transactions on older server versions. Use the
-		/// aggregation framework ($count stage) for new code; the
-		/// Database::count() helper does this internally.
+		/// Legacy command; outside Stable API v1 since MongoDB 5.0.
+		/// Prefer aggregation $count (see Database::count).
 	static const std::string CMD_DISTINCT;
 	POCO_DEPRECATED("Deprecated since MongoDB 5.0; use the aggregation pipeline with $accumulator / $function / $out / $merge instead.")
 	static const std::string CMD_MAP_REDUCE;

--- a/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
@@ -7,7 +7,7 @@
 //
 // Definition of the OpMsgMessage class.
 //
-// Copyright (c) 2022, Applied Informatics Software Engineering GmbH.
+// Copyright (c) 2022-2025, Applied Informatics Software Engineering GmbH.
 // and Contributors.
 //
 // SPDX-License-Identifier:	BSL-1.0
@@ -50,7 +50,15 @@ public:
 	// Aggregation
 	static const std::string CMD_AGGREGATE;
 	static const std::string CMD_COUNT;
+		/// The legacy "count" command is supported by the server but is
+		/// outside the MongoDB Stable API v1 (since MongoDB 5.0), can be
+		/// inaccurate on sharded clusters (orphaned documents inflate the
+		/// count until balancer cleanup), and may not be permitted inside
+		/// multi-document transactions on older server versions. Use the
+		/// aggregation framework ($count stage) for new code; the
+		/// Database::count() helper does this internally.
 	static const std::string CMD_DISTINCT;
+	POCO_DEPRECATED("Deprecated since MongoDB 5.0; use the aggregation pipeline with $accumulator / $function / $out / $merge instead.")
 	static const std::string CMD_MAP_REDUCE;
 
 	// Replication and administration 

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -170,15 +170,13 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 	bool ssl = false;
 	Poco::Timespan connectTimeout;
 	Poco::Timespan socketTimeout;
-	std::string authMechanism = Database::AUTH_SCRAM_SHA1;
+	std::string authMechanism = Database::AUTH_SCRAM_SHA256;
 
 	Poco::URI::QueryParameters params = theURI.getQueryParameters();
 	for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
 	{
 		if (it->first == "ssl"s || it->first == "tls"s)
 		{
-			// Both "ssl=" (historical) and "tls=" (canonical since MongoDB 4.2)
-			// are accepted; they mean the same thing.
 			ssl = (it->second == "true"s);
 		}
 		else if (it->first == "connectTimeoutMS"s)

--- a/MongoDB/src/Connection.cpp
+++ b/MongoDB/src/Connection.cpp
@@ -175,8 +175,10 @@ void Connection::connect(const std::string& uri, SocketFactory& socketFactory)
 	Poco::URI::QueryParameters params = theURI.getQueryParameters();
 	for (Poco::URI::QueryParameters::const_iterator it = params.begin(); it != params.end(); ++it)
 	{
-		if (it->first == "ssl"s)
+		if (it->first == "ssl"s || it->first == "tls"s)
 		{
+			// Both "ssl=" (historical) and "tls=" (canonical since MongoDB 4.2)
+			// are accepted; they mean the same thing.
 			ssl = (it->second == "true"s);
 		}
 		else if (it->first == "connectTimeoutMS"s)

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -329,6 +329,21 @@ Poco::MongoDB::Document::Ptr Database::createIndex(
 	int expirationSeconds,
 	int version)
 {
+	return createIndex(connection, collection, indexedFields, indexName,
+		Document::Ptr(), options, expirationSeconds, version);
+}
+
+
+Poco::MongoDB::Document::Ptr Database::createIndex(
+	Connection& connection,
+	const std::string& collection,
+	const IndexedFields& indexedFields,
+	const std::string& indexName,
+	Document::Ptr extraOptions,
+	unsigned long options,
+	int expirationSeconds,
+	int version)
+{
 // https://www.mongodb.com/docs/manual/reference/command/createIndexes/
 
 	MongoDB::Document::Ptr keys = new MongoDB::Document();
@@ -348,17 +363,31 @@ Poco::MongoDB::Document::Ptr Database::createIndex(
 	if (options & INDEX_UNIQUE) {
 		index->add("unique"s, true);
 	}
-	if (options & INDEX_BACKGROUND) {
-		index->add("background"s, true);
-	}
 	if (options & INDEX_SPARSE) {
 		index->add("sparse"s, true);
 	}
+	if (options & INDEX_HIDDEN) {
+		index->add("hidden"s, true);
+	}
+	// INDEX_BACKGROUND is deprecated (MongoDB 4.2 made all index builds online);
+	// the option is left in the enum for source compatibility but is not
+	// forwarded to the server.
 	if (expirationSeconds > 0) {
 		index->add("expireAfterSeconds"s, static_cast<Poco::Int32>(expirationSeconds));
 	}
 	if (version > 0) {
 		index->add("version"s, static_cast<Poco::Int32>(version));
+	}
+
+	if (extraOptions)
+	{
+		std::vector<std::string> names;
+		extraOptions->elementNames(names);
+		for (const auto& name: names)
+		{
+			Element::Ptr element = extraOptions->get(name);
+			if (element) index->addElement(element);
+		}
 	}
 
 	MongoDB::Array::Ptr indexes = new MongoDB::Array();

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -30,6 +30,7 @@
 #include "Poco/SHA1Engine.h"
 #include "Poco/SHA2Engine.h"
 #include "Poco/StreamCopier.h"
+#include <algorithm>
 #include <map>
 #include <sstream>
 #include <utility>
@@ -131,11 +132,8 @@ namespace
 
 	bool isAsciiOnly(const std::string& s) noexcept
 	{
-		for (char c: s)
-		{
-			if (static_cast<unsigned char>(c) > 0x7F) return false;
-		}
-		return true;
+		return std::all_of(s.begin(), s.end(),
+			[](char c) { return static_cast<unsigned char>(c) <= 0x7F; });
 	}
 
 	template <class HashEngine>
@@ -287,10 +285,11 @@ bool Database::authenticate(Connection& connection, const std::string& username,
 
 bool Database::authSCRAM(Connection& connection, const std::string& username, const std::string& password)
 {
+	constexpr bool kLegacyMongoCrPasswordHash = true;
+	constexpr Poco::UInt32 kSHA1DigestLen = 20;
 	return runScramAuth<Poco::SHA1Engine>(
 		*this, connection, username, password, AUTH_SCRAM_SHA1,
-		true,  // legacy MongoDB-CR style MD5 password preprocessing
-		20);
+		kLegacyMongoCrPasswordHash, kSHA1DigestLen);
 }
 
 
@@ -301,10 +300,11 @@ bool Database::authSCRAM256(Connection& connection, const std::string& username,
 			"SCRAM-SHA-256 with non-ASCII passwords requires SASLprep (RFC 4013), "
 			"which is not yet implemented. Use SCRAM-SHA-1 or an ASCII password.");
 
+	constexpr bool kLegacyMongoCrPasswordHash = false;
+	constexpr Poco::UInt32 kSHA256DigestLen = 32;
 	return runScramAuth<Poco::SHA2Engine256>(
 		*this, connection, username, password, AUTH_SCRAM_SHA256,
-		false, // SCRAM-SHA-256 uses the password directly (after SASLprep, no-op for ASCII)
-		32);
+		kLegacyMongoCrPasswordHash, kSHA256DigestLen);
 }
 
 
@@ -352,11 +352,6 @@ Document::Ptr Database::queryServerHello(Connection& connection) const
 
 Int64 Database::count(Connection& connection, const std::string& collectionName) const
 {
-	// Use aggregation [{$count: "n"}] rather than the legacy "count" command.
-	// Aggregation $count is in the MongoDB Stable API v1, is accurate on
-	// sharded clusters (the legacy count over-reports because of orphaned
-	// documents that haven't been cleaned up by the balancer), and is
-	// permitted in multi-document transactions.
 	Poco::SharedPtr<OpMsgMessage> request = createOpMsgMessage(collectionName);
 	request->setCommandName(OpMsgMessage::CMD_AGGREGATE);
 
@@ -372,8 +367,7 @@ Int64 Database::count(Connection& connection, const std::string& collectionName)
 
 	if (!response.responseOk()) return -1;
 
-	// aggregate returns a cursor; the first batch contains the single
-	// result document { n: <Int64> }.
+	// aggregate returns a cursor; the first batch holds { n: <Int64> }.
 	const auto& body = response.body();
 	Document::Ptr cursor = body.get<Document::Ptr>("cursor", Document::Ptr());
 	if (!cursor) return -1;

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -28,6 +28,7 @@
 #include "Poco/Random.h"
 #include "Poco/RandomStream.h"
 #include "Poco/SHA1Engine.h"
+#include "Poco/SHA2Engine.h"
 #include "Poco/StreamCopier.h"
 #include <map>
 #include <sstream>
@@ -40,6 +41,7 @@ namespace Poco::MongoDB {
 
 
 const std::string Database::AUTH_SCRAM_SHA1("SCRAM-SHA-1");
+const std::string Database::AUTH_SCRAM_SHA256("SCRAM-SHA-256");
 
 
 namespace
@@ -126,6 +128,135 @@ namespace
 		}
 		return digestToHexString(md5);
 	}
+
+	bool isAsciiOnly(const std::string& s) noexcept
+	{
+		for (char c: s)
+		{
+			if (static_cast<unsigned char>(c) > 0x7F) return false;
+		}
+		return true;
+	}
+
+	template <class HashEngine>
+	bool runScramAuth(
+		Database& db,
+		Connection& connection,
+		const std::string& username,
+		const std::string& password,
+		const std::string& mechanism,
+		bool legacyMongoCrPasswordHash,
+		Poco::UInt32 dkLen)
+	{
+		std::string clientNonce(createNonce());
+		std::string clientFirstMsg = Poco::format("n=%s,r=%s", username, clientNonce);
+
+		Poco::SharedPtr<OpMsgMessage> pCommand = db.createOpMsgMessage("$cmd");
+		pCommand->setCommandName("saslStart");
+		pCommand->body()
+			.add<std::string>("mechanism", mechanism)
+			.add<Binary::Ptr>("payload", new Binary(Poco::format("n,,%s", clientFirstMsg)))
+			.add<bool>("autoAuthorize", true);
+
+		OpMsgMessage response;
+		connection.sendRequest(*pCommand, response);
+
+		Int32 conversationId = 0;
+		std::string serverFirstMsg;
+
+		if (!response.responseOk())
+		{
+			return false;
+		}
+		{
+			Document::Ptr pDoc = new Document(response.body());
+			Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
+			serverFirstMsg = pPayload->toRawString();
+			conversationId = pDoc->get<Int32>("conversationId");
+		}
+
+		std::map<std::string, std::string> kvm = parseKeyValueList(serverFirstMsg);
+		const std::string serverNonce = kvm["r"];
+		const std::string salt = decodeBase64(kvm["s"]);
+		const unsigned iterations = Poco::NumberParser::parseUnsigned(kvm["i"]);
+
+		// SCRAM-SHA-1 path (MongoDB legacy): hash the credential as MD5 hex
+		//   of "username:mongo:password" before passing to PBKDF2. SCRAM-SHA-256
+		//   uses the password directly (after SASLprep, which is a no-op for
+		//   ASCII input).
+		std::string preprocessedPassword = legacyMongoCrPasswordHash
+			? hashCredentials(username, password)
+			: password;
+
+		Poco::PBKDF2Engine<Poco::HMACEngine<HashEngine>> pbkdf2(salt, iterations, dkLen);
+		pbkdf2.update(preprocessedPassword);
+		std::string saltedPassword = digestToBinaryString(pbkdf2);
+
+		std::string clientFinalNoProof = Poco::format("c=biws,r=%s", serverNonce);
+		std::string authMessage = Poco::format("%s,%s,%s", clientFirstMsg, serverFirstMsg, clientFinalNoProof);
+
+		Poco::HMACEngine<HashEngine> hmacKey(saltedPassword);
+		hmacKey.update(std::string("Client Key"));
+		std::string clientKey = digestToBinaryString(hmacKey);
+
+		HashEngine h;
+		h.update(clientKey);
+		std::string storedKey = digestToBinaryString(h);
+
+		Poco::HMACEngine<HashEngine> hmacSig(storedKey);
+		hmacSig.update(authMessage);
+		std::string clientSignature = digestToBinaryString(hmacSig);
+
+		std::string clientProof(clientKey);
+		for (std::size_t i = 0; i < clientProof.size(); i++)
+		{
+			clientProof[i] ^= clientSignature[i];
+		}
+
+		std::string clientFinal = Poco::format("%s,p=%s", clientFinalNoProof, encodeBase64(clientProof));
+
+		pCommand = db.createOpMsgMessage("$cmd");
+		pCommand->setCommandName("saslContinue");
+		pCommand->body()
+			.add<Poco::Int32>("conversationId", conversationId)
+			.add<Binary::Ptr>("payload", new Binary(clientFinal));
+
+		std::string serverSecondMsg;
+		connection.sendRequest(*pCommand, response);
+
+		if (!response.responseOk())
+		{
+			return false;
+		}
+		{
+			Document::Ptr pDoc = new Document(response.body());
+			Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
+			serverSecondMsg = pPayload->toRawString();
+		}
+
+		Poco::HMACEngine<HashEngine> hmacSKey(saltedPassword);
+		hmacSKey.update(std::string("Server Key"));
+		std::string serverKey = digestToBinaryString(hmacSKey);
+
+		Poco::HMACEngine<HashEngine> hmacSSig(serverKey);
+		hmacSSig.update(authMessage);
+		std::string serverSignature = digestToBase64(hmacSSig);
+
+		kvm = parseKeyValueList(serverSecondMsg);
+		std::string serverSignatureReceived = kvm["v"];
+
+		if (serverSignature != serverSignatureReceived)
+			throw Poco::ProtocolException("server signature verification failed");
+
+		pCommand = db.createOpMsgMessage("$cmd");
+		pCommand->setCommandName("saslContinue");
+		pCommand->body()
+			.add<Poco::Int32>("conversationId", conversationId)
+			.add<Binary::Ptr>("payload", new Binary);
+
+		connection.sendRequest(*pCommand, response);
+		return response.responseOk();
+	}
 } // namespace
 
 
@@ -147,6 +278,8 @@ bool Database::authenticate(Connection& connection, const std::string& username,
 
 	if (method == AUTH_SCRAM_SHA1)
 		return authSCRAM(connection, username, password);
+	else if (method == AUTH_SCRAM_SHA256)
+		return authSCRAM256(connection, username, password);
 	else
 		throw Poco::InvalidArgumentException("authentication method", method);
 }
@@ -154,109 +287,24 @@ bool Database::authenticate(Connection& connection, const std::string& username,
 
 bool Database::authSCRAM(Connection& connection, const std::string& username, const std::string& password)
 {
-	std::string clientNonce(createNonce());
-	std::string clientFirstMsg = Poco::format("n=%s,r=%s", username, clientNonce);
+	return runScramAuth<Poco::SHA1Engine>(
+		*this, connection, username, password, AUTH_SCRAM_SHA1,
+		true,  // legacy MongoDB-CR style MD5 password preprocessing
+		20);
+}
 
-	Poco::SharedPtr<OpMsgMessage> pCommand = createOpMsgMessage("$cmd");
-	pCommand->setCommandName("saslStart");
-	pCommand->body()
-		.add<std::string>("mechanism", AUTH_SCRAM_SHA1)
-		.add<Binary::Ptr>("payload", new Binary(Poco::format("n,,%s", clientFirstMsg)))
-		.add<bool>("autoAuthorize", true);
 
-	OpMsgMessage response;
-	connection.sendRequest(*pCommand, response);
+bool Database::authSCRAM256(Connection& connection, const std::string& username, const std::string& password)
+{
+	if (!isAsciiOnly(password))
+		throw Poco::NotImplementedException(
+			"SCRAM-SHA-256 with non-ASCII passwords requires SASLprep (RFC 4013), "
+			"which is not yet implemented. Use SCRAM-SHA-1 or an ASCII password.");
 
-	Int32 conversationId = 0;
-	std::string serverFirstMsg;
-
-	if (!response.responseOk())
-	{
-		return false;
-	}
-	{
-		Document::Ptr pDoc = new Document(response.body());
-		Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
-		serverFirstMsg = pPayload->toRawString();
-		conversationId = pDoc->get<Int32>("conversationId");
-	}
-
-	std::map<std::string, std::string> kvm = parseKeyValueList(serverFirstMsg);
-	const std::string serverNonce = kvm["r"];
-	const std::string salt = decodeBase64(kvm["s"]);
-	const unsigned iterations = Poco::NumberParser::parseUnsigned(kvm["i"]);
-	const Poco::UInt32 dkLen = 20;
-
-	std::string hashedPassword = hashCredentials(username, password);
-
-	Poco::PBKDF2Engine<Poco::HMACEngine<Poco::SHA1Engine> > pbkdf2(salt, iterations, dkLen);
-	pbkdf2.update(hashedPassword);
-	std::string saltedPassword = digestToBinaryString(pbkdf2);
-
-	std::string clientFinalNoProof = Poco::format("c=biws,r=%s", serverNonce);
-	std::string authMessage = Poco::format("%s,%s,%s", clientFirstMsg, serverFirstMsg, clientFinalNoProof);
-
-	Poco::HMACEngine<Poco::SHA1Engine> hmacKey(saltedPassword);
-	hmacKey.update(std::string("Client Key"));
-	std::string clientKey = digestToBinaryString(hmacKey);
-
-	Poco::SHA1Engine sha1;
-	sha1.update(clientKey);
-	std::string storedKey = digestToBinaryString(sha1);
-
-	Poco::HMACEngine<Poco::SHA1Engine> hmacSig(storedKey);
-	hmacSig.update(authMessage);
-	std::string clientSignature = digestToBinaryString(hmacSig);
-
-	std::string clientProof(clientKey);
-	for (std::size_t i = 0; i < clientProof.size(); i++)
-	{
-		clientProof[i] ^= clientSignature[i];
-	}
-
-	std::string clientFinal = Poco::format("%s,p=%s", clientFinalNoProof, encodeBase64(clientProof));
-
-	pCommand = createOpMsgMessage("$cmd");
-	pCommand->setCommandName("saslContinue");
-	pCommand->body()
-		.add<Poco::Int32>("conversationId", conversationId)
-		.add<Binary::Ptr>("payload", new Binary(clientFinal));
-
-	std::string serverSecondMsg;
-	connection.sendRequest(*pCommand, response);
-
-	if (!response.responseOk())
-	{
-		return false;
-	}
-	{
-		Document::Ptr pDoc = new Document(response.body());
-		Binary::Ptr pPayload = pDoc->get<Binary::Ptr>("payload");
-		serverSecondMsg = pPayload->toRawString();
-	}
-
-	Poco::HMACEngine<Poco::SHA1Engine> hmacSKey(saltedPassword);
-	hmacSKey.update(std::string("Server Key"));
-	std::string serverKey = digestToBinaryString(hmacSKey);
-
-	Poco::HMACEngine<Poco::SHA1Engine> hmacSSig(serverKey);
-	hmacSSig.update(authMessage);
-	std::string serverSignature = digestToBase64(hmacSSig);
-
-	kvm = parseKeyValueList(serverSecondMsg);
-	std::string serverSignatureReceived = kvm["v"];
-
-	if (serverSignature != serverSignatureReceived)
-		throw Poco::ProtocolException("server signature verification failed");
-
-	pCommand = createOpMsgMessage("$cmd");
-	pCommand->setCommandName("saslContinue");
-	pCommand->body()
-		.add<Poco::Int32>("conversationId", conversationId)
-		.add<Binary::Ptr>("payload", new Binary);
-
-	connection.sendRequest(*pCommand, response);
-	return response.responseOk();
+	return runScramAuth<Poco::SHA2Engine256>(
+		*this, connection, username, password, AUTH_SCRAM_SHA256,
+		false, // SCRAM-SHA-256 uses the password directly (after SASLprep, no-op for ASCII)
+		32);
 }
 
 

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -352,19 +352,38 @@ Document::Ptr Database::queryServerHello(Connection& connection) const
 
 Int64 Database::count(Connection& connection, const std::string& collectionName) const
 {
-	Poco::SharedPtr<Poco::MongoDB::OpMsgMessage> request = createOpMsgMessage(collectionName);
-	request->setCommandName(OpMsgMessage::CMD_COUNT);
+	// Use aggregation [{$count: "n"}] rather than the legacy "count" command.
+	// Aggregation $count is in the MongoDB Stable API v1, is accurate on
+	// sharded clusters (the legacy count over-reports because of orphaned
+	// documents that haven't been cleaned up by the balancer), and is
+	// permitted in multi-document transactions.
+	Poco::SharedPtr<OpMsgMessage> request = createOpMsgMessage(collectionName);
+	request->setCommandName(OpMsgMessage::CMD_AGGREGATE);
 
-	Poco::MongoDB::OpMsgMessage response;
+	Array::Ptr pipeline = new Array();
+	Document::Ptr countStage = new Document();
+	countStage->add("$count"s, "n"s);
+	pipeline->add(countStage);
+	request->body().add("pipeline"s, pipeline);
+	request->body().addNewDocument("cursor"s);
+
+	OpMsgMessage response;
 	connection.sendRequest(*request, response);
 
-	if (response.responseOk())
-	{
-		const auto& body = response.body();
-		return body.getInteger("n");
-	}
+	if (!response.responseOk()) return -1;
 
-	return -1;
+	// aggregate returns a cursor; the first batch contains the single
+	// result document { n: <Int64> }.
+	const auto& body = response.body();
+	Document::Ptr cursor = body.get<Document::Ptr>("cursor", Document::Ptr());
+	if (!cursor) return -1;
+
+	Array::Ptr firstBatch = cursor->get<Array::Ptr>("firstBatch", Array::Ptr());
+	if (!firstBatch || firstBatch->size() == 0) return 0;
+
+	Document::Ptr first = firstBatch->get<Document::Ptr>(0, Document::Ptr());
+	if (!first || !first->exists("n")) return 0;
+	return first->getInteger("n");
 }
 
 

--- a/MongoDB/src/Decimal128.cpp
+++ b/MongoDB/src/Decimal128.cpp
@@ -1,0 +1,444 @@
+//
+// Decimal128.cpp
+//
+// Library: MongoDB
+// Package: MongoDB
+// Module:  Decimal128
+//
+// Copyright (c) 2025, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "Poco/MongoDB/Decimal128.h"
+#include "Poco/Exception.h"
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+
+namespace Poco::MongoDB {
+
+
+namespace
+{
+	constexpr Poco::Int32  DECIMAL128_BIAS                = 6176;
+	constexpr Poco::Int32  DECIMAL128_EXPONENT_MAX        =  6144;
+	constexpr Poco::Int32  DECIMAL128_EXPONENT_MIN        = -6143;
+	constexpr Poco::Int32  DECIMAL128_MAX_DIGITS          = 34;
+
+	constexpr Poco::UInt64 SIGN_MASK                      = 0x8000000000000000ULL;
+	constexpr Poco::UInt64 COMBINATION_MASK               = 0x7800000000000000ULL;
+	constexpr Poco::UInt64 SPECIAL_COMBINATION            = 0x7800000000000000ULL;
+	constexpr Poco::UInt64 NAN_BIT                        = 0x0400000000000000ULL;
+	constexpr Poco::UInt64 LARGE_COEFF_COMBINATION_MASK   = 0x6000000000000000ULL;
+	constexpr Poco::UInt64 LARGE_COEFF_COMBINATION_VALUE  = 0x6000000000000000ULL;
+
+	struct Coefficient
+		/// 113-bit unsigned integer stored as four little-endian UInt32 limbs.
+		/// Used for in-place decimal-by-10 division when stringifying.
+	{
+		Poco::UInt32 limbs[4];
+
+		void clear() noexcept
+		{
+			limbs[0] = limbs[1] = limbs[2] = limbs[3] = 0;
+		}
+
+		void fromHighLow(Poco::UInt64 coeffHigh, Poco::UInt64 coeffLow) noexcept
+		{
+			limbs[0] = static_cast<Poco::UInt32>(coeffLow);
+			limbs[1] = static_cast<Poco::UInt32>(coeffLow >> 32);
+			limbs[2] = static_cast<Poco::UInt32>(coeffHigh);
+			limbs[3] = static_cast<Poco::UInt32>(coeffHigh >> 32);
+		}
+
+		[[nodiscard]] bool isZero() const noexcept
+		{
+			return limbs[0] == 0 && limbs[1] == 0 && limbs[2] == 0 && limbs[3] == 0;
+		}
+
+		unsigned divmod10() noexcept
+		{
+			Poco::UInt64 r = 0;
+			for (int i = 3; i >= 0; --i)
+			{
+				Poco::UInt64 v = (r << 32) | limbs[i];
+				limbs[i] = static_cast<Poco::UInt32>(v / 10);
+				r = v % 10;
+			}
+			return static_cast<unsigned>(r);
+		}
+
+		void mul10Add(unsigned digit) noexcept
+		{
+			Poco::UInt64 carry = digit;
+			for (int i = 0; i < 4; ++i)
+			{
+				Poco::UInt64 v = static_cast<Poco::UInt64>(limbs[i]) * 10 + carry;
+				limbs[i] = static_cast<Poco::UInt32>(v);
+				carry = v >> 32;
+			}
+		}
+
+		void packHighLow(Poco::UInt64& coeffHigh, Poco::UInt64& coeffLow) const noexcept
+		{
+			coeffLow  = (static_cast<Poco::UInt64>(limbs[1]) << 32) | limbs[0];
+			coeffHigh = (static_cast<Poco::UInt64>(limbs[3]) << 32) | limbs[2];
+		}
+	};
+} // namespace
+
+
+Decimal128::Decimal128():
+	_low(0),
+	_high(0x3040000000000000ULL) // exponent = 0, coefficient = 0
+{
+}
+
+
+Decimal128::Decimal128(Poco::UInt64 low, Poco::UInt64 high):
+	_low(low),
+	_high(high)
+{
+}
+
+
+bool Decimal128::isNaN() const noexcept
+{
+	return (_high & 0x7C00000000000000ULL) == 0x7C00000000000000ULL;
+}
+
+
+bool Decimal128::isInfinite() const noexcept
+{
+	return (_high & 0x7C00000000000000ULL) == SPECIAL_COMBINATION;
+}
+
+
+bool Decimal128::isNegative() const noexcept
+{
+	return (_high & SIGN_MASK) != 0;
+}
+
+
+Decimal128 Decimal128::positiveZero()
+{
+	return Decimal128(0, 0x3040000000000000ULL);
+}
+
+
+Decimal128 Decimal128::negativeZero()
+{
+	return Decimal128(0, 0xB040000000000000ULL);
+}
+
+
+Decimal128 Decimal128::positiveInfinity()
+{
+	return Decimal128(0, 0x7800000000000000ULL);
+}
+
+
+Decimal128 Decimal128::negativeInfinity()
+{
+	return Decimal128(0, 0xF800000000000000ULL);
+}
+
+
+Decimal128 Decimal128::nan()
+{
+	return Decimal128(0, 0x7C00000000000000ULL);
+}
+
+
+std::string Decimal128::toString() const
+{
+	const bool negative = isNegative();
+
+	if (isNaN())
+	{
+		return "NaN";
+	}
+	if (isInfinite())
+	{
+		return negative ? "-Infinity" : "Infinity";
+	}
+
+	Poco::Int32 biasedExponent;
+	Coefficient coeff;
+	coeff.clear();
+
+	if ((_high & LARGE_COEFF_COMBINATION_MASK) == LARGE_COEFF_COMBINATION_VALUE)
+	{
+		// Large-coefficient encoding: implicit leading "100" makes the
+		// coefficient >= 10^33 and therefore representable, but the
+		// resulting value is non-canonical. Per the BSON spec the value
+		// must be treated as zero.
+		biasedExponent = static_cast<Poco::Int32>((_high >> 47) & 0x3FFF);
+		(void)biasedExponent; // ignored
+		// Coefficient renders as "0".
+		std::string out;
+		out.reserve(8);
+		if (negative) out += '-';
+		out += '0';
+		Poco::Int32 exponent = static_cast<Poco::Int32>((_high >> 47) & 0x3FFF) - DECIMAL128_BIAS;
+		if (exponent != 0)
+		{
+			out += 'E';
+			if (exponent > 0) out += '+';
+			out += std::to_string(exponent);
+		}
+		return out;
+	}
+
+	// Standard encoding: bits 126..113 are the biased exponent; bits 112..0
+	// are the coefficient. The 14-bit exponent field occupies the top 14
+	// bits of the high word after the sign bit, i.e. (_high >> 49) & 0x3FFF.
+	biasedExponent = static_cast<Poco::Int32>((_high >> 49) & 0x3FFF);
+	Poco::UInt64 coeffHigh = _high & 0x0001FFFFFFFFFFFFULL; // bottom 49 bits
+	coeff.fromHighLow(coeffHigh, _low);
+
+	const Poco::Int32 exponent = biasedExponent - DECIMAL128_BIAS;
+
+	// Extract decimal digits (least significant first) by repeated divmod10.
+	char digits[DECIMAL128_MAX_DIGITS + 4];
+	int digitCount = 0;
+	if (coeff.isZero())
+	{
+		digits[digitCount++] = '0';
+	}
+	else
+	{
+		while (!coeff.isZero())
+		{
+			unsigned d = coeff.divmod10();
+			digits[digitCount++] = static_cast<char>('0' + d);
+		}
+	}
+
+	// digits[] currently holds digits in reverse (least significant first).
+	const int significantDigits = digitCount;
+	const Poco::Int32 adjusted = exponent + significantDigits - 1;
+
+	std::string out;
+	out.reserve(48);
+	if (negative) out += '-';
+
+	// Canonical form (IEEE 754-2008 Section 5.12.4):
+	//   - If exponent <= 0 AND adjusted >= -6:
+	//     render without 'E' notation.
+	//   - Otherwise: scientific notation (one digit before the decimal
+	//     point, then optional fraction, then 'E' followed by adjusted).
+	if (exponent <= 0 && adjusted >= -6)
+	{
+		if (exponent == 0)
+		{
+			for (int i = significantDigits - 1; i >= 0; --i)
+				out += digits[i];
+		}
+		else
+		{
+			// Need to insert a decimal point.
+			const int integerDigits = significantDigits + exponent; // exponent < 0
+			if (integerDigits <= 0)
+			{
+				out += "0.";
+				for (int i = 0; i < -integerDigits; ++i) out += '0';
+				for (int i = significantDigits - 1; i >= 0; --i)
+					out += digits[i];
+			}
+			else
+			{
+				for (int i = significantDigits - 1; i >= significantDigits - integerDigits; --i)
+					out += digits[i];
+				out += '.';
+				for (int i = significantDigits - integerDigits - 1; i >= 0; --i)
+					out += digits[i];
+			}
+		}
+	}
+	else
+	{
+		// Scientific notation.
+		out += digits[significantDigits - 1];
+		if (significantDigits > 1)
+		{
+			out += '.';
+			for (int i = significantDigits - 2; i >= 0; --i)
+				out += digits[i];
+		}
+		out += 'E';
+		if (adjusted >= 0) out += '+';
+		out += std::to_string(adjusted);
+	}
+
+	return out;
+}
+
+
+Decimal128 Decimal128::fromString(const std::string& s)
+{
+	if (s.empty())
+		throw Poco::SyntaxException("Decimal128::fromString: empty string");
+
+	std::size_t i = 0;
+	bool negative = false;
+	if (s[i] == '+' || s[i] == '-')
+	{
+		negative = (s[i] == '-');
+		++i;
+	}
+
+	if (i >= s.size())
+		throw Poco::SyntaxException("Decimal128::fromString: missing digits in '" + s + "'");
+
+	// Match NaN / Infinity (case-insensitive).
+	auto matchKeyword = [&s, &i](const char* kw)
+	{
+		std::size_t k = 0;
+		std::size_t j = i;
+		while (kw[k] != '\0' && j < s.size())
+		{
+			if (std::tolower(static_cast<unsigned char>(s[j])) !=
+			    std::tolower(static_cast<unsigned char>(kw[k])))
+			{
+				return false;
+			}
+			++j;
+			++k;
+		}
+		if (kw[k] != '\0') return false;
+		i = j;
+		return true;
+	};
+
+	if (matchKeyword("nan"))
+	{
+		if (i != s.size())
+			throw Poco::SyntaxException("Decimal128::fromString: trailing junk after NaN in '" + s + "'");
+		Decimal128 v = Decimal128::nan();
+		if (negative) return Decimal128(v.low(), v.high() | SIGN_MASK);
+		return v;
+	}
+	if (matchKeyword("infinity") || matchKeyword("inf"))
+	{
+		if (i != s.size())
+			throw Poco::SyntaxException("Decimal128::fromString: trailing junk after Infinity in '" + s + "'");
+		return negative ? Decimal128::negativeInfinity() : Decimal128::positiveInfinity();
+	}
+
+	// Finite literal: integer-part [ "." fractional-part ] [ ("E"|"e") [+-]? exp-digits ]
+	std::string digits;
+	digits.reserve(DECIMAL128_MAX_DIGITS + 4);
+	Poco::Int32 implicitExponent = 0;
+	bool sawDigit = false;
+	bool sawDecimalPoint = false;
+
+	for (; i < s.size(); ++i)
+	{
+		char c = s[i];
+		if (c == '.')
+		{
+			if (sawDecimalPoint)
+				throw Poco::SyntaxException("Decimal128::fromString: multiple decimal points in '" + s + "'");
+			sawDecimalPoint = true;
+		}
+		else if (c >= '0' && c <= '9')
+		{
+			sawDigit = true;
+			digits += c;
+			if (sawDecimalPoint) --implicitExponent;
+		}
+		else if (c == 'E' || c == 'e')
+		{
+			++i;
+			break;
+		}
+		else
+		{
+			throw Poco::SyntaxException("Decimal128::fromString: invalid character in '" + s + "'");
+		}
+	}
+
+	if (!sawDigit)
+		throw Poco::SyntaxException("Decimal128::fromString: no digits in '" + s + "'");
+
+	Poco::Int32 explicitExponent = 0;
+	if (i <= s.size())
+	{
+		// We may have consumed past the 'E' indicator. Check whether the loop
+		// exited because of 'E' (i was advanced) or end-of-string.
+		std::size_t expStart = i;
+		if (expStart < s.size())
+		{
+			bool expNegative = false;
+			if (s[expStart] == '+' || s[expStart] == '-')
+			{
+				expNegative = (s[expStart] == '-');
+				++expStart;
+			}
+			if (expStart >= s.size())
+				throw Poco::SyntaxException("Decimal128::fromString: missing exponent digits in '" + s + "'");
+
+			Poco::Int64 acc = 0;
+			for (std::size_t k = expStart; k < s.size(); ++k)
+			{
+				char c = s[k];
+				if (c < '0' || c > '9')
+					throw Poco::SyntaxException("Decimal128::fromString: invalid exponent in '" + s + "'");
+				acc = acc * 10 + (c - '0');
+				if (acc > 1000000000LL)
+					throw Poco::RangeException("Decimal128::fromString: exponent out of range in '" + s + "'");
+			}
+			explicitExponent = static_cast<Poco::Int32>(expNegative ? -acc : acc);
+		}
+	}
+
+	Poco::Int32 exponent = implicitExponent + explicitExponent;
+
+	// Strip leading zeros from digits.
+	std::size_t firstNonZero = 0;
+	while (firstNonZero + 1 < digits.size() && digits[firstNonZero] == '0')
+		++firstNonZero;
+	digits.erase(0, firstNonZero);
+
+	// Drop trailing zeros only if doing so won't violate the exponent
+	// bounds; we want the canonical form when possible but we must not
+	// adjust the exponent above DECIMAL128_EXPONENT_MAX or below
+	// DECIMAL128_EXPONENT_MIN.
+	while (digits.size() > 1 && digits.back() == '0' && exponent < DECIMAL128_EXPONENT_MAX)
+	{
+		digits.pop_back();
+		++exponent;
+	}
+
+	if (digits.size() > static_cast<std::size_t>(DECIMAL128_MAX_DIGITS))
+		throw Poco::RangeException("Decimal128::fromString: more than 34 significant digits in '" + s + "'");
+
+	if (exponent > DECIMAL128_EXPONENT_MAX || exponent < DECIMAL128_EXPONENT_MIN)
+		throw Poco::RangeException("Decimal128::fromString: exponent out of range in '" + s + "'");
+
+	// Build the coefficient by mul10/add for each digit.
+	Coefficient coeff;
+	coeff.clear();
+	for (char c: digits)
+	{
+		coeff.mul10Add(static_cast<unsigned>(c - '0'));
+	}
+
+	Poco::UInt64 coeffHigh = 0;
+	Poco::UInt64 coeffLow  = 0;
+	coeff.packHighLow(coeffHigh, coeffLow);
+
+	const Poco::UInt64 biasedExponent = static_cast<Poco::UInt64>(exponent + DECIMAL128_BIAS) & 0x3FFFULL;
+	Poco::UInt64 high = (biasedExponent << 49) | (coeffHigh & 0x0001FFFFFFFFFFFFULL);
+	if (negative) high |= SIGN_MASK;
+
+	return Decimal128(coeffLow, high);
+}
+
+
+} // namespace Poco::MongoDB

--- a/MongoDB/src/Decimal128.cpp
+++ b/MongoDB/src/Decimal128.cpp
@@ -30,11 +30,11 @@ namespace
 	constexpr Poco::Int32  DECIMAL128_MAX_DIGITS          = 34;
 
 	constexpr Poco::UInt64 SIGN_MASK                      = 0x8000000000000000ULL;
-	constexpr Poco::UInt64 COMBINATION_MASK               = 0x7800000000000000ULL;
-	constexpr Poco::UInt64 SPECIAL_COMBINATION            = 0x7800000000000000ULL;
-	constexpr Poco::UInt64 NAN_BIT                        = 0x0400000000000000ULL;
-	constexpr Poco::UInt64 LARGE_COEFF_COMBINATION_MASK   = 0x6000000000000000ULL;
-	constexpr Poco::UInt64 LARGE_COEFF_COMBINATION_VALUE  = 0x6000000000000000ULL;
+	constexpr Poco::UInt64 SPECIAL_MASK                   = 0x7C00000000000000ULL;
+	constexpr Poco::UInt64 INF_VALUE                      = 0x7800000000000000ULL;
+	constexpr Poco::UInt64 NAN_VALUE                      = 0x7C00000000000000ULL;
+	constexpr Poco::UInt64 LARGE_COEFF_MASK               = 0x6000000000000000ULL;
+	constexpr Poco::UInt64 LARGE_COEFF_VALUE              = 0x6000000000000000ULL;
 
 	struct Coefficient
 		/// 113-bit unsigned integer stored as four little-endian UInt32 limbs.
@@ -108,13 +108,13 @@ Decimal128::Decimal128(Poco::UInt64 low, Poco::UInt64 high):
 
 bool Decimal128::isNaN() const noexcept
 {
-	return (_high & 0x7C00000000000000ULL) == 0x7C00000000000000ULL;
+	return (_high & SPECIAL_MASK) == NAN_VALUE;
 }
 
 
 bool Decimal128::isInfinite() const noexcept
 {
-	return (_high & 0x7C00000000000000ULL) == SPECIAL_COMBINATION;
+	return (_high & SPECIAL_MASK) == INF_VALUE;
 }
 
 
@@ -158,117 +158,86 @@ std::string Decimal128::toString() const
 {
 	const bool negative = isNegative();
 
-	if (isNaN())
-	{
-		return "NaN";
-	}
-	if (isInfinite())
-	{
-		return negative ? "-Infinity" : "Infinity";
-	}
+	if (isNaN()) return "NaN";
+	if (isInfinite()) return negative ? "-Infinity" : "Infinity";
 
 	Poco::Int32 biasedExponent;
 	Coefficient coeff;
 	coeff.clear();
 
-	if ((_high & LARGE_COEFF_COMBINATION_MASK) == LARGE_COEFF_COMBINATION_VALUE)
+	if ((_high & LARGE_COEFF_MASK) == LARGE_COEFF_VALUE)
 	{
 		// Large-coefficient encoding: implicit leading "100" makes the
 		// coefficient >= 10^33 and therefore representable, but the
 		// resulting value is non-canonical. Per the BSON spec the value
-		// must be treated as zero.
+		// renders as zero with the encoded exponent.
 		biasedExponent = static_cast<Poco::Int32>((_high >> 47) & 0x3FFF);
-		(void)biasedExponent; // ignored
-		// Coefficient renders as "0".
-		std::string out;
-		out.reserve(8);
-		if (negative) out += '-';
-		out += '0';
-		Poco::Int32 exponent = static_cast<Poco::Int32>((_high >> 47) & 0x3FFF) - DECIMAL128_BIAS;
-		if (exponent != 0)
-		{
-			out += 'E';
-			if (exponent > 0) out += '+';
-			out += std::to_string(exponent);
-		}
-		return out;
 	}
-
-	// Standard encoding: bits 126..113 are the biased exponent; bits 112..0
-	// are the coefficient. The 14-bit exponent field occupies the top 14
-	// bits of the high word after the sign bit, i.e. (_high >> 49) & 0x3FFF.
-	biasedExponent = static_cast<Poco::Int32>((_high >> 49) & 0x3FFF);
-	Poco::UInt64 coeffHigh = _high & 0x0001FFFFFFFFFFFFULL; // bottom 49 bits
-	coeff.fromHighLow(coeffHigh, _low);
+	else
+	{
+		// Standard encoding: bits 126..113 = biased exponent, bits 112..0 =
+		// coefficient.
+		biasedExponent = static_cast<Poco::Int32>((_high >> 49) & 0x3FFF);
+		const Poco::UInt64 coeffHigh = _high & 0x0001FFFFFFFFFFFFULL;
+		coeff.fromHighLow(coeffHigh, _low);
+	}
 
 	const Poco::Int32 exponent = biasedExponent - DECIMAL128_BIAS;
 
-	// Extract decimal digits (least significant first) by repeated divmod10.
-	char digits[DECIMAL128_MAX_DIGITS + 4];
-	int digitCount = 0;
+	std::string mantissa;
+	mantissa.reserve(DECIMAL128_MAX_DIGITS);
 	if (coeff.isZero())
 	{
-		digits[digitCount++] = '0';
+		mantissa.push_back('0');
 	}
 	else
 	{
 		while (!coeff.isZero())
 		{
-			unsigned d = coeff.divmod10();
-			digits[digitCount++] = static_cast<char>('0' + d);
+			mantissa.push_back(static_cast<char>('0' + coeff.divmod10()));
 		}
+		std::reverse(mantissa.begin(), mantissa.end());
 	}
 
-	// digits[] currently holds digits in reverse (least significant first).
-	const int significantDigits = digitCount;
+	const int significantDigits = static_cast<int>(mantissa.size());
 	const Poco::Int32 adjusted = exponent + significantDigits - 1;
 
 	std::string out;
 	out.reserve(48);
 	if (negative) out += '-';
 
-	// Canonical form (IEEE 754-2008 Section 5.12.4):
-	//   - If exponent <= 0 AND adjusted >= -6:
-	//     render without 'E' notation.
-	//   - Otherwise: scientific notation (one digit before the decimal
-	//     point, then optional fraction, then 'E' followed by adjusted).
+	// Canonical form (IEEE 754-2008 Section 5.12.4): non-scientific notation
+	// when exponent <= 0 AND adjusted >= -6, otherwise one-digit-then-E.
 	if (exponent <= 0 && adjusted >= -6)
 	{
 		if (exponent == 0)
 		{
-			for (int i = significantDigits - 1; i >= 0; --i)
-				out += digits[i];
+			out += mantissa;
 		}
 		else
 		{
-			// Need to insert a decimal point.
 			const int integerDigits = significantDigits + exponent; // exponent < 0
 			if (integerDigits <= 0)
 			{
 				out += "0.";
-				for (int i = 0; i < -integerDigits; ++i) out += '0';
-				for (int i = significantDigits - 1; i >= 0; --i)
-					out += digits[i];
+				out.append(-integerDigits, '0');
+				out += mantissa;
 			}
 			else
 			{
-				for (int i = significantDigits - 1; i >= significantDigits - integerDigits; --i)
-					out += digits[i];
+				out.append(mantissa, 0, integerDigits);
 				out += '.';
-				for (int i = significantDigits - integerDigits - 1; i >= 0; --i)
-					out += digits[i];
+				out.append(mantissa, integerDigits, std::string::npos);
 			}
 		}
 	}
 	else
 	{
-		// Scientific notation.
-		out += digits[significantDigits - 1];
+		out += mantissa[0];
 		if (significantDigits > 1)
 		{
 			out += '.';
-			for (int i = significantDigits - 2; i >= 0; --i)
-				out += digits[i];
+			out.append(mantissa, 1, std::string::npos);
 		}
 		out += 'E';
 		if (adjusted >= 0) out += '+';
@@ -336,6 +305,7 @@ Decimal128 Decimal128::fromString(const std::string& s)
 	Poco::Int32 implicitExponent = 0;
 	bool sawDigit = false;
 	bool sawDecimalPoint = false;
+	bool sawExponent = false;
 
 	for (; i < s.size(); ++i)
 	{
@@ -354,7 +324,7 @@ Decimal128 Decimal128::fromString(const std::string& s)
 		}
 		else if (c == 'E' || c == 'e')
 		{
-			++i;
+			sawExponent = true;
 			break;
 		}
 		else
@@ -367,53 +337,39 @@ Decimal128 Decimal128::fromString(const std::string& s)
 		throw Poco::SyntaxException("Decimal128::fromString: no digits in '" + s + "'");
 
 	Poco::Int32 explicitExponent = 0;
-	if (i <= s.size())
+	if (sawExponent)
 	{
-		// We may have consumed past the 'E' indicator. Check whether the loop
-		// exited because of 'E' (i was advanced) or end-of-string.
-		std::size_t expStart = i;
-		if (expStart < s.size())
+		std::size_t expStart = i + 1; // skip past 'E' or 'e'
+		bool expNegative = false;
+		if (expStart < s.size() && (s[expStart] == '+' || s[expStart] == '-'))
 		{
-			bool expNegative = false;
-			if (s[expStart] == '+' || s[expStart] == '-')
-			{
-				expNegative = (s[expStart] == '-');
-				++expStart;
-			}
-			if (expStart >= s.size())
-				throw Poco::SyntaxException("Decimal128::fromString: missing exponent digits in '" + s + "'");
-
-			Poco::Int64 acc = 0;
-			for (std::size_t k = expStart; k < s.size(); ++k)
-			{
-				char c = s[k];
-				if (c < '0' || c > '9')
-					throw Poco::SyntaxException("Decimal128::fromString: invalid exponent in '" + s + "'");
-				acc = acc * 10 + (c - '0');
-				if (acc > 1000000000LL)
-					throw Poco::RangeException("Decimal128::fromString: exponent out of range in '" + s + "'");
-			}
-			explicitExponent = static_cast<Poco::Int32>(expNegative ? -acc : acc);
+			expNegative = (s[expStart] == '-');
+			++expStart;
 		}
+		if (expStart >= s.size())
+			throw Poco::SyntaxException("Decimal128::fromString: missing exponent digits in '" + s + "'");
+
+		Poco::Int64 acc = 0;
+		for (std::size_t k = expStart; k < s.size(); ++k)
+		{
+			char c = s[k];
+			if (c < '0' || c > '9')
+				throw Poco::SyntaxException("Decimal128::fromString: invalid exponent in '" + s + "'");
+			acc = acc * 10 + (c - '0');
+			if (acc > 1000000000LL)
+				throw Poco::RangeException("Decimal128::fromString: exponent out of range in '" + s + "'");
+		}
+		explicitExponent = static_cast<Poco::Int32>(expNegative ? -acc : acc);
 	}
 
 	Poco::Int32 exponent = implicitExponent + explicitExponent;
 
-	// Strip leading zeros from digits.
+	// Strip leading zeros; trailing zeros are part of the canonical
+	// (coefficient, exponent) pair and must be preserved.
 	std::size_t firstNonZero = 0;
 	while (firstNonZero + 1 < digits.size() && digits[firstNonZero] == '0')
 		++firstNonZero;
 	digits.erase(0, firstNonZero);
-
-	// Drop trailing zeros only if doing so won't violate the exponent
-	// bounds; we want the canonical form when possible but we must not
-	// adjust the exponent above DECIMAL128_EXPONENT_MAX or below
-	// DECIMAL128_EXPONENT_MIN.
-	while (digits.size() > 1 && digits.back() == '0' && exponent < DECIMAL128_EXPONENT_MAX)
-	{
-		digits.pop_back();
-		++exponent;
-	}
 
 	if (digits.size() > static_cast<std::size_t>(DECIMAL128_MAX_DIGITS))
 		throw Poco::RangeException("Decimal128::fromString: more than 34 significant digits in '" + s + "'");
@@ -421,7 +377,6 @@ Decimal128 Decimal128::fromString(const std::string& s)
 	if (exponent > DECIMAL128_EXPONENT_MAX || exponent < DECIMAL128_EXPONENT_MIN)
 		throw Poco::RangeException("Decimal128::fromString: exponent out of range in '" + s + "'");
 
-	// Build the coefficient by mul10/add for each digit.
 	Coefficient coeff;
 	coeff.clear();
 	for (char c: digits)

--- a/MongoDB/src/Document.cpp
+++ b/MongoDB/src/Document.cpp
@@ -15,7 +15,10 @@
 #include "Poco/MongoDB/Document.h"
 #include "Poco/MongoDB/Array.h"
 #include "Poco/MongoDB/Binary.h"
+#include "Poco/MongoDB/Decimal128.h"
 #include "Poco/MongoDB/JavaScriptCode.h"
+#include "Poco/MongoDB/MaxKey.h"
+#include "Poco/MongoDB/MinKey.h"
 #include "Poco/MongoDB/ObjectId.h"
 #include "Poco/MongoDB/RegularExpression.h"
 #include "Poco/Exception.h"
@@ -156,6 +159,15 @@ void Document::read(BinaryReader& reader)
 		case ElementTraits<Int64>::TypeId:
 			element = new ConcreteElement<Int64>(name, 0);
 			break;
+		case ElementTraits<Decimal128::Ptr>::TypeId:
+			element = new ConcreteElement<Decimal128::Ptr>(name, new Decimal128);
+			break;
+		case ElementTraits<MinKey>::TypeId:
+			element = new ConcreteElement<MinKey>(name, MinKey{});
+			break;
+		case ElementTraits<MaxKey>::TypeId:
+			element = new ConcreteElement<MaxKey>(name, MaxKey{});
+			break;
 		default:
 			{
 				std::stringstream ss;
@@ -163,8 +175,6 @@ void Document::read(BinaryReader& reader)
 				throw Poco::NotImplementedException(ss.str());
 			}
 		//TODO: x0F -> JavaScript code with scope
-		//		xFF -> Min Key
-		//		x7F -> Max Key
 		}
 
 		element->read(reader);

--- a/MongoDB/testsuite/src/BSONTest.cpp
+++ b/MongoDB/testsuite/src/BSONTest.cpp
@@ -241,9 +241,8 @@ void BSONTest::testDuplicateDocumentMembers()
 
 void BSONTest::testDocumentAddElementMerge()
 {
-	// Mirrors how Database::createIndex(extraOptions) merges caller-supplied
-	// elements into the per-index spec: build a "base" document, then iterate
-	// a second document's elements() and addElement() each into the base.
+	// Copy every element from a source Document into a destination via
+	// elementNames() + get() + addElement().
 	Document::Ptr base = new Document();
 	base->add("name"s, "idx_age"s);
 	base->add("unique"s, true);
@@ -816,6 +815,11 @@ void BSONTest::testDecimal128FromString()
 		{"1E+5",      "1E+5"},
 		{"1.234E+10", "1.234E+10"},
 		{"-1E-3",     "-0.001"},
+		// Trailing zeros are part of the canonical (coefficient, exponent)
+		// pair per the BSON Decimal128 spec and must round-trip.
+		{"100",       "100"},
+		{"1.10",      "1.10"},
+		{"0.10",      "0.10"},
 		{"NaN",       "NaN"},
 		{"Infinity",  "Infinity"},
 		{"-Infinity", "-Infinity"},
@@ -829,13 +833,35 @@ void BSONTest::testDecimal128FromString()
 		assertEqual(std::string(c.out), v.toString());
 	}
 
-	try
+	const char* syntaxErrors[] = {
+		"not a number",
+		"1E",        // exponent indicator with no digits
+		"1E+",       // exponent sign with no digits
+		"1e-",
+		"1.2.3"      // multiple decimal points
+	};
+	for (const char* bad: syntaxErrors)
 	{
-		Decimal128::fromString("not a number");
-		failmsg("expected SyntaxException on malformed input");
+		try
+		{
+			Decimal128::fromString(bad);
+			failmsg(std::string("expected SyntaxException for '") + bad + "'");
+		}
+		catch (const Poco::SyntaxException&) {}
 	}
-	catch (const Poco::SyntaxException&)
+
+	const char* rangeErrors[] = {
+		"12345678901234567890123456789012345",  // 35 digits, > 34 max
+		"1E10000"                                // exponent above EXPONENT_MAX (6144)
+	};
+	for (const char* bad: rangeErrors)
 	{
+		try
+		{
+			Decimal128::fromString(bad);
+			failmsg(std::string("expected RangeException for '") + bad + "'");
+		}
+		catch (const Poco::RangeException&) {}
 	}
 }
 
@@ -904,9 +930,7 @@ void BSONTest::testMinKeyMaxKeySerializeDocument()
 
 void BSONTest::testAuthMechanismConstants()
 {
-	// SCRAM-SHA-1 was the only mechanism in 1.14.x; SCRAM-SHA-256 was
-	// added alongside this change and is now the default. Lock both
-	// constant values in to catch accidental string changes.
+	// Lock wire strings; these are part of the public API.
 	assertEqual(std::string("SCRAM-SHA-1"), Database::AUTH_SCRAM_SHA1);
 	assertEqual(std::string("SCRAM-SHA-256"), Database::AUTH_SCRAM_SHA256);
 }
@@ -914,11 +938,8 @@ void BSONTest::testAuthMechanismConstants()
 
 void BSONTest::testAuthSCRAM256RejectsNonAscii()
 {
-	// SCRAM-SHA-256 requires SASLprep on the password. Until full RFC 4013
-	// support lands, the ASCII-only fast path is enforced by throwing
-	// NotImplementedException *before* any network I/O. Verify the throw
-	// happens by passing a UTF-8 password containing a non-ASCII byte and
-	// a never-connected Connection (the ASCII check is reached first).
+	// Non-ASCII password must throw NotImplementedException before any
+	// network I/O (SASLprep is not implemented).
 	Poco::MongoDB::Database db("test");
 	Poco::MongoDB::Connection conn;
 	const std::string nonAsciiPassword = "p\xC3\xA9ncil"; // "pencil" with e-acute
@@ -958,60 +979,20 @@ namespace
 
 void BSONTest::testConnectionURITlsAlias()
 {
-	// Verify that "tls=true" in the URI flips the same internal flag as
-	// "ssl=true". RecordingSocketFactory captures the `secure` argument the
-	// Connection passes in, then aborts the call.
+	// "tls=" and "ssl=" must flip the same internal secure flag.
+	auto check = [this](const std::string& uri, bool expectSecure)
 	{
 		Poco::MongoDB::Connection conn;
 		RecordingSocketFactory factory;
-		try
-		{
-			conn.connect("mongodb://localhost:27017/admin?tls=true", factory);
-		}
-		catch (const Poco::NotImplementedException&)
-		{
-		}
+		try { conn.connect(uri, factory); }
+		catch (const Poco::NotImplementedException&) {}
 		assertTrue(factory.called);
-		assertTrue(factory.secureRequested);
-	}
+		assertEqual(expectSecure, factory.secureRequested);
+	};
 
-	{
-		Poco::MongoDB::Connection conn;
-		RecordingSocketFactory factory;
-		try
-		{
-			conn.connect("mongodb://localhost:27017/admin?ssl=true", factory);
-		}
-		catch (const Poco::NotImplementedException&)
-		{
-		}
-		assertTrue(factory.called);
-		assertTrue(factory.secureRequested);
-	}
-
-	{
-		// No tls/ssl: secure flag must be false.
-		Poco::MongoDB::Connection conn;
-		RecordingSocketFactory factory;
-		try
-		{
-			conn.connect("mongodb://localhost:27017/admin", factory);
-		}
-		catch (const Poco::NotImplementedException&)
-		{
-			// Default factory does not throw for non-secure; ours doesn't
-			// either, but its base may attempt a real connect. We tolerate
-			// either path.
-		}
-		catch (const Poco::Exception&)
-		{
-		}
-		// secureRequested defaults to false; verify it stayed false.
-		if (factory.called)
-		{
-			assertFalse(factory.secureRequested);
-		}
-	}
+	check("mongodb://localhost:27017/admin?tls=true", true);
+	check("mongodb://localhost:27017/admin?ssl=true", true);
+	check("mongodb://localhost:27017/admin",          false);
 }
 
 

--- a/MongoDB/testsuite/src/BSONTest.cpp
+++ b/MongoDB/testsuite/src/BSONTest.cpp
@@ -935,6 +935,86 @@ void BSONTest::testAuthSCRAM256RejectsNonAscii()
 }
 
 
+namespace
+{
+	class RecordingSocketFactory: public Poco::MongoDB::Connection::SocketFactory
+	{
+	public:
+		bool secureRequested = false;
+		bool called = false;
+
+		Poco::Net::StreamSocket createSocket(const std::string& /*host*/,
+			int /*port*/, Poco::Timespan /*connectTimeout*/, bool secure) override
+		{
+			called = true;
+			secureRequested = secure;
+			// We don't actually want to open a socket; throw to abort the
+			// connect() call after the URI options have been parsed.
+			throw Poco::NotImplementedException("Test factory does not connect");
+		}
+	};
+}
+
+
+void BSONTest::testConnectionURITlsAlias()
+{
+	// Verify that "tls=true" in the URI flips the same internal flag as
+	// "ssl=true". RecordingSocketFactory captures the `secure` argument the
+	// Connection passes in, then aborts the call.
+	{
+		Poco::MongoDB::Connection conn;
+		RecordingSocketFactory factory;
+		try
+		{
+			conn.connect("mongodb://localhost:27017/admin?tls=true", factory);
+		}
+		catch (const Poco::NotImplementedException&)
+		{
+		}
+		assertTrue(factory.called);
+		assertTrue(factory.secureRequested);
+	}
+
+	{
+		Poco::MongoDB::Connection conn;
+		RecordingSocketFactory factory;
+		try
+		{
+			conn.connect("mongodb://localhost:27017/admin?ssl=true", factory);
+		}
+		catch (const Poco::NotImplementedException&)
+		{
+		}
+		assertTrue(factory.called);
+		assertTrue(factory.secureRequested);
+	}
+
+	{
+		// No tls/ssl: secure flag must be false.
+		Poco::MongoDB::Connection conn;
+		RecordingSocketFactory factory;
+		try
+		{
+			conn.connect("mongodb://localhost:27017/admin", factory);
+		}
+		catch (const Poco::NotImplementedException&)
+		{
+			// Default factory does not throw for non-secure; ours doesn't
+			// either, but its base may attempt a real connect. We tolerate
+			// either path.
+		}
+		catch (const Poco::Exception&)
+		{
+		}
+		// secureRequested defaults to false; verify it stayed false.
+		if (factory.called)
+		{
+			assertFalse(factory.secureRequested);
+		}
+	}
+}
+
+
 void BSONTest::testDocumentSerialization()
 {
 	Document::Ptr doc = new Document();
@@ -1503,6 +1583,8 @@ CppUnit::Test* BSONTest::suite()
 
 	CppUnit_addTest(pSuite, BSONTest, testAuthMechanismConstants);
 	CppUnit_addTest(pSuite, BSONTest, testAuthSCRAM256RejectsNonAscii);
+
+	CppUnit_addTest(pSuite, BSONTest, testConnectionURITlsAlias);
 
 	// Serialization/Deserialization tests
 	CppUnit_addTest(pSuite, BSONTest, testDocumentSerialization);

--- a/MongoDB/testsuite/src/BSONTest.cpp
+++ b/MongoDB/testsuite/src/BSONTest.cpp
@@ -14,9 +14,14 @@
 #include "Poco/MongoDB/Document.h"
 #include "Poco/MongoDB/Array.h"
 #include "Poco/MongoDB/Binary.h"
+#include "Poco/MongoDB/Decimal128.h"
+#include "Poco/MongoDB/MaxKey.h"
+#include "Poco/MongoDB/MinKey.h"
 #include "Poco/MongoDB/ObjectId.h"
 #include "Poco/MongoDB/RegularExpression.h"
 #include "Poco/MongoDB/JavaScriptCode.h"
+#include "Poco/BinaryReader.h"
+#include "Poco/BinaryWriter.h"
 #include "Poco/DateTime.h"
 #include "Poco/UUIDGenerator.h"
 #include <sstream>
@@ -759,6 +764,141 @@ void BSONTest::testJavaScriptCode()
 }
 
 
+void BSONTest::testDecimal128Specials()
+{
+	Decimal128 zero;
+	assertFalse(zero.isNaN());
+	assertFalse(zero.isInfinite());
+	assertFalse(zero.isNegative());
+	assertEqual(std::string("0"), zero.toString());
+
+	Decimal128 negZero = Decimal128::negativeZero();
+	assertTrue(negZero.isNegative());
+	assertEqual(std::string("-0"), negZero.toString());
+
+	Decimal128 nan = Decimal128::nan();
+	assertTrue(nan.isNaN());
+	assertEqual(std::string("NaN"), nan.toString());
+
+	Decimal128 posInf = Decimal128::positiveInfinity();
+	assertTrue(posInf.isInfinite());
+	assertFalse(posInf.isNegative());
+	assertEqual(std::string("Infinity"), posInf.toString());
+
+	Decimal128 negInf = Decimal128::negativeInfinity();
+	assertTrue(negInf.isInfinite());
+	assertTrue(negInf.isNegative());
+	assertEqual(std::string("-Infinity"), negInf.toString());
+}
+
+
+void BSONTest::testDecimal128FromString()
+{
+	struct Case
+	{
+		const char* in;
+		const char* out;
+	};
+	const Case cases[] = {
+		{"0",         "0"},
+		{"-0",        "-0"},
+		{"1",         "1"},
+		{"-1",        "-1"},
+		{"123",       "123"},
+		{"-456",      "-456"},
+		{"1.5",       "1.5"},
+		{"-1.5",      "-1.5"},
+		{"0.1",       "0.1"},
+		{"0.0001",    "0.0001"},
+		{"1E+5",      "1E+5"},
+		{"1.234E+10", "1.234E+10"},
+		{"-1E-3",     "-0.001"},
+		{"NaN",       "NaN"},
+		{"Infinity",  "Infinity"},
+		{"-Infinity", "-Infinity"},
+		{"inf",       "Infinity"},
+		{"-inf",      "-Infinity"}
+	};
+
+	for (const Case& c: cases)
+	{
+		Decimal128 v = Decimal128::fromString(c.in);
+		assertEqual(std::string(c.out), v.toString());
+	}
+
+	try
+	{
+		Decimal128::fromString("not a number");
+		failmsg("expected SyntaxException on malformed input");
+	}
+	catch (const Poco::SyntaxException&)
+	{
+	}
+}
+
+
+void BSONTest::testDecimal128RoundTrip()
+{
+	// Round-trip via toString -> fromString -> toString.
+	Decimal128 a = Decimal128::fromString("3.14159265358979323846");
+	Decimal128 b = Decimal128::fromString(a.toString());
+	assertTrue(a == b);
+	assertEqual(a.toString(), b.toString());
+
+	// Raw construction round-trips the bits.
+	Decimal128 raw(0x0102030405060708ULL, 0x3040000000000000ULL);
+	Decimal128 raw2(raw.low(), raw.high());
+	assertTrue(raw == raw2);
+}
+
+
+void BSONTest::testDecimal128SerializeDocument()
+{
+	// Serialize a Document containing a Decimal128 to BSON, then read it
+	// back and verify the value survives the round trip.
+	Document::Ptr doc = new Document();
+	Decimal128::Ptr value = new Decimal128(Decimal128::fromString("3.14159265358979"));
+	doc->add("pi"s, value);
+
+	std::stringstream stream;
+	Poco::BinaryWriter writer(stream, Poco::BinaryWriter::LITTLE_ENDIAN_BYTE_ORDER);
+	doc->write(writer);
+	writer.flush();
+
+	Document::Ptr restored = new Document();
+	Poco::BinaryReader reader(stream, Poco::BinaryReader::LITTLE_ENDIAN_BYTE_ORDER);
+	restored->read(reader);
+
+	assertTrue(restored->exists("pi"));
+	Decimal128::Ptr round = restored->get<Decimal128::Ptr>("pi");
+	assertFalse(round.isNull());
+	assertEqual(value->toString(), round->toString());
+	assertTrue(*value == *round);
+}
+
+
+void BSONTest::testMinKeyMaxKeySerializeDocument()
+{
+	Document::Ptr doc = new Document();
+	doc->add("min"s, MinKey{});
+	doc->add("max"s, MaxKey{});
+
+	std::stringstream stream;
+	Poco::BinaryWriter writer(stream, Poco::BinaryWriter::LITTLE_ENDIAN_BYTE_ORDER);
+	doc->write(writer);
+	writer.flush();
+
+	Document::Ptr restored = new Document();
+	Poco::BinaryReader reader(stream, Poco::BinaryReader::LITTLE_ENDIAN_BYTE_ORDER);
+	restored->read(reader);
+
+	assertTrue(restored->exists("min"));
+	assertTrue(restored->exists("max"));
+	assertTrue(restored->isType<MinKey>("min"));
+	assertTrue(restored->isType<MaxKey>("max"));
+}
+
+
 void BSONTest::testDocumentSerialization()
 {
 	Document::Ptr doc = new Document();
@@ -1318,6 +1458,12 @@ CppUnit::Test* BSONTest::suite()
 
 	// JavaScriptCode tests
 	CppUnit_addTest(pSuite, BSONTest, testJavaScriptCode);
+
+	CppUnit_addTest(pSuite, BSONTest, testDecimal128Specials);
+	CppUnit_addTest(pSuite, BSONTest, testDecimal128FromString);
+	CppUnit_addTest(pSuite, BSONTest, testDecimal128RoundTrip);
+	CppUnit_addTest(pSuite, BSONTest, testDecimal128SerializeDocument);
+	CppUnit_addTest(pSuite, BSONTest, testMinKeyMaxKeySerializeDocument);
 
 	// Serialization/Deserialization tests
 	CppUnit_addTest(pSuite, BSONTest, testDocumentSerialization);

--- a/MongoDB/testsuite/src/BSONTest.cpp
+++ b/MongoDB/testsuite/src/BSONTest.cpp
@@ -231,6 +231,44 @@ void BSONTest::testDuplicateDocumentMembers()
 }
 
 
+void BSONTest::testDocumentAddElementMerge()
+{
+	// Mirrors how Database::createIndex(extraOptions) merges caller-supplied
+	// elements into the per-index spec: build a "base" document, then iterate
+	// a second document's elements() and addElement() each into the base.
+	Document::Ptr base = new Document();
+	base->add("name"s, "idx_age"s);
+	base->add("unique"s, true);
+
+	Document::Ptr filter = new Document();
+	filter->add("age"s, static_cast<Poco::Int32>(18));
+
+	Document::Ptr extras = new Document();
+	extras->add("partialFilterExpression"s, filter);
+	extras->add("hidden"s, true);
+
+	std::vector<std::string> names;
+	extras->elementNames(names);
+	for (const auto& name: names)
+	{
+		Element::Ptr element = extras->get(name);
+		assertFalse(element.isNull());
+		base->addElement(element);
+	}
+
+	assertEqual(static_cast<std::size_t>(4), base->size());
+	assertTrue(base->exists("name"));
+	assertTrue(base->exists("unique"));
+	assertTrue(base->exists("partialFilterExpression"));
+	assertTrue(base->exists("hidden"));
+
+	Document::Ptr partial = base->get<Document::Ptr>("partialFilterExpression");
+	assertFalse(partial.isNull());
+	assertEqual(static_cast<Poco::Int32>(18), partial->get<Poco::Int32>("age"));
+	assertEqual(true, base->get<bool>("hidden"));
+}
+
+
 void BSONTest::testArray()
 {
 	Array::Ptr arr = new Array();
@@ -1249,6 +1287,7 @@ CppUnit::Test* BSONTest::suite()
 	CppUnit_addTest(pSuite, BSONTest, testDocumentElementNames);
 	CppUnit_addTest(pSuite, BSONTest, testNestedDocuments);
 	CppUnit_addTest(pSuite, BSONTest, testDuplicateDocumentMembers);
+	CppUnit_addTest(pSuite, BSONTest, testDocumentAddElementMerge);
 
 	// Array tests
 	CppUnit_addTest(pSuite, BSONTest, testArray);

--- a/MongoDB/testsuite/src/BSONTest.cpp
+++ b/MongoDB/testsuite/src/BSONTest.cpp
@@ -14,6 +14,8 @@
 #include "Poco/MongoDB/Document.h"
 #include "Poco/MongoDB/Array.h"
 #include "Poco/MongoDB/Binary.h"
+#include "Poco/MongoDB/Connection.h"
+#include "Poco/MongoDB/Database.h"
 #include "Poco/MongoDB/Decimal128.h"
 #include "Poco/MongoDB/MaxKey.h"
 #include "Poco/MongoDB/MinKey.h"
@@ -22,6 +24,7 @@
 #include "Poco/MongoDB/JavaScriptCode.h"
 #include "Poco/BinaryReader.h"
 #include "Poco/BinaryWriter.h"
+#include "Poco/Exception.h"
 #include "Poco/DateTime.h"
 #include "Poco/UUIDGenerator.h"
 #include <sstream>
@@ -899,6 +902,39 @@ void BSONTest::testMinKeyMaxKeySerializeDocument()
 }
 
 
+void BSONTest::testAuthMechanismConstants()
+{
+	// SCRAM-SHA-1 was the only mechanism in 1.14.x; SCRAM-SHA-256 was
+	// added alongside this change and is now the default. Lock both
+	// constant values in to catch accidental string changes.
+	assertEqual(std::string("SCRAM-SHA-1"), Database::AUTH_SCRAM_SHA1);
+	assertEqual(std::string("SCRAM-SHA-256"), Database::AUTH_SCRAM_SHA256);
+}
+
+
+void BSONTest::testAuthSCRAM256RejectsNonAscii()
+{
+	// SCRAM-SHA-256 requires SASLprep on the password. Until full RFC 4013
+	// support lands, the ASCII-only fast path is enforced by throwing
+	// NotImplementedException *before* any network I/O. Verify the throw
+	// happens by passing a UTF-8 password containing a non-ASCII byte and
+	// a never-connected Connection (the ASCII check is reached first).
+	Poco::MongoDB::Database db("test");
+	Poco::MongoDB::Connection conn;
+	const std::string nonAsciiPassword = "p\xC3\xA9ncil"; // "pencil" with e-acute
+
+	try
+	{
+		db.authenticate(conn, "alice", nonAsciiPassword,
+			Poco::MongoDB::Database::AUTH_SCRAM_SHA256);
+		failmsg("expected NotImplementedException on non-ASCII password");
+	}
+	catch (const Poco::NotImplementedException&)
+	{
+	}
+}
+
+
 void BSONTest::testDocumentSerialization()
 {
 	Document::Ptr doc = new Document();
@@ -1464,6 +1500,9 @@ CppUnit::Test* BSONTest::suite()
 	CppUnit_addTest(pSuite, BSONTest, testDecimal128RoundTrip);
 	CppUnit_addTest(pSuite, BSONTest, testDecimal128SerializeDocument);
 	CppUnit_addTest(pSuite, BSONTest, testMinKeyMaxKeySerializeDocument);
+
+	CppUnit_addTest(pSuite, BSONTest, testAuthMechanismConstants);
+	CppUnit_addTest(pSuite, BSONTest, testAuthSCRAM256RejectsNonAscii);
 
 	// Serialization/Deserialization tests
 	CppUnit_addTest(pSuite, BSONTest, testDocumentSerialization);

--- a/MongoDB/testsuite/src/BSONTest.h
+++ b/MongoDB/testsuite/src/BSONTest.h
@@ -74,6 +74,10 @@ public:
 	void testDecimal128SerializeDocument();
 	void testMinKeyMaxKeySerializeDocument();
 
+	// Authentication constants and SASLprep guard
+	void testAuthMechanismConstants();
+	void testAuthSCRAM256RejectsNonAscii();
+
 	// Serialization/Deserialization tests
 	void testDocumentSerialization();
 	void testDocumentDeserialization();

--- a/MongoDB/testsuite/src/BSONTest.h
+++ b/MongoDB/testsuite/src/BSONTest.h
@@ -67,6 +67,13 @@ public:
 	// JavaScriptCode tests
 	void testJavaScriptCode();
 
+	// Decimal128 / MinKey / MaxKey tests
+	void testDecimal128Specials();
+	void testDecimal128FromString();
+	void testDecimal128RoundTrip();
+	void testDecimal128SerializeDocument();
+	void testMinKeyMaxKeySerializeDocument();
+
 	// Serialization/Deserialization tests
 	void testDocumentSerialization();
 	void testDocumentDeserialization();

--- a/MongoDB/testsuite/src/BSONTest.h
+++ b/MongoDB/testsuite/src/BSONTest.h
@@ -35,6 +35,7 @@ public:
 	void testDocumentElementNames();
 	void testNestedDocuments();
 	void testDuplicateDocumentMembers();
+	void testDocumentAddElementMerge();
 
 	// Array tests
 	void testArray();

--- a/MongoDB/testsuite/src/BSONTest.h
+++ b/MongoDB/testsuite/src/BSONTest.h
@@ -78,6 +78,9 @@ public:
 	void testAuthMechanismConstants();
 	void testAuthSCRAM256RejectsNonAscii();
 
+	// Connection URI parsing: tls alias
+	void testConnectionURITlsAlias();
+
 	// Serialization/Deserialization tests
 	void testDocumentSerialization();
 	void testDocumentDeserialization();


### PR DESCRIPTION
## Summary

Audit of Poco::MongoDB versus MongoDB server 6.0 / 7.0 / 8.0, plus a set
of contained gap closures for the 1.15.3 release. The branch ships six
commits: five feature/docs commits and one consolidated review-feedback
fix commit produced by a four-agent code review (general / simplification
+ C++17 / comments / README accuracy).

### Server-feature compatibility doc

  - New `MongoDB/README.md` with status tables for MongoDB 6.0 / 7.0 / 8.0
    server features (driver baseline, aggregation, indexes, BSON types),
    plus a section listing features obsolete in recent MongoDB that are
    still exposed by Poco (e.g. `CMD_MAP_REDUCE`, `CMD_COUNT`,
    `INDEX_BACKGROUND`).

### New API surface

  - `Database::createIndex(connection, coll, fields, name, extraOptions, ...)`
    overload: every element of `extraOptions` is merged into the per-index
    spec, making `partialFilterExpression` (3.2+), `collation` (3.4+),
    `wildcardProjection` (4.2+ / 7.0 compound wildcard), text / 2dsphere /
    geo options reachable from the typed helper.
  - New `Database::INDEX_HIDDEN` flag (MongoDB 4.4+).
  - New BSON types `Decimal128` (TypeId 0x13, MongoDB 3.4+) with
    canonical IEEE 754-2008 string conversion, `MinKey` (TypeId 0xFF),
    `MaxKey` (TypeId 0x7F). `Document::read` no longer throws
    `NotImplementedException` on these types.
  - New `AUTH_SCRAM_SHA256` constant; `Database::authenticate()` default
    flipped from SCRAM-SHA-1 to SCRAM-SHA-256, matching the MongoDB
    server default for users created since 4.0 and the convention used
    by every official MongoDB driver. ASCII passwords only on the
    SCRAM-SHA-256 path; non-ASCII throws `NotImplementedException`
    pending full SASLprep (RFC 4013).
  - `Connection::connect(uri, ...)` accepts `tls=true` as an alias for
    the historical `ssl=true` URI option. URI default `authMechanism`
    also flipped to SCRAM-SHA-256 to match `Database::authenticate()`.

### Deprecations / modernization

  - `OpMsgMessage::CMD_MAP_REDUCE` marked `POCO_DEPRECATED` (mapReduce
    deprecated by MongoDB in 5.0). Use the aggregation pipeline.
  - `Database::INDEX_BACKGROUND` marked `POCO_DEPRECATED` (4.2 server
    no-op). Kept for source compatibility; no longer forwarded.
  - `Database::count()` rewritten internally to use aggregation
    `[{$count: "n"}]` rather than the legacy `count` command. Same
    signature. Aggregation `$count` is in the Stable API v1, accurate on
    sharded clusters, and permitted in multi-document transactions.

### Tests

98 offline tests pass (8 new BSONTest cases for createIndex element
merging, Decimal128 specials / parsing / round-trip / serialization with
trailing-zero preservation per the BSON spec, plus SyntaxException /
RangeException paths, MinKey/MaxKey serialization, auth constants, the
SASLprep ASCII guard, and the `tls=` URI alias).

### Notes

  - The CHANGELOG is owned separately and left untouched in this PR.
    User-visible changes that warrant entries: the two default-auth
    flips (`Database::authenticate()` and `Connection::connect(uri)`
    URI), `Database::count()` internal rewrite, `INDEX_BACKGROUND` /
    `CMD_MAP_REDUCE` `POCO_DEPRECATED` markings, plus the new feature
    bullets (`createIndex` extraOptions overload, `INDEX_HIDDEN`,
    Decimal128 / MinKey / MaxKey, `tls=` URI alias).
  - This PR targets the 1.15.3 release.

## Test plan

  - [x] `cmake -B build -DENABLE_TESTS=ON -DPOCO_MINIMAL_BUILD=ON
        -DENABLE_MONGODB=ON -DENABLE_FOUNDATION=ON -DENABLE_NET=ON
        -DENABLE_CRYPTO=ON -DENABLE_JSON=ON -DENABLE_UTIL=ON`
  - [x] `cmake --build build --target MongoDB-testrunner`
  - [x] `POCO_BASE=$PWD PATH="$PATH:$PWD/build/bin" ./build/bin/MongoDB-testrunner -all` -- expect 98 OK.
