### PR TITLE
fix(ci): always run the make sanity build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,12 +360,11 @@ jobs:
   # run (cmake jobs above already cover the test signal). Samples are skipped.
   # Uses the Linux-c++20 config to match the cmake default (C++20 since 1.15.0);
   # the codebase has moved past C++17 in places (e.g. std::ranges).
+  # Always run: the ci_core path filter does not cover the make build system
+  # (build/**, configure, component Makefiles), so gating on it would skip this
+  # sanity check on the very PRs that change the legacy make path.
   linux-gcc-make-build:
     runs-on: ubuntu-24.04
-    needs: changes
-    if: |
-      needs.changes.outputs.ci_core == 'true' ||
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
       - run: >-


### PR DESCRIPTION
The `linux-gcc-make-build` job was gated on the `ci_core` path filter (`CMakeLists.txt`, `cmake/**`, `.github/workflows/ci.yml`, `.github/actions/**`) plus push/dispatch events. That filter does not cover the make build system -- `build/**`, `configure`, or component `Makefile`s -- so a PR that changes only those files skipped the make sanity build, the one job that would catch a regression in the legacy make path (e.g. #5387, which changed `build/rules/compile`).

Remove the `needs: changes` dependency and the `if:` gate so the job runs on every workflow trigger, subject only to the top-level docs-only `paths-ignore`. Dropping `needs: changes` also lets it start immediately instead of waiting behind the `changes` job.