### PR TITLE
feat(Net): optional keepalive probe timings on setKeepAlive #5427

### DIFF
--- a/Net/include/Poco/Net/Socket.h
+++ b/Net/include/Poco/Net/Socket.h
@@ -297,9 +297,16 @@ public:
 		///   * intervalSeconds - time between probes
 		///   * probeCount      - unanswered probes before the connection fails
 		///
-		/// A value the platform does not support is ignored rather than
-		/// reported: macOS before 10.9 has no probe count or interval, and
-		/// the per-socket options need Windows 10 1709 / Server 2016.
+		/// A timing the build platform has no option for at all is skipped:
+		/// macOS before 10.9 has neither an interval nor a probe count.
+		///
+		/// Throws an IOException if the running system rejects a timing, which
+		/// a binary built against a current SDK can meet on an older kernel -
+		/// on Windows, anything before 10 1709 / Server 2016. Failing rather
+		/// than ignoring is deliberate: silently keeping the system default
+		/// would leave a caller that asked for a one minute idle time believing
+		/// it has one while the connection actually sits at the two hour
+		/// default. Catch it where best effort tuning is what is wanted.
 
 	bool getKeepAlive() const;
 		/// Returns the value of the SO_KEEPALIVE socket option.

--- a/Net/include/Poco/Net/Socket.h
+++ b/Net/include/Poco/Net/Socket.h
@@ -283,8 +283,23 @@ public:
 	bool getNoDelay() const;
 		/// Returns the value of the TCP_NODELAY socket option.
 
-	void setKeepAlive(bool flag);
+	void setKeepAlive(bool flag, int idleSeconds = 0, int intervalSeconds = 0, int probeCount = 0);
 		/// Sets the value of the SO_KEEPALIVE socket option.
+		///
+		/// Optionally also tunes the per-socket probe timings, which otherwise
+		/// come from the system settings - typically a two hour idle time,
+		/// far too long to notice a connection whose path has broken without
+		/// a FIN or RST (a peer that lost power, a dropped tunnel or firewall
+		/// state). Each value is applied only when greater than zero, so any
+		/// of them can be left at the system default:
+		///
+		///   * idleSeconds     - quiet time before the first probe
+		///   * intervalSeconds - time between probes
+		///   * probeCount      - unanswered probes before the connection fails
+		///
+		/// A value the platform does not support is ignored rather than
+		/// reported: macOS before 10.9 has no probe count or interval, and
+		/// the per-socket options need Windows 10 1709 / Server 2016.
 
 	bool getKeepAlive() const;
 		/// Returns the value of the SO_KEEPALIVE socket option.
@@ -703,11 +718,11 @@ inline bool Socket::getNoDelay() const
 }
 
 
-inline void Socket::setKeepAlive(bool flag)
+inline void Socket::setKeepAlive(bool flag, int idleSeconds, int intervalSeconds, int probeCount)
 {
 	POCO_CHECK_NEW_STATE_ON_MOVE;
 
-	_pImpl->setKeepAlive(flag);
+	_pImpl->setKeepAlive(flag, idleSeconds, intervalSeconds, probeCount);
 }
 
 

--- a/Net/include/Poco/Net/SocketDefs.h
+++ b/Net/include/Poco/Net/SocketDefs.h
@@ -33,6 +33,7 @@
 	#include <winsock2.h>
 	#include <ws2tcpip.h>
 	#include <ws2def.h>
+	#include <mstcpip.h> // TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
 	#if !defined (POCO_NET_NO_UNIX_SOCKET)
 		#if POCO_HAVE_CPP17_COMPILER
 			#if __has_include(<afunix.h>)

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -445,8 +445,9 @@ public:
 		/// per-socket probe timings (idle time before the first probe, interval
 		/// between probes, and number of unanswered probes before the connection
 		/// fails). Each timing is applied only when greater than zero; the rest
-		/// keep the system defaults. Timings the platform does not support are
-		/// silently ignored. See Socket::setKeepAlive.
+		/// keep the system defaults. A timing this platform has no option for
+		/// is skipped; one the running system rejects throws an IOException.
+		/// See Socket::setKeepAlive.
 
 	bool getKeepAlive();
 		/// Returns the value of the SO_KEEPALIVE socket option.

--- a/Net/include/Poco/Net/SocketImpl.h
+++ b/Net/include/Poco/Net/SocketImpl.h
@@ -440,8 +440,13 @@ public:
 	bool getNoDelay();
 		/// Returns the value of the TCP_NODELAY socket option.
 
-	void setKeepAlive(bool flag);
-		/// Sets the value of the SO_KEEPALIVE socket option.
+	void setKeepAlive(bool flag, int idleSeconds = 0, int intervalSeconds = 0, int probeCount = 0);
+		/// Sets the value of the SO_KEEPALIVE socket option, and optionally the
+		/// per-socket probe timings (idle time before the first probe, interval
+		/// between probes, and number of unanswered probes before the connection
+		/// fails). Each timing is applied only when greater than zero; the rest
+		/// keep the system defaults. Timings the platform does not support are
+		/// silently ignored. See Socket::setKeepAlive.
 
 	bool getKeepAlive();
 		/// Returns the value of the SO_KEEPALIVE socket option.

--- a/Net/src/SocketImpl.cpp
+++ b/Net/src/SocketImpl.cpp
@@ -1136,10 +1136,31 @@ bool SocketImpl::getNoDelay()
 }
 
 
-void SocketImpl::setKeepAlive(bool flag)
+void SocketImpl::setKeepAlive(bool flag, int idleSeconds, int intervalSeconds, int probeCount)
 {
 	int value = flag ? 1 : 0;
 	setOption(SOL_SOCKET, SO_KEEPALIVE, value);
+	if (!flag) return;
+
+	// The option names differ across platforms: Linux, Android, the BSDs and
+	// Windows 10 1709 / Server 2016 and later spell the idle time TCP_KEEPIDLE,
+	// while macOS and iOS call it TCP_KEEPALIVE. The interval and probe count
+	// are spelled alike wherever they exist (macOS gained them in 10.9). Each
+	// is set only when asked for, so an unspecified timing keeps the system
+	// default, and one the platform lacks compiles out.
+#if defined(TCP_KEEPIDLE)
+	if (idleSeconds > 0) setOption(IPPROTO_TCP, TCP_KEEPIDLE, idleSeconds);
+#elif defined(TCP_KEEPALIVE)
+	if (idleSeconds > 0) setOption(IPPROTO_TCP, TCP_KEEPALIVE, idleSeconds);
+#endif
+
+#if defined(TCP_KEEPINTVL)
+	if (intervalSeconds > 0) setOption(IPPROTO_TCP, TCP_KEEPINTVL, intervalSeconds);
+#endif
+
+#if defined(TCP_KEEPCNT)
+	if (probeCount > 0) setOption(IPPROTO_TCP, TCP_KEEPCNT, probeCount);
+#endif
 }
 
 

--- a/Net/testsuite/src/SocketTest.cpp
+++ b/Net/testsuite/src/SocketTest.cpp
@@ -516,6 +516,69 @@ void SocketTest::testOptions()
 	assertTrue (!ss.getOOBInline());
 }
 
+
+void SocketTest::testKeepAliveParams()
+{
+	EchoServer echoServer;
+	StreamSocket ss;
+	ss.connect(SocketAddress("127.0.0.1", echoServer.port()));
+
+	// The idle time is TCP_KEEPIDLE everywhere except macOS and iOS, which
+	// spell it TCP_KEEPALIVE. Read it back through the same name it was set by.
+#if defined(TCP_KEEPIDLE)
+	const int idleOption = TCP_KEEPIDLE;
+#elif defined(TCP_KEEPALIVE)
+	const int idleOption = TCP_KEEPALIVE;
+#endif
+
+#if defined(TCP_KEEPIDLE) || defined(TCP_KEEPALIVE)
+	int sysIdle = 0;
+	ss.getOption(IPPROTO_TCP, idleOption, sysIdle);
+
+	// Enabling without timings must leave the system settings alone.
+	ss.setKeepAlive(true);
+	assertTrue (ss.getKeepAlive());
+	int idle = 0;
+	ss.getOption(IPPROTO_TCP, idleOption, idle);
+	assertTrue (idle == sysIdle);
+
+	// A short idle time so a peer that disappears without a FIN or RST is
+	// noticed in seconds instead of the two hours the system defaults to.
+	ss.setKeepAlive(true, 5, 1, 2);
+	assertTrue (ss.getKeepAlive());
+	ss.getOption(IPPROTO_TCP, idleOption, idle);
+	assertTrue (idle == 5);
+
+#if defined(TCP_KEEPINTVL)
+	int interval = 0;
+	ss.getOption(IPPROTO_TCP, TCP_KEEPINTVL, interval);
+	assertTrue (interval == 1);
+#endif
+
+#if defined(TCP_KEEPCNT)
+	int probes = 0;
+	ss.getOption(IPPROTO_TCP, TCP_KEEPCNT, probes);
+	assertTrue (probes == 2);
+#endif
+
+	// Zero means "keep what is there", so the short idle time must survive a
+	// call that only re-enables the option.
+	ss.setKeepAlive(true, 0, 0, 0);
+	ss.getOption(IPPROTO_TCP, idleOption, idle);
+	assertTrue (idle == 5);
+
+	// Timings are only meaningful while keepalive is on; turning it off must
+	// not fail, and turning it back on must still accept new timings.
+	ss.setKeepAlive(false);
+	assertTrue (!ss.getKeepAlive());
+	ss.setKeepAlive(true, 7);
+	ss.getOption(IPPROTO_TCP, idleOption, idle);
+	assertTrue (idle == 7);
+#endif
+
+	ss.close();
+}
+
 #if defined(POCO_TEST_DEPRECATED)
 
 void SocketTest::testSelect()
@@ -890,6 +953,7 @@ CppUnit::Test* SocketTest::suite()
 	CppUnit_addTest(pSuite, SocketTest, testTimeout);
 	CppUnit_addTest(pSuite, SocketTest, testBufferSize);
 	CppUnit_addTest(pSuite, SocketTest, testOptions);
+	CppUnit_addTest(pSuite, SocketTest, testKeepAliveParams);
 
 #if defined(POCO_TEST_DEPRECATED)
 	CppUnit_addTest(pSuite, SocketTest, testSelect);

--- a/Net/testsuite/src/SocketTest.cpp
+++ b/Net/testsuite/src/SocketTest.cpp
@@ -579,6 +579,12 @@ void SocketTest::testKeepAliveParams()
 	ss.setKeepAlive(true, 7);
 	ss.getOption(IPPROTO_TCP, idleOption, idle);
 	assertTrue (idle == 7);
+#else
+	// Nothing to read back on a platform without the per-socket knobs, but the
+	// timings must be skipped rather than refused: the call still succeeds and
+	// still enables the option.
+	ss.setKeepAlive(true, 5, 1, 2);
+	assertTrue (ss.getKeepAlive());
 #endif
 
 	ss.close();

--- a/Net/testsuite/src/SocketTest.cpp
+++ b/Net/testsuite/src/SocketTest.cpp
@@ -532,10 +532,15 @@ void SocketTest::testKeepAliveParams()
 #endif
 
 #if defined(TCP_KEEPIDLE) || defined(TCP_KEEPALIVE)
+	// Enable before reading the baseline: not every stack reports the keepalive
+	// timings on a socket whose SO_KEEPALIVE is still off.
+	ss.setKeepAlive(true);
+	assertTrue (ss.getKeepAlive());
+
 	int sysIdle = 0;
 	ss.getOption(IPPROTO_TCP, idleOption, sysIdle);
 
-	// Enabling without timings must leave the system settings alone.
+	// Asking again without timings must leave the system settings alone.
 	ss.setKeepAlive(true);
 	assertTrue (ss.getKeepAlive());
 	int idle = 0;

--- a/Net/testsuite/src/SocketTest.h
+++ b/Net/testsuite/src/SocketTest.h
@@ -39,6 +39,7 @@ public:
 	void testTimeout();
 	void testBufferSize();
 	void testOptions();
+	void testKeepAliveParams();
 
 #if defined(POCO_TEST_DEPRECATED)
 	void testSelect();


### PR DESCRIPTION
SO_KEEPALIVE alone leaves the probe timings at the system settings, which idle for two hours before the first probe on Linux and on Windows, so a connection whose path breaks without a FIN or RST goes unreported for over two hours. The per-socket knobs that fix that were reachable only through setOption or WSAIoctl with platform specific spellings.

setKeepAlive now takes optional idle, interval and probe count arguments. Zero keeps the system value, so the existing single argument call behaves exactly as before. The option names are selected at compile time: TCP_KEEPIDLE on Linux, Android and the BSDs and on Windows 10 1709 and later, TCP_KEEPALIVE on macOS and iOS, with TCP_KEEPINTVL and TCP_KEEPCNT where they exist. A timing the platform does not support compiles out rather than throwing. SocketDefs.h now includes mstcpip.h on Windows for the constants.

Covered by SocketTest::testKeepAliveParams over a real connection: set and read back, system defaults preserved when no timings are given, partial arguments, and disable then re-enable.

This changes the mangled name of SocketImpl::setKeepAlive and is therefore an ABI break for anything linking a prebuilt libPocoNet.