### PR TITLE
fix(data): release MemoryDB's SQLite Connector registration via RAII …

### DIFF
--- a/Data/SQLite/include/Poco/Data/SQLite/MemoryDB.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/MemoryDB.h
@@ -414,9 +414,29 @@ private:
 	std::string shardPath(Poco::UInt32 id, const Poco::Timestamp& createdAt) const;
 	void cleanOrphans();
 
+	// RAII holder for the SQLite Connector registration; released whether the
+	// MemoryDB is destroyed normally or its constructor throws part-way through.
+	// Without the release the Connector's SharedPtr lingers in the process-global
+	// SessionFactory (in PocoData) until static teardown; by then, on Windows,
+	// PocoDataSQLite has unloaded, so ~SessionFactory destroying it dispatches a
+	// virtual through an unmapped vtable - an access violation in PocoData.dll on
+	// process shutdown.
+	struct ConnectorRegistration
+	{
+		ConnectorRegistration();
+		~ConnectorRegistration();
+	};
+
 	std::string                _dir;
 	std::string                _memName;     // shared-cache in-memory URI name
 	Options                    _opts;
+	// MUST be declared before _session/_persist/_catalog and never reordered
+	// after them: members construct in declaration order, so this registers the
+	// Connector before the Sessions are built (they need it), and destruct in
+	// reverse, so it releases only after the Sessions are gone. Moving it below a
+	// Session would build that Session against an unregistered connector and, on
+	// teardown, release the registration while a Session still lives.
+	ConnectorRegistration      _connectorReg;
 	Session                    _session;      // user-facing in-memory connection
 	Session                    _persist;      // second connection to the same in-memory db (flush/IO)
 	Session                    _catalog;      // on-disk manifest.db

--- a/Data/SQLite/src/MemoryDB.cpp
+++ b/Data/SQLite/src/MemoryDB.cpp
@@ -246,12 +246,13 @@ MemoryDB::ColumnCopy MemoryDB::columnCopy(Session& s, const std::string& table)
 
 // registerConnector()/unregisterConnector() are refcounted through
 // SessionFactory, so several live MemoryDB instances keep the connector
-// registered until the last one is gone. Both calls are swallowed: they run
-// during construction/destruction, where a throw is not actionable.
+// registered until the last one is gone. A failed registration propagates:
+// construction cannot proceed without it (the Session members need the
+// connector), so the caller must see the failure instead of getting a MemoryDB
+// wired to a missing connector.
 MemoryDB::ConnectorRegistration::ConnectorRegistration()
 {
-	try { Connector::registerConnector(); }
-	catch (...) {}
+	Connector::registerConnector();
 }
 
 

--- a/Data/SQLite/src/MemoryDB.cpp
+++ b/Data/SQLite/src/MemoryDB.cpp
@@ -244,6 +244,24 @@ MemoryDB::ColumnCopy MemoryDB::columnCopy(Session& s, const std::string& table)
 }
 
 
+// registerConnector()/unregisterConnector() are refcounted through
+// SessionFactory, so several live MemoryDB instances keep the connector
+// registered until the last one is gone. Both calls are swallowed: they run
+// during construction/destruction, where a throw is not actionable.
+MemoryDB::ConnectorRegistration::ConnectorRegistration()
+{
+	try { Connector::registerConnector(); }
+	catch (...) {}
+}
+
+
+MemoryDB::ConnectorRegistration::~ConnectorRegistration()
+{
+	try { Connector::unregisterConnector(); }
+	catch (...) {}
+}
+
+
 //
 // construction / lifecycle
 //
@@ -315,9 +333,6 @@ MemoryDB::~MemoryDB()
 
 std::string MemoryDB::prepare(const std::string& dir)
 {
-	try { Connector::registerConnector(); }
-	catch (...) {} // already registered
-
 	std::string abs = Poco::Path(dir).absolute().toString();
 	Poco::File(abs).createDirectories();
 	return abs;

--- a/Data/SQLite/testsuite/src/MemoryDBTest.cpp
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.cpp
@@ -15,6 +15,7 @@
 #include "Poco/Data/SQLite/Connector.h"
 #include "Poco/Data/SQLite/Utility.h"
 #include "Poco/Data/Session.h"
+#include "Poco/Data/SessionFactory.h"
 #include "Poco/File.h"
 #include "Poco/Path.h"
 #include "Poco/TemporaryFile.h"
@@ -57,6 +58,53 @@ void MemoryDBTest::tearDown()
 {
 	try { Poco::File(_dir).remove(true); }
 	catch (...) {}
+}
+
+
+void MemoryDBTest::testConnectorRegistrationBalanced()
+{
+	using Poco::Data::SessionFactory;
+	using Poco::Data::SQLite::Connector;
+
+	// Is the SQLite connector currently registered in the (process-global,
+	// refcounted) SessionFactory? Probe by trying to make a throwaway session;
+	// create() throws NotFoundException when the connector is absent.
+	auto registered = []() -> bool
+	{
+		try { SessionFactory::instance().create(Connector::KEY, ":memory:"); return true; }
+		catch (const Poco::NotFoundException&) { return false; }
+	};
+
+	// Establish a clean baseline by draining every outstanding registration,
+	// counting each one so we can restore the exact refcount afterwards and leave
+	// the process-global SessionFactory exactly as we found it. remove() throws
+	// (poco_assert) once the refcount reaches zero and the entry is erased.
+	int saved = 0;
+	for (;;)
+	{
+		try { Connector::unregisterConnector(); ++saved; }
+		catch (const Poco::Exception&) { break; }
+	}
+	assertTrue (!registered());
+
+	{
+		MemoryDB db(_dir);              // ctor registers the connector
+		assertTrue (registered());      // registered while the MemoryDB is alive
+	}                                   // ~MemoryDB must unregister (balance the ctor)
+
+	// The crux: creating and destroying a MemoryDB must leave the connector
+	// registration exactly as it found it. Without ~MemoryDB unregistering, the
+	// connector's SharedPtr lingers in the SessionFactory singleton (PocoData.dll)
+	// until process-exit static teardown - by which point, on Windows,
+	// PocoDataSQLite.dll has unloaded, so ~SessionFactory destroying the connector
+	// dispatches its virtual dtor through an unmapped vtable: the access violation
+	// in PocoData.dll seen when Hub.exe terminates.
+	const bool balanced = !registered();
+
+	// Restore the exact original refcount so nothing else in the process is disturbed.
+	for (int i = 0; i < saved; ++i) Connector::registerConnector();
+
+	assertTrue (balanced);
 }
 
 
@@ -1349,6 +1397,7 @@ CppUnit::Test* MemoryDBTest::suite()
 {
 	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("MemoryDBTest");
 
+	CppUnit_addTest(pSuite, MemoryDBTest, testConnectorRegistrationBalanced);
 	CppUnit_addTest(pSuite, MemoryDBTest, testPersistAndReload);
 	CppUnit_addTest(pSuite, MemoryDBTest, testManualFlushAndDirty);
 	CppUnit_addTest(pSuite, MemoryDBTest, testDestructorFlush);

--- a/Data/SQLite/testsuite/src/MemoryDBTest.cpp
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.cpp
@@ -85,6 +85,21 @@ void MemoryDBTest::testConnectorRegistrationBalanced()
 		try { Connector::unregisterConnector(); ++saved; }
 		catch (const Poco::Exception&) { break; }
 	}
+
+	// Restore the drained registrations however this test exits - a failing
+	// assertTrue throws, so a manual restore at the end would be skipped and
+	// leave the process-global refcount altered for later tests. RAII restores it
+	// during unwinding.
+	struct Restore
+	{
+		int n;
+		~Restore()
+		{
+			for (int i = 0; i < n; ++i)
+				Poco::Data::SQLite::Connector::registerConnector();
+		}
+	} restore{ saved };
+
 	assertTrue (!registered());
 
 	{
@@ -99,12 +114,7 @@ void MemoryDBTest::testConnectorRegistrationBalanced()
 	// PocoDataSQLite.dll has unloaded, so ~SessionFactory destroying the connector
 	// dispatches its virtual dtor through an unmapped vtable: the access violation
 	// in PocoData.dll seen when Hub.exe terminates.
-	const bool balanced = !registered();
-
-	// Restore the exact original refcount so nothing else in the process is disturbed.
-	for (int i = 0; i < saved; ++i) Connector::registerConnector();
-
-	assertTrue (balanced);
+	assertTrue (!registered());
 }
 
 

--- a/Data/SQLite/testsuite/src/MemoryDBTest.h
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.h
@@ -25,6 +25,7 @@ public:
 	MemoryDBTest(const std::string& name);
 	~MemoryDBTest();
 
+	void testConnectorRegistrationBalanced();
 	void testPersistAndReload();
 	void testManualFlushAndDirty();
 	void testDestructorFlush();


### PR DESCRIPTION
…#5411

MemoryDB registered the SQLite Connector during construction but never unregistered it, so the registration outlived every instance and stayed in the process-global SessionFactory singleton (in PocoData) until static teardown.

SessionFactory holds each connector by SharedPtr<Connector>. On Windows the module unload order at process exit unloads PocoDataSQLite - which owns the Connector's code and vtable - before PocoData's static SessionFactory is destroyed. ~SessionFactory then releases the still-registered connector's SharedPtr and dispatches its virtual destructor through a vtable in unmapped memory: a deterministic access violation in PocoData.dll on shutdown.

SessionFactory::add/remove are refcounted, so a symmetric unregister is safe with several live MemoryDB instances - the connector is removed only when the last one is destroyed.

Replace the registerConnector() in prepare() with an RAII member that registers in its constructor and unregisters in its destructor, declared before the Session members so it registers before they are built and releases only after they are destroyed. This also balances the registration when the constructor throws part-way through, which a destructor-only release would miss.

Adds a regression test asserting a create/destroy leaves the connector's registration state unchanged.