### PR TITLE
chore: replace `for (;;)` with `while (true)`

### DIFF
--- a/CppUnit/src/TextTestResult.cpp
+++ b/CppUnit/src/TextTestResult.cpp
@@ -89,7 +89,7 @@ void TextTestResult::ignoring(const std::string ignore)
 {
 	std::string::const_iterator it = ignore.begin();
 	std::string::const_iterator end = ignore.end();
-	for (;;)
+	while (true)
 	{
 		while (it != end && (std::isspace(*it) || *it == '"' || *it == ',' || *it == '\'')) ++it;
 		if (it == end)

--- a/Data/SQLParser/src/parser/bison_parser.cpp
+++ b/Data/SQLParser/src/parser/bison_parser.cpp
@@ -2318,7 +2318,7 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-      for (;;)
+      while (true)
         switch (*++yyp)
           {
           case '\'':
@@ -7027,7 +7027,7 @@ yyerrlab1:
   yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   /* Pop stack until we find a state that shifts the error token.  */
-  for (;;)
+  while (true)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))

--- a/Data/SQLParser/src/parser/bison_parser.cpp
+++ b/Data/SQLParser/src/parser/bison_parser.cpp
@@ -2318,7 +2318,7 @@ yytnamerr (char *yyres, const char *yystr)
     {
       YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
-      while (true)
+      for (;;)
         switch (*++yyp)
           {
           case '\'':

--- a/Data/SQLParser/src/sql/Expr.h
+++ b/Data/SQLParser/src/sql/Expr.h
@@ -251,7 +251,7 @@ struct SQLParser_API Expr {
     Expr zero = {type};               \
     var = (Expr*)malloc(sizeof *var); \
     *var = zero;                      \
-  } while (0);
+  } while (false);
 #undef ALLOC_EXPR
 
 }  // namespace hsql

--- a/Data/SQLite/testsuite/src/MemoryDBTest.cpp
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.cpp
@@ -80,7 +80,7 @@ void MemoryDBTest::testConnectorRegistrationBalanced()
 	// the process-global SessionFactory exactly as we found it. remove() throws
 	// (poco_assert) once the refcount reaches zero and the entry is erased.
 	int saved = 0;
-	for (;;)
+	while (true)
 	{
 		try { Connector::unregisterConnector(); ++saved; }
 		catch (const Poco::Exception&) { break; }

--- a/Foundation/include/Poco/Bugcheck.h
+++ b/Foundation/include/Poco/Bugcheck.h
@@ -90,13 +90,13 @@ protected:
 // https://developer.klocwork.com/documentation/en/insight/10-1/tuning-cc-analysis#Usingthe__KLOCWORK__macro
 
 #include <cstdlib> // for abort
-#define poco_assert_dbg(cond)           do { if (!(cond)) std::abort(); } while (0)
-#define poco_assert_msg_dbg(cond, text) do { if (!(cond)) std::abort(); } while (0)
-#define poco_assert(cond)               do { if (!(cond)) std::abort(); } while (0)
-#define poco_assert_msg(cond, text)     do { if (!(cond)) std::abort(); } while (0)
-#define poco_check_ptr(ptr)             do { if (!(ptr)) std::abort(); } while (0)
-#define poco_bugcheck()                 do { std::abort(); } while (0)
-#define poco_bugcheck_msg(msg)          do { std::abort(); } while (0)
+#define poco_assert_dbg(cond)           do { if (!(cond)) std::abort(); } while (false)
+#define poco_assert_msg_dbg(cond, text) do { if (!(cond)) std::abort(); } while (false)
+#define poco_assert(cond)               do { if (!(cond)) std::abort(); } while (false)
+#define poco_assert_msg(cond, text)     do { if (!(cond)) std::abort(); } while (false)
+#define poco_check_ptr(ptr)             do { if (!(ptr)) std::abort(); } while (false)
+#define poco_bugcheck()                 do { std::abort(); } while (false)
+#define poco_bugcheck_msg(msg)          do { std::abort(); } while (false)
 
 
 #else // defined(__KLOCWORK__) || defined(__clang_analyzer__)

--- a/Foundation/include/Poco/Logger.h
+++ b/Foundation/include/Poco/Logger.h
@@ -526,7 +526,7 @@ private:
 #define POCO_AMBIGUOUS_ELSE_BLOCKER_BEG do {
 
 #define POCO_AMBIGUOUS_ELSE_BLOCKER_END \
-	} while(0)
+	} while(false)
 #endif
 
 #define poco_fatal(logger, msg) \

--- a/Foundation/include/Poco/MPSCQueue.h
+++ b/Foundation/include/Poco/MPSCQueue.h
@@ -129,7 +129,7 @@ public:
 	{
 		std::size_t head = _head.load(std::memory_order_relaxed);
 
-		for (;;)
+		while (true)
 		{
 			Slot& slot = _slots[index(head)];
 			std::size_t seq = slot.sequence.load(std::memory_order_acquire);

--- a/Foundation/samples/NotificationQueue/src/NotificationQueue.cpp
+++ b/Foundation/samples/NotificationQueue/src/NotificationQueue.cpp
@@ -66,7 +66,7 @@ public:
 	void run()
 	{
 		Poco::Random rnd;
-		for (;;)
+		while (true)
 		{
 			Notification::Ptr pNf(_queue.waitDequeueNotification());
 			if (pNf)

--- a/Foundation/src/ActiveThreadPool.cpp
+++ b/Foundation/src/ActiveThreadPool.cpp
@@ -219,7 +219,7 @@ void ActivePooledThread::join()
 void ActivePooledThread::run()
 {
 	FastMutex::ScopedLock lock(_pool.mutex);
-	for (;;)
+	while (true)
 	{
 		auto r = _target;
 		_target.reset();

--- a/Foundation/src/DeflatingStream.cpp
+++ b/Foundation/src/DeflatingStream.cpp
@@ -205,7 +205,7 @@ std::streamsize DeflatingStreamBuf::readFromDevice(char* buffer, std::streamsize
 	}
 	_pZstr->next_out  = (unsigned char*) buffer;
 	_pZstr->avail_out = static_cast<unsigned>(length);
-	for (;;)
+	while (true)
 	{
 		int rc = deflate(_pZstr, _eof ? Z_FINISH : Z_NO_FLUSH);
 		if (_eof && rc == Z_STREAM_END)
@@ -250,7 +250,7 @@ std::streamsize DeflatingStreamBuf::writeToDevice(const char* buffer, std::strea
 	_pZstr->avail_in  = static_cast<unsigned>(length);
 	_pZstr->next_out  = (unsigned char*) _buffer;
 	_pZstr->avail_out = DEFLATE_BUFFER_SIZE;
-	for (;;)
+	while (true)
 	{
 		int rc = deflate(_pZstr, Z_NO_FLUSH);
 		if (rc != Z_OK) throw IOException(zError(rc));

--- a/Foundation/src/Environment_UNIX.cpp
+++ b/Foundation/src/Environment_UNIX.cpp
@@ -228,7 +228,7 @@ void EnvironmentImpl::nodeIdImpl(NodeId& id)
 	int len = 100*sizeof(struct ifreq);
 	struct ifconf ifc;
 	char* buf = nullptr;
-	for (;;)
+	while (true)
 	{
 		buf = new char[len];
 		ifc.ifc_len = len;

--- a/Foundation/src/Environment_VX.cpp
+++ b/Foundation/src/Environment_VX.cpp
@@ -133,7 +133,7 @@ void EnvironmentImpl::nodeIdImpl(NodeId& id)
 
 	int ifIndex = 1;
 	char ifName[32];
-	for (;;)
+	while (true)
 	{
 		if (ifIndexToIfName(ifIndex, ifName) == OK)
 		{

--- a/Foundation/src/InflatingStream.cpp
+++ b/Foundation/src/InflatingStream.cpp
@@ -157,7 +157,7 @@ std::streamsize InflatingStreamBuf::readFromDevice(char* buffer, std::streamsize
 	}
 	_pZstr->next_out  = (unsigned char*) buffer;
 	_pZstr->avail_out = static_cast<unsigned>(length);
-	for (;;)
+	while (true)
 	{
 		int rc = inflate(_pZstr, Z_NO_FLUSH);
 		if (rc == Z_DATA_ERROR && !_check)
@@ -205,7 +205,7 @@ std::streamsize InflatingStreamBuf::writeToDevice(const char* buffer, std::strea
 	_pZstr->avail_in  = static_cast<unsigned>(length);
 	_pZstr->next_out  = (unsigned char*) _buffer;
 	_pZstr->avail_out = INFLATE_BUFFER_SIZE;
-	for (;;)
+	while (true)
 	{
 		int rc = inflate(_pZstr, Z_NO_FLUSH);
 		if (rc == Z_STREAM_END)

--- a/Foundation/src/Mutex.cpp
+++ b/Foundation/src/Mutex.cpp
@@ -112,7 +112,7 @@ void SpinlockMutex::lock()
 	}
 
 	// Sleep phase
-	for (;;)
+	while (true)
 	{
 		std::this_thread::sleep_for(std::chrono::microseconds(100));
 		if (tryAcquire(_flag))

--- a/Foundation/src/ProcessRunner.cpp
+++ b/Foundation/src/ProcessRunner.cpp
@@ -316,7 +316,7 @@ void ProcessRunner::stop()
 				//   EPERM  - group exists but no permission (still alive)
 				// Note: errno must be captured immediately after kill()
 				// since Thread::sleep() may overwrite it.
-				for (;;)
+				while (true)
 				{
 					int rc = ::kill(-pid, 0);
 					int err = errno;
@@ -326,7 +326,7 @@ void ProcessRunner::stop()
 					{
 						::kill(-pid, SIGKILL);
 						Stopwatch killSw; killSw.start();
-						for (;;)
+						while (true)
 						{
 							rc = ::kill(-pid, 0);
 							err = errno;

--- a/Foundation/src/RWLock_WIN32.cpp
+++ b/Foundation/src/RWLock_WIN32.cpp
@@ -92,7 +92,7 @@ void RWLockImpl::readLockImpl()
 
 bool RWLockImpl::tryReadLockImpl()
 {
-	for (;;)
+	while (true)
 	{
 		if (_writers != 0 || _writersWaiting != 0)
 			return false;

--- a/Foundation/src/ThreadPool.cpp
+++ b/Foundation/src/ThreadPool.cpp
@@ -175,7 +175,7 @@ void PooledThread::release()
 void PooledThread::run()
 {
 	_started.set();
-	for (;;)
+	while (true)
 	{
 		_targetReady.wait();
 		_mutex.lock();

--- a/Foundation/src/TimedNotificationQueue.cpp
+++ b/Foundation/src/TimedNotificationQueue.cpp
@@ -96,7 +96,7 @@ Notification* TimedNotificationQueue::dequeueNextNotification()
 
 Notification* TimedNotificationQueue::waitDequeueNotification()
 {
-	for (;;)
+	while (true)
 	{
 		_mutex.lock();
 		auto it = _nfQueue.begin();

--- a/Foundation/src/UUIDGenerator.cpp
+++ b/Foundation/src/UUIDGenerator.cpp
@@ -200,7 +200,7 @@ UUID UUIDGenerator::createV7()
 Timestamp::UtcTimeVal UUIDGenerator::timeStamp()
 {
 	Timestamp now;
-	for (;;)
+	while (true)
 	{
 		if (now != _lastTime)
 		{

--- a/Net/src/TCPServerDispatcher.cpp
+++ b/Net/src/TCPServerDispatcher.cpp
@@ -100,7 +100,7 @@ void TCPServerDispatcher::run()
 
 	int idleTime = (int) _pParams->getThreadIdleTime().totalMilliseconds();
 
-	for (;;)
+	while (true)
 	{
 		try
 		{

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -752,7 +752,7 @@ void HTTPReactorServerTest::testSendTimeoutClosesStalledClient()
 	char buf[16 * 1024];
 	try
 	{
-		for (;;)
+		while (true)
 		{
 			int n = s.receiveBytes(buf, sizeof(buf));
 			if (n <= 0) { closed = true; break; }

--- a/Util/src/PropertyFileConfiguration.cpp
+++ b/Util/src/PropertyFileConfiguration.cpp
@@ -102,7 +102,7 @@ void PropertyFileConfiguration::load(const std::string& path)
 
 void PropertyFileConfiguration::loadStream(std::istream& istr, const std::string& basePath, const std::string& currentFile, std::set<std::string>& includeStack)
 {
-	for (;;)
+	while (true)
 	{
 		if (!istr.good())
 		{
@@ -750,7 +750,7 @@ void PropertyFileConfiguration::parseLine(std::istream& istr, const std::string&
 
 int PropertyFileConfiguration::readChar(std::istream& istr)
 {
-	for (;;)
+	while (true)
 	{
 		int c = istr.get();
 		if (c == '\\')

--- a/Util/testsuite/src/AbstractConfigurationTest.h
+++ b/Util/testsuite/src/AbstractConfigurationTest.h
@@ -85,7 +85,7 @@ protected:
 		CppUnit_addTest(suite, cls, testRemove); \
 		CppUnit_addTest(suite, cls, testChangeEvents); \
 		CppUnit_addTest(suite, cls, testRemoveEvents); \
-	} while(0)
+	} while (false)
 
 
 #endif // AbstractConfigurationTest_INCLUDED


### PR DESCRIPTION
This PR replaces `for (;;)`, which seems to be an archaism and vestige of 90s-era C (when compilers would skip evaluating `for (;;)`'s conditions but always evaluate `while (1)`'s condition), with `while (true)`, which is clearer in intent and reads much more smoothly in human language, and also compiles to the same thing.