### PR TITLE
fix(Net): release FTPClientSession control socket on constructor failure; document readWelcomeMessage #5413

### DIFF
--- a/Net/include/Poco/Net/FTPClientSession.h
+++ b/Net/include/Poco/Net/FTPClientSession.h
@@ -67,6 +67,17 @@ public:
 		/// Creates an FTPClientSession using the given
 		/// connected socket for the control connection.
 		///
+		/// If readWelcomeMessage is true (the default), the welcome reply
+		/// sent by the server on connect is read from the socket and made
+		/// available through welcomeMessage().
+		///
+		/// Pass false only if the welcome reply has already been read from
+		/// the socket. The session then considers the server ready and sends
+		/// the next command without waiting for a reply. Passing false while
+		/// the welcome reply is still pending desynchronizes the session,
+		/// because that reply is then taken as the response to the next
+		/// command sent.
+		///
 		/// Passive mode will be used for data transfers.
 
 	FTPClientSession(const std::string& host, Poco::UInt16 port = FTP_PORT,
@@ -306,9 +317,18 @@ public:
 
 	[[nodiscard]] const std::string& welcomeMessage();
 		/// Returns the welcome message.
+		///
+		/// Empty if the session was created with readWelcomeMessage
+		/// set to false, as the welcome reply is then read by the caller.
 
 protected:
 	virtual void receiveServerReadyReply();
+		/// Reads the welcome reply sent by the server on connect and
+		/// marks the server ready.
+		///
+		/// Does nothing if the server is already marked ready, which is
+		/// the case after the reply has been read once, and after
+		/// construction with readWelcomeMessage set to false.
 
 	enum StatusClass
 	{

--- a/Net/src/FTPClientSession.cpp
+++ b/Net/src/FTPClientSession.cpp
@@ -57,14 +57,24 @@ FTPClientSession::FTPClientSession(const StreamSocket& socket,
 	_isLoggedIn(false),
 	_timeout(DEFAULT_TIMEOUT)
 {
-	_pControlSocket->setReceiveTimeout(_timeout);
-	if (readWelcomeMessage)
+	// The destructor does not run if the constructor throws, so the control
+	// socket has to be released here to close the connection.
+	try
 	{
-		FTPClientSession::receiveServerReadyReply();
+		_pControlSocket->setReceiveTimeout(_timeout);
+		if (readWelcomeMessage)
+		{
+			FTPClientSession::receiveServerReadyReply();
+		}
+		else
+		{
+			_serverReady = true;
+		}
 	}
-	else
+	catch (...)
 	{
-		_serverReady = true;
+		delete _pControlSocket;
+		throw;
 	}
 }
 
@@ -86,9 +96,19 @@ FTPClientSession::FTPClientSession(const std::string& host,
 	_isLoggedIn(false),
 	_timeout(DEFAULT_TIMEOUT)
 {
-	_pControlSocket->setReceiveTimeout(_timeout);
-	if (!username.empty())
-		login(username, password);
+	// The destructor does not run if the constructor throws, so the control
+	// socket has to be released here to close the connection.
+	try
+	{
+		_pControlSocket->setReceiveTimeout(_timeout);
+		if (!username.empty())
+			login(username, password);
+	}
+	catch (...)
+	{
+		delete _pControlSocket;
+		throw;
+	}
 }
 
 

--- a/Net/testsuite/src/FTPClientSessionTest.cpp
+++ b/Net/testsuite/src/FTPClientSessionTest.cpp
@@ -14,6 +14,7 @@
 #include "DialogServer.h"
 #include "Poco/Net/FTPClientSession.h"
 #include "Poco/Net/DialogSocket.h"
+#include "Poco/Net/ServerSocket.h"
 #include "Poco/Net/StreamSocket.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/NetException.h"
@@ -26,6 +27,7 @@
 
 using Poco::Net::FTPClientSession;
 using Poco::Net::DialogSocket;
+using Poco::Net::ServerSocket;
 using Poco::Net::StreamSocket;
 using Poco::Net::SocketAddress;
 using Poco::Net::FTPException;
@@ -62,31 +64,31 @@ namespace
 		FTPClientSession& _session;
 	};
 
-	class SocketCloser
-		/// Closes a socket handed to an FTPClientSession constructor.
-		///
-		/// A constructor that throws leaks the control socket, leaving the
-		/// connection open. DialogServer's destructor would then wait forever
-		/// for its peer to disconnect, turning a test failure into a hang.
+	class ActiveConnector
+		/// Runs the connecting constructor off the test thread, so that the
+		/// test itself can accept the connection and script the reply.
 	{
 	public:
-		SocketCloser(StreamSocket& socket): _socket(socket)
+		ActiveConnector():
+			connect(this, &ActiveConnector::connectImpl)
 		{
 		}
 
-		~SocketCloser()
+		ActiveMethod<bool, Poco::UInt16, ActiveConnector> connect;
+
+	protected:
+		bool connectImpl(const Poco::UInt16& port)
 		{
 			try
 			{
-				_socket.close();
+				FTPClientSession session("127.0.0.1", port, "user", "password");
 			}
-			catch (...)
+			catch (FTPException&)
 			{
+				return true;
 			}
+			return false;
 		}
-
-	private:
-		StreamSocket& _socket;
 	};
 };
 
@@ -115,6 +117,16 @@ void FTPClientSessionTest::login(DialogServer& server, FTPClientSession& session
 	assertTrue (cmd == "TYPE I");
 
 	assertTrue (session.getFileType() == FTPClientSession::TYPE_BINARY);
+}
+
+
+void FTPClientSessionTest::assertConnectionClosed(DialogSocket& peer)
+{
+	// The timeout keeps a still-open connection from blocking the test
+	// forever; receiveBytes() returns 0 once the peer has disconnected.
+	peer.setReceiveTimeout(Poco::Timespan(10, 0));
+	char buffer[16];
+	assertTrue (peer.receiveBytes(buffer, sizeof(buffer)) == 0);
 }
 
 
@@ -239,7 +251,6 @@ void FTPClientSessionTest::testWelcomeMessageRead()
 	DialogServer server;
 	server.addResponse("220 localhost FTP ready");
 	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
-	SocketCloser closer(socket);
 
 	FTPClientSession session(socket);
 	assertTrue (session.isOpen());
@@ -260,7 +271,6 @@ void FTPClientSessionTest::testWelcomeMessageNotRead()
 	DialogServer server;
 	server.addResponse("220 localhost FTP ready");
 	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
-	SocketCloser closer(socket);
 
 	// readWelcomeMessage == false means the caller has already read the
 	// welcome reply from the socket.
@@ -283,6 +293,47 @@ void FTPClientSessionTest::testWelcomeMessageNotRead()
 	server.addResponse("221 Good Bye");
 	session.close();
 	assertTrue (!session.isOpen());
+}
+
+
+void FTPClientSessionTest::testConstructorFailureClosesSocket1()
+{
+	ServerSocket serverSocket(SocketAddress("127.0.0.1", 0));
+	DialogSocket peer;
+	{
+		StreamSocket clientSocket(SocketAddress("127.0.0.1", serverSocket.address().port()));
+		peer = serverSocket.acceptConnection();
+		peer.sendMessage("421 Service not available");
+		try
+		{
+			FTPClientSession session(clientSocket);
+			fail("server not ready - must throw");
+		}
+		catch (FTPException&)
+		{
+		}
+	}
+
+	// The constructor threw after taking over the socket, so releasing the
+	// caller's own reference must close the connection. DialogServer is not
+	// used here: it only leaves its receive loop once the peer disconnects,
+	// so a socket kept open would hang the test instead of failing it.
+	assertConnectionClosed(peer);
+}
+
+
+void FTPClientSessionTest::testConstructorFailureClosesSocket2()
+{
+	ServerSocket serverSocket(SocketAddress("127.0.0.1", 0));
+	ActiveConnector connector;
+	ActiveResult<bool> result = connector.connect(serverSocket.address().port());
+
+	DialogSocket peer = serverSocket.acceptConnection();
+	peer.sendMessage("421 Service not available");
+	result.wait();
+	assertTrue (result.data());
+
+	assertConnectionClosed(peer);
 }
 
 
@@ -675,6 +726,8 @@ CppUnit::Test* FTPClientSessionTest::suite()
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testLoginFailed2);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testWelcomeMessageRead);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testWelcomeMessageNotRead);
+	CppUnit_addTest(pSuite, FTPClientSessionTest, testConstructorFailureClosesSocket1);
+	CppUnit_addTest(pSuite, FTPClientSessionTest, testConstructorFailureClosesSocket2);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testCommands);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testDownloadPORT);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testDownloadEPRT);

--- a/Net/testsuite/src/FTPClientSessionTest.cpp
+++ b/Net/testsuite/src/FTPClientSessionTest.cpp
@@ -14,9 +14,11 @@
 #include "DialogServer.h"
 #include "Poco/Net/FTPClientSession.h"
 #include "Poco/Net/DialogSocket.h"
+#include "Poco/Net/StreamSocket.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/NetException.h"
 #include "Poco/Thread.h"
+#include "Poco/Timespan.h"
 #include "Poco/ActiveMethod.h"
 #include "Poco/StreamCopier.h"
 #include <sstream>
@@ -24,6 +26,7 @@
 
 using Poco::Net::FTPClientSession;
 using Poco::Net::DialogSocket;
+using Poco::Net::StreamSocket;
 using Poco::Net::SocketAddress;
 using Poco::Net::FTPException;
 using Poco::ActiveMethod;
@@ -57,6 +60,33 @@ namespace
 
 	private:
 		FTPClientSession& _session;
+	};
+
+	class SocketCloser
+		/// Closes a socket handed to an FTPClientSession constructor.
+		///
+		/// A constructor that throws leaks the control socket, leaving the
+		/// connection open. DialogServer's destructor would then wait forever
+		/// for its peer to disconnect, turning a test failure into a hang.
+	{
+	public:
+		SocketCloser(StreamSocket& socket): _socket(socket)
+		{
+		}
+
+		~SocketCloser()
+		{
+			try
+			{
+				_socket.close();
+			}
+			catch (...)
+			{
+			}
+		}
+
+	private:
+		StreamSocket& _socket;
 	};
 };
 
@@ -201,6 +231,58 @@ void FTPClientSessionTest::testLoginFailed2()
 	}
 	server.addResponse("221 Good Bye");
 	session.close();
+}
+
+
+void FTPClientSessionTest::testWelcomeMessageRead()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
+	SocketCloser closer(socket);
+
+	FTPClientSession session(socket);
+	assertTrue (session.isOpen());
+	assertTrue (!session.isLoggedIn());
+	assertTrue (session.welcomeMessage() == "220 localhost FTP ready");
+
+	login(server, session);
+	assertTrue (session.isLoggedIn());
+
+	server.addResponse("221 Good Bye");
+	session.close();
+	assertTrue (!session.isOpen());
+}
+
+
+void FTPClientSessionTest::testWelcomeMessageNotRead()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
+	SocketCloser closer(socket);
+
+	// readWelcomeMessage == false means the caller has already read the
+	// welcome reply from the socket.
+	{
+		DialogSocket ds(socket);
+		std::string response;
+		int status = ds.receiveStatusMessage(response);
+		assertTrue (status == 220);
+	}
+
+	FTPClientSession session(socket, false);
+	assertTrue (session.isOpen());
+	assertTrue (session.welcomeMessage().empty());
+
+	// Reading the welcome reply again would block until this timeout expires.
+	session.setTimeout(Poco::Timespan(5, 0));
+	login(server, session);
+	assertTrue (session.isLoggedIn());
+
+	server.addResponse("221 Good Bye");
+	session.close();
+	assertTrue (!session.isOpen());
 }
 
 
@@ -591,6 +673,8 @@ CppUnit::Test* FTPClientSessionTest::suite()
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testLogin3);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testLoginFailed1);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testLoginFailed2);
+	CppUnit_addTest(pSuite, FTPClientSessionTest, testWelcomeMessageRead);
+	CppUnit_addTest(pSuite, FTPClientSessionTest, testWelcomeMessageNotRead);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testCommands);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testDownloadPORT);
 	CppUnit_addTest(pSuite, FTPClientSessionTest, testDownloadEPRT);

--- a/Net/testsuite/src/FTPClientSessionTest.h
+++ b/Net/testsuite/src/FTPClientSessionTest.h
@@ -37,6 +37,8 @@ public:
 	void testLogin3();
 	void testLoginFailed1();
 	void testLoginFailed2();
+	void testWelcomeMessageRead();
+	void testWelcomeMessageNotRead();
 	void testCommands();
 	void testDownloadPORT();
 	void testDownloadEPRT();

--- a/Net/testsuite/src/FTPClientSessionTest.h
+++ b/Net/testsuite/src/FTPClientSessionTest.h
@@ -21,6 +21,7 @@
 namespace Poco::Net {
 
 class FTPClientSession;
+class DialogSocket;
 
 } // namespace Poco::Net
 
@@ -39,6 +40,8 @@ public:
 	void testLoginFailed2();
 	void testWelcomeMessageRead();
 	void testWelcomeMessageNotRead();
+	void testConstructorFailureClosesSocket1();
+	void testConstructorFailureClosesSocket2();
 	void testCommands();
 	void testDownloadPORT();
 	void testDownloadEPRT();
@@ -54,6 +57,7 @@ public:
 
 private:
 	void login(DialogServer& server, Poco::Net::FTPClientSession& session);
+	void assertConnectionClosed(Poco::Net::DialogSocket& peer);
 };
 
 

--- a/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/FTPSClientSession.h
@@ -46,6 +46,11 @@ public:
 		/// Creates an FTPSClientSession using the given
 		/// connected socket for the control connection.
 		///
+		/// If readWelcomeMessage is true (the default), the welcome reply
+		/// sent by the server on connect is read from the socket. Pass false
+		/// only if the welcome reply has already been read from the socket;
+		/// see FTPClientSession for the implications.
+		///
 		/// Passive mode will be used for data transfers.
 
 	FTPSClientSession(const std::string& host, Poco::UInt16 port = FTP_PORT, const std::string& username = "", const std::string& password = "", Context::Ptr pContext = nullptr);

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
@@ -13,9 +13,11 @@
 #include "CppUnit/TestSuite.h"
 #include "Poco/Net/FTPSClientSession.h"
 #include "Poco/Net/DialogSocket.h"
+#include "Poco/Net/StreamSocket.h"
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Net/NetException.h"
 #include "Poco/Thread.h"
+#include "Poco/Timespan.h"
 #include "Poco/ActiveMethod.h"
 #include "Poco/StreamCopier.h"
 #include "Poco/Net/Session.h"
@@ -25,6 +27,7 @@
 
 using Poco::Net::FTPSClientSession;
 using Poco::Net::DialogSocket;
+using Poco::Net::StreamSocket;
 using Poco::Net::SocketAddress;
 using Poco::Net::FTPException;
 using Poco::ActiveMethod;
@@ -59,6 +62,33 @@ namespace
 
 	private:
 		FTPSClientSession& _session;
+	};
+
+	class SocketCloser
+		/// Closes a socket handed to an FTPSClientSession constructor.
+		///
+		/// A constructor that throws leaks the control socket, leaving the
+		/// connection open. DialogServer's destructor would then wait forever
+		/// for its peer to disconnect, turning a test failure into a hang.
+	{
+	public:
+		SocketCloser(StreamSocket& socket): _socket(socket)
+		{
+		}
+
+		~SocketCloser()
+		{
+			try
+			{
+				_socket.close();
+			}
+			catch (...)
+			{
+			}
+		}
+
+	private:
+		StreamSocket& _socket;
 	};
 };
 
@@ -208,6 +238,60 @@ void FTPSClientSessionTest::testLoginFailed2()
 	}
 	server.addResponse("221 Good Bye");
 	session.close();
+}
+
+
+void FTPSClientSessionTest::testWelcomeMessageRead()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
+	SocketCloser closer(socket);
+
+	// The control connection is kept in plain mode; the TLS upgrade is
+	// covered by the SSL tests.
+	FTPSClientSession session(socket, true, false);
+	assertTrue (session.isOpen());
+	assertTrue (!session.isLoggedIn());
+	assertTrue (session.welcomeMessage() == "220 localhost FTP ready");
+
+	login(server, session);
+	assertTrue (session.isLoggedIn());
+
+	server.addResponse("221 Good Bye");
+	session.close();
+	assertTrue (!session.isOpen());
+}
+
+
+void FTPSClientSessionTest::testWelcomeMessageNotRead()
+{
+	DialogServer server;
+	server.addResponse("220 localhost FTP ready");
+	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
+	SocketCloser closer(socket);
+
+	// readWelcomeMessage == false means the caller has already read the
+	// welcome reply from the socket.
+	{
+		DialogSocket ds(socket);
+		std::string response;
+		int status = ds.receiveStatusMessage(response);
+		assertTrue (status == 220);
+	}
+
+	FTPSClientSession session(socket, false, false);
+	assertTrue (session.isOpen());
+	assertTrue (session.welcomeMessage().empty());
+
+	// Reading the welcome reply again would block until this timeout expires.
+	session.setTimeout(Poco::Timespan(5, 0));
+	login(server, session);
+	assertTrue (session.isLoggedIn());
+
+	server.addResponse("221 Good Bye");
+	session.close();
+	assertTrue (!session.isOpen());
 }
 
 
@@ -634,6 +718,8 @@ CppUnit::Test* FTPSClientSessionTest::suite()
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLogin3);
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLoginFailed1);
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testLoginFailed2);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testWelcomeMessageRead);
+	CppUnit_addTest(pSuite, FTPSClientSessionTest, testWelcomeMessageNotRead);
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testCommands);
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadPORT);
 	CppUnit_addTest(pSuite, FTPSClientSessionTest, testDownloadEPRT);

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.cpp
@@ -63,33 +63,6 @@ namespace
 	private:
 		FTPSClientSession& _session;
 	};
-
-	class SocketCloser
-		/// Closes a socket handed to an FTPSClientSession constructor.
-		///
-		/// A constructor that throws leaks the control socket, leaving the
-		/// connection open. DialogServer's destructor would then wait forever
-		/// for its peer to disconnect, turning a test failure into a hang.
-	{
-	public:
-		SocketCloser(StreamSocket& socket): _socket(socket)
-		{
-		}
-
-		~SocketCloser()
-		{
-			try
-			{
-				_socket.close();
-			}
-			catch (...)
-			{
-			}
-		}
-
-	private:
-		StreamSocket& _socket;
-	};
 };
 
 
@@ -246,7 +219,6 @@ void FTPSClientSessionTest::testWelcomeMessageRead()
 	DialogServer server;
 	server.addResponse("220 localhost FTP ready");
 	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
-	SocketCloser closer(socket);
 
 	// The control connection is kept in plain mode; the TLS upgrade is
 	// covered by the SSL tests.
@@ -269,7 +241,6 @@ void FTPSClientSessionTest::testWelcomeMessageNotRead()
 	DialogServer server;
 	server.addResponse("220 localhost FTP ready");
 	StreamSocket socket(SocketAddress("127.0.0.1", server.port()));
-	SocketCloser closer(socket);
 
 	// readWelcomeMessage == false means the caller has already read the
 	// welcome reply from the socket.

--- a/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
+++ b/NetSSL_OpenSSL/testsuite/src/FTPSClientSessionTest.h
@@ -39,6 +39,8 @@ public:
 	void testLogin3();
 	void testLoginFailed1();
 	void testLoginFailed2();
+	void testWelcomeMessageRead();
+	void testWelcomeMessageNotRead();
 	void testCommands();
 	void testDownloadPORT();
 	void testDownloadEPRT();


### PR DESCRIPTION
## Documentation (#5413)

`readWelcomeMessage` has been undocumented since it was added in #2335 (released in 1.10.0), and its name suggests "read it later" rather than "it was already read". #5413 questions the `_serverReady = true` assignment in the `false` branch. That assignment is intentional: without it, the next `login()` blocks waiting for a welcome reply that was already consumed, and `FTPSClientSession` stalls before sending `AUTH TLS`. The behavior is unchanged in every release since 1.10.0.

Documented in `FTPClientSession.h` and `FTPSClientSession.h`:

- what each value of `readWelcomeMessage` means, and that passing `false` while the welcome reply is still pending desynchronizes the session, because that reply is then taken as the response to the next command
- `welcomeMessage()` is empty when the caller read the reply
- `receiveServerReadyReply()` does nothing once the server is marked ready

## Control socket leak

Found while writing the tests. `_pControlSocket` is a raw pointer, so a constructor that throws never releases it: the destructor does not run for a partially constructed object. The socket stays open and the peer never sees a disconnect. This is reachable whenever the server answers with a negative welcome reply, for example `421 Service not available`, or the read times out.

Both affected constructors now release the control socket and rethrow. The member type is unchanged, since it is protected and `FTPSClientSession` dereferences it directly, so switching to a smart pointer would break third-party subclasses.

## Tests

The `StreamSocket` constructor had no coverage at all. Added to `FTPClientSessionTest` and `FTPSClientSessionTest`:

- `testWelcomeMessageRead` / `testWelcomeMessageNotRead` cover both values of the flag
- `testConstructorFailureClosesSocket1` / `testConstructorFailureClosesSocket2` cover the connection being closed after each constructor throws

The leak tests use a plain `ServerSocket` instead of `DialogServer`. `DialogServer` only leaves its receive loop once the peer disconnects, so a leaked socket would hang the suite rather than fail it; the new tests assert the server side reaches EOF under a receive timeout. Each test was checked against a reverted fix to confirm it fails when the corresponding change is missing.

Closes #5413.
