### PR TITLE
chore(ci): add macOS LibreSSL build and test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,39 @@ jobs:
             ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(sysctl -n hw.ncpu) -R "^(Foundation|Util|Crypto)$"
       - uses: ./.github/actions/upload-test-report
 
+  # LibreSSL probe: Crypto/NetSSL/JWT built against brew libressl, which keeps
+  # the non-OpenSSL API divergences (opaque DH since 2.7.0, no X448 in the curve
+  # parser) under CI. NetSSL is build-only: LibreSSL does not resume TLS 1.3
+  # sessions the way TCPServerTest::testReuseSessionTLS13 expects.
+  macos-clang-cmake-libressl:
+    runs-on: macos-latest
+    needs: changes
+    if: |
+      needs.changes.outputs.crypto_netssl == 'true' ||
+      needs.changes.outputs.ci_core == 'true' ||
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v5
+      - run: brew install libressl
+      - run: >-
+          cmake -S. -Bcmake-build
+          -DPOCO_MINIMAL_BUILD=ON -DENABLE_TESTS=ON
+          -DENABLE_CRYPTO=ON -DENABLE_NETSSL=ON -DENABLE_JWT=ON
+          -DOPENSSL_ROOT_DIR=$(brew --prefix libressl)
+      - run: cmake --build cmake-build --target all --parallel $(sysctl -n hw.ncpu)
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build &&
+            PWD=`pwd`
+            ctest ${{ env.POCO_CTEST_COMMON }} --parallel $(sysctl -n hw.ncpu) -R "^(Crypto|JWT)$"
+      - uses: ./.github/actions/upload-test-report
+        with:
+          suffix: libressl
+
   # Build-only: compile-warnings-as-signal across as many modules as possible.
   macos-clang-cmake-warnings:
     runs-on: macos-latest


### PR DESCRIPTION
### Summary

Adds a `macos-clang-cmake-libressl` CI job that builds Crypto, NetSSL_OpenSSL and
JWT against LibreSSL (Homebrew `libressl`, currently 4.3.2).

LibreSSL diverges from OpenSSL in ways that only a real LibreSSL build catches:
`DH` has been opaque since LibreSSL 2.7.0, and its curve list parser does not
know `X448`. Neither is visible in any existing job.

macOS is used because Ubuntu ships no LibreSSL `libssl`/`libcrypto` package at
all -- the `libtls-dev` package there is LibreTLS, a port of libtls on top of
OpenSSL. On macOS `brew install libressl` gives a real keg-only LibreSSL.

### Scope

- Gated on the existing `crypto_netssl` path filter, so it only runs when
  `Crypto/**`, `NetSSL_OpenSSL/**` or `JWT/**` change.
- Builds all three components; ctest runs `Crypto` and `JWT` only.
- NetSSL is build-only: `TCPServerTest::testReuseSessionTLS13` fails under
  LibreSSL, which does not resume TLS 1.3 sessions the way the test expects.
  Everything else in the NetSSL suite passes (65/66), verified on both macOS and
  Linux.

### Merge order

**This job is red on current `main` and must not be merged before the LibreSSL
fixes land.** `main` fails to compile against LibreSSL with 8
`member access into incomplete type 'DH'` errors in `NetSSL_OpenSSL/src/Context.cpp`.
That is exactly what this job is meant to catch, but it means #5461 (or an
equivalent fix) has to go in first.

Two further items showed up while validating this job, both outside its scope:

- `Crypto/include/Poco/Crypto/OpenSSLInitializer.h` has a `#else` absorbed into a
  comment (`// OpenSSL 1.x legacy FIPS module#else`), so `isFIPSEnabled()` returns
  nothing on the LibreSSL path.
- The TLS 1.3 resumption difference above, which keeps NetSSL build-only here.
