### PR TITLE
fix(all): ABI-affecting build options, unbundled billion laughs protection, environment-dependent tests #5470

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,26 @@ jobs:
             PWD=`pwd`
             ctest -V
 
+  # POCO_ENABLE_STD_MUTEX=ON probe: Foundation only.
+  linux-gcc-cmake-std-mutex:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt -y update && sudo apt -y install cmake ninja-build
+      - run: >-
+          cmake -S. -Bcmake-build -GNinja -DENABLE_TESTS=ON -DPOCO_MINIMAL_BUILD=ON
+          -DENABLE_FOUNDATION=ON -DPOCO_ENABLE_STD_MUTEX=ON
+      - run: cmake --build cmake-build --target Foundation-testrunner --parallel 4
+      - uses: ./.github/actions/retry-action
+        with:
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_on: any
+          command: >-
+            cd cmake-build &&
+            PWD=`pwd`
+            ctest -V -R "^Foundation$"
+
   linux-gcc-cmake-ubsan:
     runs-on: ubuntu-24.04
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ option(ENABLE_TESTS
 option(ENABLE_TEST_DEPRECATED
 	"Set to OFF|ON (default is OFF) to enable build of tests for deprecated functionality" OFF)
 
-option(POCO_DATA_NO_SQL_PARSER "Disable SQL parser" OFF)
+option(POCO_DATA_NO_SQL_PARSER "Set to OFF|ON (default is OFF) to build Poco::Data without the SQL parser" OFF)
 
 option(ENABLE_COMPILER_WARNINGS
 	"Set to OFF|ON (default is OFF) to enable additional compiler warnings. Intended primarily for maintainers." OFF)
@@ -331,11 +331,7 @@ if(POCO_NO_FORK_EXEC)
 	add_definitions(-DPOCO_NO_FORK_EXEC=1)
 endif()
 
-option(POCO_ENABLE_STD_MUTEX "Set to OFF|NO using mutex from standard library (default OFF)" OFF)
-
-if (POCO_ENABLE_STD_MUTEX)
-	add_compile_definitions(POCO_ENABLE_STD_MUTEX)
-endif ()
+option(POCO_ENABLE_STD_MUTEX "Set to OFF|ON (default is OFF) to implement Poco::Mutex and Poco::FastMutex with std::recursive_mutex and std::mutex" OFF)
 
 if(ENABLE_TRACE)
 	add_compile_definitions(POCO_ENABLE_TRACE)
@@ -571,9 +567,6 @@ endif(OPENSSL_FOUND)
 
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/Data AND ENABLE_DATA)
-	if(POCO_DATA_NO_SQL_PARSER)
-		add_compile_definitions(POCO_DATA_NO_SQL_PARSER=1)
-	endif()
 	add_subdirectory(Data)
 	list(APPEND Poco_COMPONENTS "Data")
 endif()

--- a/Data/CMakeLists.txt
+++ b/Data/CMakeLists.txt
@@ -35,7 +35,11 @@ set_target_properties(Data
 )
 
 if (NOT POCO_DATA_NO_SQL_PARSER)
-	target_compile_definitions(Data PUBLIC -DSQLParser_EXPORTS)
+	target_compile_definitions(Data PUBLIC SQLParser_EXPORTS)
+else()
+	# Guards private members in Statement.h, so it must reach consumers of the
+	# installed headers as well.
+	target_compile_definitions(Data PUBLIC POCO_DATA_NO_SQL_PARSER=1)
 endif()
 target_link_libraries(Data PUBLIC Poco::Foundation)
 

--- a/Data/include/Poco/Data/Statement.h
+++ b/Data/include/Poco/Data/Statement.h
@@ -564,9 +564,16 @@ private:
 		/// Returns true if the statement is of the argument type.
 
 	Poco::SharedPtr<Parser::SQLParserResult> _pParseResult;
-	std::string _parseError;
+
+#else
+
+	// Layout placeholder, always null: SharedPtr is two pointers whatever it
+	// points to, so Statement has the same size and offsets in both builds.
+	Poco::SharedPtr<char> _pParseResult;
 
 #endif // POCO_DATA_NO_SQL_PARSER
+
+	std::string _parseError;
 
 	StatementImpl::Ptr _pImpl;
 

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -49,10 +49,8 @@ Statement::Statement(Session& session):
 
 
 Statement::Statement(const Statement& stmt):
-#ifndef POCO_DATA_NO_SQL_PARSER
 	_pParseResult(stmt._pParseResult),
 	_parseError(stmt._parseError),
-#endif
 	_pImpl(stmt._pImpl),
 	_async(stmt._async),
 	_pResult(stmt._pResult),
@@ -65,10 +63,8 @@ Statement::Statement(const Statement& stmt):
 
 
 Statement::Statement(Statement&& stmt) noexcept:
-#ifndef POCO_DATA_NO_SQL_PARSER
 	_pParseResult(std::move(stmt._pParseResult)),
 	_parseError(std::move(stmt._parseError)),
-#endif
 	_pImpl(std::move(stmt._pImpl)),
 	_async(stmt._async),
 	_pResult(std::move(stmt._pResult)),
@@ -95,10 +91,8 @@ void Statement::clear() noexcept
 	_arguments.clear();
 	_pRowFormatter = nullptr;
 	_stmtString.clear();
-#ifndef POCO_DATA_NO_SQL_PARSER
 	_pParseResult = nullptr;
 	_parseError.clear();
-#endif
 }
 
 
@@ -112,11 +106,9 @@ Statement& Statement::operator = (const Statement& stmt)
 
 Statement& Statement::operator = (Statement&& stmt) noexcept
 {
-#ifndef POCO_DATA_NO_SQL_PARSER
 	_pParseResult = std::move(stmt._pParseResult);
 	_parseError = std::move(stmt._parseError);
 	_parseError.clear();
-#endif
 	_pImpl = std::move(stmt._pImpl);
 	stmt._pImpl = nullptr;
 	_async = std::move(stmt._async);
@@ -138,10 +130,8 @@ Statement& Statement::operator = (Statement&& stmt) noexcept
 void Statement::swap(Statement& other) noexcept
 {
 	using std::swap;
-#ifndef POCO_DATA_NO_SQL_PARSER
 	swap(_pParseResult, other._pParseResult);
 	swap(_parseError, other._parseError);
-#endif
 	swap(_pImpl, other._pImpl);
 	swap(_async, other._async);
 	swap(_pResult, other._pResult);
@@ -237,12 +227,7 @@ bool Statement::hasType(unsigned int type) const
 
 const std::string& Statement::parseError()
 {
-#ifdef POCO_DATA_NO_SQL_PARSER
-	static std::string empty;
-	return empty;
-#else
 	return _parseError;
-#endif
 }
 
 

--- a/Data/src/Statement.cpp
+++ b/Data/src/Statement.cpp
@@ -108,21 +108,14 @@ Statement& Statement::operator = (Statement&& stmt) noexcept
 {
 	_pParseResult = std::move(stmt._pParseResult);
 	_parseError = std::move(stmt._parseError);
-	_parseError.clear();
 	_pImpl = std::move(stmt._pImpl);
-	stmt._pImpl = nullptr;
-	_async = std::move(stmt._async);
-	stmt._async = false;
+	_async = stmt._async;
 	_pResult = std::move(stmt._pResult);
-	stmt._pResult = nullptr;
 	_pAsyncExec = std::move(stmt._pAsyncExec);
-	stmt._pAsyncExec = nullptr;
 	_arguments = std::move(stmt._arguments);
-	stmt._arguments.clear();
 	_pRowFormatter = std::move(stmt._pRowFormatter);
-	stmt._pRowFormatter = nullptr;
 	_stmtString = std::move(stmt._stmtString);
-	stmt._stmtString.clear();
+	stmt.clear();
 
 	return *this;
 }

--- a/Data/testsuite/src/DataTest.cpp
+++ b/Data/testsuite/src/DataTest.cpp
@@ -153,6 +153,25 @@ void DataTest::testStatementFormatting()
 }
 
 
+void DataTest::testStatementMoveAssignment()
+{
+	Session sess(SessionFactory::instance().create("test", "cs"));
+
+	Statement source = (sess << "SELEC * FROM Person");
+	source.parse();
+	const std::string parseError = source.parseError();
+#ifndef POCO_DATA_NO_SQL_PARSER
+	assertTrue (!parseError.empty());
+#endif
+
+	Statement target(sess);
+	target = std::move(source);
+	assertTrue (target.toString() == "SELEC * FROM Person");
+	assertTrue (target.parseError() == parseError);
+	assertTrue (source.parseError().empty());
+}
+
+
 void DataTest::testFeatures()
 {
 	Session sess(SessionFactory::instance().create("test", "cs"));
@@ -1723,6 +1742,7 @@ CppUnit::Test* DataTest::suite()
 
 	CppUnit_addTest(pSuite, DataTest, testSession);
 	CppUnit_addTest(pSuite, DataTest, testStatementFormatting);
+	CppUnit_addTest(pSuite, DataTest, testStatementMoveAssignment);
 	CppUnit_addTest(pSuite, DataTest, testFeatures);
 	CppUnit_addTest(pSuite, DataTest, testProperties);
 	CppUnit_addTest(pSuite, DataTest, testLOB);

--- a/Data/testsuite/src/DataTest.h
+++ b/Data/testsuite/src/DataTest.h
@@ -29,6 +29,7 @@ public:
 
 	void testSession();
 	void testStatementFormatting();
+	void testStatementMoveAssignment();
 	void testFeatures();
 	void testProperties();
 	void testLOB();

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -64,7 +64,10 @@ endif(POCO_UNBUNDLED)
 add_library(Foundation ${SRCS})
 if (POCO_UNBUNDLED)
 	target_link_libraries(Foundation PRIVATE ZLIB::ZLIB Pcre2::Pcre2 Utf8Proc::Utf8Proc)
-	target_include_directories(Foundation PRIVATE ${EMBEDDED_PCRE2_INCLUDE})
+	# Only Unicode.cpp and the embedded tables need pcre2's internal headers;
+	# RegularExpression.cpp must see the system pcre2.h it links against.
+	set_source_files_properties(src/Unicode.cpp ${EMBEDDED_PCRE2_SOURCES}
+		PROPERTIES INCLUDE_DIRECTORIES "${EMBEDDED_PCRE2_INCLUDE}")
 	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED PRIVATE HAVE_CONFIG_H)
 else()
 	# BUILD_LOCAL_INTERFACE is used to ensure that the dependent libraries are used

--- a/Foundation/CMakeLists.txt
+++ b/Foundation/CMakeLists.txt
@@ -108,6 +108,12 @@ if (NOT POCO_SOO)
 	target_compile_definitions(Foundation PUBLIC POCO_NO_SOO)
 endif()
 
+# Selects MutexImpl in Mutex.h, so it must reach consumers of the installed
+# headers as well; otherwise they disagree with the library about Mutex.
+if (POCO_ENABLE_STD_MUTEX)
+	target_compile_definitions(Foundation PUBLIC POCO_ENABLE_STD_MUTEX)
+endif()
+
 target_compile_definitions(Foundation PUBLIC POCO_CMAKE)
 
 target_include_directories(Foundation

--- a/Foundation/testsuite/src/PatternFormatterTest.cpp
+++ b/Foundation/testsuite/src/PatternFormatterTest.cpp
@@ -14,11 +14,17 @@
 #include "Poco/PatternFormatter.h"
 #include "Poco/Message.h"
 #include "Poco/DateTime.h"
+#include "Poco/DateTimeFormatter.h"
+#include "Poco/Timestamp.h"
+#include "Poco/Timezone.h"
 
 
 using Poco::PatternFormatter;
 using Poco::Message;
 using Poco::DateTime;
+using Poco::DateTimeFormatter;
+using Poco::Timestamp;
+using Poco::Timezone;
 
 
 PatternFormatterTest::PatternFormatterTest(const std::string& name): CppUnit::TestCase(name)
@@ -65,7 +71,11 @@ void PatternFormatterTest::testPatternFormatter()
 	assertTrue (fmt.getProperty("times") == "UTC");
 	fmt.setProperty("times", "local");
 	fmt.format(msg, result);
-	assertTrue (result.find("2005-01-01 ") == 0);
+	// Mirrors the conversion in PatternFormatter::format(); hard-coding the date
+	// fails wherever the local offset pushes the message past midnight.
+	Timestamp localTime = msg.getTime();
+	localTime += (Timezone::utcOffset() + Timezone::dst()) * Timestamp::resolution();
+	assertTrue (result.find(DateTimeFormatter::format(localTime, "%Y-%m-%d %H:%M:%S [")) == 0);
 	assertTrue (result.find(":TestSource]3-Test message text") != std::string::npos);
 
 	result.clear();

--- a/Foundation/testsuite/src/TimerTest.cpp
+++ b/Foundation/testsuite/src/TimerTest.cpp
@@ -21,6 +21,14 @@ using Poco::Thread;
 using Poco::Stopwatch;
 
 
+namespace
+{
+	// Well above the 100/200 ms intervals even under sanitizers, so a timer
+	// that never fires fails the test instead of hanging the runner.
+	const long WAIT_TIMEOUT_MS = 5000;
+}
+
+
 TimerTest::TimerTest(const std::string& name): CppUnit::TestCase(name)
 {
 }
@@ -39,19 +47,17 @@ void TimerTest::testTimer()
 
 	Stopwatch sw;
 	TimerCallback<TimerTest> tc(*this, &TimerTest::onTimer);
+	// Only lower bounds, measured from one start: the timer runs at a fixed
+	// rate, so it can never fire before 100, 300 and 500 ms, whereas no
+	// scheduler can promise an upper bound on how late it fires under load.
 	sw.start();
 	t.start(tc);
-	_event.wait();
-	sw.stop();
-	assertTrue (sw.elapsed() >= 80000 && sw.elapsed() < 120000);
-	sw.restart();
-	_event.wait();
-	sw.stop();
-	assertTrue (sw.elapsed() >= 180000 && sw.elapsed() < 250000);
-	sw.restart();
-	_event.wait();
-	sw.stop();
-	assertTrue (sw.elapsed() >= 180000 && sw.elapsed() < 250000);
+	_event.wait(WAIT_TIMEOUT_MS);
+	assertTrue (sw.elapsed() >= 80000);
+	_event.wait(WAIT_TIMEOUT_MS);
+	assertTrue (sw.elapsed() >= 280000);
+	_event.wait(WAIT_TIMEOUT_MS);
+	assertTrue (sw.elapsed() >= 480000);
 	t.stop();
 }
 
@@ -64,7 +70,7 @@ void TimerTest::testDuplicateStop()
 
 	TimerCallback<TimerTest> tc(*this, &TimerTest::onTimer);
 	t.start(tc);
-	_event.wait();
+	_event.wait(WAIT_TIMEOUT_MS);
 	t.stop();
 	t.stop();
 }

--- a/XML/CMakeLists.txt
+++ b/XML/CMakeLists.txt
@@ -16,6 +16,10 @@ add_library(XML ${SRCS})
 if (POCO_UNBUNDLED)
 	target_link_libraries(XML PRIVATE EXPAT::EXPAT)
 	target_compile_definitions(XML PUBLIC POCO_UNBUNDLED)
+	# expat.h declares the billion laughs protection only under XML_DTD (2.4,
+	# 2.5, 2.6.1 onwards) or XML_GE == 1 (2.6.0), so the system header needs
+	# both. The bundled build gets XML_DTD from _BUNDLED_EXPAT.
+	target_compile_definitions(XML PRIVATE XML_DTD XML_GE=1)
 else()
 	target_link_libraries(XML PRIVATE "$<BUILD_LOCAL_INTERFACE:EXPAT::EXPAT>")
 endif()

--- a/XML/src/ParserEngine.cpp
+++ b/XML/src/ParserEngine.cpp
@@ -518,7 +518,8 @@ void ParserEngine::init()
 	XML_SetParamEntityParsing(_parser, _externalParameterEntities ? XML_PARAM_ENTITY_PARSING_ALWAYS : XML_PARAM_ENTITY_PARSING_NEVER);
 	XML_SetUnknownEncodingHandler(_parser, handleUnknownEncoding, this);
 
-#if defined(XML_DTD) && (XML_MAJOR_VERSION > 2 || (XML_MAJOR_VERSION == 2 && XML_MINOR_VERSION >= 4))
+#if (defined(XML_DTD) || (defined(XML_GE) && XML_GE == 1)) && \
+	(XML_MAJOR_VERSION > 2 || (XML_MAJOR_VERSION == 2 && XML_MINOR_VERSION >= 4))
 	if (_maximumAmplificationFactor > 1.0)
 	{
 		XML_SetBillionLaughsAttackProtectionMaximumAmplification(_parser, _maximumAmplificationFactor);

--- a/XML/testsuite/src/SAXParserTest.cpp
+++ b/XML/testsuite/src/SAXParserTest.cpp
@@ -167,6 +167,36 @@ void SAXParserTest::testInternalEntity()
 }
 
 
+void SAXParserTest::testBillionLaughsProtection()
+{
+	// Expands to ~40 kB from ~300 bytes of source. The default expat threshold
+	// (8 MiB) never fires for a document this small, so reaching the limit below
+	// proves the explicitly configured limits were actually handed to expat.
+	const std::string bomb(
+		"<?xml version='1.0'?>"
+		"<!DOCTYPE root ["
+		"<!ENTITY a '0123456789012345678901234567890123456789'>"
+		"<!ENTITY b '&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;'>"
+		"<!ENTITY c '&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;'>"
+		"<!ENTITY d '&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;'>"
+		"]>"
+		"<root>&d;</root>");
+
+	SAXParser parser;
+	parser.setProperty(SAXParser::PROPERTY_BLA_MAXIMUM_AMPLIFICATION, std::string("1.5"));
+	parser.setProperty(SAXParser::PROPERTY_BLA_ACTIVATION_THRESHOLD, std::string("64"));
+
+	try
+	{
+		parse(parser, XMLWriter::CANONICAL, bomb);
+		fail("entity expansion beyond the amplification limit must be rejected");
+	}
+	catch (XMLException&)
+	{
+	}
+}
+
+
 void SAXParserTest::testNotation()
 {
 	SAXParser parser;
@@ -426,6 +456,7 @@ CppUnit::Test* SAXParserTest::suite()
 	CppUnit_addTest(pSuite, SAXParserTest, testPI);
 	CppUnit_addTest(pSuite, SAXParserTest, testDTD);
 	CppUnit_addTest(pSuite, SAXParserTest, testInternalEntity);
+	CppUnit_addTest(pSuite, SAXParserTest, testBillionLaughsProtection);
 	CppUnit_addTest(pSuite, SAXParserTest, testNotation);
 	CppUnit_addTest(pSuite, SAXParserTest, testExternalUnparsed);
 	CppUnit_addTest(pSuite, SAXParserTest, testExternalParsed);

--- a/XML/testsuite/src/SAXParserTest.h
+++ b/XML/testsuite/src/SAXParserTest.h
@@ -33,6 +33,7 @@ public:
 	void testPI();
 	void testDTD();
 	void testInternalEntity();
+	void testBillionLaughsProtection();
 	void testNotation();
 	void testExternalUnparsed();
 	void testExternalParsed();

--- a/configure
+++ b/configure
@@ -78,6 +78,10 @@ $(ls -C "$base"/build/config/)
     Compile with -DPOCO_NO_SOO.
     Disables small object optimization.
 
+  --std-mutex
+    Compile with -DPOCO_ENABLE_STD_MUTEX.
+    Implements Poco::Mutex and Poco::FastMutex with std::recursive_mutex and std::mutex.
+
   --no-sqlparser
     Compile with -DPOCO_DATA_NO_SQL_PARSER
     Disables compilation of the SQLParser.
@@ -261,6 +265,9 @@ while [ $# -ge 1 ]; do
 
 	--no-soo)
 		flags="$flags -DPOCO_NO_SOO" ;;
+
+	--std-mutex)
+		flags="$flags -DPOCO_ENABLE_STD_MUTEX" ;;
 
 	--no-sqlparser)
 		flags="$flags -DPOCO_DATA_NO_SQL_PARSER"

--- a/cppignore.lnx
+++ b/cppignore.lnx
@@ -17,7 +17,6 @@ CppUnit::TestCaller<TimerTest>.testScheduleAtFixedRate
 CppUnit::TestCaller<TimerTest>.testScheduleInterval
 CppUnit::TestCaller<TimerTest>.testScheduleIntervalClock
 CppUnit::TestCaller<TimerTest>.testScheduleIntervalTimestamp
-CppUnit::TestCaller<TimerTest>.testTimer
 CppUnit::TestCaller<TimestampTest>.testTimestamp
 CppUnit::TestCaller<SocketAddressTest>.testSocketAddress
 CppUnit::TestCaller<RawSocketTest>.testEchoIPv4

--- a/cppignore.win
+++ b/cppignore.win
@@ -11,7 +11,6 @@ class CppUnit::TestCaller<class TCPServerTest>.testReuseSocket
 class CppUnit::TestCaller<class HTTPSClientSessionTest>.testInterop
 class CppUnit::TestCaller<class PathTest>.testFind
 class CppUnit::TestCaller<class ThreadTest>.testSleep
-class CppUnit::TestCaller<class TimerTest>.testTimer
 class CppUnit::TestCaller<class TimerTest>.testScheduleInterval
 class CppUnit::TestCaller<class TimerTest>.testScheduleIntervalTimestamp
 class CppUnit::TestCaller<class TimerTest>.testScheduleIntervalClock

--- a/dependencies/expat/CMakeLists.txt
+++ b/dependencies/expat/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 if(POCO_UNBUNDLED)
 	if (ENABLE_XML)
-		find_package(EXPAT REQUIRED)
+		# 2.4 added the billion laughs protection that Poco::XML exposes.
+		find_package(EXPAT 2.4 REQUIRED)
 		set_target_properties(EXPAT::EXPAT PROPERTIES IMPORTED_GLOBAL TRUE)
 	endif()
 else()


### PR DESCRIPTION
Fixes #5470.

Reviewing the patches Debian and Fedora carry for POCO turned up three defects still present in `main`. Two pre-existing bugs found while reviewing the fix are included as well.

**Build options that change ABI never reached consumers.** `POCO_DATA_NO_SQL_PARSER` and `POCO_ENABLE_STD_MUTEX` were applied with directory-scope `add_compile_definitions()`, so a consumer of the installed headers saw a different class layout than the library it linked. Both are now `PUBLIC` on their targets, matching the existing `POCO_NO_SOO` precedent, and `Statement` is made layout-neutral so the parser option stops being ABI-relevant at all (224 bytes in both modes; it was 224 vs 184).

**Billion laughs protection was inactive in unbundled builds.** expat.h declares the API only under `XML_DTD`, or `XML_GE == 1` for 2.6.0, and only the bundled expat target defined it, so `POCO_UNBUNDLED=ON` builds, which is what Debian and Fedora ship, silently ignored the amplification limits. Both macros are now defined for the unbundled XML target, and `find_package(EXPAT 2.4 REQUIRED)` enforces the version that introduced the API. The first test for the feature is added; it fails against an unbundled build without the fix.

**Environment-dependent tests.** `PatternFormatterTest` hard-coded a local date and failed at UTC+10 and later; Debian's reproducible-builds run uses UTC+14. `TimerTest::testTimer` asserted upper timing bounds a loaded scheduler cannot meet; it now asserts cumulative lower bounds with bounded waits, and is removed from both cppignore files.

**Also fixed.** `Statement` move assignment cleared the destination's parse error instead of the source's; a regression test is added. Unbundled builds compiled `RegularExpression.cpp` against the bundled `pcre2.h`; the include is now scoped to the two sources that need pcre2 internals.

Plus house-style help text for both options, a `--std-mutex` `configure` switch for the make build, and a CI job building Foundation with `POCO_ENABLE_STD_MUTEX=ON`.

Verified on macOS and Linux: Foundation (963 tests), XML bundled and unbundled (140), Data with the parser on and off, PatternFormatterTest across seven timezones, TimerTest over 20 runs under full-core load, and the installed CMake packages carry both definitions.

Targets `poco-1.15.4` and reaches `main` when the release branch is merged. The CI job is written in this branch's workflow style; `main` uses a newer layout, so keep `main`'s `ci.yml` at that merge and re-add the job there.
