### PR TITLE
fix(ci): use MongoDB service containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,14 @@ jobs:
     env:
       TSAN_OPTIONS: ${{ matrix.name == 'tsan' && format('suppressions={0}/tsan.suppress,second_deadlock_stack=1', github.workspace) || '' }}
       ASAN_OPTIONS: ${{ matrix.name == 'hidden-asan' && 'detect_odr_violation=2' || '' }}
+    services:
+      mongodb:
+        image: mongo:8
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v5
       - run: sysctl vm.legacy_va_layout
@@ -186,7 +194,6 @@ jobs:
       - run: >-
           sudo apt -y update && sudo apt -y install libssl-dev libssh-dev libltdl-dev apache2-dev libapr1-dev libaprutil1-dev libavahi-client-dev
           libsqlite3-dev redis-server
-      - uses: supercharge/mongodb-github-action@1.12.1
       - run: >-
           cmake -S. -Bcmake-build -GNinja
           ${{ matrix.visibility == 'hidden' && '-DCMAKE_CXX_VISIBILITY_PRESET=hidden' || '' }}
@@ -959,9 +966,16 @@ jobs:
     env:
       POCO_BASE: ${{ github.workspace }}
       LD_LIBRARY_PATH: ${{ github.workspace }}/cmake-build/lib
+    services:
+      mongodb:
+        image: mongo:8
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v5
-      - uses: supercharge/mongodb-github-action@1.12.1
       - uses: actions/download-artifact@v8
         with:
           name: data-build-artifacts


### PR DESCRIPTION
This PR adresses #5419, reported by @matejk.

This PR replaces the third-party mongoDB github action with native service containers to fix reported transient CI failure.

## Summary

- Replaces both uses of supercharge/mongodb-github-action@1.12.1.
- Adds a mongo:8 service container to the sanitizer matrix and mongoDB data-test jobs.
- Maps port 27017 and waits for mongoDB using a mongosh ping health check
- Keeps the existing standalone, unauthenticated mongoDB configuration.

## Testing

- Started mongo:8 locally with the same health-check command and timing options used by the workflow, and confirmed that the container reached the healthy state.
- Parsed the updated workflow successfully.
- Ran `git diff --check`.
- Confirmed both old action references were removed and no remaining references to supercharge/mongodb-github-action exist.