### PR TITLE
fix(net): preserve exception type in HTTPReactorServer::onError #5407

### DIFF
--- a/Net/include/Poco/Net/HTTPReactorServer.h
+++ b/Net/include/Poco/Net/HTTPReactorServer.h
@@ -9,7 +9,6 @@
 #include "Poco/Net/HTTPSession.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/TCPReactorServer.h"
-#include "Poco/ThreadPool.h"
 namespace Poco::Net {
 
 
@@ -30,14 +29,16 @@ public:
 	int port() const { return _tcpReactorServer.port(); }
 	void onMessage(const TcpReactorConnectionPtr& conn);
 	void onError(const Poco::Exception& ex);
+		/// Rethrows ex preserving its dynamic type, so callers up the stack can
+		/// classify the failure. Handlers run inline on the reactor worker
+		/// thread, so this propagates into TCPReactorServerConnection::onRead.
+
 	void sendErrorResponse(HTTPSession& session, HTTPResponse::HTTPStatus status);
 
 private:
 	TCPReactorServer               _tcpReactorServer;
 	HTTPServerParams::Ptr          _pParams;
 	HTTPRequestHandlerFactory::Ptr _pFactory;
-
-	ThreadPool _threadPool;
 };
 
 } // namespace Poco::Net

--- a/Net/include/Poco/Net/TCPReactorAcceptor.h
+++ b/Net/include/Poco/Net/TCPReactorAcceptor.h
@@ -34,7 +34,7 @@ private:
 private:
 	TCPReactorAcceptor(const TCPReactorAcceptor&) = delete;
 	TCPReactorAcceptor&                         operator=(const TCPReactorAcceptor&) = delete;
-	std::vector<std::shared_ptr<SocketReactor>> _wokerReactors;
+	std::vector<std::shared_ptr<SocketReactor>> _workerReactors;
 	SocketReactor&                              _selfReactor;
 	bool                                        _useSelfReactor;
 	std::shared_ptr<ThreadPool>                 _threadPool;

--- a/Net/src/HTTPReactorServer.cpp
+++ b/Net/src/HTTPReactorServer.cpp
@@ -124,7 +124,15 @@ void HTTPReactorServer::sendErrorResponse(HTTPSession& session, HTTPResponse::HT
 
 void HTTPReactorServer::onError(const Poco::Exception& ex)
 {
-	throw ex;
+	// rethrow(), not `throw ex`. The parameter is a Poco::Exception reference, so
+	// `throw ex` copy-constructs a plain Poco::Exception and SLICES the dynamic
+	// type away. Everything downstream that classifies the failure by type then
+	// fails to recognize it: TCPReactorServerConnection::onRead dynamic_casts for
+	// ConnectionReset/ConnectionAborted/Timeout to log routine client churn at
+	// debug, and a sliced exception falls through to the error branch instead.
+	// rethrow() is virtual and each POCO_DECLARE_EXCEPTION class implements it as
+	// `throw *this`, preserving the derived type.
+	ex.rethrow();
 }
 
 } // namespace Poco::Net

--- a/Net/src/TCPReactorAcceptor.cpp
+++ b/Net/src/TCPReactorAcceptor.cpp
@@ -19,7 +19,7 @@ TCPReactorAcceptor::TCPReactorAcceptor(Poco::Net::ServerSocket& socket, Poco::Ne
 		for (int i = 0; i < workerThreads; i++)
 		{
 			std::shared_ptr<SocketReactor> workerReactor(std::make_shared<SocketReactor>());
-			_wokerReactors.push_back(workerReactor);
+			_workerReactors.push_back(workerReactor);
 			_threadPool->start(*workerReactor);
 		}
 	}
@@ -40,7 +40,7 @@ void TCPReactorAcceptor::stop()
 	{
 		return;
 	}
-	for (auto& worker : _wokerReactors)
+	for (auto& worker : _workerReactors)
 	{
 		worker->stop();
 	}
@@ -57,7 +57,7 @@ SocketReactor& TCPReactorAcceptor::reactor()
 		return _selfReactor;
 	}
 	static std::atomic_uint index(0);
-	return *_wokerReactors[index++ % _wokerReactors.size()];
+	return *_workerReactors[index++ % _workerReactors.size()];
 }
 
 TCPReactorServerConnection* TCPReactorAcceptor::createServiceHandler(Poco::Net::StreamSocket& socket)

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -10,6 +10,7 @@
 #include "Poco/Net/HTTPServerResponse.h"
 #include "Poco/Net/StreamSocket.h"
 #include "Poco/Net/SocketAddress.h"
+#include "Poco/Net/NetException.h"
 #include "Poco/StreamCopier.h"
 #include "Poco/Thread.h"
 #include "Poco/Timespan.h"
@@ -667,6 +668,54 @@ void HTTPReactorServerTest::testHandlerExceptionKeepsServerAlive()
 	srv.stop();
 }
 
+void HTTPReactorServerTest::testOnErrorPreservesExceptionType()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setReactorMode(true);
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+
+	// onError() rethrows the exception it is handed. It MUST preserve the dynamic
+	// type: onRead classifies failures with dynamic_cast to keep routine client
+	// churn (reset/abort/timeout) at debug and only log genuine faults at error.
+	// `throw ex` on a Poco::Exception& slices to the base class, so every such
+	// disconnect would be misreported as an error — silently defeating the
+	// classification while everything still "works". Assert the derived type
+	// survives, for a Net exception and for a Foundation one.
+	try
+	{
+		srv.onError(Poco::Net::ConnectionResetException("reset"));
+		fail("onError must rethrow");
+	}
+	catch (const Poco::Net::ConnectionResetException&) { }
+	catch (const Poco::Exception&)
+	{
+		fail("ConnectionResetException was sliced to Poco::Exception");
+	}
+
+	try
+	{
+		srv.onError(Poco::TimeoutException("timeout"));
+		fail("onError must rethrow");
+	}
+	catch (const Poco::TimeoutException&) { }
+	catch (const Poco::Exception&)
+	{
+		fail("TimeoutException was sliced to Poco::Exception");
+	}
+
+	// A plain Poco::Exception must still round-trip unchanged.
+	try
+	{
+		srv.onError(Poco::Exception("plain"));
+		fail("onError must rethrow");
+	}
+	catch (const Poco::Exception& e)
+	{
+		assertTrue(std::string(e.message()) == "plain");
+	}
+}
+
+
 void HTTPReactorServerTest::testSendTimeoutClosesStalledClient()
 {
 	HTTPServerParams* pParams = new HTTPServerParams;
@@ -750,6 +799,7 @@ CppUnit::Test* HTTPReactorServerTest::suite()
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutParam);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testClientAbortKeepsServerAlive);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testHandlerExceptionKeepsServerAlive);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testOnErrorPreservesExceptionType);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutClosesStalledClient);
 
 	return pSuite;

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -703,7 +703,11 @@ void HTTPReactorServerTest::testOnErrorPreservesExceptionType()
 		fail("TimeoutException was sliced to Poco::Exception");
 	}
 
-	// A plain Poco::Exception must still round-trip unchanged.
+	// A plain Poco::Exception must still round-trip with its payload intact.
+	// Prefix, NOT equality: under ENABLE_TRACE (which every CI job sets) the
+	// Exception constructor APPENDS a captured stack trace to _msg — see
+	// Foundation/src/Exception.cpp — so message() is "plain\n<trace>" there and
+	// exactly "plain" in a default build. Asserting the prefix holds in both.
 	try
 	{
 		srv.onError(Poco::Exception("plain"));
@@ -711,7 +715,7 @@ void HTTPReactorServerTest::testOnErrorPreservesExceptionType()
 	}
 	catch (const Poco::Exception& e)
 	{
-		assertTrue(std::string(e.message()) == "plain");
+		assertTrue(std::string(e.message()).rfind("plain", 0) == 0);
 	}
 }
 

--- a/Net/testsuite/src/HTTPReactorServerTest.h
+++ b/Net/testsuite/src/HTTPReactorServerTest.h
@@ -27,6 +27,7 @@ public:
 	void testSendTimeoutParam();
 	void testClientAbortKeepsServerAlive();
 	void testHandlerExceptionKeepsServerAlive();
+	void testOnErrorPreservesExceptionType();
 	void testSendTimeoutClosesStalledClient();
 
 	void setUp();


### PR DESCRIPTION
onError takes a const Poco::Exception& and rethrew it with throw ex, which copy-constructs a base Poco::Exception and slices the dynamic type away. Any downstream classification by type then fails silently: TCPReactorServerConnection::onRead dynamic_casts for ConnectionReset, ConnectionAborted and Timeout so routine client disconnects log at debug and only genuine faults log at error. A sliced exception matches none of them and falls through to the error branch, so ordinary client churn is reported as a fault.

Use ex.rethrow(), which is virtual and implemented by POCO_DECLARE_EXCEPTION as throw *this, preserving the derived type.

Also remove the unused HTTPReactorServer::_threadPool member. It was never referenced, and the ThreadPool constructor eagerly starts minCapacity threads, so every server instance spawned two threads that never received work. Its presence also implied a dispatch pool that does not exist: request handlers run inline on the reactor worker thread. Note this changes the class layout, so dependents linking PocoNet need a rebuild.

Fix the _wokerReactors misspelling in TCPReactorAcceptor.

Adds testOnErrorPreservesExceptionType, which asserts a Net exception, a Foundation exception and a plain Poco::Exception all survive onError with their type intact. Verified to fail with the sliced form and pass with rethrow.