### PR TITLE
fix(Foundation): return value from ScopedLockWithUnlock::tryLock

### DIFF
--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -142,7 +142,7 @@ public:
 		_bOwns = true;
 	}
 
-	bool tryLock()
+	[[nodiscard]] bool tryLock()
 	{
 		poco_assert(_pMutex != nullptr);
 		poco_assert(_bOwns == false);

--- a/Foundation/include/Poco/ScopedLock.h
+++ b/Foundation/include/Poco/ScopedLock.h
@@ -148,6 +148,7 @@ public:
 		poco_assert(_bOwns == false);
 
 		_bOwns = _pMutex->tryLock();
+		return _bOwns;
 	}
 
 	void unlock()

--- a/Foundation/testsuite/Makefile-Driver
+++ b/Foundation/testsuite/Makefile-Driver
@@ -28,7 +28,7 @@ objects = ActiveMethodTest ActivityTest ActiveDispatcherTest \
 	StreamsTestSuite StringTest StringTokenizerTest TaskTestSuite TaskTest \
 	TaskManagerTest TestChannel TeeStreamTest UTF8StringTest \
 	TextConverterTest TextIteratorTest TextBufferIteratorTest TextTestSuite TextEncodingTest \
-	ThreadLocalTest ThreadPoolTest ActiveThreadPoolTest ThreadTest ThreadingTestSuite TimerTest SpinlockMutexTest \
+	ThreadLocalTest ThreadPoolTest ActiveThreadPoolTest ThreadTest ThreadingTestSuite TimerTest SpinlockMutexTest MutexTest \
 	TimespanTest TimestampTest TimezoneTest URIStreamOpenerTest URITest \
 	URITestSuite UUIDGeneratorTest UUIDTest UUIDTestSuite \
 	ULIDTest ULIDGeneratorTest ULIDTestSuite ZLibTest \

--- a/Foundation/testsuite/src/MutexTest.cpp
+++ b/Foundation/testsuite/src/MutexTest.cpp
@@ -1,0 +1,124 @@
+//
+// MutexTest.cpp
+//
+// Copyright (c) 2026, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#include "MutexTest.h"
+#include "CppUnit/TestCaller.h"
+#include "CppUnit/TestSuite.h"
+#include "Poco/Mutex.h"
+#include "Poco/ScopedLock.h"
+#include "Poco/Thread.h"
+#include "Poco/Runnable.h"
+#include "Poco/Event.h"
+
+
+using Poco::FastMutex;
+using Poco::ScopedLockWithUnlock;
+using Poco::Thread;
+using Poco::Runnable;
+using Poco::Event;
+
+
+namespace
+{
+	class Holder: public Runnable
+		/// Holds the mutex until released, so the main thread can observe a failed tryLock.
+	{
+	public:
+		Holder(FastMutex& mutex): _mutex(mutex)
+		{
+		}
+
+		void run()
+		{
+			_mutex.lock();
+			_locked.set();
+			_release.wait();
+			_mutex.unlock();
+		}
+
+		void waitLocked()
+		{
+			_locked.wait();
+		}
+
+		void release()
+		{
+			_release.set();
+		}
+
+	private:
+		FastMutex& _mutex;
+		Event _locked;
+		Event _release;
+	};
+}
+
+
+MutexTest::MutexTest(const std::string& name): CppUnit::TestCase(name)
+{
+}
+
+
+MutexTest::~MutexTest()
+{
+}
+
+
+void MutexTest::testScopedLockWithUnlockTryLock()
+{
+	FastMutex mutex;
+
+	{
+		ScopedLockWithUnlock<FastMutex> lock(mutex, std::defer_lock);
+		assertTrue (lock.tryLock());
+		assertFalse (mutex.tryLock());
+		lock.unlock();
+		assertTrue (mutex.tryLock());
+		mutex.unlock();
+	}
+
+	{
+		Holder holder(mutex);
+		Thread thread;
+		thread.start(holder);
+		holder.waitLocked();
+
+		ScopedLockWithUnlock<FastMutex> lock(mutex, std::defer_lock);
+		assertFalse (lock.tryLock());
+
+		holder.release();
+		thread.join();
+
+		assertTrue (lock.tryLock());
+	}
+
+	assertTrue (mutex.tryLock());
+	mutex.unlock();
+}
+
+
+void MutexTest::setUp()
+{
+}
+
+
+void MutexTest::tearDown()
+{
+}
+
+
+CppUnit::Test* MutexTest::suite()
+{
+	CppUnit::TestSuite* pSuite = new CppUnit::TestSuite("MutexTest");
+
+	CppUnit_addTest(pSuite, MutexTest, testScopedLockWithUnlockTryLock);
+
+	return pSuite;
+}

--- a/Foundation/testsuite/src/MutexTest.cpp
+++ b/Foundation/testsuite/src/MutexTest.cpp
@@ -58,6 +58,42 @@ namespace
 		Event _locked;
 		Event _release;
 	};
+
+
+	class TryLocker: public Runnable
+	{
+	public:
+		TryLocker(FastMutex& mutex): _mutex(mutex)
+		{
+		}
+
+		void run()
+		{
+			_locked = _mutex.tryLock();
+			if (_locked) _mutex.unlock();
+		}
+
+		bool locked() const
+		{
+			return _locked;
+		}
+
+	private:
+		FastMutex& _mutex;
+		bool _locked = false;
+	};
+
+
+	bool tryLockFromOtherThread(FastMutex& mutex)
+		/// FastMutex is recursive on Windows, so a locked mutex can only be
+		/// observed as locked from a thread that does not already own it.
+	{
+		TryLocker locker(mutex);
+		Thread thread;
+		thread.start(locker);
+		thread.join();
+		return locker.locked();
+	}
 }
 
 
@@ -77,11 +113,15 @@ void MutexTest::testScopedLockWithUnlockTryLock()
 
 	{
 		ScopedLockWithUnlock<FastMutex> lock(mutex, std::defer_lock);
+		assertFalse (lock.ownsLock());
+
 		assertTrue (lock.tryLock());
-		assertFalse (mutex.tryLock());
+		assertTrue (lock.ownsLock());
+		assertFalse (tryLockFromOtherThread(mutex));
+
 		lock.unlock();
-		assertTrue (mutex.tryLock());
-		mutex.unlock();
+		assertFalse (lock.ownsLock());
+		assertTrue (tryLockFromOtherThread(mutex));
 	}
 
 	{
@@ -92,15 +132,16 @@ void MutexTest::testScopedLockWithUnlockTryLock()
 
 		ScopedLockWithUnlock<FastMutex> lock(mutex, std::defer_lock);
 		assertFalse (lock.tryLock());
+		assertFalse (lock.ownsLock());
 
 		holder.release();
 		thread.join();
 
 		assertTrue (lock.tryLock());
+		assertTrue (lock.ownsLock());
 	}
 
-	assertTrue (mutex.tryLock());
-	mutex.unlock();
+	assertTrue (tryLockFromOtherThread(mutex));
 }
 
 

--- a/Foundation/testsuite/src/MutexTest.h
+++ b/Foundation/testsuite/src/MutexTest.h
@@ -1,0 +1,36 @@
+//
+// MutexTest.h
+//
+// Definition of the MutexTest class.
+//
+// Copyright (c) 2026, Applied Informatics Software Engineering GmbH.
+// and Contributors.
+//
+// SPDX-License-Identifier:	BSL-1.0
+//
+
+
+#ifndef MutexTest_INCLUDED
+#define MutexTest_INCLUDED
+
+
+#include "Poco/Foundation.h"
+#include "CppUnit/TestCase.h"
+
+
+class MutexTest: public CppUnit::TestCase
+{
+public:
+	MutexTest(const std::string& name);
+	~MutexTest();
+
+	void testScopedLockWithUnlockTryLock();
+
+	void setUp();
+	void tearDown();
+
+	static CppUnit::Test* suite();
+};
+
+
+#endif // MutexTest_INCLUDED

--- a/Foundation/testsuite/src/ThreadingTestSuite.cpp
+++ b/Foundation/testsuite/src/ThreadingTestSuite.cpp
@@ -21,6 +21,7 @@
 #include "ConditionTest.h"
 #include "ActiveThreadPoolTest.h"
 #include "SpinlockMutexTest.h"
+#include "MutexTest.h"
 
 
 CppUnit::Test* ThreadingTestSuite::suite()
@@ -39,6 +40,7 @@ CppUnit::Test* ThreadingTestSuite::suite()
 	pSuite->addTest(ConditionTest::suite());
 	pSuite->addTest(ActiveThreadPoolTest::suite());
 	pSuite->addTest(SpinlockMutexTest::suite());
+	pSuite->addTest(MutexTest::suite());
 
 	return pSuite;
 }


### PR DESCRIPTION
`ScopedLockWithUnlock<M>::tryLock()` is declared `bool` but had no `return` statement (undefined behaviour; there were no in-tree callers and no test for the class).

- Return `_bOwns` from `tryLock()`.
- Add `MutexTest` (Foundation testsuite, `ThreadingTestSuite`) covering `tryLock()` success, failure while another thread holds the mutex, and re-acquire after release.
