### PR TITLE
Mark all methods which necessarily throw, as `[[noreturn]]` (addresses #5152)

### DIFF
--- a/CppParser/include/Poco/CppParser/CppToken.h
+++ b/CppParser/include/Poco/CppParser/CppToken.h
@@ -34,7 +34,7 @@ public:
 	~CppToken();
 
 protected:
-	void syntaxError(const std::string& expected, const std::string& actual);
+	[[noreturn]] void syntaxError(const std::string& expected, const std::string& actual);
 };
 
 

--- a/CppParser/include/Poco/CppParser/Parser.h
+++ b/CppParser/include/Poco/CppParser/Parser.h
@@ -95,7 +95,7 @@ protected:
 	[[nodiscard]] static bool isKeyword(const Poco::Token* pToken, int kind);
 	[[nodiscard]] static bool isEOF(const Poco::Token* pToken);
 	static void expectOperator(const Poco::Token* pToken, int kind, const std::string& msg);
-	static void syntaxError(const std::string& msg);
+	[[noreturn]] static void syntaxError(const std::string& msg);
 	static void append(std::string& decl, const std::string& token);
 	static void append(std::string& decl, const Poco::Token* pToken);
 

--- a/CppUnit/include/CppUnit/TestCase.h
+++ b/CppUnit/include/CppUnit/TestCase.h
@@ -211,7 +211,7 @@ protected:
 					long lineNumber = CppUnitException::CPPUNIT_UNKNOWNLINENUMBER,
 					const std::string& fileName = CppUnitException::CPPUNIT_UNKNOWNFILENAME);
 
-	void fail(const std::string& message = "",
+	[[noreturn]] void fail(const std::string& message = "",
 			  long lineNumber = CppUnitException::CPPUNIT_UNKNOWNLINENUMBER,
 			  const std::string& fileName = CppUnitException::CPPUNIT_UNKNOWNFILENAME);
 

--- a/Crypto/include/Poco/Crypto/CryptoException.h
+++ b/Crypto/include/Poco/Crypto/CryptoException.h
@@ -42,7 +42,7 @@ public:
 	[[nodiscard]] const char* name() const noexcept;
 	[[nodiscard]] const char* className() const noexcept;
 	[[nodiscard]] Poco::Exception* clone() const;
-	void rethrow() const;
+	[[noreturn]] void rethrow() const;
 
 private:
 	void setExtMessage();

--- a/Crypto/include/Poco/Crypto/Envelope.h
+++ b/Crypto/include/Poco/Crypto/Envelope.h
@@ -100,7 +100,7 @@ private:
 
 	[[nodiscard]] int ivSize() const;
 	[[nodiscard]] int blockSize() const;
-	void handleErrors(std::string&& msg);
+	[[noreturn]] void handleErrors(std::string&& msg);
 
 	const EVP_CIPHER* _pCipher;
 	EVP_CIPHER_CTX*   _pCtx;

--- a/Crypto/src/CipherImpl.cpp
+++ b/Crypto/src/CipherImpl.cpp
@@ -24,7 +24,7 @@ namespace Poco::Crypto {
 
 namespace
 {
-	void throwError()
+	[[noreturn]] void throwError()
 	{
 		unsigned long err;
 		std::string msg;

--- a/Crypto/src/CipherKeyImpl.cpp
+++ b/Crypto/src/CipherKeyImpl.cpp
@@ -23,7 +23,7 @@
 
 namespace
 {
-	void throwError()
+	[[noreturn]] void throwError()
 	{
 		unsigned long err;
 		std::string msg;

--- a/Crypto/src/EVPCipherImpl.cpp
+++ b/Crypto/src/EVPCipherImpl.cpp
@@ -26,7 +26,7 @@ namespace Poco::Crypto {
 
 namespace
 {
-	void throwError(std::string&& msg)
+	[[noreturn]] void throwError(std::string&& msg)
 	{
 		unsigned long err;
 		while ((err = ERR_get_error()))

--- a/Crypto/src/RSACipherImpl.cpp
+++ b/Crypto/src/RSACipherImpl.cpp
@@ -26,7 +26,7 @@ namespace Poco::Crypto {
 
 namespace
 {
-	void throwError()
+	[[noreturn]] void throwError()
 	{
 		unsigned long err;
 		std::string msg;

--- a/Data/DataTest/src/SQLExecutor.cpp
+++ b/Data/DataTest/src/SQLExecutor.cpp
@@ -4405,7 +4405,7 @@ struct TestCommitTransactor
 
 struct TestRollbackTransactor
 {
-	void operator () (Session& session) const
+	[[noreturn]] void operator () (Session& session) const
 	{
 		session << "INSERT INTO Person VALUES ('lastName','firstName','address',10)", now;
 		throw Poco::Exception("test");

--- a/Data/MySQL/include/Poco/Data/MySQL/MySQLException.h
+++ b/Data/MySQL/include/Poco/Data/MySQL/MySQLException.h
@@ -63,7 +63,7 @@ public:
 		/// The copy can later be thrown again by
 		/// invoking rethrow() on it.
 
-	void rethrow() const;
+	[[noreturn]] void rethrow() const;
 		/// (Re)Throws the exception.
 		///
 		/// This is useful for temporarily storing a

--- a/Data/ODBC/include/Poco/Data/ODBC/ODBCException.h
+++ b/Data/ODBC/include/Poco/Data/ODBC/ODBCException.h
@@ -104,7 +104,7 @@ public:
 		return new HandleException(*this);
 	}
 
-	void rethrow() const
+	[[noreturn]] void rethrow() const
 		/// Re-throws the HandleException.
 	{
 		throw *this;

--- a/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
+++ b/Data/PostgreSQL/include/Poco/Data/PostgreSQL/PostgreSQLException.h
@@ -59,7 +59,7 @@ public:
 		/// The copy can later be thrown again by
 		/// invoking rethrow() on it.
 
-	void rethrow() const;
+	[[noreturn]] void rethrow() const;
 		/// (Re)Throws the exception.
 		///
 		/// This is useful for temporarily storing a

--- a/Data/SQLite/testsuite/src/SQLiteTest.cpp
+++ b/Data/SQLite/testsuite/src/SQLiteTest.cpp
@@ -3822,7 +3822,7 @@ struct TestCommitTransactor
 
 struct TestRollbackTransactor
 {
-	void operator () (Session& session) const
+	[[noreturn]] void operator () (Session& session) const
 	{
 		session << "INSERT INTO Person VALUES ('lastName','firstName','address',10)", now;
 		throw Poco::Exception("test");

--- a/Foundation/include/Poco/Bugcheck.h
+++ b/Foundation/include/Poco/Bugcheck.h
@@ -39,23 +39,19 @@ class Foundation_API Bugcheck
 	/// automatically provide useful context information.
 {
 public:
-	[[noreturn]]
-	static void assertion(const char* cond, const char* file, LineNumber line, const char* text = nullptr);
+	[[noreturn]] static void assertion(const char* cond, const char* file, LineNumber line, const char* text = nullptr);
 		/// An assertion failed. Break into the debugger, if
 		/// possible, then throw an AssertionViolationException.
 
-	[[noreturn]]
-	static void nullPointer(const char* ptr, const char* file, LineNumber line);
+	[[noreturn]] static void nullPointer(const char* ptr, const char* file, LineNumber line);
 		/// An null pointer was encountered. Break into the debugger, if
 		/// possible, then throw an NullPointerException.
 
-	[[noreturn]]
-	static void bugcheck(const char* file, LineNumber line);
+	[[noreturn]] static void bugcheck(const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 
-	[[noreturn]]
-	static void bugcheck(const char* msg, const char* file, LineNumber line);
+	[[noreturn]] static void bugcheck(const char* msg, const char* file, LineNumber line);
 		/// An internal error was encountered. Break into the debugger, if
 		/// possible, then throw an BugcheckException.
 

--- a/Foundation/include/Poco/Exception.h
+++ b/Foundation/include/Poco/Exception.h
@@ -81,7 +81,7 @@ public:
 		/// The copy can later be thrown again by
 		/// invoking rethrow() on it.
 
-	virtual void rethrow() const;
+	[[noreturn]] virtual void rethrow() const;
 		/// (Re)Throws the exception.
 		///
 		/// This is useful for temporarily storing a
@@ -161,6 +161,7 @@ inline int Exception::code() const
 		const char* className() const noexcept;										\
 		[[nodiscard]]                                                               \
 		Poco::Exception* clone() const;												\
+		[[noreturn]]                                                                \
 		void rethrow() const;														\
 	};
 

--- a/Foundation/include/Poco/FastLogger.h
+++ b/Foundation/include/Poco/FastLogger.h
@@ -355,14 +355,14 @@ public:
 		///
 		/// Note: This should not be called from a static destructor.
 
-	static void setPattern(const std::string& pattern);
+	[[noreturn]] static void setPattern(const std::string& pattern);
 		/// Not supported: throws NotImplementedException.
 		///
 		/// The output pattern is configured per logger through a PatternFormatter on
 		/// the Channel passed to setChannel(); a Quill logger binds its format at
 		/// creation and cannot be changed through a global setter.
 
-	static void addFileSink(const std::string& filename);
+	[[noreturn]] static void addFileSink(const std::string& filename);
 		/// Not supported: throws NotImplementedException.
 		///
 		/// File output is configured through a FileChannel on the Channel passed to

--- a/Foundation/include/Poco/File.h
+++ b/Foundation/include/Poco/File.h
@@ -287,7 +287,7 @@ public:
 	[[nodiscard]] bool operator >  (const File& file) const;
 	[[nodiscard]] bool operator >= (const File& file) const;
 
-	static void handleLastError(const std::string& path);
+	[[noreturn]] static void handleLastError(const std::string& path);
 		/// For internal use only. Throws an appropriate
 		/// exception for the last file-related error.
 

--- a/Foundation/include/Poco/File_UNIX.h
+++ b/Foundation/include/Poco/File_UNIX.h
@@ -67,8 +67,8 @@ protected:
 	[[nodiscard]] FileSizeImpl totalSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl usableSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl freeSpaceImpl() const;
-	static void handleLastErrorImpl(int err, const std::string& path);
-	static void handleLastErrorImpl(const std::string& path);
+	[[noreturn]] static void handleLastErrorImpl(int err, const std::string& path);
+	[[noreturn]] static void handleLastErrorImpl(const std::string& path);
 
 private:
 	std::string _path;

--- a/Foundation/include/Poco/File_VX.h
+++ b/Foundation/include/Poco/File_VX.h
@@ -66,7 +66,7 @@ protected:
 	[[nodiscard]] FileSizeImpl totalSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl usableSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl freeSpaceImpl() const;
-	static void handleLastErrorImpl(const std::string& path);
+	[[noreturn]] static void handleLastErrorImpl(const std::string& path);
 
 private:
 	std::string _path;

--- a/Foundation/include/Poco/File_WIN32U.h
+++ b/Foundation/include/Poco/File_WIN32U.h
@@ -67,7 +67,7 @@ protected:
 	[[nodiscard]] FileSizeImpl totalSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl usableSpaceImpl() const;
 	[[nodiscard]] FileSizeImpl freeSpaceImpl() const;
-	static void handleLastErrorImpl(const std::string& path);
+	[[noreturn]] static void handleLastErrorImpl(const std::string& path);
 	static void convertPath(const std::string& utf8Path, std::wstring& utf16Path);
 
 private:

--- a/Foundation/include/Poco/SignalHandler.h
+++ b/Foundation/include/Poco/SignalHandler.h
@@ -80,7 +80,7 @@ public:
 	sigjmp_buf& jumpBuffer();
 		/// Returns the top-most sigjmp_buf for the current thread.
 
-	static void throwSignalException(int sig);
+	[[noreturn]] static void throwSignalException(int sig);
 		/// Throws a SignalException with a textual description
 		/// of the given signal as argument.
 
@@ -89,7 +89,7 @@ public:
 		/// and SIGSYS.
 
 protected:
-	static void handleSignal(int sig);
+	[[noreturn]] static void handleSignal(int sig);
 		/// The actual signal handler.
 
 	struct JumpBuffer

--- a/Foundation/testsuite/src/AsyncNotificationCenterTest.h
+++ b/Foundation/testsuite/src/AsyncNotificationCenterTest.h
@@ -95,7 +95,7 @@ protected:
 	void handleAuto(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleCount(const Poco::AutoPtr<Poco::Notification>& pNf);
 	Poco::NotificationResult handleSync(const Poco::AutoPtr<Poco::Notification>& pNf);
-	void handleThrow(const Poco::AutoPtr<Poco::Notification>& pNf);
+	[[noreturn]] void handleThrow(const Poco::AutoPtr<Poco::Notification>& pNf);
 	void handleThreadSafe(const Poco::AutoPtr<Poco::Notification>& pNf);
 	bool matchAsync(const std::string& name) const;
 

--- a/Net/include/Poco/Net/DNS.h
+++ b/Net/include/Poco/Net/DNS.h
@@ -173,10 +173,10 @@ protected:
 	[[nodiscard]] static int lastError();
 		/// Returns the code of the last error.
 
-	static void error(int code, const std::string& arg);
+	[[noreturn]] static void error(int code, const std::string& arg);
 		/// Throws an exception according to the error code.
 
-	static void aierror(int code, const std::string& arg);
+	[[noreturn]] static void aierror(int code, const std::string& arg);
 		/// Throws an exception according to the getaddrinfo() error code.
 
 	[[nodiscard]] static std::string encodeIDNLabel(const std::string& idn);

--- a/Net/include/Poco/Net/HTTPReactorServer.h
+++ b/Net/include/Poco/Net/HTTPReactorServer.h
@@ -28,7 +28,7 @@ public:
 	void stop();
 	int port() const { return _tcpReactorServer.port(); }
 	void onMessage(const TcpReactorConnectionPtr& conn);
-	void onError(const Poco::Exception& ex);
+	[[noreturn]] void onError(const Poco::Exception& ex);
 		/// Rethrows ex preserving its dynamic type, so callers up the stack can
 		/// classify the failure. Handlers run inline on the reactor worker
 		/// thread, so this propagates into TCPReactorServerConnection::onRead.

--- a/PDF/include/Poco/PDF/PDFException.h
+++ b/PDF/include/Poco/PDF/PDFException.h
@@ -26,7 +26,7 @@
 namespace Poco::PDF {
 
 
-void HPDF_Error_Handler(HPDF_STATUS error_no, HPDF_STATUS detail_no, void* user_data);
+[[noreturn]] void HPDF_Error_Handler(HPDF_STATUS error_no, HPDF_STATUS detail_no, void* user_data);
 	/// HARU library error handler function.
 	/// Throws appropriate exception.
 

--- a/SevenZip/src/Archive.cpp
+++ b/SevenZip/src/Archive.cpp
@@ -250,13 +250,13 @@ protected:
 		}
 	}
 
-	void handleError(int err)
+	[[noreturn]] void handleError(int err)
 	{
 		std::string arg;
 		handleError(err, arg);
 	}
 
-	void handleError(int err, const std::string& arg)
+	[[noreturn]] void handleError(int err, const std::string& arg)
 	{
 		switch (err)
 		{

--- a/XML/include/Poco/DOM/DOMException.h
+++ b/XML/include/Poco/DOM/DOMException.h
@@ -78,7 +78,7 @@ public:
 	[[nodiscard]] Poco::Exception* clone() const;
 		/// Creates an exact copy of the exception.
 
-	void rethrow() const;
+	[[noreturn]] void rethrow() const;
 		/// (Re)Throws the exception.
 
 	[[nodiscard]] unsigned short code() const;

--- a/XML/include/Poco/SAX/SAXException.h
+++ b/XML/include/Poco/SAX/SAXException.h
@@ -112,7 +112,7 @@ public:
 	[[nodiscard]] Poco::Exception* clone() const;
 		/// Creates an exact copy of the exception.
 
-	void rethrow() const;
+	[[noreturn]] void rethrow() const;
 		/// (Re)Throws the exception.
 
 	[[nodiscard]] const XMLString& getPublicId() const;

--- a/XML/include/Poco/XML/XMLStreamParser.h
+++ b/XML/include/Poco/XML/XMLStreamParser.h
@@ -277,7 +277,7 @@ private:
 	void init();
 	[[nodiscard]] EventType nextImpl(bool peek);
 	[[nodiscard]] EventType nextBody();
-	void handleError();
+	[[noreturn]] void handleError();
 
 #ifndef POCO_DOC
 	// If _size is 0, then data is std::istream. Otherwise, it is a buffer.

--- a/XML/src/ParserEngine.h
+++ b/XML/src/ParserEngine.h
@@ -217,11 +217,11 @@ protected:
 	std::streamsize readChars(XMLCharInputStream& istr, XMLChar* pBuffer, std::streamsize bufferSize);
 		/// Reads at most bufferSize chars from the given stream into the given buffer.
 
-	void handleError(int errorNo);
+	[[noreturn]] void handleError(int errorNo);
 		/// Throws an XMLException with a message corresponding
 		/// to the given Expat error code.
 
-	void checkError(XML_Parser parser);
+	[[noreturn]] void checkError(XML_Parser parser);
 		/// Called after a failed XML_Parse()/XML_ParseBuffer() call.
 		/// If a C++ exception thrown from within a handler has been
 		/// captured by abortParse(), rethrows it (and clears it);


### PR DESCRIPTION
This PR adds the `[[noreturn]]` attribute to all methods which necessarily throw, or do not return.

One possible regression is that, because `Poco::Exception::rethrow()` is marked `[[noreturn]]`, any client code which overrides it to not throw and instead return, could potentially invoke undefined behaviour. However, I do not forsee this being a problem as code which does this would be violating the intended use of the method anyway.

Virtual overrides whose whole body is a throw (`WebSocketImpl::bind()`, `SecureStreamSocketImpl::listen()`, `DTDMap::setNamedItem()`, `Document::copyNode()` and etc.) are intentionally not annotated, because the attribute only aids direct calls on the derived type and none of those classes are `final`.

Continues to address #5152.