### PR TITLE
fix(Crypto,NetSSL): restore missing #else in isFIPSEnabled(), add OpenSSL 1.1.1 CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,82 @@ jobs:
             ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Crypto|NetSSL|JWT)$"
       - uses: ./.github/actions/upload-test-report
 
+  # Minimum supported OpenSSL (1.1.1, enforced by Crypto.h). ubuntu-24.04 ships
+  # OpenSSL 3, so 1.1.1 is built from source and cached. This is the only job
+  # that compiles the pre-3.0 preprocessor branches in Crypto and NetSSL;
+  # -Werror=return-type turns a mis-nested #if/#else in those branches into a
+  # build failure instead of a warning nobody reads.
+  linux-gcc-cmake-openssl111:
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: |
+      needs.changes.outputs.crypto_netssl == 'true' ||
+      needs.changes.outputs.ci_core == 'true' ||
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    env:
+      OPENSSL111_VERSION: 1.1.1w
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set OpenSSL ${{ env.OPENSSL111_VERSION }} paths
+        run: |
+          prefix="${GITHUB_WORKSPACE}/.openssl-${OPENSSL111_VERSION}"
+          echo "OPENSSL111_PREFIX=${prefix}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${prefix}/lib" >> "$GITHUB_ENV"
+      - name: Cache OpenSSL ${{ env.OPENSSL111_VERSION }}
+        id: openssl111-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.OPENSSL111_PREFIX }}
+          key: openssl111-${{ env.OPENSSL111_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+      - name: Build OpenSSL ${{ env.OPENSSL111_VERSION }}
+        if: steps.openssl111-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt -y update && sudo apt -y install build-essential curl perl
+          curl -fsSL -O "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL111_VERSION}.tar.gz"
+          tar xzf "openssl-${OPENSSL111_VERSION}.tar.gz"
+          cd "openssl-${OPENSSL111_VERSION}"
+          ./config --prefix="${OPENSSL111_PREFIX}" --openssldir="${OPENSSL111_PREFIX}/ssl" shared
+          make -j"$(nproc)"
+          make install_sw install_ssldirs
+      - name: Verify OpenSSL ${{ env.OPENSSL111_VERSION }}
+        run: |
+          "${OPENSSL111_PREFIX}/bin/openssl" version
+          "${OPENSSL111_PREFIX}/bin/openssl" version | grep -q "^OpenSSL 1[.]1[.]1" || {
+            echo "expected OpenSSL 1.1.1" >&2
+            exit 1
+          }
+      - run: sudo apt -y update && sudo apt -y install cmake ninja-build
+      - run: >-
+          cmake -S. -Bcmake-build -GNinja
+          -DCMAKE_CXX_FLAGS="-Werror=return-type"
+          -DPOCO_MINIMAL_BUILD=ON -DENABLE_TESTS=ON
+          -DENABLE_CRYPTO=ON -DENABLE_NETSSL=ON -DENABLE_JWT=ON
+          -DOPENSSL_ROOT_DIR=${{ env.OPENSSL111_PREFIX }}
+          -DCMAKE_BUILD_RPATH=${{ env.OPENSSL111_PREFIX }}/lib
+          -DCMAKE_INSTALL_RPATH=${{ env.OPENSSL111_PREFIX }}/lib
+      # NetSSL is built but its tests are not run here: TCPServerTest's
+      # testClientClosesWithoutReadingTLS13 is flaky against 1.1.1 (it passes
+      # consistently against OpenSSL 3). Compiling NetSSL is what this job is
+      # for; the flake is tracked separately.
+      - run: cmake --build cmake-build --target all --parallel $(nproc)
+      - name: Verify Poco linked against OpenSSL 1.1.1
+        run: |
+          ldd cmake-build/lib/libPocoCrypto.so
+          ldd cmake-build/lib/libPocoCrypto.so | grep -q "libcrypto[.]so[.]1[.]1" || {
+            echo "PocoCrypto did not link against OpenSSL 1.1.1" >&2
+            exit 1
+          }
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build &&
+            PWD=`pwd`
+            ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(nproc) -R "^(Crypto|JWT)$"
+      - uses: ./.github/actions/upload-test-report
+
   # POCO_SOO=OFF probe: Foundation only.
   linux-gcc-cmake-poco-soo-off:
     runs-on: ubuntu-24.04

--- a/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
+++ b/Crypto/include/Poco/Crypto/OpenSSLInitializer.h
@@ -76,9 +76,11 @@ inline bool OpenSSLInitializer::isFIPSEnabled()
 {
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	// OpenSSL 3.x: OPENSSL_FIPS no longer exists. FIPS is now provider-based.
-	return EVP_default_properties_is_fips_enabled(NULL) ? true : false;
+	return EVP_default_properties_is_fips_enabled(nullptr) ? true : false;
 #elif defined(OPENSSL_FIPS)
-	// OpenSSL 1.x legacy FIPS module#else
+	// OpenSSL 1.x legacy FIPS module
+	return FIPS_mode() ? true : false;
+#else
 	return false;
 #endif
 }

--- a/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -383,9 +383,9 @@ inline bool SSLManager::isFIPSEnabled()
 {
 #if POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)
 	// OpenSSL 3.x: OPENSSL_FIPS no longer exists. FIPS is now provider-based.
-	return EVP_default_properties_is_fips_enabled(NULL) ? true : false;
+	return EVP_default_properties_is_fips_enabled(nullptr) ? true : false;
 #elif defined(OPENSSL_FIPS)
-	// OpenSSL 1.x legacy FIPS module#else
+	// OpenSSL 1.x legacy FIPS module
 	return FIPS_mode() ? true : false;
 #else
 	return false;


### PR DESCRIPTION
## Problem

`#5460` left a mis-nested preprocessor block in `isFIPSEnabled()`. The `#else` was swallowed into the trailing comment:

```c
#elif defined(OPENSSL_FIPS)
	// OpenSSL 1.x legacy FIPS module#else
	return false;
#endif
```

In `Crypto/include/Poco/Crypto/OpenSSLInitializer.h` this leaves the function with **no return statement at all** when `POCO_OPENSSL_VERSION_PREREQ(3, 0, 0)` is false and `OPENSSL_FIPS` is undefined -- which is every build against OpenSSL 1.1.1 (the minimum enforced by `Crypto.h`) and every build against LibreSSL, which reports `OPENSSL_VERSION_NUMBER` as `0x20000000`. Falling off the end of a non-void function is undefined behavior.

Confirmed against a real OpenSSL 1.1.1w build on Linux/GCC; the warning appears in every translation unit that includes the header:

```
Crypto/include/Poco/Crypto/OpenSSLInitializer.h:84:1: warning: no return statement in function returning non-void [-Wreturn-type]
```

`NetSSL_OpenSSL/include/Poco/Net/SSLManager.h` has the same mangled comment, but a real `#else` follows it there, so only the comment is wrong.

## Changes

1. Restore the `#else` and the OpenSSL 1.x `FIPS_mode()` branch in `OpenSSLInitializer.h`; fix the comment in `SSLManager.h`. `NULL` is changed to `nullptr` on the two lines being touched, per the convention adopted in #5043.

2. Add `linux-gcc-cmake-openssl111`, a CI job that builds against OpenSSL 1.1.1w. ubuntu-24.04 ships OpenSSL 3, so 1.1.1 is built from source and cached. This is the only job that compiles the pre-3.0 preprocessor branches in Crypto and NetSSL -- no existing job does, which is why this went unnoticed.

The job passes `-Werror=return-type` so a mis-nested `#if`/`#else` fails the build instead of producing a warning nobody reads. `ENABLE_COMPILER_WARNINGS` is not `-Werror`, so it would not have caught this either.

## Verification

Against OpenSSL 1.1.1w on Linux/GCC:

- Without the fix, the new job's configuration fails to build: `error: no return statement in function returning non-void [-Werror=return-type]`.
- With the fix, `--target all` builds clean, `ldd` confirms `libcrypto.so.1.1`, and Crypto and JWT tests pass (3 consecutive runs, no flakes).

## Note on NetSSL tests

The job builds NetSSL but does not run its test suite. `TCPServerTest::testClientClosesWithoutReadingTLS13` is flaky against 1.1.1 -- it failed 2 of 3 runs, while passing 3 of 3 against OpenSSL 3 on the same machine. Compiling NetSSL is what this job is for, so the tests are left out rather than made a source of CI noise. Worth investigating separately; it may relate to the TLS 1.3 session-resumption work in #5417.
