### PR TITLE
fix(Net): register error and shutdown handlers in TCPReactorServerConnection

### DIFF
--- a/Net/include/Poco/Net/SocketAcceptor.h
+++ b/Net/include/Poco/Net/SocketAcceptor.h
@@ -146,8 +146,13 @@ public:
 		}
 	}
 
-	void onAccept(const AutoPtr<ReadableNotification>& pNotification)
+	virtual void onAccept(const AutoPtr<ReadableNotification>& pNotification)
 		/// Accepts connection and creates event handler.
+		///
+		/// Subclasses can override this method, e.g. to contain exceptions
+		/// thrown by the accept path; an escaping exception is re-dispatched
+		/// by the SocketReactor as an ErrorNotification broadcast to all
+		/// registered handlers.
 	{
 		StreamSocket sock = _socket.acceptConnection();
 		_pReactor->wakeUp();

--- a/Net/include/Poco/Net/SocketReactor.h
+++ b/Net/include/Poco/Net/SocketReactor.h
@@ -353,13 +353,17 @@ inline bool SocketReactor::has(const Socket& socket) const
 
 inline void SocketReactor::onError(const Socket& socket, int code, const std::string& description)
 {
-	dispatch(new ErrorNotification(this, socket, code, description));
+	// dispatch() does not take ownership (it is also called with borrowed
+	// member notifications), so a holder must release the initial reference.
+	Poco::AutoPtr<ErrorNotification> pNf(new ErrorNotification(this, socket, code, description));
+	dispatch(pNf);
 }
 
 
 inline void SocketReactor::onError(int code, const std::string& description)
 {
-	dispatch(new ErrorNotification(this, code, description));
+	Poco::AutoPtr<ErrorNotification> pNf(new ErrorNotification(this, code, description));
+	dispatch(pNf);
 }
 
 

--- a/Net/include/Poco/Net/TCPReactorAcceptor.h
+++ b/Net/include/Poco/Net/TCPReactorAcceptor.h
@@ -24,6 +24,8 @@ public:
 	SocketReactor& reactor();
 	void stop();
 
+	void onAccept(const AutoPtr<ReadableNotification>& pNf) override;
+
 	void setRecvMessageCallback(const RecvMessageCallback& cb)
 	{
 		_recvMessageCallback = cb;

--- a/Net/src/TCPReactorAcceptor.cpp
+++ b/Net/src/TCPReactorAcceptor.cpp
@@ -1,4 +1,5 @@
 #include "Poco/Net/TCPReactorAcceptor.h"
+#include "Poco/ErrorHandler.h"
 #include <atomic>
 
 
@@ -48,6 +49,32 @@ void TCPReactorAcceptor::stop()
 	if (_threadPool)
 	{
 		_threadPool->joinAll();
+	}
+}
+
+void TCPReactorAcceptor::onAccept(const AutoPtr<ReadableNotification>& pNf)
+{
+	// An exception escaping the accept path is re-dispatched by the reactor
+	// as an ErrorNotification broadcast, closing every connection registered
+	// for it on this reactor (all of them in self-reactor mode). Accept
+	// failures (ECONNABORTED, EMFILE, a failing setsockopt on the accepted
+	// socket) concern only the pending connection, so contain them here,
+	// like TCPServer::run() does.
+	try
+	{
+		SocketAcceptor<TCPReactorServerConnection>::onAccept(pNf);
+	}
+	catch (Poco::Exception& exc)
+	{
+		ErrorHandler::handle(exc);
+	}
+	catch (std::exception& exc)
+	{
+		ErrorHandler::handle(exc);
+	}
+	catch (...)
+	{
+		ErrorHandler::handle();
 	}
 }
 

--- a/Net/src/TCPReactorServer.cpp
+++ b/Net/src/TCPReactorServer.cpp
@@ -55,15 +55,17 @@ void TCPReactorServer::stop()
 	{
 		return;
 	}
-	for (auto& acceptor : _acceptors)
-	{
-		acceptor->stop();
-	}
+	// Stop accepting first: a connection accepted after a worker reactor has
+	// dispatched its shutdown notification would never be closed.
 	for (auto& reactor : _reactors)
 	{
 		reactor.stop();
 	}
 	_threadPool.joinAll();
+	for (auto& acceptor : _acceptors)
+	{
+		acceptor->stop();
+	}
 }
 
 }} // namespace Poco::Net

--- a/Net/src/TCPReactorServerConnection.cpp
+++ b/Net/src/TCPReactorServerConnection.cpp
@@ -27,6 +27,19 @@ void TCPReactorServerConnection::initialize()
 		_socket,
 		HTTPObserver<TCPReactorServerConnection, ReadableNotification>(
 			shared_from_this(), &TCPReactorServerConnection::onRead));
+	// Registering for ErrorNotification also makes the reactor include
+	// POLL_ERROR in the poll mask for this socket; without it socket errors
+	// surface only when a later read fails.
+	_reactor.addEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ErrorNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onError));
+	// ShutdownNotification is dispatched when the reactor stops; without it
+	// the connection (and its socket) outlives the reactor's run loop.
+	_reactor.addEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ShutdownNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onShutdown));
 }
 
 void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf)
@@ -105,7 +118,17 @@ void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf
 
 void TCPReactorServerConnection::onError(const AutoPtr<ErrorNotification>& pNf)
 {
+	// Copy the payload before handleClose(): it may destroy this, so only
+	// locals may be touched afterwards (same rule as in onRead).
+	int code = pNf->code();
+	std::string description = pNf->description();
 	handleClose();
+	try
+	{
+		Poco::Logger& log = Poco::Logger::get("Poco.Net.TCPReactorServer");
+		if (log.debug()) log.debug("connection closed on socket error: code=%d %s", code, description);
+	}
+	catch (...) {}
 }
 
 void TCPReactorServerConnection::onShutdown(const AutoPtr<ShutdownNotification>& pNf)
@@ -117,7 +140,20 @@ void TCPReactorServerConnection::handleClose()
 {
 	// here must keep _socket to delay the _socket destrcutor
 	StreamSocket keepSocket = _socket;
-	// here will delete this, so memberships' destructor will be invoked
+	// The reactor's observers hold the only owning shared_ptrs, so the last
+	// removal deletes this (at the end of its full-expression, once the
+	// temporary observer argument releases its reference). Remove Readable
+	// last: removeEventHandler drops the socket from the pollset only with the
+	// last observer, so the intermediate poll-mask updates never pass mode 0,
+	// and no member is touched after the final removal.
+	_reactor.removeEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ErrorNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onError));
+	_reactor.removeEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ShutdownNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onShutdown));
 	_reactor.removeEventHandler(
 		_socket,
 		HTTPObserver<TCPReactorServerConnection, ReadableNotification>(

--- a/Net/src/TCPReactorServerConnection.cpp
+++ b/Net/src/TCPReactorServerConnection.cpp
@@ -23,23 +23,27 @@ TCPReactorServerConnection::~TCPReactorServerConnection()
 
 void TCPReactorServerConnection::initialize()
 {
-	_reactor.addEventHandler(
-		_socket,
-		HTTPObserver<TCPReactorServerConnection, ReadableNotification>(
-			shared_from_this(), &TCPReactorServerConnection::onRead));
-	// Registering for ErrorNotification also makes the reactor include
-	// POLL_ERROR in the poll mask for this socket; without it socket errors
-	// surface only when a later read fails.
-	_reactor.addEventHandler(
-		_socket,
-		HTTPObserver<TCPReactorServerConnection, ErrorNotification>(
-			shared_from_this(), &TCPReactorServerConnection::onError));
 	// ShutdownNotification is dispatched when the reactor stops; without it
 	// the connection (and its socket) outlives the reactor's run loop.
 	_reactor.addEventHandler(
 		_socket,
 		HTTPObserver<TCPReactorServerConnection, ShutdownNotification>(
 			shared_from_this(), &TCPReactorServerConnection::onShutdown));
+	// Without a registered ErrorNotification observer the reactor's error
+	// dispatch is dropped by the NotificationCenter, so socket errors would
+	// surface only when a later read fails.
+	_reactor.addEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ErrorNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onError));
+	// Readable must come last: this may run on the acceptor's thread while
+	// the reactor polls, and once the socket is readable an immediately
+	// disconnecting client could run handleClose() on the reactor thread
+	// before registration completes, leaving a half-registered connection.
+	_reactor.addEventHandler(
+		_socket,
+		HTTPObserver<TCPReactorServerConnection, ReadableNotification>(
+			shared_from_this(), &TCPReactorServerConnection::onRead));
 }
 
 void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf)
@@ -119,10 +123,16 @@ void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf
 void TCPReactorServerConnection::onError(const AutoPtr<ErrorNotification>& pNf)
 {
 	// Copy the payload before handleClose(): it may destroy this, so only
-	// locals may be touched afterwards (same rule as in onRead).
+	// locals may be touched afterwards (same rule as in onRead). Guard the
+	// close: a throw would abort the reactor's notification loop for the
+	// remaining connections.
 	int code = pNf->code();
 	std::string description = pNf->description();
-	handleClose();
+	try
+	{
+		handleClose();
+	}
+	catch (...) {}
 	try
 	{
 		Poco::Logger& log = Poco::Logger::get("Poco.Net.TCPReactorServer");
@@ -133,19 +143,24 @@ void TCPReactorServerConnection::onError(const AutoPtr<ErrorNotification>& pNf)
 
 void TCPReactorServerConnection::onShutdown(const AutoPtr<ShutdownNotification>& pNf)
 {
-	handleClose();
+	// A throw here would abort the reactor's shutdown broadcast, leaving the
+	// remaining connections open.
+	try
+	{
+		handleClose();
+	}
+	catch (...) {}
 }
 
 void TCPReactorServerConnection::handleClose()
 {
-	// here must keep _socket to delay the _socket destrcutor
+	// keepSocket delays the socket close until the removals are done
 	StreamSocket keepSocket = _socket;
-	// The reactor's observers hold the only owning shared_ptrs, so the last
-	// removal deletes this (at the end of its full-expression, once the
-	// temporary observer argument releases its reference). Remove Readable
-	// last: removeEventHandler drops the socket from the pollset only with the
-	// last observer, so the intermediate poll-mask updates never pass mode 0,
-	// and no member is touched after the final removal.
+	// The reactor's observers hold the only owning shared_ptrs; removing them
+	// ends this object's lifetime (the dispatching NotificationCenter keeps
+	// it alive until the current handler returns). Remove Readable last so
+	// the intermediate poll-mask updates never pass mode 0, and touch no
+	// member after the removals.
 	_reactor.removeEventHandler(
 		_socket,
 		HTTPObserver<TCPReactorServerConnection, ErrorNotification>(

--- a/Net/src/TCPReactorServerConnection.cpp
+++ b/Net/src/TCPReactorServerConnection.cpp
@@ -122,21 +122,14 @@ void TCPReactorServerConnection::onRead(const AutoPtr<ReadableNotification>& pNf
 
 void TCPReactorServerConnection::onError(const AutoPtr<ErrorNotification>& pNf)
 {
-	// Copy the payload before handleClose(): it may destroy this, so only
-	// locals may be touched afterwards (same rule as in onRead). Guard the
-	// close: a throw would abort the reactor's notification loop for the
-	// remaining connections.
-	int code = pNf->code();
-	std::string description = pNf->description();
+	// A throw would abort the reactor's notification loop for the remaining
+	// connections. The payload is deliberately not reported: the POLL_ERROR
+	// dispatch carries none (code 0, empty description), and on the exception
+	// paths SocketReactor::run() has already passed the exception itself to
+	// the ErrorHandler.
 	try
 	{
 		handleClose();
-	}
-	catch (...) {}
-	try
-	{
-		Poco::Logger& log = Poco::Logger::get("Poco.Net.TCPReactorServer");
-		if (log.debug()) log.debug("connection closed on socket error: code=%d %s", code, description);
 	}
 	catch (...) {}
 }

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -208,7 +208,7 @@ void HTTPReactorServerTest::testBodyReadTwice()
 	istr.read(buffer1, 10);
 	int n1 = istr.gcount();
 	char buffer2[32];
-	istr.read(buffer2, 50);
+	istr.read(buffer2, sizeof(buffer2));
 	int n2 = istr.gcount();
 
 	std::string fullBody = std::string(buffer1, n1) + std::string(buffer2, n2);

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -9,7 +9,10 @@
 #include "Poco/Net/HTTPServerRequest.h"
 #include "Poco/Net/HTTPServerResponse.h"
 #include "Poco/Net/StreamSocket.h"
+#include "Poco/Net/ServerSocket.h"
 #include "Poco/Net/SocketAddress.h"
+#include "Poco/Net/SocketReactor.h"
+#include "Poco/Net/TCPReactorServerConnection.h"
 #include "Poco/Net/NetException.h"
 #include "Poco/StreamCopier.h"
 #include "Poco/Thread.h"
@@ -18,6 +21,7 @@
 #include "CppUnit/TestSuite.h"
 #include "CppUnit/TestCaller.h"
 #include <stdexcept>
+#include <vector>
 
 
 using Poco::Net::HTTPServerParams;
@@ -116,6 +120,49 @@ namespace
 			return new EchoBodyRequestHandler;
 		}
 	};
+
+	// Opens a raw keep-alive connection and completes the given number of
+	// request/response round trips, proving the connection is open and
+	// reusable when the caller proceeds (e.g. to stop the server).
+	Poco::Net::StreamSocket openKeepAliveConnection(int port, int roundTrips)
+	{
+		Poco::Net::StreamSocket s;
+		s.connect(Poco::Net::SocketAddress("127.0.0.1", port));
+		s.setReceiveTimeout(Poco::Timespan(5, 0));
+		for (int i = 0; i < roundTrips; ++i)
+		{
+			std::string req("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nping");
+			s.sendBytes(req.data(), static_cast<int>(req.size()));
+			std::string resp;
+			char buf[4096];
+			while (resp.find("ping") == std::string::npos)
+			{
+				int n = s.receiveBytes(buf, sizeof(buf));
+				if (n <= 0) throw Poco::IOException("connection closed before stop");
+				resp.append(buf, n);
+			}
+		}
+		return s;
+	}
+
+	// True if the connection is closed (EOF or reset), false on a receive
+	// timeout, i.e. a connection left open.
+	bool connectionClosed(Poco::Net::StreamSocket& s)
+	{
+		char buf[256];
+		try
+		{
+			return s.receiveBytes(buf, sizeof(buf)) == 0;
+		}
+		catch (const Poco::TimeoutException&)
+		{
+			return false;
+		}
+		catch (const Poco::Net::NetException&)
+		{
+			return true;
+		}
+	}
 }
 
 HTTPReactorServerTest::HTTPReactorServerTest(const std::string& name): CppUnit::TestCase(name)
@@ -784,42 +831,109 @@ void HTTPReactorServerTest::testStopClosesConnections()
 	srv.start();
 	int port = srv.port();
 
-	// One keep-alive request over a raw socket, so the connection is idle but
-	// open when the server stops.
-	Poco::Net::StreamSocket s;
-	s.connect(Poco::Net::SocketAddress("127.0.0.1", port));
-	s.setReceiveTimeout(Poco::Timespan(5, 0));
-	std::string req("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nping");
-	s.sendBytes(req.data(), static_cast<int>(req.size()));
-	std::string resp;
-	char buf[4096];
-	while (resp.find("ping") == std::string::npos)
-	{
-		int n = s.receiveBytes(buf, sizeof(buf));
-		assertTrue(n > 0);
-		resp.append(buf, n);
-	}
+	// Two round trips prove the keep-alive connection is open and reusable
+	// at the moment the server stops, so the EOF below can only come from
+	// the shutdown path.
+	Poco::Net::StreamSocket s = openKeepAliveConnection(port, 2);
 
 	// stop() joins the reactor threads, so the ShutdownNotification has been
 	// dispatched by the time it returns. The connection must be closed then:
 	// expect EOF (or a reset), not a receive timeout, while the server object
 	// is still alive.
 	srv.stop();
+	assertTrue(connectionClosed(s));
+}
 
-	bool closed = false;
-	try
+void HTTPReactorServerTest::testStopClosesMultipleConnections()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(true);
+	pParams->setMaxThreads(2);
+	pParams->setReactorMode(true);
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// The shutdown broadcast iterates the notifier list while each closing
+	// connection removes itself from it; several connections make that
+	// erase-while-dispatching path observable.
+	std::vector<Poco::Net::StreamSocket> sockets;
+	for (int i = 0; i < 4; ++i)
 	{
-		closed = (s.receiveBytes(buf, sizeof(buf)) == 0);
+		sockets.push_back(openKeepAliveConnection(port, 1));
 	}
-	catch (const Poco::TimeoutException&)
+
+	srv.stop();
+	for (auto& s : sockets)
 	{
-		closed = false;    // connection left open: shutdown never reached it
+		assertTrue(connectionClosed(s));
 	}
-	catch (const Poco::Net::NetException&)
+}
+
+void HTTPReactorServerTest::testStopClosesConnectionsSelfReactor()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(true);
+	pParams->setReactorMode(true);
+	pParams->setUseSelfReactor(true);
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// In self-reactor mode the connections share the acceptor's reactor, so
+	// the shutdown broadcast also visits the acceptor's own notifier.
+	std::vector<Poco::Net::StreamSocket> sockets;
+	for (int i = 0; i < 2; ++i)
 	{
-		closed = true;
+		sockets.push_back(openKeepAliveConnection(port, 1));
 	}
-	assertTrue(closed);
+
+	srv.stop();
+	for (auto& s : sockets)
+	{
+		assertTrue(connectionClosed(s));
+	}
+}
+
+namespace
+{
+	// Exposes the protected error broadcast, standing in for an exception
+	// escaping a handler on the reactor.
+	class ErrorBroadcastReactor: public Poco::Net::SocketReactor
+	{
+	public:
+		using Poco::Net::SocketReactor::onError;
+	};
+}
+
+void HTTPReactorServerTest::testReactorErrorClosesConnection()
+{
+	ErrorBroadcastReactor reactor;
+	Poco::Thread thread;
+	thread.start(reactor);
+
+	Poco::Net::ServerSocket ss(Poco::Net::SocketAddress("127.0.0.1", 0));
+	Poco::Net::StreamSocket client;
+	client.connect(ss.address());
+	client.setReceiveTimeout(Poco::Timespan(5, 0));
+	Poco::Net::StreamSocket accepted = ss.acceptConnection();
+
+	auto conn = std::make_shared<Poco::Net::TCPReactorServerConnection>(accepted, reactor);
+	conn->initialize();
+	// Drop the local socket and connection references: only the reactor's
+	// observers keep the connection (and its fd) alive, as in the server.
+	accepted = Poco::Net::StreamSocket();
+	conn.reset();
+
+	// The error broadcast must reach the connection through the registered
+	// ErrorNotification observer and close it.
+	reactor.onError(0, "simulated reactor error");
+	assertTrue(connectionClosed(client));
+
+	reactor.stop();
+	thread.join();
 }
 
 void HTTPReactorServerTest::setUp()
@@ -855,6 +969,9 @@ CppUnit::Test* HTTPReactorServerTest::suite()
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testOnErrorPreservesExceptionType);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutClosesStalledClient);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testStopClosesConnections);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testStopClosesMultipleConnections);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testStopClosesConnectionsSelfReactor);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testReactorErrorClosesConnection);
 
 	return pSuite;
 }

--- a/Net/testsuite/src/HTTPReactorServerTest.cpp
+++ b/Net/testsuite/src/HTTPReactorServerTest.cpp
@@ -773,6 +773,55 @@ void HTTPReactorServerTest::testSendTimeoutClosesStalledClient()
 	srv.stop();
 }
 
+void HTTPReactorServerTest::testStopClosesConnections()
+{
+	HTTPServerParams* pParams = new HTTPServerParams;
+	pParams->setKeepAlive(true);
+	pParams->setMaxThreads(1);
+	pParams->setReactorMode(true);
+
+	Poco::Net::HTTPReactorServer srv(0, pParams, new RequestHandlerFactory);
+	srv.start();
+	int port = srv.port();
+
+	// One keep-alive request over a raw socket, so the connection is idle but
+	// open when the server stops.
+	Poco::Net::StreamSocket s;
+	s.connect(Poco::Net::SocketAddress("127.0.0.1", port));
+	s.setReceiveTimeout(Poco::Timespan(5, 0));
+	std::string req("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nping");
+	s.sendBytes(req.data(), static_cast<int>(req.size()));
+	std::string resp;
+	char buf[4096];
+	while (resp.find("ping") == std::string::npos)
+	{
+		int n = s.receiveBytes(buf, sizeof(buf));
+		assertTrue(n > 0);
+		resp.append(buf, n);
+	}
+
+	// stop() joins the reactor threads, so the ShutdownNotification has been
+	// dispatched by the time it returns. The connection must be closed then:
+	// expect EOF (or a reset), not a receive timeout, while the server object
+	// is still alive.
+	srv.stop();
+
+	bool closed = false;
+	try
+	{
+		closed = (s.receiveBytes(buf, sizeof(buf)) == 0);
+	}
+	catch (const Poco::TimeoutException&)
+	{
+		closed = false;    // connection left open: shutdown never reached it
+	}
+	catch (const Poco::Net::NetException&)
+	{
+		closed = true;
+	}
+	assertTrue(closed);
+}
+
 void HTTPReactorServerTest::setUp()
 {
 }
@@ -805,6 +854,7 @@ CppUnit::Test* HTTPReactorServerTest::suite()
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testHandlerExceptionKeepsServerAlive);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testOnErrorPreservesExceptionType);
 	CppUnit_addTest(pSuite, HTTPReactorServerTest, testSendTimeoutClosesStalledClient);
+	CppUnit_addTest(pSuite, HTTPReactorServerTest, testStopClosesConnections);
 
 	return pSuite;
 }

--- a/Net/testsuite/src/HTTPReactorServerTest.h
+++ b/Net/testsuite/src/HTTPReactorServerTest.h
@@ -29,6 +29,7 @@ public:
 	void testHandlerExceptionKeepsServerAlive();
 	void testOnErrorPreservesExceptionType();
 	void testSendTimeoutClosesStalledClient();
+	void testStopClosesConnections();
 
 	void setUp();
 	void tearDown();

--- a/Net/testsuite/src/HTTPReactorServerTest.h
+++ b/Net/testsuite/src/HTTPReactorServerTest.h
@@ -30,6 +30,9 @@ public:
 	void testOnErrorPreservesExceptionType();
 	void testSendTimeoutClosesStalledClient();
 	void testStopClosesConnections();
+	void testStopClosesMultipleConnections();
+	void testStopClosesConnectionsSelfReactor();
+	void testReactorErrorClosesConnection();
 
 	void setUp();
 	void tearDown();


### PR DESCRIPTION
Fixes #5466.

`TCPReactorServerConnection` declared `onError()` and `onShutdown()` but never registered them with the reactor, so socket errors were only detected by a failing read, and connections survived `TCPReactorServer::stop()` until the server object was destroyed.

Changes:

- Register `ErrorNotification` and `ShutdownNotification` observers in `initialize()`; `handleClose()` removes all three observers. `onError()` logs the error at debug level.
- Registration order is Shutdown, Error, Readable: the socket becomes readable-pollable only after registration is complete, so an immediately disconnecting client cannot close the connection mid-registration.
- `onError()`/`onShutdown()` contain exceptions so a throw cannot abort the reactor's shutdown or error broadcast for the remaining connections.
- `SocketAcceptor::onAccept()` is now virtual; `TCPReactorAcceptor` overrides it and contains accept-path exceptions (`ECONNABORTED`, `EMFILE`, a failing setsockopt on the accepted socket) via `ErrorHandler`, like `TCPServer::run()`. Without this, an escaped accept exception is re-dispatched as an `ErrorNotification` broadcast and, with the new observers, would close every connection on the reactor (all of them in the default self-reactor mode).
- `TCPReactorServer::stop()` stops the acceptor reactors before the worker reactors, so connections accepted while `stop()` is in progress still receive the shutdown notification.
- `SocketReactor::onError()` releases the dispatched `ErrorNotification`; previously one notification object leaked per exception caught in the reactor loop.
- Test-only: bound a read in `testBodyReadTwice` by the buffer size (flagged by cppcheck).

New tests: `testStopClosesConnections` (an idle keep-alive connection must see EOF after `stop()` while the server object is alive), `testStopClosesMultipleConnections`, `testStopClosesConnectionsSelfReactor`, and `testReactorErrorClosesConnection` (deterministic delivery of the error broadcast to a connection).

Verified with `HTTPReactorServerTest`, `SocketReactorTest` and `TCPServerTest` on macOS and Linux, including TSan and ASan+UBSan (leak detection) runs, and with out-of-tree reproducers for the accept-failure broadcast (established connections stay open under `EMFILE`) and for the `stop()` window (0/8 cycles leak connections accepted during `stop()`, previously 8/8).

Note: a `SocketAcceptor` subclass that shadowed `onAccept()` with the same signature will now have its method invoked, since `onAccept()` is virtual.
