### PR TITLE
fix(DataSQLite): defer MemoryDB archived-shard DETACH while the connection is busy

### DIFF
--- a/Data/SQLite/include/Poco/Data/SQLite/MemoryDB.h
+++ b/Data/SQLite/include/Poco/Data/SQLite/MemoryDB.h
@@ -304,6 +304,13 @@ public:
 
 	void detachArchived(Poco::UInt32 shardId);
 		/// Detaches a previously attached sealed shard. Thread-safe (see attachArchived).
+		///
+		/// SQLite refuses a DETACH while the attached database is in any
+		/// transaction state (busy statements hold read transactions on all
+		/// attached databases). If the refusal persists past a short retry, the
+		/// physical DETACH is deferred: the call returns normally and a later
+		/// attach/detach, deleteShard(), detachAllArchived(), or destruction
+		/// completes it.
 
 	void attachAllArchived();
 		/// Attaches every sealed shard read-only that is not already attached. Convenient
@@ -445,6 +452,8 @@ private:
 	ShardInfo* activeShard();                            // caller holds _stateMutex
 	ShardInfo* owningShard(const std::string& table, Poco::Int64 row); // caller holds _stateMutex
 	void rebuildActiveLo();                              // caller holds _stateMutex
+	bool tryDetach(Poco::UInt32 shardId);                // caller holds _attachMutex
+	void sweepDetached();                                // caller holds _attachMutex
 	void throwIfRejected() const;
 	std::string shardPath(Poco::UInt32 id, const Poco::Timestamp& createdAt) const;
 	void cleanOrphans();
@@ -494,7 +503,8 @@ private:
 	                                          // memory while recording the message.
 	std::atomic<bool>          _poisoned{false};
 	std::map<Poco::UInt32, int> _attached;    // sealed shards attached read-only,
-	                                          // value = reference count (matched attach calls).
+	                                          // value = reference count (matched attach calls);
+	                                          // 0 = deferred detach, completed by sweepDetached().
 	                                          // Always accessed under _attachMutex; entries
 	                                          // are read concurrently via _stateMutex only by
 	                                          // the dtor's snapshot path - mutation paths do

--- a/Data/SQLite/src/MemoryDB.cpp
+++ b/Data/SQLite/src/MemoryDB.cpp
@@ -877,6 +877,37 @@ namespace
 }
 
 
+bool MemoryDB::tryDetach(Poco::UInt32 shardId)
+{
+	std::string alias = "arc_" + Poco::NumberFormatter::format(shardId);
+	try
+	{
+		InternalGuard guard;
+		DbMutexGuard dbm(_memHandle);
+		_session << ("DETACH DATABASE " + alias), now;
+		return true;
+	}
+	catch (const Poco::Exception&)
+	{
+		return false;
+	}
+}
+
+
+void MemoryDB::sweepDetached()
+{
+	// Complete deferred detaches (refcount 0, see detachArchived). Failures
+	// leave the entry for a later sweep.
+	for (auto it = _attached.begin(); it != _attached.end(); )
+	{
+		if (it->second == 0 && tryDetach(it->first))
+			it = _attached.erase(it);
+		else
+			++it;
+	}
+}
+
+
 std::string MemoryDB::attachArchived(Poco::UInt32 shardId)
 {
 	// Coordination layers (also see the comment block on the mutex declarations
@@ -895,7 +926,11 @@ std::string MemoryDB::attachArchived(Poco::UInt32 shardId)
 
 	std::string alias = "arc_" + Poco::NumberFormatter::format(shardId);
 	auto it = _attached.find(shardId);
+	// refcount 0 = deferred detach; the alias is still attached, reuse it
 	if (it != _attached.end()) { ++it->second; return alias; }
+
+	// reclaim attach slots held by deferred detaches before taking a new one
+	sweepDetached();
 
 	std::string file;
 	{
@@ -928,24 +963,15 @@ std::string MemoryDB::attachArchived(Poco::UInt32 shardId)
 
 void MemoryDB::detachArchived(Poco::UInt32 shardId)
 {
-	std::string alias = "arc_" + Poco::NumberFormatter::format(shardId);
-	std::string sql = "DETACH DATABASE " + alias;
-
-	// SQLite's DETACH fails with "database <alias> is locked" if the attached
-	// btree is in any transaction state (sqlite3.c:125750). This check
-	// returns immediately - sqlite3_busy_timeout() does NOT retry it. Under
-	// concurrent load on the same connection (constant prepare/step/finalize
-	// from other threads' stmts) arc_<id>'s btree can transiently show
-	// SQLITE_TXN_READ even when no one is querying arc_<id> directly. Retry
-	// briefly with backoff; the window where DETACH is rejected is short.
-	//
-	// We RELEASE _attachMutex across the sleep so that a concurrent
-	// deleteShard() waiting on _attachMutex (while holding _flushMutex) does
-	// not transitively stall the flush IO loop. Each iteration re-acquires
-	// _attachMutex, re-checks the refcount (another caller may have brought
-	// it above 1), attempts DETACH, and either succeeds or sleeps. Bounded
-	// by maxAttempts so a pathological hold cannot loop forever.
-	constexpr int maxAttempts = 100;
+	// SQLite refuses DETACH while the attached btree is in any transaction
+	// state, and a busy statement - even one reading only main - holds read
+	// transactions on all attached btrees while it steps, so under load the
+	// window may never open. Retry briefly, then defer: refcount 0 keeps the
+	// alias attached without an owner until sweepDetached(), deleteShard's
+	// force-detach, or detachAllArchived completes the DETACH.
+	// _attachMutex is released across the sleep so a deleteShard() waiting
+	// on it (while holding _flushMutex) does not stall the flush IO loop.
+	constexpr int maxAttempts = 10;
 	for (int attempt = 0; ; ++attempt)
 	{
 		{
@@ -953,20 +979,16 @@ void MemoryDB::detachArchived(Poco::UInt32 shardId)
 			auto it = _attached.find(shardId);
 			if (it == _attached.end()) return;
 			if (it->second > 1) { --it->second; return; }
-			// refcount == 1; we are the last detacher. Run DETACH first;
-			// only erase on success so an exception here leaves _attached
-			// consistent with the actual SQLite state.
-			try
+			// last detacher (refcount 1) or completing a deferred detach (0)
+			if (tryDetach(shardId))
 			{
-				InternalGuard guard;
-				DbMutexGuard dbm(_memHandle);
-				_session << sql, now;
-				_attached.erase(shardId);
+				_attached.erase(it);
 				return;
 			}
-			catch (const Poco::Exception&)
+			if (attempt + 1 >= maxAttempts)
 			{
-				if (attempt + 1 >= maxAttempts) throw;
+				it->second = 0; // defer the physical DETACH
+				return;
 			}
 		} // release _attachMutex before sleeping
 		Poco::Thread::sleep(1);

--- a/Data/SQLite/src/MemoryDB.cpp
+++ b/Data/SQLite/src/MemoryDB.cpp
@@ -880,30 +880,37 @@ namespace
 bool MemoryDB::tryDetach(Poco::UInt32 shardId)
 {
 	std::string alias = "arc_" + Poco::NumberFormatter::format(shardId);
-	try
-	{
-		InternalGuard guard;
-		DbMutexGuard dbm(_memHandle);
-		_session << ("DETACH DATABASE " + alias), now;
-		return true;
-	}
-	catch (const Poco::Exception&)
-	{
-		return false;
-	}
+	InternalGuard guard;
+	DbMutexGuard dbm(_memHandle);
+	// The held connection mutex keeps other threads' statements from starting
+	// or completing, so the observed state cannot change before the DETACH.
+	const int txn = sqlite3_txn_state(_memHandle, alias.c_str());
+	if (txn < 0)
+		return true;  // not attached (e.g. detached out-of-band via
+		              // session()); the end state holds, resync
+	if (txn != SQLITE_TXN_NONE)
+		return false; // a busy statement holds a transaction; defer
+	_session << ("DETACH DATABASE " + alias), now; // unexpected failures propagate
+	return true;
 }
 
 
 void MemoryDB::sweepDetached()
 {
 	// Complete deferred detaches (refcount 0, see detachArchived). Failures
-	// leave the entry for a later sweep.
+	// leave the entry for a later sweep; unexpected DETACH errors are not
+	// propagated here because the sweep runs on behalf of unrelated
+	// attach/detach calls.
 	for (auto it = _attached.begin(); it != _attached.end(); )
 	{
-		if (it->second == 0 && tryDetach(it->first))
-			it = _attached.erase(it);
-		else
-			++it;
+		bool detached = false;
+		if (it->second == 0)
+		{
+			try { detached = tryDetach(it->first); }
+			catch (const Poco::Exception&) { }
+		}
+		if (detached) it = _attached.erase(it);
+		else ++it;
 	}
 }
 

--- a/Data/SQLite/testsuite/src/MemoryDBTest.cpp
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.cpp
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <random>
 #include <thread>
 #include <vector>
@@ -1041,6 +1042,56 @@ void MemoryDBTest::testShardCeilingAutoDrop()
 }
 
 
+void MemoryDBTest::testDetachDeferredUnderReadTxn()
+{
+	// A busy statement holds a read transaction on the attached shard, so
+	// SQLite refuses the DETACH; detachArchived() must defer (alias stays
+	// attached) instead of throwing, and a later detach completes it.
+	MemoryDB db(_dir);
+	db << "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)", now;
+	for (int i = 0; i < 5; ++i)
+	{
+		std::string v("v" + Poco::NumberFormatter::format(i));
+		db << "INSERT INTO t(v) VALUES(:v)", use(v), now;
+	}
+	db.sealActive();
+	db.flush();
+
+	std::vector<Poco::UInt32> ids = db.archivedShardIds();
+	assertTrue (ids.size() == 1);
+	const std::string alias = db.attachArchived(ids[0]);
+
+	{
+		int id = 0;
+		Poco::Data::Statement stmt = (db.session() <<
+			("SELECT id FROM " + alias + ".t"), into(id), limit(1));
+		stmt.execute(); // partially stepped: holds a read txn on the shard
+
+		db.detachArchived(ids[0]); // deferred, must not throw
+
+		int n = 0;
+		db << ("SELECT count(*) FROM " + alias + ".t"), into(n), now;
+		assertTrue (n == 5); // physically still attached
+	} // statement finalized; the read txn is released
+
+	db.detachArchived(ids[0]); // completes the deferred DETACH
+	try
+	{
+		int n = 0;
+		db << ("SELECT count(*) FROM " + alias + ".t"), into(n), now;
+		fail ("alias must be detached");
+	}
+	catch (Poco::Exception&) { }
+
+	// the shard can be attached and detached cleanly again
+	assertTrue (db.attachArchived(ids[0]) == alias);
+	int n = 0;
+	db << ("SELECT count(*) FROM " + alias + ".t"), into(n), now;
+	assertTrue (n == 5);
+	db.detachArchived(ids[0]);
+}
+
+
 void MemoryDBTest::testConcurrentAccess()
 {
 	// 5-second stress test of MemoryDB's thread-safe surfaces.
@@ -1103,6 +1154,7 @@ void MemoryDBTest::testConcurrentAccess()
 
 		std::atomic<bool> stop{false};
 		std::atomic<int>  errors{0};
+		std::mutex logMutex; // workers log concurrently; cerr itself is not synchronized
 		std::vector<std::atomic<long>> iters(workers);
 		for (auto& a: iters) a.store(0);
 
@@ -1228,6 +1280,7 @@ void MemoryDBTest::testConcurrentAccess()
 						msg.find("another row available") != std::string::npos;
 					if (!transient)
 					{
+						std::lock_guard<std::mutex> lg(logMutex);
 						std::cerr << "[concur] worker " << idx << " " << roleName(idx)
 							<< " Poco::Exception: " << msg << '\n';
 						errors.fetch_add(1, std::memory_order_relaxed);
@@ -1235,6 +1288,7 @@ void MemoryDBTest::testConcurrentAccess()
 				}
 				catch (std::exception& exc)
 				{
+					std::lock_guard<std::mutex> lg(logMutex);
 					std::cerr << "[concur] worker " << idx << " " << roleName(idx)
 						<< " std::exception: " << exc.what() << '\n';
 					errors.fetch_add(1, std::memory_order_relaxed);
@@ -1723,6 +1777,7 @@ CppUnit::Test* MemoryDBTest::suite()
 	CppUnit_addTest(pSuite, MemoryDBTest, testHistoryViewTimeRange);
 	CppUnit_addTest(pSuite, MemoryDBTest, testHistoryViewTimeRangeOverflow);
 	CppUnit_addTest(pSuite, MemoryDBTest, testDetachAllArchived);
+	CppUnit_addTest(pSuite, MemoryDBTest, testDetachDeferredUnderReadTxn);
 	CppUnit_addTest(pSuite, MemoryDBTest, testShardCeilingAutoDrop);
 	CppUnit_addTest(pSuite, MemoryDBTest, testConcurrentAccess);
 

--- a/Data/SQLite/testsuite/src/MemoryDBTest.cpp
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.cpp
@@ -1089,6 +1089,17 @@ void MemoryDBTest::testDetachDeferredUnderReadTxn()
 	db << ("SELECT count(*) FROM " + alias + ".t"), into(n), now;
 	assertTrue (n == 5);
 	db.detachArchived(ids[0]);
+
+	// an out-of-band DETACH through session() must not strand the
+	// bookkeeping: detachArchived resyncs and a fresh attach works
+	assertTrue (db.attachArchived(ids[0]) == alias);
+	db.session() << ("DETACH DATABASE " + alias), now;
+	db.detachArchived(ids[0]);
+	assertTrue (db.attachArchived(ids[0]) == alias);
+	n = 0;
+	db << ("SELECT count(*) FROM " + alias + ".t"), into(n), now;
+	assertTrue (n == 5);
+	db.detachArchived(ids[0]);
 }
 
 

--- a/Data/SQLite/testsuite/src/MemoryDBTest.h
+++ b/Data/SQLite/testsuite/src/MemoryDBTest.h
@@ -63,6 +63,7 @@ public:
 	void testHistoryViewTimeRange();
 	void testHistoryViewTimeRangeOverflow();
 	void testDetachAllArchived();
+	void testDetachDeferredUnderReadTxn();
 	void testShardCeilingAutoDrop();
 	void testConcurrentAccess();
 


### PR DESCRIPTION
Fixes intermittent `MemoryDBTest::testConcurrentAccess` failures under ThreadSanitizer on macOS arm64: HIST workers failed with `Invalid SQL statement: database arc_N is locked`.

## Root cause

SQLite's DETACH refuses while the attached btree is in any transaction state (`detachFunc`, not retried by `sqlite3_busy_timeout()`). A busy statement on the connection - even one that only reads `main` - holds read transactions on **all** attached btrees for its whole stepping lifetime. Under steady statement traffic the no-transaction window may never open, so `detachArchived()`'s bounded retry (100 x 1 ms) exhausted and threw. TSan's 5-15x slowdown made the window vanish reliably; instrumentation showed the transaction holders were plain `SELECT ... FROM events LIMIT 50` statements mid-stepping.

Linux TSan does not reproduce the failure (6/6 runs green on main); the timing is specific to macOS arm64 under TSan, but the underlying condition exists everywhere.

## Fix

`detachArchived()` now defers instead of throwing: after a short retry (10 x 1 ms) the alias stays attached with refcount 0 (no owner), and the physical DETACH is completed later by `sweepDetached()` - run from `attachArchived()` before a new attach consumes an attach slot, or from a later `detachArchived()` - or by `deleteShard()`'s force-detach, `detachAllArchived()`, or destruction. This matches the existing attach-cache semantics (`historyView` already keeps attachments alive deliberately).

Also serializes the stress test's worker `std::cerr` logging with a mutex (TSan reported the unsynchronized stream writes in libc++ as a data race).

## Tests

- New deterministic `testDetachDeferredUnderReadTxn`: a partially-stepped `Statement` holds the read transaction; reproduces the exact `database arc_N is locked` failure on the old code without TSan, and verifies deferral, later completion of the DETACH, and clean re-attach.
- `testConcurrentAccess`'s transient allowlist is unchanged, so regressions still surface.

## Verification

- macOS arm64 plain: full DataSQLite suite 194/194.
- macOS arm64 TSan: `testConcurrentAccess` 8/8 green (baseline main: 8/8 failing); full MemoryDBTest green.
- Linux (Ubuntu 26.04, gcc 15) TSan: full MemoryDBTest 4/4 runs green.
