### PR TITLE
fix(Crypto,NetSSL): build with OpenSSL no-deprecated (#5415)

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -34,3 +34,8 @@ data:
 
 sqlparser:
   - 'Data/SQLParser/**'
+
+crypto_netssl:
+  - 'Crypto/**'
+  - 'NetSSL_OpenSSL/**'
+  - 'JWT/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       arm_cross: ${{ steps.filter.outputs.arm_cross }}
       data: ${{ steps.filter.outputs.data }}
       sqlparser: ${{ steps.filter.outputs.sqlparser }}
+      crypto_netssl: ${{ steps.filter.outputs.crypto_netssl }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v4
@@ -232,6 +233,36 @@ jobs:
             cd cmake-build &&
             PWD=`pwd`
             ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Foundation|Net|Crypto|Util|XML|JSON|Data|DataSQLite)$"
+      - uses: ./.github/actions/upload-test-report
+
+  # OpenSSL no-deprecated probe: build Crypto/NetSSL/JWT with deprecated
+  # OpenSSL declarations hidden (#5415). Debug + -D_DEBUG so that
+  # poco_assert_dbg expressions compile too.
+  linux-gcc-cmake-openssl-no-deprecated:
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: |
+      needs.changes.outputs.crypto_netssl == 'true' ||
+      needs.changes.outputs.ci_core == 'true' ||
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v5
+      - run: sudo apt -y update && sudo apt -y install cmake ninja-build libssl-dev
+      - run: >-
+          cmake -S. -Bcmake-build -GNinja -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_CXX_FLAGS="-DOPENSSL_NO_DEPRECATED -D_DEBUG"
+          -DPOCO_MINIMAL_BUILD=ON -DENABLE_TESTS=ON
+          -DENABLE_CRYPTO=ON -DENABLE_NETSSL=ON -DENABLE_JWT=ON
+      - run: cmake --build cmake-build --target all --parallel $(nproc)
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build &&
+            PWD=`pwd`
+            ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Crypto|JWT)$"
       - uses: ./.github/actions/upload-test-report
 
   # POCO_SOO=OFF probe: Foundation only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,9 @@ jobs:
             ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Foundation|Net|Crypto|Util|XML|JSON|Data|DataSQLite)$"
       - uses: ./.github/actions/upload-test-report
 
-  # OpenSSL no-deprecated probe: build Crypto/NetSSL/JWT with deprecated
-  # OpenSSL declarations hidden (#5415). Debug + -D_DEBUG so that
-  # poco_assert_dbg expressions compile too.
+  # OpenSSL no-deprecated probe: build and test Crypto/NetSSL/JWT with
+  # deprecated OpenSSL declarations hidden. Debug + -D_DEBUG so that
+  # poco_assert_dbg expressions are compiled as well.
   linux-gcc-cmake-openssl-no-deprecated:
     runs-on: ubuntu-24.04
     needs: changes
@@ -262,7 +262,7 @@ jobs:
           command: >-
             cd cmake-build &&
             PWD=`pwd`
-            ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Crypto|JWT)$"
+            ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Crypto|NetSSL|JWT)$"
       - uses: ./.github/actions/upload-test-report
 
   # POCO_SOO=OFF probe: Foundation only.

--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -202,8 +202,13 @@ private:
 		const std::string& keyFile,
 		const std::string& pass = "")
 	{
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 		poco_assert_dbg (((typeid(K*) == typeid(RSA*) || typeid(K*) == typeid(EC_KEY*)) && getFunc) ||
 						((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc));
+#else
+		// RSA/EC_KEY types are not declared; only EVP_PKEY loading is possible
+		poco_assert_dbg ((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc);
+#endif
 		poco_check_ptr (ppKey);
 		poco_assert_dbg (!*ppKey);
 
@@ -274,8 +279,13 @@ private:
 		std::istream* pIstr,
 		const std::string& pass = "")
 	{
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 		poco_assert_dbg (((typeid(K*) == typeid(RSA*) || typeid(K*) == typeid(EC_KEY*)) && getFunc) ||
 						((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc));
+#else
+		// RSA/EC_KEY types are not declared; only EVP_PKEY loading is possible
+		poco_assert_dbg ((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc);
+#endif
 		poco_check_ptr(ppKey);
 		poco_assert_dbg(!*ppKey);
 

--- a/Crypto/include/Poco/Crypto/EVPPKey.h
+++ b/Crypto/include/Poco/Crypto/EVPPKey.h
@@ -29,6 +29,7 @@
 #include <openssl/pem.h>
 #include <sstream>
 #include <map>
+#include <type_traits>
 
 
 namespace Poco::Crypto {
@@ -202,12 +203,13 @@ private:
 		const std::string& keyFile,
 		const std::string& pass = "")
 	{
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-		poco_assert_dbg (((typeid(K*) == typeid(RSA*) || typeid(K*) == typeid(EC_KEY*)) && getFunc) ||
-						((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc));
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+		// Native key extraction is only compiled for OpenSSL < 3.0; the RSA and
+		// EC_KEY types are not even declared when deprecated APIs are disabled.
+		poco_assert_dbg ((std::is_same_v<K, EVP_PKEY> && !getFunc));
 #else
-		// RSA/EC_KEY types are not declared; only EVP_PKEY loading is possible
-		poco_assert_dbg ((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc);
+		poco_assert_dbg (((std::is_same_v<K, RSA> || std::is_same_v<K, EC_KEY>) && getFunc) ||
+						(std::is_same_v<K, EVP_PKEY> && !getFunc));
 #endif
 		poco_check_ptr (ppKey);
 		poco_assert_dbg (!*ppKey);
@@ -242,7 +244,7 @@ private:
 						}
 						else
 						{
-							poco_assert_dbg (typeid(K*) == typeid(EVP_PKEY*));
+							poco_assert_dbg ((std::is_same_v<K, EVP_PKEY>));
 							*ppKey = (K*)pKey;
 						}
 						if (!*ppKey) goto error;
@@ -279,12 +281,13 @@ private:
 		std::istream* pIstr,
 		const std::string& pass = "")
 	{
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-		poco_assert_dbg (((typeid(K*) == typeid(RSA*) || typeid(K*) == typeid(EC_KEY*)) && getFunc) ||
-						((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc));
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+		// Native key extraction is only compiled for OpenSSL < 3.0; the RSA and
+		// EC_KEY types are not even declared when deprecated APIs are disabled.
+		poco_assert_dbg ((std::is_same_v<K, EVP_PKEY> && !getFunc));
 #else
-		// RSA/EC_KEY types are not declared; only EVP_PKEY loading is possible
-		poco_assert_dbg ((typeid(K*) == typeid(EVP_PKEY*)) && !getFunc);
+		poco_assert_dbg (((std::is_same_v<K, RSA> || std::is_same_v<K, EC_KEY>) && getFunc) ||
+						(std::is_same_v<K, EVP_PKEY> && !getFunc));
 #endif
 		poco_check_ptr(ppKey);
 		poco_assert_dbg(!*ppKey);
@@ -314,7 +317,7 @@ private:
 						}
 						else
 						{
-							poco_assert_dbg (typeid(K*) == typeid(EVP_PKEY*));
+							poco_assert_dbg ((std::is_same_v<K, EVP_PKEY>));
 							*ppKey = (K*)pKey;
 						}
 						if (!*ppKey) goto error;

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -190,7 +190,9 @@ public:
 		/// Returns the underlying socket descriptor.
 
 	X509* peerCertificate() const;
-		/// Returns the peer's certificate.
+		/// Returns the peer's certificate, or a null pointer if
+		/// no certificate is available. The caller is responsible
+		/// for releasing the returned reference with X509_free().
 
 	Context::Ptr context() const;
 		/// Returns the SSL context used for this socket.

--- a/NetSSL_OpenSSL/src/SSLManager.cpp
+++ b/NetSSL_OpenSSL/src/SSLManager.cpp
@@ -301,7 +301,11 @@ int SSLManager::verifyOCSPResponseCallback(SSL* pSSL, void* arg)
 		return 0;
 	}
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	X509* pPeerCert = SSL_get1_peer_certificate(pSSL);
+#else
 	X509* pPeerCert = SSL_get_peer_certificate(pSSL);
+#endif
 	if (!pPeerCert)
 	{
 		OCSP_BASICRESP_free(pBasicResp);

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -486,7 +486,11 @@ long SecureSocketImpl::verifyPeerCertificateImpl(const std::string& hostName)
 		return X509_V_OK;
 	}
 
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	::X509* pCert = ::SSL_get1_peer_certificate(_pSSL);
+#else
 	::X509* pCert = ::SSL_get_peer_certificate(_pSSL);
+#endif
 	if (pCert)
 	{
 		X509Certificate cert(pCert);
@@ -514,10 +518,14 @@ X509* SecureSocketImpl::peerCertificate() const
 {
 	LockT l(_mutex);
 
-	if (_pSSL)
-		return ::SSL_get_peer_certificate(_pSSL);
-	else
+	if (_pSSL == nullptr)
 		return nullptr;
+
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	return ::SSL_get1_peer_certificate(_pSSL);
+#else
+	return ::SSL_get_peer_certificate(_pSSL);
+#endif
 }
 
 


### PR DESCRIPTION
Fixes the two remaining build failures against OpenSSL 3.x compiled with `no-deprecated` (#5415), completing the work started in #5313:

- NetSSL: `SSL_get_peer_certificate` is only a macro alias on OpenSSL 3.0+ and disappears under `OPENSSL_NO_DEPRECATED`. The three call sites (`SSLManager.cpp`, `SecureSocketImpl.cpp`) now call `SSL_get1_peer_certificate` on 3.0+; semantics are identical (+1 reference), so behavior is unchanged. OpenSSL 1.1.1 and LibreSSL keep the existing call.
- Crypto: the `poco_assert_dbg` expressions in `EVPPKey.h` referenced the `RSA`/`EC_KEY` typedefs, which OpenSSL 3 hides under `OPENSSL_NO_DEPRECATED_3_0`; this broke Debug builds (`_DEBUG`). The asserts are now guarded, with a reduced EVP_PKEY-only assert when the types are hidden. Thanks to @GregDomjan for the report and the patch this is based on.
- CI: new `linux-gcc-cmake-openssl-no-deprecated` probe builds Crypto/NetSSL/JWT with `-DOPENSSL_NO_DEPRECATED -D_DEBUG` against stock libssl-dev, so both failure modes stay covered without a custom OpenSSL build.

Verified on macOS (clang, Homebrew OpenSSL 3) and Linux (gcc, OpenSSL 3): no-deprecated Debug build compiles cleanly, Crypto and NetSSL test suites pass; default builds unchanged.

Fixes #5415