### PR TITLE
fix(test): short-circuit Redis testsuite when broker is unreachable

### DIFF
--- a/Redis/testsuite/src/RedisTest.cpp
+++ b/Redis/testsuite/src/RedisTest.cpp
@@ -24,6 +24,7 @@ using namespace Poco::Redis;
 
 
 bool RedisTest::_connected = false;
+bool RedisTest::_connectFailed = false;
 Poco::Redis::Client RedisTest::_redis;
 
 
@@ -35,17 +36,22 @@ RedisTest::RedisTest(const std::string& name):
 #if POCO_OS == POCO_OS_ANDROID
 	_host = "10.0.2.2";
 #endif
-	if (!_connected)
+	// Skip the connect attempt if a prior test in this run already failed —
+	// otherwise every one of the ~54 tests pays the timeout (and on Windows
+	// the firewall silently drops instead of refusing, so each attempt eats
+	// the full timeout). One failure is enough to know Redis isn't there.
+	if (!_connected && !_connectFailed)
 	{
 		try
 		{
-			Poco::Timespan t(10, 0); // Connect within 10 seconds
+			Poco::Timespan t(1, 0); // 1 second is plenty for localhost
 			_redis.connect(_host, _port, t);
 			_connected = true;
 			std::cout << "Connected to [" << _host << ':' << _port << ']' << std::endl;
 		}
 		catch (Poco::Exception& e)
 		{
+			_connectFailed = true;
 			std::cout << "Couldn't connect to [" << _host << ':' << _port << ']' << e.message() << ". " << std::endl;
 		}
 	}

--- a/Redis/testsuite/src/RedisTest.h
+++ b/Redis/testsuite/src/RedisTest.h
@@ -95,6 +95,7 @@ private:
 	std::string _host;
 	unsigned    _port;
 	static bool _connected;
+	static bool _connectFailed;
 	static Poco::Redis::Client _redis;
 
 };


### PR DESCRIPTION
## Problem

When Redis isn't running, every one of the ~54 tests in `RedisTest` currently pays the full per-test connect timeout. On Windows the firewall silently drops instead of refusing, so each attempt eats the entire timeout — minutes of wall time for a suite that does no real work.

## Fix

Two small changes in `Redis/testsuite/src/RedisTest.{cpp,h}`:

1. **Latch a `_connectFailed` flag.** One failed connect is enough to know the broker isn't there. Set the flag in the ctor's catch block and gate the connect attempt on `!_connected && !_connectFailed`. Subsequent tests skip the connect step entirely.
2. **Tighten the per-test connect timeout from 10s to 1s.** These tests target `localhost` (or the Android emulator host `10.0.2.2`); the previous 10s was orders of magnitude beyond what a real local connect needs.

Net effect on a Redis-less run: total wait time drops from ~54 × 10s ≈ 9 minutes to a single 1s probe. Runs that *do* have Redis available are unaffected (`_connectFailed` stays `false`, the connect succeeds well under 1s on any sane localhost).

## Provenance

The patch originates in macchina.io as commit [`6a02d696b`](https://github.com/aleph-us/macchina.io/commit/6a02d696b) by @aleks-f; this PR brings it upstream so the next macchina sync (and any other Poco user without a local Redis) gets it for free.