### PR TITLE
enh(NetSSL_OpenSSL): TLS 1.3 session resumption when session cache is enabled #5414

### DIFF
--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -365,7 +365,8 @@ public:
 		///
 		/// To enable session caching on the server side, use the
 		/// two-argument version of this method to specify
-		/// a session ID context.
+		/// a session ID context. See that overload for the effect
+		/// of session caching on TLS 1.3 session tickets.
 
 	void enableSessionCache(bool flag, const std::string& sessionIdContext);
 		/// Enables or disables SSL/TLS session caching on the server.
@@ -384,11 +385,23 @@ public:
 		///
 		/// For TLS 1.3 connections, enabling the session cache also
 		/// enables the sending of session tickets, which are required
-		/// for TLS 1.3 session resumption. With OpenSSL 3.0 or newer,
-		/// the ticket is not sent during the handshake, but together
-		/// with the first application data written after the handshake.
-		/// If session caching is disabled (default), a TLS 1.3 server
-		/// does not send session tickets and sessions cannot be resumed.
+		/// for TLS 1.3 session resumption. If session caching is
+		/// disabled (default), a TLS 1.3 server does not send session
+		/// tickets and sessions cannot be resumed.
+		///
+		/// With OpenSSL 3.0 or newer, one ticket is sent together with
+		/// the first application data written after the handshake. A
+		/// server that never writes therefore issues no ticket, and its
+		/// sessions cannot be resumed. Since a ticket can be used for
+		/// one resumption only, a client that has to resume repeatedly
+		/// (such as an FTPS client opening several data connections)
+		/// must take a new session from each connection instead of
+		/// reusing the first one.
+		///
+		/// With older OpenSSL versions, which cannot request a ticket
+		/// after the handshake, tickets are sent during the handshake
+		/// instead. A client that closes the connection without reading
+		/// them makes the handshake fail on the server side.
 		///
 		/// This method may only be called on SERVER_USE Context objects.
 

--- a/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -382,6 +382,14 @@ public:
 		/// session caching is disabled to avoid problems with clients
 		/// requesting to reuse a session (e.g. Firefox 3.6).
 		///
+		/// For TLS 1.3 connections, enabling the session cache also
+		/// enables the sending of session tickets, which are required
+		/// for TLS 1.3 session resumption. With OpenSSL 3.0 or newer,
+		/// the ticket is not sent during the handshake, but together
+		/// with the first application data written after the handshake.
+		/// If session caching is disabled (default), a TLS 1.3 server
+		/// does not send session tickets and sessions cannot be resumed.
+		///
 		/// This method may only be called on SERVER_USE Context objects.
 
 	bool sessionCacheEnabled() const;

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureSocketImpl.h
@@ -293,6 +293,7 @@ private:
 	Poco::AutoPtr<SocketImpl> _pSocket;
 	Context::Ptr _pContext;
 	bool _needHandshake;
+	bool _ticketPending;
 	std::string _peerHostName;
 	Session::Ptr _pSession;
 	mutable MutexT _mutex;

--- a/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocket.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SecureStreamSocket.h
@@ -252,6 +252,12 @@ public:
 		/// is enabled).
 		///
 		/// If no connection is established, returns null.
+		///
+		/// For a TLS 1.3 connection, a session that can be reused
+		/// only becomes available once the server has sent a session
+		/// ticket, which happens with the first application data it
+		/// writes. Calling this immediately after the handshake
+		/// returns a session that cannot be resumed.
 
 	void useSession(Session::Ptr pSession);
 		/// Sets the SSL session to use for the next

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -92,17 +92,25 @@ void SecureSocketImpl::acceptSSL()
 		throw SSLException("Cannot create SSL object");
 	}
 
-	/* TLS 1.3 server sends session tickets after a handhake as part of
-	* the SSL_accept(). If a client finishes all its job before server
-	* sends the tickets, SSL_accept() fails with EPIPE errno. Since we
-	* are not interested in a session resumption, we can not to send the
-	* tickets. */
-	if (1 != SSL_set_num_tickets(_pSSL, 0))
+	/* A TLS 1.3 server sends session tickets at handshake completion. If the
+	 * client sends its data and closes without reading, the ticket write fails
+	 * with EPIPE and the handshake is reported as failed even though the peer
+	 * completed it. Therefore, no tickets are sent during the handshake.
+	 * With OpenSSL >= 3.0, if the session cache is enabled, a ticket is queued
+	 * after the handshake instead and goes out with the first application data
+	 * written (see completeHandshake()). With older OpenSSL, handshake-time
+	 * tickets are the only way to support session resumption, so they are kept
+	 * enabled when the session cache is enabled. */
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	const bool suppressTickets = true;
+#else
+	const bool suppressTickets = !_pContext->sessionCacheEnabled();
+#endif
+	if (suppressTickets && 1 != SSL_set_num_tickets(_pSSL, 0))
 	{
 		::BIO_free(pBIO);
-		throw SSLException("Cannot create SSL object");
+		throw SSLException("Cannot disable session tickets");
 	}
-	//Otherwise we can perform two-way shutdown. Client must call SSL_read() before the final SSL_shutdown().
 
 	::SSL_set_bio(_pSSL, pBIO, pBIO);
 	::SSL_set_accept_state(_pSSL);
@@ -453,6 +461,18 @@ int SecureSocketImpl::completeHandshake()
 		return handleError(rc);
 	}
 	_needHandshake = false;
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	if (SSL_is_server(_pSSL) && _pContext->sessionCacheEnabled())
+	{
+		/* Deferred replacement for the handshake-time tickets suppressed in
+		 * acceptSSL(): queue a ticket to be sent with the next application
+		 * data write. Deliberately not flushed here, because an immediate
+		 * flush would fail with EPIPE if the peer has already closed.
+		 * The return value is ignored: the call fails for TLS < 1.3, where
+		 * tickets are handled during the handshake. */
+		SSL_new_session_ticket(_pSSL);
+	}
+#endif
 	return rc;
 }
 

--- a/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -42,7 +42,8 @@ SecureSocketImpl::SecureSocketImpl(Poco::AutoPtr<SocketImpl> pSocketImpl, Contex
 	_pSSL(nullptr),
 	_pSocket(pSocketImpl),
 	_pContext(pContext),
-	_needHandshake(false)
+	_needHandshake(false),
+	_ticketPending(false)
 {
 	poco_check_ptr (_pSocket);
 	poco_check_ptr (_pContext);
@@ -95,12 +96,13 @@ void SecureSocketImpl::acceptSSL()
 	/* A TLS 1.3 server sends session tickets at handshake completion. If the
 	 * client sends its data and closes without reading, the ticket write fails
 	 * with EPIPE and the handshake is reported as failed even though the peer
-	 * completed it. Therefore, no tickets are sent during the handshake.
-	 * With OpenSSL >= 3.0, if the session cache is enabled, a ticket is queued
-	 * after the handshake instead and goes out with the first application data
-	 * written (see completeHandshake()). With older OpenSSL, handshake-time
-	 * tickets are the only way to support session resumption, so they are kept
-	 * enabled when the session cache is enabled. */
+	 * completed it.
+	 * With OpenSSL >= 3.0 tickets are therefore always suppressed here; when the
+	 * session cache is enabled, one is requested later, immediately before the
+	 * first application data write (see sendBytes()).
+	 * Older OpenSSL has no way to request a ticket after the handshake, so for
+	 * TLS 1.3 resumption there the handshake-time tickets have to be kept, at
+	 * the price of reinstating the failure described above. */
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	const bool suppressTickets = true;
 #else
@@ -109,6 +111,8 @@ void SecureSocketImpl::acceptSSL()
 	if (suppressTickets && 1 != SSL_set_num_tickets(_pSSL, 0))
 	{
 		::BIO_free(pBIO);
+		::SSL_free(_pSSL);
+		_pSSL = nullptr;
 		throw SSLException("Cannot disable session tickets");
 	}
 
@@ -360,6 +364,16 @@ int SecureSocketImpl::sendBytes(const void* buffer, int length, int flags)
 		else
 			return rc;
 	}
+#if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
+	if (_ticketPending)
+	{
+		/* The ticket is queued, not written, and goes out with the data below.
+		 * The return value is ignored: it also reports "not applicable", which
+		 * is the case for every connection below TLS 1.3. */
+		::SSL_new_session_ticket(_pSSL);
+		_ticketPending = false;
+	}
+#endif
 	const auto sendTimeout = _pSocket->getSendTimeout();
 	Poco::Timestamp tsStart;
 	while (true)
@@ -462,16 +476,12 @@ int SecureSocketImpl::completeHandshake()
 	}
 	_needHandshake = false;
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
-	if (SSL_is_server(_pSSL) && _pContext->sessionCacheEnabled())
-	{
-		/* Deferred replacement for the handshake-time tickets suppressed in
-		 * acceptSSL(): queue a ticket to be sent with the next application
-		 * data write. Deliberately not flushed here, because an immediate
-		 * flush would fail with EPIPE if the peer has already closed.
-		 * The return value is ignored: the call fails for TLS < 1.3, where
-		 * tickets are handled during the handshake. */
-		SSL_new_session_ticket(_pSSL);
-	}
+	/* Request the ticket suppressed in acceptSSL() only once, and only in
+	 * sendBytes(): SSL_new_session_ticket() puts the connection back into the
+	 * handshake state until the ticket is written, and SSL_shutdown() fails
+	 * while in that state. Deferring it to the write keeps the state alive
+	 * only across the call that immediately flushes it. */
+	_ticketPending = ::SSL_is_server(_pSSL) && _pContext->sessionCacheEnabled();
 #endif
 	return rc;
 }
@@ -681,6 +691,7 @@ void SecureSocketImpl::reset()
 		::SSL_set_ex_data(_pSSL, SSLManager::instance().socketIndex(), nullptr);
 		::SSL_free(_pSSL);
 		_pSSL = nullptr;
+		_ticketPending = false;
 	}
 }
 

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
@@ -26,6 +26,7 @@
 #include "Poco/Util/AbstractConfiguration.h"
 #include "Poco/Thread.h"
 #include "Poco/Mutex.h"
+#include "Poco/Timestamp.h"
 #include <iostream>
 
 
@@ -48,6 +49,122 @@ using Poco::Util::Application;
 namespace
 {
 	static Poco::FastMutex cerrMutex;
+
+	class CollectingConnection: public TCPServerConnection
+		/// Reads until the peer closes and stores what arrived, without
+		/// ever writing back.
+	{
+	public:
+		CollectingConnection(const StreamSocket& s): TCPServerConnection(s)
+		{
+		}
+
+		void run()
+		{
+			try
+			{
+				StreamSocket& ss = socket();
+				char buffer[256];
+				int n = ss.receiveBytes(buffer, sizeof(buffer));
+				while (n > 0)
+				{
+					Poco::FastMutex::ScopedLock l(_mutex);
+					_data.append(buffer, n);
+					n = ss.receiveBytes(buffer, sizeof(buffer));
+				}
+			}
+			catch (const Poco::Exception& exc)
+			{
+				Poco::FastMutex::ScopedLock l(_mutex);
+				_error = exc.displayText();
+			}
+		}
+
+		static void reset()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			_data.clear();
+			_error.clear();
+		}
+
+		static std::string data()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			return _data;
+		}
+
+		static std::string error()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			return _error;
+		}
+
+	private:
+		static Poco::FastMutex _mutex;
+		static std::string _data;
+		static std::string _error;
+	};
+
+	Poco::FastMutex CollectingConnection::_mutex;
+	std::string CollectingConnection::_data;
+	std::string CollectingConnection::_error;
+
+
+	class HandshakeOnlyConnection: public TCPServerConnection
+		/// Completes the handshake, then shuts down without reading or
+		/// writing any application data.
+	{
+	public:
+		HandshakeOnlyConnection(const StreamSocket& s): TCPServerConnection(s)
+		{
+		}
+
+		void run()
+		{
+			try
+			{
+				SecureStreamSocket sss(socket());
+				sss.completeHandshake();
+				sss.shutdown();
+			}
+			catch (const Poco::Exception& exc)
+			{
+				Poco::FastMutex::ScopedLock l(_mutex);
+				_error = exc.displayText();
+			}
+			Poco::FastMutex::ScopedLock l(_mutex);
+			_done = true;
+		}
+
+		static void reset()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			_done = false;
+			_error.clear();
+		}
+
+		static bool done()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			return _done;
+		}
+
+		static std::string error()
+		{
+			Poco::FastMutex::ScopedLock l(_mutex);
+			return _error;
+		}
+
+	private:
+		static Poco::FastMutex _mutex;
+		static bool _done;
+		static std::string _error;
+	};
+
+	Poco::FastMutex HandshakeOnlyConnection::_mutex;
+	bool HandshakeOnlyConnection::_done = false;
+	std::string HandshakeOnlyConnection::_error;
+
 
 	class EchoConnection: public TCPServerConnection
 	{
@@ -461,6 +578,8 @@ void TCPServerTest::testReuseSessionTLS13()
 
 	Session::Ptr pSession = ss1.currentSession();
 	assertTrue (!pSession.isNull());
+	// guard against the test silently degrading to the TLS 1.2 ticket path
+	assertTrue (SSL_SESSION_get_protocol_version(pSession->sslSession()) == TLS1_3_VERSION);
 	assertTrue (pSession->isResumable());
 	ss1.close();
 	Thread::sleep(300);
@@ -521,24 +640,128 @@ void TCPServerTest::testNoSessionTicketsTLS13()
 	assertTrue (n > 0);
 	assertTrue (std::string(buffer, n) == data);
 
+	// without a server session cache no ticket is issued, so the session
+	// exists but cannot be resumed
 	Session::Ptr pSession = ss1.currentSession();
-	assertTrue (pSession.isNull() || !pSession->isResumable());
+	assertTrue (!pSession.isNull());
+	assertTrue (!pSession->isResumable());
 	ss1.close();
 	Thread::sleep(300);
 	assertTrue (srv.currentConnections() == 0);
 
-	if (!pSession.isNull())
+	ss1.useSession(pSession);
+	ss1.connect(sa);
+	ss1.sendBytes(data.data(), (int) data.size());
+	n = ss1.receiveBytes(buffer, sizeof(buffer));
+	assertTrue (!ss1.sessionWasReused());
+	assertTrue (n > 0);
+	assertTrue (std::string(buffer, n) == data);
+	ss1.close();
+	Thread::sleep(300);
+	assertTrue (srv.currentConnections() == 0);
+}
+
+
+void TCPServerTest::testClientClosesWithoutReadingTLS13()
+{
+	// A TLS 1.3 client that sends data and closes without reading must not
+	// make the server-side handshake fail, and its data must still arrive.
+	// The server session cache is enabled, so this covers the connections
+	// for which a session ticket is issued.
+	Context::Ptr pDefaultServerContext = SSLManager::instance().defaultServerContext();
+	Context::Ptr pDefaultClientContext = SSLManager::instance().defaultClientContext();
+
+	Context::Ptr pServerContext = new Context(
+		Context::TLS_SERVER_USE,
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.caConfig"),
+		Context::VERIFY_NONE,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pServerContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+	pServerContext->enableSessionCache(true, "TestSuite");
+
+	SecureServerSocket svs(0, 64, pServerContext);
+	TCPServer srv(new TCPServerConnectionFactoryImpl<CollectingConnection>(), svs);
+	srv.start();
+
+	Context::Ptr pClientContext = new Context(
+		Context::TLS_CLIENT_USE,
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.caConfig"),
+		Context::VERIFY_RELAXED,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pClientContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+
+	CollectingConnection::reset();
+	const std::string data("hello, world");
+	SocketAddress sa("127.0.0.1", svs.address().port());
+	SecureStreamSocket ss1(sa, pClientContext);
+	ss1.sendBytes(data.data(), (int) data.size());
+	ss1.close();   // close without ever reading
+
+	Poco::Timestamp waitStart;
+	while (srv.currentConnections() > 0 && !waitStart.isElapsed(10000000))
+		Thread::sleep(100);
+	assertTrue (srv.currentConnections() == 0);
+	assertTrue (CollectingConnection::data() == data);
+	assertTrue (CollectingConnection::error().empty());
+}
+
+
+void TCPServerTest::testShutdownWithoutDataTLS13()
+{
+	// A server that completes the handshake and shuts down without reading or
+	// writing must not fail: requesting a session ticket puts the connection
+	// back into the handshake state, and SSL_shutdown() fails while in it.
+	Context::Ptr pDefaultServerContext = SSLManager::instance().defaultServerContext();
+	Context::Ptr pDefaultClientContext = SSLManager::instance().defaultClientContext();
+
+	Context::Ptr pServerContext = new Context(
+		Context::TLS_SERVER_USE,
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.caConfig"),
+		Context::VERIFY_NONE,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pServerContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+	pServerContext->enableSessionCache(true, "TestSuite");
+
+	SecureServerSocket svs(0, 64, pServerContext);
+	TCPServer srv(new TCPServerConnectionFactoryImpl<HandshakeOnlyConnection>(), svs);
+	srv.start();
+
+	Context::Ptr pClientContext = new Context(
+		Context::TLS_CLIENT_USE,
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.caConfig"),
+		Context::VERIFY_RELAXED,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pClientContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+
+	HandshakeOnlyConnection::reset();
+	SocketAddress sa("127.0.0.1", svs.address().port());
 	{
-		ss1.useSession(pSession);
-		ss1.connect(sa);
-		ss1.sendBytes(data.data(), (int) data.size());
-		n = ss1.receiveBytes(buffer, sizeof(buffer));
-		assertTrue (!ss1.sessionWasReused());
-		assertTrue (n > 0);
+		SecureStreamSocket ss1(sa, pClientContext);
+		ss1.sendBytes("x", 1);   // make the server-side handshake complete
+		Poco::Timestamp waitStart;
+		while (!HandshakeOnlyConnection::done() && !waitStart.isElapsed(10000000))
+			Thread::sleep(100);
 		ss1.close();
-		Thread::sleep(300);
-		assertTrue (srv.currentConnections() == 0);
 	}
+
+	assertTrue (HandshakeOnlyConnection::done());
+	assertTrue (HandshakeOnlyConnection::error().empty());
 }
 
 
@@ -656,6 +879,8 @@ CppUnit::Test* TCPServerTest::suite()
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSession);
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSessionTLS13);
 	CppUnit_addTest(pSuite, TCPServerTest, testNoSessionTicketsTLS13);
+	CppUnit_addTest(pSuite, TCPServerTest, testClientClosesWithoutReadingTLS13);
+	CppUnit_addTest(pSuite, TCPServerTest, testShutdownWithoutDataTLS13);
 	CppUnit_addTest(pSuite, TCPServerTest, testContextInvalidCertificateHandler);
 	CppUnit_addTest(pSuite, TCPServerTest, testAddCertificateAuthority);
 

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.cpp
@@ -413,6 +413,135 @@ void TCPServerTest::testReuseSession()
 }
 
 
+void TCPServerTest::testReuseSessionTLS13()
+{
+	// ensure OpenSSL machinery is fully setup
+	Context::Ptr pDefaultServerContext = SSLManager::instance().defaultServerContext();
+	Context::Ptr pDefaultClientContext = SSLManager::instance().defaultClientContext();
+
+	Context::Ptr pServerContext = new Context(
+		Context::TLS_SERVER_USE,
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.caConfig"),
+		Context::VERIFY_NONE,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pServerContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+	pServerContext->enableSessionCache(true, "TestSuite");
+	pServerContext->setSessionTimeout(10);
+	pServerContext->setSessionCacheSize(1000);
+
+	SecureServerSocket svs(0, 64, pServerContext);
+	TCPServer srv(new TCPServerConnectionFactoryImpl<EchoConnection>(), svs);
+	srv.start();
+
+	Context::Ptr pClientContext = new Context(
+		Context::TLS_CLIENT_USE,
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.caConfig"),
+		Context::VERIFY_RELAXED,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pClientContext->enableSessionCache(true);
+
+	SocketAddress sa("127.0.0.1", svs.address().port());
+	SecureStreamSocket ss1(sa, pClientContext);
+	assertTrue (!ss1.sessionWasReused());
+	std::string data("hello, world");
+	ss1.sendBytes(data.data(), (int) data.size());
+	char buffer[256];
+	// the echo reply also carries the session ticket issued after the handshake
+	int n = ss1.receiveBytes(buffer, sizeof(buffer));
+	assertTrue (n > 0);
+	assertTrue (std::string(buffer, n) == data);
+
+	Session::Ptr pSession = ss1.currentSession();
+	assertTrue (!pSession.isNull());
+	assertTrue (pSession->isResumable());
+	ss1.close();
+	Thread::sleep(300);
+	assertTrue (srv.currentConnections() == 0);
+
+	ss1.useSession(pSession);
+	ss1.connect(sa);
+	ss1.sendBytes(data.data(), (int) data.size());
+	n = ss1.receiveBytes(buffer, sizeof(buffer));
+	assertTrue (ss1.sessionWasReused());
+	assertTrue (n > 0);
+	assertTrue (std::string(buffer, n) == data);
+	ss1.close();
+	Thread::sleep(300);
+	assertTrue (srv.currentConnections() == 0);
+}
+
+
+void TCPServerTest::testNoSessionTicketsTLS13()
+{
+	// ensure OpenSSL machinery is fully setup
+	Context::Ptr pDefaultServerContext = SSLManager::instance().defaultServerContext();
+	Context::Ptr pDefaultClientContext = SSLManager::instance().defaultClientContext();
+
+	// server session cache not enabled: no session tickets are issued
+	Context::Ptr pServerContext = new Context(
+		Context::TLS_SERVER_USE,
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.privateKeyFile"),
+		Application::instance().config().getString("openSSL.server.caConfig"),
+		Context::VERIFY_NONE,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pServerContext->requireMinimumProtocol(Context::PROTO_TLSV1_3);
+
+	SecureServerSocket svs(0, 64, pServerContext);
+	TCPServer srv(new TCPServerConnectionFactoryImpl<EchoConnection>(), svs);
+	srv.start();
+
+	Context::Ptr pClientContext = new Context(
+		Context::TLS_CLIENT_USE,
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.privateKeyFile"),
+		Application::instance().config().getString("openSSL.client.caConfig"),
+		Context::VERIFY_RELAXED,
+		9,
+		true,
+		"ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+	pClientContext->enableSessionCache(true);
+
+	SocketAddress sa("127.0.0.1", svs.address().port());
+	SecureStreamSocket ss1(sa, pClientContext);
+	std::string data("hello, world");
+	ss1.sendBytes(data.data(), (int) data.size());
+	char buffer[256];
+	int n = ss1.receiveBytes(buffer, sizeof(buffer));
+	assertTrue (n > 0);
+	assertTrue (std::string(buffer, n) == data);
+
+	Session::Ptr pSession = ss1.currentSession();
+	assertTrue (pSession.isNull() || !pSession->isResumable());
+	ss1.close();
+	Thread::sleep(300);
+	assertTrue (srv.currentConnections() == 0);
+
+	if (!pSession.isNull())
+	{
+		ss1.useSession(pSession);
+		ss1.connect(sa);
+		ss1.sendBytes(data.data(), (int) data.size());
+		n = ss1.receiveBytes(buffer, sizeof(buffer));
+		assertTrue (!ss1.sessionWasReused());
+		assertTrue (n > 0);
+		ss1.close();
+		Thread::sleep(300);
+		assertTrue (srv.currentConnections() == 0);
+	}
+}
+
+
 void TCPServerTest::testContextInvalidCertificateHandler()
 {
 	SecureServerSocket svs(0);
@@ -525,6 +654,8 @@ CppUnit::Test* TCPServerTest::suite()
 	CppUnit_addTest(pSuite, TCPServerTest, testMultiConnections);
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSocket);
 	CppUnit_addTest(pSuite, TCPServerTest, testReuseSession);
+	CppUnit_addTest(pSuite, TCPServerTest, testReuseSessionTLS13);
+	CppUnit_addTest(pSuite, TCPServerTest, testNoSessionTicketsTLS13);
 	CppUnit_addTest(pSuite, TCPServerTest, testContextInvalidCertificateHandler);
 	CppUnit_addTest(pSuite, TCPServerTest, testAddCertificateAuthority);
 

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
@@ -31,6 +31,8 @@ public:
 	void testReuseSession();
 	void testReuseSessionTLS13();
 	void testNoSessionTicketsTLS13();
+	void testClientClosesWithoutReadingTLS13();
+	void testShutdownWithoutDataTLS13();
 	void testContextInvalidCertificateHandler();
 	void testAddCertificateAuthority();
 

--- a/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/TCPServerTest.h
@@ -29,6 +29,8 @@ public:
 	void testMultiConnections();
 	void testReuseSocket();
 	void testReuseSession();
+	void testReuseSessionTLS13();
+	void testNoSessionTicketsTLS13();
 	void testContextInvalidCertificateHandler();
 	void testAddCertificateAuthority();
 


### PR DESCRIPTION
Fixes #5414.

`SecureSocketImpl::acceptSSL()` disabled TLS 1.3 session tickets unconditionally,
so a POCO server could not offer TLS 1.3 session resumption at all. That call was
added for #2776: a TLS 1.3 server writes its tickets at handshake completion, and
if the client sends its data and closes without reading, the write fails with
EPIPE and the handshake is reported as failed even though the peer completed it.

Removing the call, as suggested in the issue, would reintroduce #2776 -- current
OpenSSL still sends tickets at handshake completion by default. Instead, tickets
become opt-in through the existing `Context::enableSessionCache()`.

## Changes

- OpenSSL >= 3.0: handshake-time tickets stay suppressed. When the session cache
  is enabled on a server context, one ticket is requested with
  `SSL_new_session_ticket()` immediately before the first application data write,
  so it goes out with that data and the EPIPE window never opens.
- OpenSSL 1.1.1, which cannot request a ticket after the handshake: tickets are
  suppressed only when the session cache is disabled.
- `acceptSSL()` now reports "Cannot disable session tickets" instead of the
  copy-pasted "Cannot create SSL object", and frees the SSL object on that path,
  consistent with `connectSSL()`.

The ticket is requested before the write rather than at handshake completion
because `SSL_new_session_ticket()` puts the connection back into the handshake
state until the ticket is written, and `SSL_shutdown()` fails in that state
("shutdown while in init"). Requesting it before the write that immediately
flushes it keeps that state from outliving a single call, and also means a
repeated `completeHandshake()` call cannot queue redundant tickets.

## Behaviour

Default behaviour is unchanged on all OpenSSL versions: `Context::init()` sets
`SSL_SESS_CACHE_OFF` and `SSLManager` defaults `cacheSessions` to false, so
tickets stay suppressed unless an application opts in.

Two consequences are documented in `Context::enableSessionCache()`:

- With OpenSSL >= 3.0 a server that never writes application data issues no
  ticket, so its sessions cannot be resumed.
- With OpenSSL 1.1.1, enabling the session cache restores handshake-time tickets
  and with them the #2776 failure mode.

A ticket can be used for one resumption only, so a client that resumes
repeatedly has to take a new session from each connection instead of reusing the
first one. `FTPSClientSession` does not do that yet -- it always takes the
session from the control connection -- so `forceSessionReuse` still fails from
the second data connection on. That is a separate client-side change.

## Tests

`TCPServerTest` gains four cases:

- `testReuseSessionTLS13` -- session cache enabled: the session is resumable and
  is reused on reconnect. Verified to fail without the change.
- `testNoSessionTicketsTLS13` -- session cache disabled: no ticket, no reuse.
- `testClientClosesWithoutReadingTLS13` -- the #2776 scenario with the session
  cache enabled: the client sends and closes without reading, the server-side
  handshake still succeeds and the data arrives.
- `testShutdownWithoutDataTLS13` -- the server completes the handshake and shuts
  down without transferring data. Verified to fail if the ticket is requested at
  handshake completion instead of before the write.

Full NetSSL suite passes on macOS and Linux (OpenSSL 3.5.3); the two `testProxy`
errors are pre-existing and need an external proxy.
