### PR TITLE
feat(MongoDB): add OP_MSG command constants and index-drop helpers

### DIFF
--- a/MongoDB/include/Poco/MongoDB/Database.h
+++ b/MongoDB/include/Poco/MongoDB/Database.h
@@ -145,6 +145,30 @@ public:
 		///
 		/// The document returned is the createIndexes response body.
 
+	Document::Ptr dropIndex(
+		Connection& connection,
+		const std::string& collection,
+		const std::string& indexName);
+		/// Drops the index with the given name from the collection. Passing "*"
+		/// drops all indexes except the _id index; prefer dropAllIndexes() for
+		/// that. The document returned is the dropIndexes response body.
+		/// (new wire protocol)
+
+	Document::Ptr dropIndex(
+		Connection& connection,
+		const std::string& collection,
+		const IndexedFields& indexedFields);
+		/// Drops the index matching the given key specification (the same
+		/// IndexedFields form accepted by createIndex). The document returned
+		/// is the dropIndexes response body. (new wire protocol)
+
+	Document::Ptr dropAllIndexes(
+		Connection& connection,
+		const std::string& collection);
+		/// Drops all indexes on the collection except the _id index (and, on a
+		/// sharded collection, the shard key index). The document returned is
+		/// the dropIndexes response body. (new wire protocol)
+
 	static const std::string AUTH_SCRAM_SHA1;
 		/// SCRAM-SHA-1 authentication mechanism (MongoDB 3.0+).
 

--- a/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
+++ b/MongoDB/include/Poco/MongoDB/OpMsgMessage.h
@@ -46,6 +46,10 @@ public:
 	static const std::string CMD_UPDATE;
 	static const std::string CMD_FIND;
 	static const std::string CMD_FIND_AND_MODIFY;
+	static const std::string CMD_BULK_WRITE;
+		/// Since MongoDB 8.0. Name constant only: the type-1 payload sections
+		/// (ops/nsInfo) are not wired into commandIdentifier(), so callers must
+		/// build the command body manually.
 
 	// Aggregation
 	static const std::string CMD_AGGREGATE;
@@ -63,17 +67,34 @@ public:
 
 	static const std::string CMD_CREATE;
 	static const std::string CMD_CREATE_INDEXES;
+	static const std::string CMD_DROP_INDEXES;
 	static const std::string CMD_DROP;
 	static const std::string CMD_DROP_DATABASE;
 	static const std::string CMD_KILL_CURSORS;
 	static const std::string CMD_LIST_DATABASES;
 	static const std::string CMD_LIST_INDEXES;
+	static const std::string CMD_LIST_COLLECTIONS;
+	static const std::string CMD_RENAME_COLLECTION;
+	static const std::string CMD_COLL_MOD;
+	static const std::string CMD_GET_PARAMETER;
+	static const std::string CMD_SET_PARAMETER;
 
 	// Diagnostic
 	static const std::string CMD_BUILD_INFO;
+	POCO_DEPRECATED("Deprecated since MongoDB 6.2; use the $collStats aggregation stage instead.")
 	static const std::string CMD_COLL_STATS;
 	static const std::string CMD_DB_STATS;
 	static const std::string CMD_HOST_INFO;
+	static const std::string CMD_PING;
+	static const std::string CMD_SERVER_STATUS;
+	static const std::string CMD_CONNECTION_STATUS;
+	static const std::string CMD_EXPLAIN;
+	static const std::string CMD_LIST_COMMANDS;
+	static const std::string CMD_GET_LOG;
+
+	// Authentication
+	static const std::string CMD_SASL_START;
+	static const std::string CMD_SASL_CONTINUE;
 
 
 	enum Flags : UInt32

--- a/MongoDB/src/Database.cpp
+++ b/MongoDB/src/Database.cpp
@@ -150,7 +150,7 @@ namespace
 		std::string clientFirstMsg = Poco::format("n=%s,r=%s", username, clientNonce);
 
 		Poco::SharedPtr<OpMsgMessage> pCommand = db.createOpMsgMessage("$cmd");
-		pCommand->setCommandName("saslStart");
+		pCommand->setCommandName(OpMsgMessage::CMD_SASL_START);
 		pCommand->body()
 			.add<std::string>("mechanism", mechanism)
 			.add<Binary::Ptr>("payload", new Binary(Poco::format("n,,%s", clientFirstMsg)))
@@ -214,7 +214,7 @@ namespace
 		std::string clientFinal = Poco::format("%s,p=%s", clientFinalNoProof, encodeBase64(clientProof));
 
 		pCommand = db.createOpMsgMessage("$cmd");
-		pCommand->setCommandName("saslContinue");
+		pCommand->setCommandName(OpMsgMessage::CMD_SASL_CONTINUE);
 		pCommand->body()
 			.add<Poco::Int32>("conversationId", conversationId)
 			.add<Binary::Ptr>("payload", new Binary(clientFinal));
@@ -247,13 +247,24 @@ namespace
 			throw Poco::ProtocolException("server signature verification failed");
 
 		pCommand = db.createOpMsgMessage("$cmd");
-		pCommand->setCommandName("saslContinue");
+		pCommand->setCommandName(OpMsgMessage::CMD_SASL_CONTINUE);
 		pCommand->body()
 			.add<Poco::Int32>("conversationId", conversationId)
 			.add<Binary::Ptr>("payload", new Binary);
 
 		connection.sendRequest(*pCommand, response);
 		return response.responseOk();
+	}
+
+
+	Document::Ptr keysFromIndexedFields(const Database::IndexedFields& indexedFields)
+	{
+		Document::Ptr keys = new Document();
+		for (const auto& [name, ascending]: indexedFields)
+		{
+			keys->add(name, ascending ? 1 : -1);
+		}
+		return keys;
 	}
 } // namespace
 
@@ -407,11 +418,7 @@ Poco::MongoDB::Document::Ptr Database::createIndex(
 {
 // https://www.mongodb.com/docs/manual/reference/command/createIndexes/
 
-	MongoDB::Document::Ptr keys = new MongoDB::Document();
-
-	for (const auto& [name, ascending]: indexedFields) {
-		keys->add(name, ascending ? 1 : -1);
-	}
+	MongoDB::Document::Ptr keys = keysFromIndexedFields(indexedFields);
 
 	MongoDB::Document::Ptr index = new MongoDB::Document();
 	index->add("key"s, keys);
@@ -464,6 +471,50 @@ Poco::MongoDB::Document::Ptr Database::createIndex(
 	MongoDB::Document::Ptr result = new MongoDB::Document(response.body());
 
 	return result;
+}
+
+
+Poco::MongoDB::Document::Ptr Database::dropIndex(
+	Connection& connection,
+	const std::string& collection,
+	const std::string& indexName)
+{
+// https://www.mongodb.com/docs/manual/reference/command/dropIndexes/
+
+	auto request = createOpMsgMessage(collection);
+	request->setCommandName(OpMsgMessage::CMD_DROP_INDEXES);
+	request->body().add("index"s, indexName);
+
+	OpMsgMessage response;
+	connection.sendRequest(*request, response);
+
+	return new MongoDB::Document(response.body());
+}
+
+
+Poco::MongoDB::Document::Ptr Database::dropIndex(
+	Connection& connection,
+	const std::string& collection,
+	const IndexedFields& indexedFields)
+{
+// https://www.mongodb.com/docs/manual/reference/command/dropIndexes/
+
+	auto request = createOpMsgMessage(collection);
+	request->setCommandName(OpMsgMessage::CMD_DROP_INDEXES);
+	request->body().add("index"s, keysFromIndexedFields(indexedFields));
+
+	OpMsgMessage response;
+	connection.sendRequest(*request, response);
+
+	return new MongoDB::Document(response.body());
+}
+
+
+Poco::MongoDB::Document::Ptr Database::dropAllIndexes(
+	Connection& connection,
+	const std::string& collection)
+{
+	return dropIndex(connection, collection, "*"s);
 }
 
 

--- a/MongoDB/src/OpMsgMessage.cpp
+++ b/MongoDB/src/OpMsgMessage.cpp
@@ -32,6 +32,7 @@ const std::string OpMsgMessage::CMD_DELETE { "delete"s };
 const std::string OpMsgMessage::CMD_UPDATE { "update"s };
 const std::string OpMsgMessage::CMD_FIND { "find"s };
 const std::string OpMsgMessage::CMD_FIND_AND_MODIFY { "findAndModify"s };
+const std::string OpMsgMessage::CMD_BULK_WRITE { "bulkWrite"s };
 const std::string OpMsgMessage::CMD_GET_MORE { "getMore"s };
 
 // Aggregation
@@ -47,17 +48,33 @@ const std::string OpMsgMessage::CMD_REPL_SET_GET_CONFIG { "replSetGetConfig"s };
 
 const std::string OpMsgMessage::CMD_CREATE { "create"s };
 const std::string OpMsgMessage::CMD_CREATE_INDEXES { "createIndexes"s };
+const std::string OpMsgMessage::CMD_DROP_INDEXES { "dropIndexes"s };
 const std::string OpMsgMessage::CMD_DROP { "drop"s };
 const std::string OpMsgMessage::CMD_DROP_DATABASE { "dropDatabase"s };
 const std::string OpMsgMessage::CMD_KILL_CURSORS { "killCursors"s };
 const std::string OpMsgMessage::CMD_LIST_DATABASES { "listDatabases"s };
 const std::string OpMsgMessage::CMD_LIST_INDEXES { "listIndexes"s };
+const std::string OpMsgMessage::CMD_LIST_COLLECTIONS { "listCollections"s };
+const std::string OpMsgMessage::CMD_RENAME_COLLECTION { "renameCollection"s };
+const std::string OpMsgMessage::CMD_COLL_MOD { "collMod"s };
+const std::string OpMsgMessage::CMD_GET_PARAMETER { "getParameter"s };
+const std::string OpMsgMessage::CMD_SET_PARAMETER { "setParameter"s };
 
 // Diagnostic
 const std::string OpMsgMessage::CMD_BUILD_INFO { "buildInfo"s };
 const std::string OpMsgMessage::CMD_COLL_STATS { "collStats"s };
 const std::string OpMsgMessage::CMD_DB_STATS { "dbStats"s };
 const std::string OpMsgMessage::CMD_HOST_INFO { "hostInfo"s };
+const std::string OpMsgMessage::CMD_PING { "ping"s };
+const std::string OpMsgMessage::CMD_SERVER_STATUS { "serverStatus"s };
+const std::string OpMsgMessage::CMD_CONNECTION_STATUS { "connectionStatus"s };
+const std::string OpMsgMessage::CMD_EXPLAIN { "explain"s };
+const std::string OpMsgMessage::CMD_LIST_COMMANDS { "listCommands"s };
+const std::string OpMsgMessage::CMD_GET_LOG { "getLog"s };
+
+// Authentication
+const std::string OpMsgMessage::CMD_SASL_START { "saslStart"s };
+const std::string OpMsgMessage::CMD_SASL_CONTINUE { "saslContinue"s };
 
 
 static const std::string& commandIdentifier(const std::string& command);

--- a/MongoDB/testsuite/src/MongoDBTest.cpp
+++ b/MongoDB/testsuite/src/MongoDBTest.cpp
@@ -224,6 +224,8 @@ CppUnit::Test* MongoDBTest::suite()
 
 		CppUnit_addTest(pSuite, MongoDBTest, testDBCount);
 
+		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdDropIndex);
+
 		CppUnit_addTest(pSuite, MongoDBTest, testOpCmdDropDatabase);		
 	}
 

--- a/MongoDB/testsuite/src/MongoDBTest.h
+++ b/MongoDB/testsuite/src/MongoDBTest.h
@@ -47,6 +47,7 @@ public:
 	void testOpCmdUnaknowledgedInsert();
 	void testOpCmdConnectionPool();
 	void testOpCmdDropDatabase();
+	void testOpCmdDropIndex();
 	void testDBCount();
 
 	static CppUnit::Test* suite();

--- a/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
+++ b/MongoDB/testsuite/src/MongoDBTestOpMsg.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <tuple>
 
 
 using namespace Poco::MongoDB;
@@ -451,6 +452,68 @@ void MongoDBTest::testOpCmdDropDatabase()
 	std::cout << response.body().toString(2) << std::endl;
 
 	assertTrue(response.responseOk());
+}
+
+
+void MongoDBTest::testOpCmdDropIndex()
+{
+	Database db("team");
+
+	// Start from a clean collection.
+	Poco::SharedPtr<OpMsgMessage> request = db.createOpMsgMessage("players");
+	OpMsgMessage response;
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response); // Ignore result: the collection may not exist yet.
+
+	// Insert one document so the collection exists.
+	request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_INSERT);
+	Document::Ptr player = new Document();
+	player->add("lastname"s, "Braem"s).add("firstname"s, "Franky"s);
+	request->documents().push_back(player);
+	_mongo->sendRequest(*request, response);
+	assertTrue(response.responseOk());
+
+	Database::IndexedFields lastnameField;
+	lastnameField.push_back(std::make_tuple("lastname", true));
+	Database::IndexedFields firstnameField;
+	firstnameField.push_back(std::make_tuple("firstname", true));
+
+	// 1. Drop by name.
+	Document::Ptr result = db.createIndex(*_mongo, "players", lastnameField, "lastname_1");
+	assertTrue(result->getInteger("ok") == 1);
+	result = db.dropIndex(*_mongo, "players", "lastname_1");
+	assertTrue(result->getInteger("ok") == 1);
+
+	// 2. Drop by key specification.
+	result = db.createIndex(*_mongo, "players", firstnameField, "firstname_1");
+	assertTrue(result->getInteger("ok") == 1);
+	result = db.dropIndex(*_mongo, "players", firstnameField);
+	assertTrue(result->getInteger("ok") == 1);
+
+	// 3. Drop all indexes: create two, then drop them at once.
+	db.createIndex(*_mongo, "players", lastnameField, "lastname_1");
+	db.createIndex(*_mongo, "players", firstnameField, "firstname_1");
+	result = db.dropAllIndexes(*_mongo, "players");
+	assertTrue(result->getInteger("ok") == 1);
+
+	// Only the _id index remains.
+	Poco::SharedPtr<OpMsgCursor> cursor = db.createOpMsgCursor("players");
+	cursor->query().setCommandName(OpMsgMessage::CMD_LIST_INDEXES);
+	auto listResponse = cursor->next(*_mongo);
+	int indexCount = 0;
+	while (true)
+	{
+		indexCount += static_cast<int>(listResponse.documents().size());
+		if (cursor->cursorID() == 0) break;
+		listResponse = cursor->next(*_mongo);
+	}
+	assertEquals (1, indexCount);
+
+	// Cleanup.
+	request = db.createOpMsgMessage("players");
+	request->setCommandName(OpMsgMessage::CMD_DROP);
+	_mongo->sendRequest(*request, response);
 }
 
 


### PR DESCRIPTION
## Summary

`Poco::MongoDB` exposed `OpMsgMessage::CMD_*` command-name constants for only a
subset of MongoDB commands (the "most often used" ones) and had no `dropIndex()`
helper on `Database`, even though `createIndex()` exists. An audit against the
MongoDB 8.0 command reference (and a comparison with the official mongocxx
driver) confirmed several commonly-used commands were missing constants, and
that two command names were hardcoded as raw string literals.

This PR:

- **Adds a curated set of command-name constants** to `OpMsgMessage`:
  `dropIndexes`, `listCollections`, `renameCollection`, `collMod`,
  `getParameter`, `setParameter`, `bulkWrite`, `ping`, `serverStatus`,
  `connectionStatus`, `explain`, `listCommands`, `getLog`, plus a new
  Authentication category with `saslStart` / `saslContinue`.
- **Adds index-drop helpers** on `Database`, mirroring `createIndex()` and the
  mongocxx `index_view` drop forms: `dropIndex()` by name, `dropIndex()` by key
  specification, and `dropAllIndexes()`. The key-building logic is factored into
  a shared helper reused by `createIndex()`.
- **Marks `collStats` with `POCO_DEPRECATED`** (deprecated since MongoDB 6.2;
  use the `$collStats` aggregation stage).
- **Replaces the hardcoded `saslStart` / `saslContinue` literals** in the SCRAM
  authentication path with the new constants.
- **Adds an integration test** (`testOpCmdDropIndex`) exercising all three drop
  forms and verifying via `listIndexes` that only the `_id` index remains.

`bulkWrite` is provided as a name constant only; its type-1 payload sections
(`ops` / `nsInfo`) are not wired into `commandIdentifier()`, so callers build the
command body manually.

## Testing

Built with the minimal MongoDB-scoped CMake configuration
(`-DPOCO_MINIMAL_BUILD=ON -DENABLE_MONGODB=ON -DENABLE_TESTS=ON`). The
`MongoDB-testrunner` suite passes (19 tests, including the new
`testOpCmdDropIndex`) against a local MongoDB instance.
