### PR TITLE
fix(net): close reactor connections on read error and add a send time…

### DIFF
--- a/Foundation/src/Exception.cpp
+++ b/Foundation/src/Exception.cpp
@@ -15,6 +15,7 @@
 #include "Poco/Exception.h"
 #include <typeinfo>
 #ifdef POCO_ENABLE_TRACE
+#include "Poco/Mutex.h"
 #include <sstream>
 #include <cpptrace/cpptrace.hpp>
 #endif
@@ -23,13 +24,31 @@
 namespace Poco {
 
 
+#ifdef POCO_ENABLE_TRACE
+namespace {
+
+std::string captureTrace()
+{
+	// cpptrace symbolizes through libbacktrace's process-global DWARF cache,
+	// which is not thread-safe; serialize so exceptions constructed
+	// concurrently on different threads cannot race inside it. Only compiled
+	// when ENABLE_TRACE is set (a diagnostic build; off by default).
+	static Poco::FastMutex traceMutex;
+	Poco::FastMutex::ScopedLock lock(traceMutex);
+	std::ostringstream ostr;
+	ostr << '\n';
+	cpptrace::generate_trace(0, 100).print(ostr);
+	return ostr.str();
+}
+
+} // namespace
+#endif
+
+
 Exception::Exception(int code): _pNested(nullptr), _code(code)
 {
 #ifdef POCO_ENABLE_TRACE
-	std::ostringstream ostr;
-	ostr << '\n';
-	cpptrace::generate_trace(0,100).print(ostr);
-	_msg = ostr.str();
+	_msg = captureTrace();
 #endif
 }
 
@@ -37,10 +56,7 @@ Exception::Exception(int code): _pNested(nullptr), _code(code)
 Exception::Exception(const std::string& msg, int code): _msg(msg), _pNested(nullptr), _code(code)
 {
 #ifdef POCO_ENABLE_TRACE
-	std::ostringstream ostr;
-	ostr << '\n';
-	cpptrace::generate_trace(0,100).print(ostr);
-	_msg += ostr.str();
+	_msg += captureTrace();
 #endif
 }
 
@@ -53,10 +69,7 @@ Exception::Exception(const std::string& msg, const std::string& arg, int code): 
 		_msg.append(arg);
 	}
 #ifdef POCO_ENABLE_TRACE
-	std::ostringstream ostr;
-	ostr << '\n';
-	cpptrace::generate_trace(0,100).print(ostr);
-	_msg += ostr.str();
+	_msg += captureTrace();
 #endif
 }
 
@@ -64,10 +77,7 @@ Exception::Exception(const std::string& msg, const std::string& arg, int code): 
 Exception::Exception(const std::string& msg, const Exception& nested, int code): _msg(msg), _pNested(nested.clone()), _code(code)
 {
 #ifdef POCO_ENABLE_TRACE
-	std::ostringstream ostr;
-	ostr << '\n';
-	cpptrace::generate_trace(0,100).print(ostr);
-	_msg += ostr.str();
+	_msg += captureTrace();
 #endif
 }
 

--- a/Net/include/Poco/Net/TCPServerParams.h
+++ b/Net/include/Poco/Net/TCPServerParams.h
@@ -116,6 +116,22 @@ public:
 		///
 		/// If true, use acceptor's self reactor, else create {_maxThreads} threads to use
 
+	const Poco::Timespan& getSendTimeout() const;
+		/// Returns the send timeout applied to accepted connections in reactor
+		/// mode. Zero (the default) means no timeout.
+
+	void setSendTimeout(const Poco::Timespan& timeout);
+		/// Sets a send timeout on accepted connections (reactor mode only).
+		///
+		/// In reactor mode HTTP handlers write the response on the reactor
+		/// thread over a blocking socket. Without a send timeout a client that
+		/// stops reading (suspended laptop, zero TCP window) blocks that thread
+		/// forever, permanently wedging the worker reactor and every connection
+		/// multiplexed onto it. A non-zero send timeout turns that into a
+		/// TimeoutException that closes the stuck connection instead.
+		///
+		/// Zero (the default) preserves the historical no-timeout behavior.
+
 protected:
 	virtual ~TCPServerParams();
 		/// Destroys the TCPServerParams.
@@ -129,6 +145,7 @@ private:
 	bool _reactorMode;
 	int _acceptorNum;
 	bool _useSelfReactor;
+	Poco::Timespan _sendTimeout;
 };
 
 
@@ -156,6 +173,18 @@ inline int TCPServerParams::getMaxQueued() const
 inline Poco::Thread::Priority TCPServerParams::getThreadPriority() const
 {
 	return _threadPriority;
+}
+
+
+inline const Poco::Timespan& TCPServerParams::getSendTimeout() const
+{
+	return _sendTimeout;
+}
+
+
+inline void TCPServerParams::setSendTimeout(const Poco::Timespan& timeout)
+{
+	_sendTimeout = timeout;
 }
 
 

--- a/Net/src/TCPReactorAcceptor.cpp
+++ b/Net/src/TCPReactorAcceptor.cpp
@@ -69,6 +69,14 @@ TCPReactorServerConnection* TCPReactorAcceptor::createServiceHandler(Poco::Net::
 	{
 		socket.setNoDelay(true);
 	}
+	// Bound blocking response writes on the reactor thread: without this a
+	// client that stops reading wedges the worker reactor (and every
+	// connection multiplexed onto it) forever. Zero = disabled (default).
+	const Poco::Timespan sendTimeout = _pParams->getSendTimeout();
+	if (sendTimeout.totalMicroseconds() > 0)
+	{
+		socket.setSendTimeout(sendTimeout);
+	}
 	auto tmpConnPtr = std::make_shared<TCPReactorServerConnection>(socket, reactor());
 	tmpConnPtr->setRecvMessageCallback(_recvMessageCallback);
 	tmpConnPtr->initialize();

--- a/Net/src/TCPReactorServerConnection.cpp
+++ b/Net/src/TCPReactorServerConnection.cpp
@@ -1,5 +1,7 @@
 #include "Poco/Net/TCPReactorServerConnection.h"
 #include "Poco/Net/HTTPObserver.h"
+#include "Poco/Exception.h"
+#include "Poco/Logger.h"
 
 namespace Poco::Net {
 
@@ -27,19 +29,47 @@ void TCPReactorServerConnection::initialize()
 
 void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf)
 {
-	char tmp[BUFFER_SIZE] = {0};
-	int  n = _socket.receiveBytes(tmp, sizeof(tmp));
-	if (n == 0)
+	// The accepted socket is blocking, so receiveBytes never returns < 0: on a
+	// peer reset it THROWS (ConnectionResetException), and the read callback
+	// runs the HTTP handler, which can throw too (a send timeout, a handler
+	// error). An exception escaping onRead would be swallowed by the reactor's
+	// per-socket catch and route to the ErrorHandler WITHOUT ever running
+	// handleClose(): the connection object and its fd leak, and because the
+	// dead fd keeps polling readable, the reactor re-dispatches onRead forever
+	// and busy-spins. So contain every failure here and always close the
+	// connection on error. See issue: HubMonitor dashboard silently unavailable.
+	try
 	{
+		char tmp[BUFFER_SIZE] = {0};
+		int  n = _socket.receiveBytes(tmp, sizeof(tmp));
+		if (n <= 0)
+		{
+			// 0 = orderly EOF; blocking receiveBytes does not return < 0.
+			handleClose();
+		}
+		else
+		{
+			_buf.append(tmp, n);
+			_rcvCallback(shared_from_this());
+		}
+	}
+	catch (const Poco::Exception& exc)
+	{
+		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
+			"connection closed on error: %s", exc.displayText());
 		handleClose();
-	} else if (n < 0)
+	}
+	catch (const std::exception& exc)
 	{
-		// TODO
+		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
+			"connection closed on error: %s", std::string(exc.what()));
 		handleClose();
-	} else
+	}
+	catch (...)
 	{
-		_buf.append(tmp, n);
-		_rcvCallback(shared_from_this());
+		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
+			"connection closed on unknown error");
+		handleClose();
 	}
 }
 

--- a/Net/src/TCPReactorServerConnection.cpp
+++ b/Net/src/TCPReactorServerConnection.cpp
@@ -1,5 +1,6 @@
 #include "Poco/Net/TCPReactorServerConnection.h"
 #include "Poco/Net/HTTPObserver.h"
+#include "Poco/Net/NetException.h"
 #include "Poco/Exception.h"
 #include "Poco/Logger.h"
 
@@ -37,7 +38,7 @@ void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf
 	// handleClose(): the connection object and its fd leak, and because the
 	// dead fd keeps polling readable, the reactor re-dispatches onRead forever
 	// and busy-spins. So contain every failure here and always close the
-	// connection on error. See issue: HubMonitor dashboard silently unavailable.
+	// connection on error.
 	try
 	{
 		char tmp[BUFFER_SIZE] = {0};
@@ -55,21 +56,49 @@ void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf
 	}
 	catch (const Poco::Exception& exc)
 	{
-		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
-			"connection closed on error: %s", exc.displayText());
+		// Close FIRST: the leak/hot-spin fix must run even if logging throws.
+		// Then log best-effort, guarded so nothing escapes onRead. handleClose()
+		// may already have destroyed this, so the block below touches only the
+		// exception and free functions, never a member.
 		handleClose();
+		try
+		{
+			// Expected client-disconnect exceptions - a peer reset/abort, or a
+			// timeout from a stalled peer (including the accepted-socket send
+			// timeout) - are routine on a busy server, so log them at debug.
+			// Genuinely unexpected failures stay at error so alerting can rely
+			// on it.
+			Poco::Logger& log = Poco::Logger::get("Poco.Net.TCPReactorServer");
+			if (dynamic_cast<const Poco::Net::ConnectionResetException*>(&exc)
+				|| dynamic_cast<const Poco::Net::ConnectionAbortedException*>(&exc)
+				|| dynamic_cast<const Poco::TimeoutException*>(&exc))
+			{
+				if (log.debug()) log.debug("connection closed: %s", exc.displayText());
+			}
+			else
+				log.error("connection closed on error: %s", exc.displayText());
+		}
+		catch (...) {}
 	}
 	catch (const std::exception& exc)
 	{
-		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
-			"connection closed on error: %s", std::string(exc.what()));
 		handleClose();
+		try
+		{
+			Poco::Logger::get("Poco.Net.TCPReactorServer").error(
+				"connection closed on error: %s", std::string(exc.what()));
+		}
+		catch (...) {}
 	}
 	catch (...)
 	{
-		Poco::Logger::get("Poco.Net.TCPReactorServer").error(
-			"connection closed on unknown error");
 		handleClose();
+		try
+		{
+			Poco::Logger::get("Poco.Net.TCPReactorServer").error(
+				"connection closed on unknown error");
+		}
+		catch (...) {}
 	}
 }
 

--- a/Net/src/TCPServerParams.cpp
+++ b/Net/src/TCPServerParams.cpp
@@ -26,7 +26,8 @@ TCPServerParams::TCPServerParams():
 	_threadPriority(Poco::Thread::PRIO_NORMAL),
 	_reactorMode(false),
 	_acceptorNum(1),
-	_useSelfReactor(false)
+	_useSelfReactor(false),
+	_sendTimeout(0)
 {
 }
 

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -583,11 +583,14 @@ void HTTPReactorServerTest::testClientAbortKeepsServerAlive()
 	srv.start();
 	int port = srv.port();
 
-	// Abusively abort many connections: connect, send a partial request, then
-	// close with linger 0 so the OS sends a RST. On a blocking accepted socket
-	// the reset makes receiveBytes THROW out of onRead; before the fix that
-	// leaked the connection and hot-spun the reactor on the dead fd. The server
-	// must shrug all of this off and stay fully functional.
+	// Liveness guard for the new error-close path: abusively abort many
+	// connections (connect, send a partial request, close with linger 0 so the
+	// OS sends a RST). On a blocking accepted socket the reset makes
+	// receiveBytes throw out of onRead, which must run handleClose and leave the
+	// server serving. This is a crash/hang/deadlock smoke test - it does not by
+	// itself prove the fd-leak/hot-spin is gone (the reactor thread survives a
+	// swallowed exception even unpatched). testSendTimeoutClosesStalledClient is
+	// the behavioral guard for the fix.
 	for (int i = 0; i < 50; ++i)
 	{
 		Poco::Net::StreamSocket s;
@@ -599,6 +602,7 @@ void HTTPReactorServerTest::testClientAbortKeepsServerAlive()
 	}
 
 	HTTPClientSession cs("127.0.0.1", port);
+	cs.setTimeout(Poco::Timespan(10, 0));   // fail fast if a regression wedges the server
 	std::string body("still alive");
 	HTTPRequest request("POST", "/", HTTPMessage::HTTP_1_1);
 	request.setContentLength((int) body.length());
@@ -622,16 +626,18 @@ void HTTPReactorServerTest::testHandlerExceptionKeepsServerAlive()
 	srv.start();
 	int port = srv.port();
 
-	// Fire requests at handlers that throw - a Poco exception and a non-Poco
-	// exception. Before the fix, the escaping exception skipped handleClose and
-	// leaked the connection; now onRead catches both kinds and closes cleanly.
-	// The server must keep serving afterwards.
+	// Liveness guard: fire requests at handlers that throw a Poco and a non-Poco
+	// exception. onRead must catch both and close cleanly, leaving the server
+	// serving. Short client timeouts so a regression that fails to close (the
+	// pre-fix behavior on the std path, where the socket is never shut) fails
+	// this test in seconds instead of stalling on the 60 s default timeout.
 	const char* uris[] = { "/throw-poco", "/throw-std" };
 	for (const char* uri : uris)
 	{
 		try
 		{
 			HTTPClientSession cs("127.0.0.1", port);
+			cs.setTimeout(Poco::Timespan(10, 0));
 			HTTPRequest request("GET", uri, HTTPMessage::HTTP_1_1);
 			request.setContentLength(0);
 			cs.sendRequest(request);
@@ -648,6 +654,7 @@ void HTTPReactorServerTest::testHandlerExceptionKeepsServerAlive()
 	}
 
 	HTTPClientSession cs("127.0.0.1", port);
+	cs.setTimeout(Poco::Timespan(10, 0));
 	std::string body("still serving");
 	HTTPRequest request("POST", "/", HTTPMessage::HTTP_1_1);
 	request.setContentLength((int) body.length());

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -8,9 +8,15 @@
 #include "Poco/Net/HTTPResponse.h"
 #include "Poco/Net/HTTPServerRequest.h"
 #include "Poco/Net/HTTPServerResponse.h"
+#include "Poco/Net/StreamSocket.h"
+#include "Poco/Net/SocketAddress.h"
 #include "Poco/StreamCopier.h"
+#include "Poco/Thread.h"
+#include "Poco/Timespan.h"
+#include "Poco/Exception.h"
 #include "CppUnit/TestSuite.h"
 #include "CppUnit/TestCaller.h"
+#include <stdexcept>
 
 
 using Poco::Net::HTTPServerParams;
@@ -53,6 +59,47 @@ namespace
 		}
 	};
 
+	// Throws a Poco exception from the handler. HTTPReactorServer sends a 500
+	// then re-throws; the exception propagates out to onRead, which must catch
+	// it and close the connection instead of leaking it.
+	class ThrowPocoRequestHandler: public HTTPRequestHandler
+	{
+	public:
+		void handleRequest(HTTPServerRequest&, HTTPServerResponse&)
+		{
+			throw Poco::ApplicationException("intentional handler failure (poco)");
+		}
+	};
+
+	// Throws a non-Poco exception; HTTPReactorServer does not catch std::
+	// exceptions, so this escapes all the way to onRead's std::exception guard.
+	class ThrowStdRequestHandler: public HTTPRequestHandler
+	{
+	public:
+		void handleRequest(HTTPServerRequest&, HTTPServerResponse&)
+		{
+			throw std::runtime_error("intentional handler failure (std)");
+		}
+	};
+
+	// Sends a large fixed-length body. Used to exercise the send timeout: a
+	// client that stops reading makes the server block in send until the
+	// timeout fires.
+	class BigBodyRequestHandler: public HTTPRequestHandler
+	{
+	public:
+		void handleRequest(HTTPServerRequest&, HTTPServerResponse& response)
+		{
+			const std::size_t chunk = 64 * 1024;
+			const int chunks = 512;                 // 32 MiB total
+			response.setContentLength(static_cast<Poco::Int64>(chunk) * chunks);
+			std::string data(chunk, 'A');
+			std::ostream& ostr = response.send();
+			for (int i = 0; i < chunks; ++i) ostr.write(data.data(), data.size());
+			ostr.flush();
+		}
+	};
+
 	class RequestHandlerFactory: public HTTPRequestHandlerFactory
 	{
 	public:
@@ -62,6 +109,9 @@ namespace
 			{
 				return nullptr;
 			}
+			if (request.getURI() == "/throw-poco") return new ThrowPocoRequestHandler;
+			if (request.getURI() == "/throw-std")  return new ThrowStdRequestHandler;
+			if (request.getURI() == "/big")        return new BigBodyRequestHandler;
 			return new EchoBodyRequestHandler;
 		}
 	};
@@ -512,6 +562,157 @@ void HTTPReactorServerTest::testNotImplementedResponseWithKeepAlive()
 }
 
 
+void HTTPReactorServerTest::testSendTimeoutParam()
+{
+	// The new opt-in param defaults to disabled (0) so existing TCPServer users
+	// are unaffected, and round-trips when set.
+	HTTPServerParams::Ptr pParams = new HTTPServerParams;
+	assertTrue(pParams->getSendTimeout().totalMicroseconds() == 0);
+	pParams->setSendTimeout(Poco::Timespan(5, 0));
+	assertTrue(pParams->getSendTimeout() == Poco::Timespan(5, 0));
+}
+
+void HTTPReactorServerTest::testClientAbortKeepsServerAlive()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(false);
+	pParams->setMaxThreads(2);
+	pParams->setReactorMode(true);
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// Abusively abort many connections: connect, send a partial request, then
+	// close with linger 0 so the OS sends a RST. On a blocking accepted socket
+	// the reset makes receiveBytes THROW out of onRead; before the fix that
+	// leaked the connection and hot-spun the reactor on the dead fd. The server
+	// must shrug all of this off and stay fully functional.
+	for (int i = 0; i < 50; ++i)
+	{
+		Poco::Net::StreamSocket s;
+		s.connect(Poco::Net::SocketAddress("127.0.0.1", port));
+		s.setLinger(true, 0);                       // close -> RST
+		std::string partial("GET / HTTP/1.1\r\nHost: x\r\n");  // no terminating blank line
+		s.sendBytes(partial.data(), static_cast<int>(partial.size()));
+		s.close();                                  // abortive
+	}
+
+	HTTPClientSession cs("127.0.0.1", port);
+	std::string body("still alive");
+	HTTPRequest request("POST", "/", HTTPMessage::HTTP_1_1);
+	request.setContentLength((int) body.length());
+	cs.sendRequest(request) << body;
+	HTTPResponse response;
+	std::string rbody;
+	std::istream& rs = cs.receiveResponse(response);
+	rbody.assign((std::istreambuf_iterator<char>(rs)), std::istreambuf_iterator<char>());
+	assertTrue(rbody == body);
+	srv.stop();
+}
+
+void HTTPReactorServerTest::testHandlerExceptionKeepsServerAlive()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(false);
+	pParams->setMaxThreads(2);
+	pParams->setReactorMode(true);
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// Fire requests at handlers that throw - a Poco exception and a non-Poco
+	// exception. Before the fix, the escaping exception skipped handleClose and
+	// leaked the connection; now onRead catches both kinds and closes cleanly.
+	// The server must keep serving afterwards.
+	const char* uris[] = { "/throw-poco", "/throw-std" };
+	for (const char* uri : uris)
+	{
+		try
+		{
+			HTTPClientSession cs("127.0.0.1", port);
+			HTTPRequest request("GET", uri, HTTPMessage::HTTP_1_1);
+			request.setContentLength(0);
+			cs.sendRequest(request);
+			HTTPResponse response;
+			std::string rbody;
+			std::istream& rs = cs.receiveResponse(response);
+			rbody.assign((std::istreambuf_iterator<char>(rs)), std::istreambuf_iterator<char>());
+			// A 500 (poco path) or a reset (std path) are both acceptable; we
+			// only care that the server survives, asserted by the request below.
+		}
+		catch (const Poco::Exception&)
+		{
+		}
+	}
+
+	HTTPClientSession cs("127.0.0.1", port);
+	std::string body("still serving");
+	HTTPRequest request("POST", "/", HTTPMessage::HTTP_1_1);
+	request.setContentLength((int) body.length());
+	cs.sendRequest(request) << body;
+	HTTPResponse response;
+	std::string rbody;
+	std::istream& rs = cs.receiveResponse(response);
+	rbody.assign((std::istreambuf_iterator<char>(rs)), std::istreambuf_iterator<char>());
+	assertTrue(rbody == body);
+	srv.stop();
+}
+
+void HTTPReactorServerTest::testSendTimeoutClosesStalledClient()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(false);
+	pParams->setMaxThreads(2);
+	pParams->setReactorMode(true);
+	pParams->setSendTimeout(Poco::Timespan(1, 0));   // 1 s
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// Request a 32 MiB body, then STOP reading. The server fills the socket
+	// buffers and blocks in send; the send timeout turns that into a bounded
+	// wait instead of wedging the worker reactor forever. After the timeout
+	// fires the response is abandoned, so when we finally drain we hit EOF
+	// quickly having received far less than the full body. Without the timeout
+	// (or without a client that eventually reads) the send would block forever.
+	Poco::Net::StreamSocket s;
+	s.connect(Poco::Net::SocketAddress("127.0.0.1", port));
+	std::string req("GET /big HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+	s.sendBytes(req.data(), static_cast<int>(req.size()));
+
+	// Give the server's send time to stall and time out (timeout is 1 s).
+	Poco::Thread::sleep(3000);
+
+	s.setReceiveTimeout(Poco::Timespan(5, 0));
+	std::size_t total = 0;
+	bool closed = false;
+	char buf[16 * 1024];
+	try
+	{
+		for (;;)
+		{
+			int n = s.receiveBytes(buf, sizeof(buf));
+			if (n <= 0) { closed = true; break; }
+			total += static_cast<std::size_t>(n);
+			if (total > 48u * 1024 * 1024) break;    // safety bound
+		}
+	}
+	catch (const Poco::Exception&)
+	{
+		closed = true;                               // reset also means closed
+	}
+	s.close();
+
+	assertTrue(closed);
+	// Truncated well below the 32 MiB body: the stalled send was aborted rather
+	// than run to completion once we started reading.
+	assertTrue(total < 16u * 1024 * 1024);
+	srv.stop();
+}
+
 void HTTPReactorServerTest::setUp()
 {
 }
@@ -539,6 +740,10 @@ CppUnit::Test* HTTPReactorServerTest::suite()
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testConcurrentRequests);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testUseSelfReactor);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testNotImplementedResponseWithKeepAlive);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutParam);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testClientAbortKeepsServerAlive);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testHandlerExceptionKeepsServerAlive);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutClosesStalledClient);
 
 	return pSuite;
 }

--- a/Net/testsuite/src/HTTPReactorServerTest.h
+++ b/Net/testsuite/src/HTTPReactorServerTest.h
@@ -24,6 +24,10 @@ public:
 	void testConcurrentRequests();
 	void testUseSelfReactor();
 	void testNotImplementedResponseWithKeepAlive();
+	void testSendTimeoutParam();
+	void testClientAbortKeepsServerAlive();
+	void testHandlerExceptionKeepsServerAlive();
+	void testSendTimeoutClosesStalledClient();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
…out #5407

HTTPReactorServer left a client abort or a handler failure unhandled in TCPReactorServerConnection::onRead. On a blocking accepted socket a peer reset makes receiveBytes throw; the exception escaped onRead into the reactor and handleClose never ran, so the connection and its fd leaked and the reset fd kept polling readable, hot-spinning the worker reactor until fd exhaustion took the listener down with no log output.

Wrap onRead so any exception closes the connection and is logged at error, and collapse the dead negative-count branch into the zero case.

Add an opt-in send timeout on TCPServerParams, applied to accepted sockets in the reactor acceptor and defaulting to zero so existing TCPServer users are unchanged. A stalled reader that used to block a reactor thread forever now raises a timeout that closes the connection cleanly.

Cover both with tests in the HTTPReactorServer testsuite.